### PR TITLE
Fix preview refresh on selection for enum flags checkboxes

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         private void Options_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var listView = (AutomationDelegatingListView)sender;
-            if (listView.SelectedItem is CheckBoxOptionViewModel checkbox)
+            if (listView.SelectedItem is AbstractCheckBoxViewModel checkbox)
             {
                 ViewModel.UpdatePreview(checkbox.GetPreview());
             }


### PR DESCRIPTION
Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2243278/

Now looks like
![refresh_preview](https://github.com/user-attachments/assets/ffe6c205-a002-4412-be62-b3c288bbb5d7)
