### PR TITLE
Switch to new VMR control set

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -31,21 +31,21 @@
     https://github.com/dotnet/sdk/blob/main/src/Layout/redist/minimumMSBuildVersion#L1
   -->
 
-  <ItemGroup Condition="'$(DotnetBuildFromSource)' == 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <PackageVersion Include="Microsoft.Build" Version="17.3.4" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.4" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.3.4" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.3.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotnetBuildFromSource)' != 'true' and '$(TargetFramework)' != 'net472'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' != 'net472'">
     <PackageVersion Include="Microsoft.Build" Version="17.7.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.7.2" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.7.2" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.7.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotnetBuildFromSource)' != 'true' and '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' == 'net472'">
     <PackageVersion Include="Microsoft.Build" Version="17.10.4" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.10.4" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.4" />

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -27,6 +27,7 @@
   <Target Name="ConfigureInnerBuildArg" BeforeTargets="GetSourceBuildCommandConfiguration">
     <PropertyGroup>
       <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)Roslyn.sln"</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)'=='true'">$(InnerBuildArgs) /p:RestoreUseStaticGraphEvaluation=false</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <SystemIdentityModelTokensJwtVersion>6.34.0</SystemIdentityModelTokensJwtVersion>
     <!-- TODO: remove https://github.com/dotnet/roslyn/issues/71827 -->
-    <MicrosoftDotNetXliffTasksVersion Condition="'$(DotnetBuildFromSource)' != 'true'">9.0.0-beta.24076.5</MicrosoftDotNetXliffTasksVersion>
+    <MicrosoftDotNetXliffTasksVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">9.0.0-beta.24076.5</MicrosoftDotNetXliffTasksVersion>
     <MicrosoftIdentityClientVersion>4.61.3</MicrosoftIdentityClientVersion>
     <SystemIdentityModelTokensJwtVersion>6.34.0</SystemIdentityModelTokensJwtVersion>
   </PropertyGroup>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -252,8 +252,8 @@ function BuildSolution() {
   # Workaround for some machines in the AzDO pool not allowing long paths
   $ibcDir = $RepoRoot
 
-  # Set DotNetBuildFromSource to 'true' if we're simulating building for source-build.
-  $buildFromSource = if ($sourceBuild) { "/p:DotNetBuildFromSource=true" } else { "" }
+  # Set DotNetBuildSourceOnly to 'true' if we're simulating building for source-build.
+  $buildFromSource = if ($sourceBuild) { "/p:DotNetBuildSourceOnly=true" } else { "" }
 
   $generateDocumentationFile = if ($skipDocumentation) { "/p:GenerateDocumentationFile=false" } else { "" }
   $roslynUseHardLinks = if ($ci) { "/p:ROSLYNUSEHARDLINKS=true" } else { "" }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -279,6 +279,12 @@ function BuildSolution {
     roslyn_use_hard_links="/p:ROSLYNUSEHARDLINKS=true"
   fi
 
+  local source_build_args=""
+  if [[ "$source_build" == true ]]; then
+    source_build_args="/p:DotNetBuildSourceOnly=$source_build \
+                       /p:DotNetBuildRepo=$source_build"
+  fi
+
   # Setting /p:TreatWarningsAsErrors=true is a workaround for https://github.com/Microsoft/msbuild/issues/3062.
   # We don't pass /warnaserror to msbuild (warn_as_error is set to false by default above), but set 
   # /p:TreatWarningsAsErrors=true so that compiler reported warnings, other than IDE0055 are treated as errors. 
@@ -300,8 +306,7 @@ function BuildSolution {
     /p:ContinuousIntegrationBuild=$ci \
     /p:TreatWarningsAsErrors=true \
     /p:TestRuntimeAdditionalArguments=$test_runtime_args \
-    /p:DotNetBuildSourceOnly=$source_build \
-    /p:DotNetBuildRepo=$source_build \
+    $source_build_args \
     $test_runtime \
     $mono_tool \
     $generate_documentation_file \

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -169,9 +169,8 @@ while [[ $# > 0 ]]; do
     --warnaserror)
       warn_as_error=true
       ;;
-    --sourcebuild|/p:arcadebuildfromsource=true)
-      # Arcade specifies /p:ArcadeBuildFromSource=true instead of --sourceBuild, but that's not developer friendly so we
-      # have an alias.
+    --sourcebuild|/p:dotnetbuildsourceonly=true)
+      # Arcade passes /p:DotNetBuildSourceOnly=true and /p:DotNetBuildRepo=true when --sourcebuild or -sb is passed. Include this switch in our build scripts.
       source_build=true
       # RestoreUseStaticGraphEvaluation will cause prebuilts
       restoreUseStaticGraphEvaluation=false
@@ -302,7 +301,8 @@ function BuildSolution {
     /p:ContinuousIntegrationBuild=$ci \
     /p:TreatWarningsAsErrors=true \
     /p:TestRuntimeAdditionalArguments=$test_runtime_args \
-    /p:ArcadeBuildFromSource=$source_build \
+    /p:DotNetBuildSourceOnly=$source_build \
+    /p:DotNetBuildRepo=$source_build \
     $test_runtime \
     $mono_tool \
     $generate_documentation_file \

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -169,8 +169,7 @@ while [[ $# > 0 ]]; do
     --warnaserror)
       warn_as_error=true
       ;;
-    --sourcebuild|/p:dotnetbuildsourceonly=true)
-      # Arcade passes /p:DotNetBuildSourceOnly=true and /p:DotNetBuildRepo=true when --sourcebuild or -sb is passed. Include this switch in our build scripts.
+    --sourcebuild)
       source_build=true
       # RestoreUseStaticGraphEvaluation will cause prebuilts
       restoreUseStaticGraphEvaluation=false

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -281,8 +281,8 @@ function BuildSolution {
 
   local source_build_args=""
   if [[ "$source_build" == true ]]; then
-    source_build_args="/p:DotNetBuildSourceOnly=$source_build \
-                       /p:DotNetBuildRepo=$source_build"
+    source_build_args="/p:DotNetBuildSourceOnly=true \
+                       /p:DotNetBuildRepo=true"
   fi
 
   # Setting /p:TreatWarningsAsErrors=true is a workaround for https://github.com/Microsoft/msbuild/issues/3062.

--- a/eng/generate-vssdk-versions.csx
+++ b/eng/generate-vssdk-versions.csx
@@ -73,7 +73,7 @@ foreach (var (id, version) in properties)
     else if (!seenMsbuild)
     {
         Console.WriteLine($$"""
-            <ItemGroup Condition="'$(DotnetBuildFromSource)' != 'true' and '$(TargetFramework)' == 'net472'">
+            <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' == 'net472'">
               <PackageVersion Include="Microsoft.Build" Version="{{version}}" />
               <PackageVersion Include="Microsoft.Build.Framework" Version="{{version}}" />
               <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="{{version}}" />

--- a/eng/targets/DiaSymReaderNative.targets
+++ b/eng/targets/DiaSymReaderNative.targets
@@ -18,7 +18,7 @@
     package can't be referenced directly but rather has to have it's assets manually copied 
     out. This logic is responsible for doing that.
   -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <Content Include="$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\Microsoft.DiaSymReader.Native.x86.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>

--- a/eng/targets/Imports.BeforeArcade.targets
+++ b/eng/targets/Imports.BeforeArcade.targets
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <!-- do not restore or use the 8.0 app host in source-build -->
-  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -150,7 +150,7 @@
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 
-  <Target Name="_CheckRequiredMSBuildVersion" BeforeTargets="BeforeBuild" Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <Target Name="_CheckRequiredMSBuildVersion" BeforeTargets="BeforeBuild" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <CompareVersions Left="$(MSBuildVersion)" Right="$(MinimumMSBuildVersion)">
       <Output TaskParameter="Result" PropertyName="_VersionComparisonResult"/>
     </CompareVersions>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -20,6 +20,7 @@
     <LanguageServicesExtensionInstallationFolder>Microsoft\VBCSharp\LanguageServices</LanguageServicesExtensionInstallationFolder>
 
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <RestoreUseStaticGraphEvaluation Condition="'$(DotNetBuildSourceOnly)'=='true'">false</RestoreUseStaticGraphEvaluation>
 
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -20,7 +20,6 @@
     <LanguageServicesExtensionInstallationFolder>Microsoft\VBCSharp\LanguageServices</LanguageServicesExtensionInstallationFolder>
 
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
-    <RestoreUseStaticGraphEvaluation Condition="'$(DotNetBuildSourceOnly)'=='true'">false</RestoreUseStaticGraphEvaluation>
 
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -30,7 +30,7 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateFullPaths>true</GenerateFullPaths>
-    <EnableWindowsTargeting Condition="'$(DotNetBuildFromSource)' != 'true'">true</EnableWindowsTargeting>
+    <EnableWindowsTargeting Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</EnableWindowsTargeting>
 
     <!-- Set to non-existent file to prevent common targets from importing Microsoft.CodeAnalysis.targets -->
     <CodeAnalysisTargets>NON_EXISTENT_FILE</CodeAnalysisTargets>
@@ -154,7 +154,7 @@
   <!--
     Analyzers
   -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
@@ -169,7 +169,7 @@
   <!--
      Code indexing targets to help generating LSIF from indexing builds.
   -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="RichCodeNav.EnvVarDump" PrivateAssets="all" />
   </ItemGroup>
 
@@ -249,7 +249,7 @@
     </When>
   </Choose>
 
-  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <!-- https://github.com/dotnet/roslyn/issues/38433 Vbc does not like the extra semicolon -->
     <DefineConstants Condition="'$(DefineConstants)' != ''">DOTNET_BUILD_FROM_SOURCE;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(DefineConstants)' == ''">DOTNET_BUILD_FROM_SOURCE</DefineConstants>

--- a/eng/targets/TargetFrameworks.props
+++ b/eng/targets/TargetFrameworks.props
@@ -35,7 +35,7 @@
         bootstrap toolset in other repos doing (1). Those can be using a NetPrevious runtime hence 
         the toolset must support that.
     -->
-    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">
+    <When Condition="'$(DotNetBuildSourceOnly)' == 'true' AND '$(DotNetBuildOrchestrator)' != 'true'">
       <PropertyGroup>
         <!-- TODO until we figure out what is up with NetPrevious -->
         <NetPrevious>$(NetMinimum)</NetPrevious>
@@ -50,7 +50,7 @@
     <!--
       2. Source build the product: this is the all up build of the product which needs only NetCurrent
     -->
-    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product'">
+    <When Condition="'$(DotNetBuildSourceOnly)' == 'true' AND '$(DotNetBuildOrchestrator)' == 'true'">
       <PropertyGroup>
         <NetRoslyn>$(NetCurrent)</NetRoslyn>
         <NetRoslynSourceBuild>$(NetCurrent);$(NetPrevious)</NetRoslynSourceBuild>

--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -30,7 +30,7 @@
       Note: PrivateAssets="ContentFiles" ensures that projects referencing Microsoft.CodeAnalysis.Common package
       will import everything but content files from Microsoft.CodeAnalysis.Analyzers, specifically, analyzers.
     -->
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Condition="'$(DotNetBuildFromSource)' != 'true'" PrivateAssets="ContentFiles" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Condition="'$(DotNetBuildSourceOnly)' != 'true'" PrivateAssets="ContentFiles" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Reflection.Metadata" />
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Need to include the PerformanceSensitiveAttribute definition in source build, since we can't get it from the analyzer package. -->
-    <Compile Remove="InternalUtilities\PerformanceSensitiveAttribute.cs" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <Compile Remove="InternalUtilities\PerformanceSensitiveAttribute.cs" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp" />

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -118,7 +118,7 @@
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.TestWindow.Core" Partner="UnitTesting" Key="$(UnitTestingKey)" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="SymbolSearch\Windows\**\*.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+    <Compile Remove="SymbolSearch\Windows\**\*.cs" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <Compile Include="..\..\..\Compilers\Core\Portable\PEWriter\CompilationOptionNames.cs" Link="PdbSourceDocument\CompilationOptionNames.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\Text\TextUtilities.cs" Link="Shared\Utilities\TextUtilities.cs" />
   </ItemGroup>
@@ -137,7 +137,7 @@
       WARNING: All package references must have an OSS license since this assembly is shipped with dotnet-watch and dotnet-format.
     -->
     <PackageReference Include="Microsoft.CodeAnalysis.AnalyzerUtilities" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <PackageReference Include="Microsoft.DiaSymReader" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>CSharpInteractive</RootNamespace>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
-    <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
+    <UseAppHost Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Interactive/vbi/vbi.vbproj
+++ b/src/Interactive/vbi/vbi.vbproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <StartupObject>Sub Main</StartupObject>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
-    <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
+    <UseAppHost Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</UseAppHost>
     <RootNamespace></RootNamespace>
     <IsShipping>false</IsShipping>
   </PropertyGroup>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/DesktopCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/DesktopCompilerArtifacts.targets
@@ -24,7 +24,7 @@
     VS training data to the assemblies they produce.
   -->
 
-  <Target Name="InitializeDesktopCompilerArtifacts" Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <Target Name="InitializeDesktopCompilerArtifacts" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <ItemGroup>
       
       <!-- The Roslyn built binaries must be taken from these locations because this is the location where signing occurs -->
@@ -34,9 +34,9 @@
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.Scripting\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.CSharp.Scripting.dll" NgenArchitecture="all" NgenApplication="csi.exe"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.VisualBasic.dll" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.dll" />
-      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\Microsoft.DiaSymReader.Native.amd64.dll" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
-      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\Microsoft.DiaSymReader.Native.arm64.dll" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
-      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\Microsoft.DiaSymReader.Native.x86.dll" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
+      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\Microsoft.DiaSymReader.Native.amd64.dll" Condition="'$(DotNetBuildSourceOnly)' != 'true'"/>
+      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\Microsoft.DiaSymReader.Native.arm64.dll" Condition="'$(DotNetBuildSourceOnly)' != 'true'"/>
+      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\Microsoft.DiaSymReader.Native.x86.dll" Condition="'$(DotNetBuildSourceOnly)' != 'true'"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\csc.exe" NgenArchitecture="all" NgenApplication="csc.exe" NgenPriority="2"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\csc.exe.config"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc$(_ExeDirSuffix)\$(Configuration)\net472\csc.rsp"/>

--- a/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
+++ b/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
@@ -51,7 +51,7 @@
           AfterTargets="Build"
           Inputs="$(ArtifactsBinDir)csc\$(Configuration)\net472\csc.exe"
           Outputs="$(IntermediateOutputPath)csc.exe"
-          Condition="'$(DotNetBuildFromSource)' != 'true'">
+          Condition="'$(DotNetBuildSourceOnly)' != 'true'">
 
     <Copy SourceFiles="$(ArtifactsBinDir)csc\$(Configuration)\net472\csc.exe" DestinationFiles="$(IntermediateOutputPath)csc.exe"/>
     <Microsoft.DotNet.Arcade.Sdk.SetCorFlags FilePath="$(IntermediateOutputPath)csc.exe" AddFlags="Prefers32Bit,Requires32Bit" />

--- a/src/Setup/DevDivVsix/CompilersPackage/CompilersPackage.targets
+++ b/src/Setup/DevDivVsix/CompilersPackage/CompilersPackage.targets
@@ -47,7 +47,7 @@
           BeforeTargets="SwixBuild"
           DependsOnTargets="_SetSwrFilePath;InitializeDesktopCompilerArtifacts;_PrepareDesktopCompilerArtifactsForOptimization;ApplyOptimizations"
           Outputs="$(_SwrFilePath)"
-          Condition="'$(DotNetBuildFromSource)' != 'true'">
+          Condition="'$(DotNetBuildSourceOnly)' != 'true'">
 
     <ItemGroup>
       <_File Include="@(DesktopCompilerArtifact)">

--- a/src/Setup/Installer/Installer.Package.csproj
+++ b/src/Setup/Installer/Installer.Package.csproj
@@ -24,7 +24,7 @@
           DependsOnTargets="_CalculateInputsOutputs;ResolveProjectReferences"
           Inputs="$(MSBuildAllProjects);$(_DeploymentVsixPath)"
           Outputs="$(_InstallerFilePath)"
-          Condition="'$(DotNetBuildFromSource)' != 'true' and '$(MSBuildRuntimeType)' != 'Core'">
+          Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(MSBuildRuntimeType)' != 'Core'">
     <ItemGroup>
       <_Files Include="$(MSBuildProjectDirectory)\tools\*.*" TargetDir="tools"/>
       <_Files Include="$(MSBuildProjectDirectory)\scripts\*.*" TargetDir=""/>

--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="17.3.4" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="17.3.4" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" VersionOverride="8.0.4" PrivateAssets="All" Condition="'$(DotnetBuildFromSource)' != 'true'"/>
+    <PackageReference Include="System.Text.Json" VersionOverride="8.0.4" PrivateAssets="All" Condition="'$(DotNetBuildSourceOnly)' != 'true'"/>
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -87,7 +87,7 @@
   -->
   <Target Name="DeployNetFrameworkBuildHost" BeforeTargets="_GetPackageFiles;AssignTargetPaths" Condition="'$(DesignTimeBuild)' != 'true'">
     <!-- If we're not doing source build, we will include a net472 version for the broadest compatibility -->
-    <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+    <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
       <_NetFrameworkBuildHostProjectReference Include="..\..\..\Workspaces\Core\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj">
         <TargetFramework>net472</TargetFramework>
         <ContentFolderName>BuildHost-net472</ContentFolderName>

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" PrivateAssets="compile" />
-    <PackageReference Include="SQLitePCLRaw.bundle_green" PrivateAssets="all" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" PrivateAssets="all" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <PackageReference Include="System.Composition" />
     <!-- We only need to reference Microsoft.Bcl.AsyncInterfaces for netstandard2.0 builds; referencing it for regular .NET builds can cause problems
          since it's now automatic, and Source Build will ensure we get a proper one automatically if we do nothing; if we reference the older version
@@ -33,7 +33,7 @@
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
   <ItemGroup Label="Linked Files">
-    <Compile Remove="Storage\SQLite\**\*.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+    <Compile Remove="Storage\SQLite\**\*.cs" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.Core.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.Core.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.Desktop.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.Desktop.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -149,7 +149,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\OneOrMany.cs">
       <Link>InternalUtilities\OneOrMany.cs</Link>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\PerformanceSensitiveAttribute.cs" Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\PerformanceSensitiveAttribute.cs" Condition="'$(DotNetBuildSourceOnly)' == 'true'">
       <Link>InternalUtilities\PerformanceSensitiveAttribute.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs">


### PR DESCRIPTION
Now that roslyn is on 9.0, we can switch to the new control set. Generally:
- DotNetBuildFromSource -> DotNetBuildSourceOnly - Building a source-only build.
- DotnetBuildFromSourceFlavor == Product -> DotNetBuildOrchestrator == true - Building in the VMR, could be source-only or MS's build.
- ArcadeBuildFromSource -> DotNetBuildRepo == true -> Indicates an outer repo build.