### PR TITLE
Exclude identifiers in misplaced attributes from identifier map

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1651,11 +1651,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Binder current = this;
                     while (current is not (null or InMethodBinder { IdentifierMap: not null }))
                     {
-                        if (current is ContextualAttributeBinder)
-                        {
-                            return;
-                        }
-
                         current = current.Next;
                     }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1651,6 +1651,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Binder current = this;
                     while (current is not (null or InMethodBinder { IdentifierMap: not null }))
                     {
+                        if (current is ContextualAttributeBinder)
+                        {
+                            return;
+                        }
+
                         current = current.Next;
                     }
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -2010,6 +2010,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            // Logic in this lambda is based on Binder.IdentifierUsedAsValueFinder.CheckIdentifiersInNode.childrenNeedChecking.
+            // It can be more permissive (i.e. allow us to dive into more nodes), but should not be more restrictive
             static void addIdentifiers(CSharpSyntaxNode? node, ConcurrentDictionary<IdentifierNameSyntax, int> identifierMap)
             {
                 if (node is null)
@@ -2028,7 +2030,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             case GotoStatementSyntax { RawKind: (int)SyntaxKind.GotoStatement }:
                             case TypeParameterConstraintClauseSyntax:
                             case AliasQualifiedNameSyntax:
-                            case AttributeListSyntax:
                                 // These nodes do not have anything interesting for us
                                 return false;
 
@@ -2098,6 +2099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     inMethodBinder.IdentifierMap = null;
 
+                    // In presence of errors, we're not guaranteed to have bound all identifiers, so we don't care about correctness of our prediction
                     if (!diagnostics.HasAnyResolvedErrors())
                     {
                         foreach (var (id, flags) in identifierMap)
@@ -2131,6 +2133,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     }
 
                                     if (UnboundLambdaFinder.FoundInUnboundLambda(methodBody, id))
+                                    {
+                                        continue;
+                                    }
+
+                                    // If an attribute is misplaced (invalid target), it is expected that identifiers within were not bound.
+                                    // In that case, we emit a warning and skip binding the attribute.
+                                    if (id.Ancestors(ascendOutOfTrivia: false).OfType<AttributeListSyntax>().Any() &&
+                                        diagnostics.DiagnosticBag!.AsEnumerable().Any(d => d.Code == (int)ErrorCode.WRN_AttributeLocationOnBadDeclaration))
                                     {
                                         continue;
                                     }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -2028,6 +2028,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             case GotoStatementSyntax { RawKind: (int)SyntaxKind.GotoStatement }:
                             case TypeParameterConstraintClauseSyntax:
                             case AliasQualifiedNameSyntax:
+                            case AttributeListSyntax:
                                 // These nodes do not have anything interesting for us
                                 return false;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -10387,5 +10387,200 @@ public class C
 
             Assert.Equal("System.Int32 LocalFunc(System.String s)", methodSymbol.ToTestDisplayString());
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73905")]
+        public void IdentifierInNameofInAttributeOnLocalFunctionInAccessor()
+        {
+            var src = """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+class A : Attribute
+{
+    public A(string s) { }
+}
+
+class C
+{
+    event EventHandler E
+    {
+        add
+        {
+            [param: A(nameof(p))] void F(int p) { }
+        }
+        remove
+        {
+        }
+    }
+}
+""";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (15,14): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
+                //             [param: A(nameof(p))] void F(int p) { }
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "param").WithArguments("param", "method, return").WithLocation(15, 14),
+                // (15,40): warning CS8321: The local function 'F' is declared but never used
+                //             [param: A(nameof(p))] void F(int p) { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(15, 40));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73905")]
+        public void IdentifierInNameofInAttributeOnLocalFunctionInMethod()
+        {
+            var src = """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+class A : Attribute
+{
+    public A(string s) { }
+}
+
+class C
+{
+    void M()
+    {
+        [param: A(nameof(p))] void F(int p) { }
+    }
+}
+""";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (13,10): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
+                //         [param: A(nameof(p))] void F(int p) { }
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "param").WithArguments("param", "method, return").WithLocation(13, 10),
+                // (13,36): warning CS8321: The local function 'F' is declared but never used
+                //         [param: A(nameof(p))] void F(int p) { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(13, 36));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73905")]
+        public void IdentifierInNameofInAttributeOnLocalFunctionInMethodWithParameter()
+        {
+            var src = """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+class A : Attribute
+{
+    public A(string s) { }
+}
+
+class C
+{
+    void M(int p)
+    {
+        [param: A(nameof(p))] void F(int p2) { }
+    }
+}
+""";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (13,10): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
+                //         [param: A(nameof(p))] void F(int p2) { }
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "param").WithArguments("param", "method, return").WithLocation(13, 10),
+                // (13,36): warning CS8321: The local function 'F' is declared but never used
+                //         [param: A(nameof(p))] void F(int p2) { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(13, 36));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73905")]
+        public void IdentifierInNameofInParamAttributeOnLocalFunctionInPrimaryConstructorType()
+        {
+            var src = """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+class A : Attribute
+{
+    public A(string s) { }
+}
+
+class C(int p)
+{
+    void M()
+    {
+        [param: A(nameof(p))] void F(int p2) { }
+    }
+}
+""";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (9,13): warning CS9113: Parameter 'p' is unread.
+                // class C(int p)
+                Diagnostic(ErrorCode.WRN_UnreadPrimaryConstructorParameter, "p").WithArguments("p").WithLocation(9, 13),
+                // (13,10): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
+                //         [param: A(nameof(p))] void F(int p2) { }
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "param").WithArguments("param", "method, return").WithLocation(13, 10),
+                // (13,36): warning CS8321: The local function 'F' is declared but never used
+                //         [param: A(nameof(p))] void F(int p2) { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(13, 36));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73905")]
+        public void IdentifierInNameofInAttributeOnLocalFunctionInPrimaryConstructorType()
+        {
+            var src = """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+class A : Attribute
+{
+    public A(string s) { }
+}
+
+class C(int p)
+{
+    void M()
+    {
+        [A(nameof(p))] void F() { }
+    }
+}
+""";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (9,13): warning CS9113: Parameter 'p' is unread.
+                // class C(int p)
+                Diagnostic(ErrorCode.WRN_UnreadPrimaryConstructorParameter, "p").WithArguments("p").WithLocation(9, 13),
+                // (13,29): warning CS8321: The local function 'F' is declared but never used
+                //         [A(nameof(p))] void F() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(13, 29));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73905")]
+        public void IdentifierInAttributeOnLocalFunctionInPrimaryConstructorType()
+        {
+            var src = """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+class A : Attribute
+{
+    public A(string s) { }
+}
+
+class C(string p)
+{
+    void M()
+    {
+        [A(p)] void F() { }
+    }
+}
+""";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (9,16): warning CS9113: Parameter 'p' is unread.
+                // class C(string p)
+                Diagnostic(ErrorCode.WRN_UnreadPrimaryConstructorParameter, "p").WithArguments("p").WithLocation(9, 16),
+                // (13,12): error CS9105: Cannot use primary constructor parameter 'string p' in this context.
+                //         [A(p)] void F() { }
+                Diagnostic(ErrorCode.ERR_InvalidPrimaryConstructorParameterReference, "p").WithArguments("string p").WithLocation(13, 12),
+                // (13,12): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                //         [A(p)] void F() { }
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "p").WithLocation(13, 12),
+                // (13,21): warning CS8321: The local function 'F' is declared but never used
+                //         [A(p)] void F() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(13, 21));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -10414,7 +10414,7 @@ class C
     }
 }
 """;
-            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(src);
             comp.VerifyEmitDiagnostics(
                 // (15,14): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
                 //             [param: A(nameof(p))] void F(int p) { }
@@ -10422,6 +10422,12 @@ class C
                 // (15,40): warning CS8321: The local function 'F' is declared but never used
                 //             [param: A(nameof(p))] void F(int p) { }
                 Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(15, 40));
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var nameof = GetSyntax<InvocationExpressionSyntax>(tree, "nameof(p)");
+            var p = nameof.ArgumentList.Arguments[0].Expression;
+            Assert.Equal("System.Int32", model.GetTypeInfo(p).Type.ToTestDisplayString());
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73905")]
@@ -10444,7 +10450,7 @@ class C
     }
 }
 """;
-            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(src);
             comp.VerifyEmitDiagnostics(
                 // (13,10): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
                 //         [param: A(nameof(p))] void F(int p) { }
@@ -10474,7 +10480,7 @@ class C
     }
 }
 """;
-            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(src);
             comp.VerifyEmitDiagnostics(
                 // (13,10): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
                 //         [param: A(nameof(p))] void F(int p2) { }
@@ -10504,7 +10510,7 @@ class C(int p)
     }
 }
 """;
-            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(src);
             comp.VerifyEmitDiagnostics(
                 // (9,13): warning CS9113: Parameter 'p' is unread.
                 // class C(int p)
@@ -10537,7 +10543,7 @@ class C(int p)
     }
 }
 """;
-            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(src);
             comp.VerifyEmitDiagnostics(
                 // (9,13): warning CS9113: Parameter 'p' is unread.
                 // class C(int p)
@@ -10567,7 +10573,7 @@ class C(string p)
     }
 }
 """;
-            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(src);
             comp.VerifyEmitDiagnostics(
                 // (9,16): warning CS9113: Parameter 'p' is unread.
                 // class C(string p)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/73905

For context:
- `buildIdentifierMapOfBindIdentifierTargets` builds a map of identifiers that we expect to bind
- `adjustIdentifierMapIfAny` updates the map to record which identifiers we actually bound
- `assertBindIdentifierTargets` checks the resulting map (already ignored identifiers in presence of binding errors, but now also skips identifiers in presence of warning for misplaced attributes, which causes attributes not to be bound)
- those checks are meant to align with logic in `SynthesizedPrimaryConstructor.GetCapturedParameters`