### PR TITLE
Remove some obsolete build properties

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -49,12 +49,7 @@ schedules:
     always: true # Run even if there have been no source code changes since the last successful scheduled run
     batch: false # Do not run the pipeline if the previously scheduled run is in-progress
 
-# The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
-  - name: _DotNetValidationArtifactsCategory
-    value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
   - name: Codeql.Enabled
     value: true
@@ -308,8 +303,6 @@ extends:
                        /p:RepositoryName=$(Build.Repository.Name)
                        /p:VisualStudioDropName=$(VisualStudio.DropName)
                        /p:DotNetSignType=$(SignType)
-                       /p:PublishToSymbolServer=true
-                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                        /p:DotnetPublishUsingPipelines=true
                        /p:IgnoreIbcMergeErrors=true
                        /p:GenerateSbom=true

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -26,12 +26,7 @@ parameters:
   type: boolean
   default: false
 
-# The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
-  - name: _DotNetValidationArtifactsCategory
-    value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
   - group: DotNet-Roslyn-Insertion-Variables
   - name: Codeql.Enabled
@@ -253,8 +248,6 @@ extends:
                        /p:RepositoryName=$(Build.Repository.Name)
                        /p:VisualStudioDropName=$(VisualStudio.DropName)
                        /p:DotNetSignType=$(SignType)
-                       /p:PublishToSymbolServer=true
-                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                        /p:DotnetPublishUsingPipelines=true
                        /p:IgnoreIbcMergeErrors=true
                        /p:GenerateSbom=true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -391,6 +391,8 @@ stages:
       - powershell: eng/build.ps1 -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLogName Build.binlog /p:DotnetPublishUsingPipelines=true
         displayName: Build
 
+      # While this task is not executed in the official build, this serves as a PR check for whether symbol exclusions
+      # are properly set up.
       - task: PowerShell@2
         displayName: Publish Symbols Dry-Run
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -391,19 +391,6 @@ stages:
       - powershell: eng/build.ps1 -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLogName Build.binlog /p:DotnetPublishUsingPipelines=true
         displayName: Build
 
-      - task: PowerShell@2
-        displayName: Publish Symbols Dry-Run
-        inputs:
-          filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishToSymbolServers /p:DryRun="true" -restore -msbuildEngine dotnet
-            /p:DotNetSymbolServerTokenMsdl=DryRunPTA
-            /p:DotNetSymbolServerTokenSymWeb=DryRunPTA
-            /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
-            /p:BlobBasePath='$(Build.SourcesDirectory)/artifacts/tmp/Release/SymbolPackages/'
-            /p:SymbolPublishingExclusionsFile='$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
-            /p:Configuration=Release
-            /p:PublishToMSDL=false
-
       - script: $(Build.SourcesDirectory)\artifacts\bin\BuildBoss\Release\net472\BuildBoss.exe  -r "$(Build.SourcesDirectory)/" -c Release -p Roslyn.sln
         displayName: Validate Build Artifacts
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -391,6 +391,19 @@ stages:
       - powershell: eng/build.ps1 -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLogName Build.binlog /p:DotnetPublishUsingPipelines=true
         displayName: Build
 
+      - task: PowerShell@2
+        displayName: Publish Symbols Dry-Run
+        inputs:
+          filePath: eng\common\sdk-task.ps1
+          arguments: -task PublishToSymbolServers /p:DryRun="true" -restore -msbuildEngine dotnet
+            /p:DotNetSymbolServerTokenMsdl=DryRunPTA
+            /p:DotNetSymbolServerTokenSymWeb=DryRunPTA
+            /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
+            /p:BlobBasePath='$(Build.SourcesDirectory)/artifacts/tmp/Release/SymbolPackages/'
+            /p:SymbolPublishingExclusionsFile='$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
+            /p:Configuration=Release
+            /p:PublishToMSDL=false
+
       - script: $(Build.SourcesDirectory)\artifacts\bin\BuildBoss\Release\net472\BuildBoss.exe  -r "$(Build.SourcesDirectory)/" -c Release -p Roslyn.sln
         displayName: Validate Build Artifacts
 


### PR DESCRIPTION
The artifacts category properties are no longer functional since maybe .NET 3.0, and the symbol server publishing switch is non-functional given that DotNetPublishUsingPipelines=true is used. Symbol publishing happens in promotion.