### PR TITLE
Fix typo in RequestTelemetryLogger.UpdateTelemetryData

### DIFF
--- a/src/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -66,8 +66,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
         TelemetryLogging.LogAggregated(FunctionId.LSP_TimeInQueue, KeyValueLogMessage.Create(m =>
         {
             m[TelemetryLogging.KeyName] = _serverTypeName;
-            m[TelemetryLogging.KeyValue] = queuedDuration.Milliseconds;
-            // m[TelemetryLogging.KeyValue] = queuedDuration.TotalMilliseconds;
+            m[TelemetryLogging.KeyValue] = (int)queuedDuration.TotalMilliseconds;
             m[TelemetryLogging.KeyMetricName] = "TimeInQueue";
             m["server"] = _serverTypeName;
             m["method"] = methodName;
@@ -77,8 +76,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
         TelemetryLogging.LogAggregated(FunctionId.LSP_RequestDuration, KeyValueLogMessage.Create(m =>
         {
             m[TelemetryLogging.KeyName] = _serverTypeName + "." + methodName;
-            m[TelemetryLogging.KeyValue] = requestDuration.Milliseconds;
-            // m[TelemetryLogging.KeyValue] = requestDuration.TotalMilliseconds;
+            m[TelemetryLogging.KeyValue] = (int)requestDuration.TotalMilliseconds;
             m[TelemetryLogging.KeyMetricName] = "RequestDuration";
             m["server"] = _serverTypeName;
             m["method"] = methodName;

--- a/src/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -66,7 +66,8 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
         TelemetryLogging.LogAggregated(FunctionId.LSP_TimeInQueue, KeyValueLogMessage.Create(m =>
         {
             m[TelemetryLogging.KeyName] = _serverTypeName;
-            m[TelemetryLogging.KeyValue] = queuedDuration.TotalMilliseconds;
+            m[TelemetryLogging.KeyValue] = queuedDuration.Milliseconds;
+            // m[TelemetryLogging.KeyValue] = queuedDuration.TotalMilliseconds;
             m[TelemetryLogging.KeyMetricName] = "TimeInQueue";
             m["server"] = _serverTypeName;
             m["method"] = methodName;
@@ -76,7 +77,8 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
         TelemetryLogging.LogAggregated(FunctionId.LSP_RequestDuration, KeyValueLogMessage.Create(m =>
         {
             m[TelemetryLogging.KeyName] = _serverTypeName + "." + methodName;
-            m[TelemetryLogging.KeyValue] = requestDuration.TotalMilliseconds;
+            m[TelemetryLogging.KeyValue] = requestDuration.Milliseconds;
+            // m[TelemetryLogging.KeyValue] = requestDuration.TotalMilliseconds;
             m[TelemetryLogging.KeyMetricName] = "RequestDuration";
             m["server"] = _serverTypeName;
             m["method"] = methodName;

--- a/src/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -66,7 +66,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
         TelemetryLogging.LogAggregated(FunctionId.LSP_TimeInQueue, KeyValueLogMessage.Create(m =>
         {
             m[TelemetryLogging.KeyName] = _serverTypeName;
-            m[TelemetryLogging.KeyValue] = queuedDuration.Milliseconds;
+            m[TelemetryLogging.KeyValue] = queuedDuration.TotalMilliseconds;
             m[TelemetryLogging.KeyMetricName] = "TimeInQueue";
             m["server"] = _serverTypeName;
             m["method"] = methodName;
@@ -76,7 +76,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
         TelemetryLogging.LogAggregated(FunctionId.LSP_RequestDuration, KeyValueLogMessage.Create(m =>
         {
             m[TelemetryLogging.KeyName] = _serverTypeName + "." + methodName;
-            m[TelemetryLogging.KeyValue] = requestDuration.Milliseconds;
+            m[TelemetryLogging.KeyValue] = requestDuration.TotalMilliseconds;
             m[TelemetryLogging.KeyMetricName] = "RequestDuration";
             m["server"] = _serverTypeName;
             m["method"] = methodName;


### PR DESCRIPTION
This should be using TimeSpan.TotalMilliseconds, not TimeSpan.Milliseconds.

(This is just a copy of https://github.com/dotnet/roslyn/pull/75028 which I abandoned due to merge issues)