### PR TITLE
Log messages for Test Results

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -240,4 +240,16 @@
   <data name="Project_0_has_unresolved_dependencies" xml:space="preserve">
     <value>Project {0} has unresolved dependencies</value>
   </data>
+  <data name="Standard_Output_Messages" xml:space="preserve">
+    <value>Standard Output Messages</value>
+  </data>
+  <data name="Standard_Error_Messages" xml:space="preserve">
+    <value>Standard Error Messages</value>
+  </data>
+  <data name="Debug_Trace_Messages" xml:space="preserve">
+    <value>Debug Trace Messages</value>
+  </data>
+  <data name="Additional_Info_Messages" xml:space="preserve">
+    <value>Additional Info Messages</value>
+  </data>
 </root>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestRunner.TestRunHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestRunner.TestRunHandler.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Text;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Testing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
@@ -138,21 +141,51 @@ internal partial class TestRunner
             {
                 var messageBuilder = new StringBuilder();
                 messageBuilder.Append($"[{result.Outcome}] {result.TestCase.DisplayName}");
-                if (result.ErrorMessage != null || result.ErrorStackTrace != null)
-                {
-                    messageBuilder.AppendLine();
-                }
 
                 if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
                 {
+                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(IndentString($"{LanguageServerResources.Message}:", 4));
                     messageBuilder.AppendLine(IndentString(result.ErrorMessage, 8));
                 }
 
                 if (!string.IsNullOrWhiteSpace(result.ErrorStackTrace))
                 {
+                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Stack_Trace}:", 4));
                     messageBuilder.AppendLine(IndentString(result.ErrorStackTrace, 8));
+                }
+
+                var standardOutputMessages = GetTestMessages(result.Messages, TestResultMessage.StandardOutCategory);
+                if (standardOutputMessages.Length > 0)
+                {
+                    messageBuilder.AppendLine();
+                    messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Standard_Output_Messages}:", 4));
+                    messageBuilder.AppendLine(FormatMessages(standardOutputMessages, 8));
+                }
+
+                var standardErrorMessages = GetTestMessages(result.Messages, TestResultMessage.StandardErrorCategory);
+                if (standardErrorMessages.Length > 0)
+                {
+                    messageBuilder.AppendLine();
+                    messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Standard_Error_Messages}:", 4));
+                    messageBuilder.AppendLine(FormatMessages(standardErrorMessages, 8));
+                }
+
+                var debugTraceMessages = GetTestMessages(result.Messages, TestResultMessage.DebugTraceCategory);
+                if (debugTraceMessages.Length > 0)
+                {
+                    messageBuilder.AppendLine();
+                    messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Debug_Trace_Messages}:", 4));
+                    messageBuilder.AppendLine(FormatMessages(debugTraceMessages, 8));
+                }
+
+                var additionalInfoMessages = GetTestMessages(result.Messages, TestResultMessage.AdditionalInfoCategory);
+                if (additionalInfoMessages.Length > 0)
+                {
+                    messageBuilder.AppendLine();
+                    messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Additional_Info_Messages}:", 4));
+                    messageBuilder.AppendLine(FormatMessages(additionalInfoMessages, 8));
                 }
 
                 return messageBuilder.ToString();
@@ -162,7 +195,29 @@ internal partial class TestRunner
 
             static string IndentString(string text, int count)
             {
-                return text.Replace(Environment.NewLine, $"{Environment.NewLine}        ").TrimEnd().Insert(0, new string(' ', count));
+                var indentation = new string(' ', count);
+                return text.Replace(Environment.NewLine, $"{Environment.NewLine}{indentation}").TrimEnd().Insert(0, indentation);
+            }
+
+            static ImmutableArray<TestResultMessage> GetTestMessages(Collection<TestResultMessage> messages, string requiredCategory)
+            {
+                return messages.WhereAsArray(static (msg, category) => msg.Category.Equals(category, StringComparison.OrdinalIgnoreCase), requiredCategory);
+            }
+
+            static string FormatMessages(ImmutableArray<TestResultMessage> messages, int indentation)
+            {
+                var builder = new StringBuilder();
+                foreach (var message in messages)
+                {
+                    if (message.Text is null)
+                        continue;
+
+                    var indentedMessage = IndentString(message.Text, indentation);
+                    if (!string.IsNullOrWhiteSpace(indentedMessage))
+                        builder.Append(indentedMessage);
+                }
+
+                return builder.ToString();
             }
         }
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestRunner.TestRunHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestRunner.TestRunHandler.cs
@@ -140,18 +140,16 @@ internal partial class TestRunner
             var results = testRunChangedEventArgs.NewTestResults.Select(result =>
             {
                 var messageBuilder = new StringBuilder();
-                messageBuilder.Append($"[{result.Outcome}] {result.TestCase.DisplayName}");
+                messageBuilder.AppendLine($"[{result.Outcome}] {result.TestCase.DisplayName}");
 
                 if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
                 {
-                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(IndentString($"{LanguageServerResources.Message}:", 4));
                     messageBuilder.AppendLine(IndentString(result.ErrorMessage, 8));
                 }
 
                 if (!string.IsNullOrWhiteSpace(result.ErrorStackTrace))
                 {
-                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Stack_Trace}:", 4));
                     messageBuilder.AppendLine(IndentString(result.ErrorStackTrace, 8));
                 }
@@ -159,7 +157,6 @@ internal partial class TestRunner
                 var standardOutputMessages = GetTestMessages(result.Messages, TestResultMessage.StandardOutCategory);
                 if (standardOutputMessages.Length > 0)
                 {
-                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Standard_Output_Messages}:", 4));
                     messageBuilder.AppendLine(FormatMessages(standardOutputMessages, 8));
                 }
@@ -167,7 +164,6 @@ internal partial class TestRunner
                 var standardErrorMessages = GetTestMessages(result.Messages, TestResultMessage.StandardErrorCategory);
                 if (standardErrorMessages.Length > 0)
                 {
-                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Standard_Error_Messages}:", 4));
                     messageBuilder.AppendLine(FormatMessages(standardErrorMessages, 8));
                 }
@@ -175,7 +171,6 @@ internal partial class TestRunner
                 var debugTraceMessages = GetTestMessages(result.Messages, TestResultMessage.DebugTraceCategory);
                 if (debugTraceMessages.Length > 0)
                 {
-                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Debug_Trace_Messages}:", 4));
                     messageBuilder.AppendLine(FormatMessages(debugTraceMessages, 8));
                 }
@@ -183,7 +178,6 @@ internal partial class TestRunner
                 var additionalInfoMessages = GetTestMessages(result.Messages, TestResultMessage.AdditionalInfoCategory);
                 if (additionalInfoMessages.Length > 0)
                 {
-                    messageBuilder.AppendLine();
                     messageBuilder.AppendLine(value: IndentString($"{LanguageServerResources.Additional_Info_Messages}:", 4));
                     messageBuilder.AppendLine(FormatMessages(additionalInfoMessages, 8));
                 }
@@ -191,7 +185,7 @@ internal partial class TestRunner
                 return messageBuilder.ToString();
             });
 
-            return string.Join(Environment.NewLine, results);
+            return string.Join("", results);
 
             static string IndentString(string text, int count)
             {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Přerušeno!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Připojování ladicího programu k procesu {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">Dokončilo se (opětovné) načtení všech projektů v čase {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Trasování zásobníku</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Abgebrochen!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Debugger wird an Prozess "{0}" angefügt</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">Abgeschlossenes (erneutes) Laden aller Projekte in {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Stapelüberwachung</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">¡Anulado!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Asociación del depurador para procesar {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">(Re)carga completa de todos los proyectos en {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Seguimiento de la pila</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Abandonné !</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Attachement du débogueur au processus {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">Chargement ou rechargement terminé de tous les projets dans {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Trace de la pile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Interrotto!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Collegamento del debugger all'elaborazione di {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">Completato il (ri)caricamento di tutti i progetti in {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Analisi dello stack</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">中止されました!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">プロセス {0} にデバッガーをアタッチしています</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">{0} のすべてのプロジェクトの (再) 読み込みが完了しました</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">スタック トレース</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">중단됨!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">프로세스 {0}에 디버거를 연결하는 중</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">{0}에 있는 모든 프로젝트의 (재)로드가 완료됨</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">스택 추적</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Przerwane!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Dołączanie debugera do procesu {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">Ukończono (ponownie)ładowanie wszystkich projektów w usłudze {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Śledzenie stosu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Anulado!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Anexar o depurador ao processo {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">(Re)carregamento concluído de todos os projetos em {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Rastreamento de pilha</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Прервано</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Подключение отладчика для обработки {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">Завершена (повторная) загрузка всех проектов в {0}</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Трассировка стека</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Durduruldu!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">Hata ayıklayıcı, {0} işlemine ekleniyor</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">Tüm projelerin (yeniden) yüklemesi {0} içinde tamamlandı</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">Yığın İzleme</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">已中止!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">正在将调试器附加到进程 {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">已完成加载(重新加载) {0} 中的所有项目</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">堆栈跟踪</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">已中止！</target>
         <note />
       </trans-unit>
+      <trans-unit id="Additional_Info_Messages">
+        <source>Additional Info Messages</source>
+        <target state="new">Additional Info Messages</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Attaching_debugger_to_process_0">
         <source>Attaching debugger to process {0}</source>
         <target state="translated">正在將偵錯工具連結到處理序 {0}</target>
@@ -31,6 +36,11 @@
         <source>Completed (re)load of all projects in {0}</source>
         <target state="translated">已完成 {0} 中所有專案的(重新)載入</target>
         <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
+      <trans-unit id="Debug_Trace_Messages">
+        <source>Debug Trace Messages</source>
+        <target state="new">Debug Trace Messages</target>
+        <note />
       </trans-unit>
       <trans-unit id="Debugging_tests">
         <source>Debugging tests...</source>
@@ -160,6 +170,16 @@
       <trans-unit id="Stack_Trace">
         <source>Stack Trace</source>
         <target state="translated">堆疊追蹤</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Error_Messages">
+        <source>Standard Error Messages</source>
+        <target state="new">Standard Error Messages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Standard_Output_Messages">
+        <source>Standard Output Messages</source>
+        <target state="new">Standard Output Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="Starting_test_discovery">


### PR DESCRIPTION
This updates our logging to match the console logger from the vstest.console runner. See https://github.com/Evangelink/vstest/blob/85ae981180b515d79721266a19a7aa31c30828c5/src/vstest.console/Internal/ConsoleLogger.cs#L295

Resolves http://github.com/dotnet/vscode-csharp/issues/6221

Output looks like:
```
Starting test discovery
Failed to read environment variable [DOTNET_ROOT], HRESULT: 0x80070002
Logging TestHost Diagnostics in file: c:\Users\jorobich\AppData\Roaming\Code\logs\20240912T105218\window1\exthost\ms-dotnettools.csharp\testLogs\vsTestLogs.host.24-09-12_10-54-07_34481_10.txt
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.5.7-pre.8+41a6ecafa6 (64-bit .NET 9.0.0-rc.1.24431.7)
[xUnit.net 00:00:00.09]   Discovering: dotnet-format.UnitTests
[xUnit.net 00:00:00.18]   Discovered:  dotnet-format.UnitTests
Found 3 tests in 1s

Starting test run
[Failed] Microsoft.CodeAnalysis.Tools.Tests.Analyzers.ThirdPartyAnalyzerFormatterTests.TestLoadingAllAnalyzers_LoadsDependenciesFromAllSearchPaths
    Message:
        System.Exception : This is an error message
    Stack Trace:
           at Microsoft.CodeAnalysis.Tools.Tests.Analyzers.ThirdPartyAnalyzerFormatterTests.TestLoadingAllAnalyzers_LoadsDependenciesFromAllSearchPaths() in c:\Users\jorobich\source\format\tests\Analyzers\ThirdPartyAnalyzerFormatterTests.cs:line 218
        --- End of stack trace from previous location ---
    Standard Output Messages:
          Determining projects to restore...
          All projects are up-to-date for restore.

[Passed] Microsoft.CodeAnalysis.Tools.Tests.Analyzers.ThirdPartyAnalyzerFormatterTests.TestStyleCopBlankLineFixer_RemovesUnnecessaryBlankLines
    Standard Output Messages:
          Determining projects to restore...
          All projects are up-to-date for restore.

[Passed] Microsoft.CodeAnalysis.Tools.Tests.Analyzers.ThirdPartyAnalyzerFormatterTests.TestIDisposableAnalyzer_AddsUsing
    Standard Output Messages:
          Determining projects to restore...
          All projects are up-to-date for restore.

==== Summary ====
Failed!  - Failed:    1, Passed:    2, Skipped:    0, Total:    3, Duration: 9s
```