### PR TITLE
Disallow ref assignment to ternary or another ref assignment

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -898,6 +898,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.ConditionalOperator:
+                    if (RequiresRefAssignableVariable(valueKind))
+                    {
+                        Error(diagnostics, ErrorCode.ERR_RefLocalOrParamExpected, node);
+                        return false;
+                    }
+
                     var conditional = (BoundConditionalOperator)expr;
 
                     // byref conditional defers to its operands
@@ -918,6 +924,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                 case BoundKind.AssignmentOperator:
+                    // Cannot ref-assign to a ref assignment.
+                    if (RequiresRefAssignableVariable(valueKind))
+                    {
+                        Error(diagnostics, ErrorCode.ERR_RefLocalOrParamExpected, node);
+                        return false;
+                    }
+
                     var assignment = (BoundAssignmentOperator)expr;
                     return CheckSimpleAssignmentValueKind(node, assignment, valueKind, diagnostics);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -1028,6 +1028,42 @@ class C
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "P").WithLocation(8, 9));
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75023")]
+        public void RefReassignToRefTernary()
+        {
+            var source = """
+                class C
+                {
+                    void M(bool b, ref int x, ref int y, ref int z)
+                    {
+                        (b ? ref x : ref y) = ref z;
+                    }
+                }
+                """;
+            CreateCompilation(source).VerifyDiagnostics(
+                // (5,10): error CS8373: The left-hand side of a ref assignment must be a ref variable.
+                //         (b ? ref x : ref y) = ref z;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "b ? ref x : ref y").WithLocation(5, 10));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75023")]
+        public void RefReassignToRefAssignment()
+        {
+            var source = """
+                class C
+                {
+                    void M(ref int x, ref int y, ref int z)
+                    {
+                        (x = ref y) = ref z;
+                    }
+                }
+                """;
+            CreateCompilation(source).VerifyDiagnostics(
+                // (5,10): error CS8373: The left-hand side of a ref assignment must be a ref variable.
+                //         (x = ref y) = ref z;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "x = ref y").WithLocation(5, 10));
+        }
+
         [Fact, WorkItem(44153, "https://github.com/dotnet/roslyn/issues/44153")]
         public void RefErrorProperty()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/75023.