### PR TITLE
BindAttributeCore - use proper binder to avoid an attribute binding cycle

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal BoundAttribute BindAttribute(AttributeSyntax node, NamedTypeSymbol attributeType, Symbol? attributedMember, BindingDiagnosticBag diagnostics)
         {
-            return this.GetRequiredBinder(node).BindAttributeCore(node, attributeType, attributedMember, diagnostics);
+            return BindAttributeCore(this.GetRequiredBinder(node), node, attributeType, attributedMember, diagnostics);
         }
 
         private Binder SkipSemanticModelBinder()
@@ -152,9 +152,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private BoundAttribute BindAttributeCore(AttributeSyntax node, NamedTypeSymbol attributeType, Symbol? attributedMember, BindingDiagnosticBag diagnostics)
+        private static BoundAttribute BindAttributeCore(Binder binder, AttributeSyntax node, NamedTypeSymbol attributeType, Symbol? attributedMember, BindingDiagnosticBag diagnostics)
         {
-            Debug.Assert(this.SkipSemanticModelBinder() == this.GetRequiredBinder(node).SkipSemanticModelBinder());
+            Debug.Assert(binder.SkipSemanticModelBinder() == binder.GetRequiredBinder(node).SkipSemanticModelBinder());
+            binder = binder.WithAdditionalFlags(BinderFlags.AttributeArgument);
 
             // If attribute name bound to an error type with a single named type
             // candidate symbol, we want to bind the attribute constructor
@@ -178,8 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Bind constructor and named attribute arguments using the attribute binder
             var argumentListOpt = node.ArgumentList;
-            Binder attributeArgumentBinder = this.WithAdditionalFlags(BinderFlags.AttributeArgument);
-            AnalyzedAttributeArguments analyzedArguments = attributeArgumentBinder.BindAttributeArguments(argumentListOpt, attributeTypeForBinding, diagnostics);
+            AnalyzedAttributeArguments analyzedArguments = binder.BindAttributeArguments(argumentListOpt, attributeTypeForBinding, diagnostics);
 
             ImmutableArray<int> argsToParamsOpt;
             bool expanded = false;
@@ -189,13 +189,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (attributeTypeForBinding.IsErrorType())
             {
                 boundConstructorArguments = analyzedArguments.ConstructorArguments.Arguments.SelectAsArray(
-                    static (arg, attributeArgumentBinder) => attributeArgumentBinder.BindToTypeForErrorRecovery(arg),
-                    attributeArgumentBinder);
+                    static (arg, binder) => binder.BindToTypeForErrorRecovery(arg),
+                    binder);
                 argsToParamsOpt = default;
             }
             else
             {
-                bool found = attributeArgumentBinder.TryPerformConstructorOverloadResolution(
+                bool found = binder.TryPerformConstructorOverloadResolution(
                     attributeTypeForBinding,
                     analyzedArguments.ConstructorArguments,
                     attributeTypeForBinding.Name,
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (memberResolutionResult.IsNotNull)
                 {
-                    this.CheckAndCoerceArguments<MethodSymbol>(node, memberResolutionResult, analyzedArguments.ConstructorArguments, diagnostics, receiver: null, invokedAsExtensionMethod: false, out argsToParamsOpt);
+                    binder.CheckAndCoerceArguments<MethodSymbol>(node, memberResolutionResult, analyzedArguments.ConstructorArguments, diagnostics, receiver: null, invokedAsExtensionMethod: false, out argsToParamsOpt);
                 }
                 else
                 {
@@ -223,17 +223,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!found)
                 {
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = attributeArgumentBinder.GetNewCompoundUseSiteInfo(diagnostics);
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
                     resultKind = resultKind.WorseResultKind(
-                        memberResolutionResult.IsValid && !attributeArgumentBinder.IsConstructorAccessible(memberResolutionResult.Member, ref useSiteInfo) ?
+                        memberResolutionResult.IsValid && !binder.IsConstructorAccessible(memberResolutionResult.Member, ref useSiteInfo) ?
                             LookupResultKind.Inaccessible :
                             LookupResultKind.OverloadResolutionFailure);
-                    boundConstructorArguments = attributeArgumentBinder.BuildArgumentsForErrorRecovery(analyzedArguments.ConstructorArguments, candidateConstructors);
+                    boundConstructorArguments = binder.BuildArgumentsForErrorRecovery(analyzedArguments.ConstructorArguments, candidateConstructors);
                     diagnostics.Add(node, useSiteInfo);
                 }
                 else
                 {
-                    attributeArgumentBinder.BindDefaultArguments(
+                    binder.BindDefaultArguments(
                         node,
                         attributeConstructor.Parameters,
                         analyzedArguments.ConstructorArguments.Arguments,
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ref argsToParamsOpt,
                         out defaultArguments,
                         expanded,
-                        enableCallerInfo: !IsEarlyAttributeBinder,
+                        enableCallerInfo: !binder.IsEarlyAttributeBinder,
                         diagnostics,
                         attributedMember: attributedMember);
                     boundConstructorArguments = analyzedArguments.ConstructorArguments.Arguments.ToImmutable();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -18983,5 +18983,24 @@ literal:literal
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "C1").WithArguments("C1.implicit operator C1(System.IFormattable)").WithLocation(18, 37)
             );
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74677")]
+        public void StackOverflow()
+        {
+            var source = """
+                using System;
+
+                [Obsolete($"{Test2}")]
+                class Test2
+                {
+                }
+                """;
+
+            CreateCompilation(source).VerifyEmitDiagnostics(
+                // (3,14): error CS0119: 'Test2' is a type, which is not valid in the given context
+                // [Obsolete($"{Test2}")]
+                Diagnostic(ErrorCode.ERR_BadSKunknown, "Test2").WithArguments("Test2", "type").WithLocation(3, 14)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes #74677.