### PR TITLE
Include initial filter node when searching for nodes to order modifiers

### DIFF
--- a/src/Analyzers/CSharp/Tests/OrderModifiers/OrderModifiersTests.cs
+++ b/src/Analyzers/CSharp/Tests/OrderModifiers/OrderModifiersTests.cs
@@ -558,4 +558,22 @@ public class OrderModifiersTests : AbstractCSharpDiagnosticProviderBasedUserDiag
             }
             """);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/7553")]
+    public async Task TestEmptySelection()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            namespace M;
+            [||]static internal class C
+            {
+            }
+            """,
+            """
+            namespace M;
+            internal static class C
+            {
+            }
+            """, TestParameters.Default.WithIncludeDiagnosticsOutsideSelection(false));
+    }
 }

--- a/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -48,7 +48,13 @@ internal abstract class AbstractOrderModifiersDiagnosticAnalyzer : AbstractBuilt
             return;
         }
 
-        Recurse(context, preferredOrder, option.Notification, context.GetAnalysisRoot(findInTrivia: false));
+        var analysisRoot = context.GetAnalysisRoot(findInTrivia: false);
+
+        // Check the root node first to see if it has any modifiers that need reordering.
+        CheckModifiers(context, preferredOrder, option.Notification, analysisRoot);
+
+        // Recurse to check the child nodes.
+        Recurse(context, preferredOrder, option.Notification, analysisRoot);
     }
 
     protected abstract void Recurse(


### PR DESCRIPTION
This works in VS but not VSCode due to differences in how the lightbulb is designed in each.  

In VS, the lightbulb API passes us an editor defined range (generally the whole line) and a selection range to use for filtering.

However in VSCode, LSP only includes a single range, which is either the caret or selection.  So the root node for the filter span ended up being the MemberDeclarationSyntax which was never looked at (only the children).

Resolves https://github.com/dotnet/vscode-csharp/issues/7553