### PR TITLE
Fix null coalescing operator emit with span conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -87,10 +87,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // if left conversion is intrinsic implicit (always succeeds) and results in a reference type
             // we can apply conversion before doing the null check that allows for a more efficient IL emit.
-            // span conversion is from a reference type (array/string) to a value type ([ReadOnly]Span) so it cannot participate here.
             Debug.Assert(rewrittenLeft.Type is { });
             if (rewrittenLeft.Type.IsReferenceType &&
-                BoundNode.GetConversion(leftConversion, leftPlaceholder) is { IsImplicit: true, IsUserDefined: false, IsSpan: false })
+                BoundNode.GetConversion(leftConversion, leftPlaceholder) is { Kind: ConversionKind.Identity or ConversionKind.ImplicitReference })
             {
                 rewrittenLeft = ApplyConversionIfNotIdentity(leftConversion, leftPlaceholder, rewrittenLeft);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -87,9 +87,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // if left conversion is intrinsic implicit (always succeeds) and results in a reference type
             // we can apply conversion before doing the null check that allows for a more efficient IL emit.
+            // span conversion is from a reference type (array/string) to a value type ([ReadOnly]Span) so it cannot participate here.
             Debug.Assert(rewrittenLeft.Type is { });
             if (rewrittenLeft.Type.IsReferenceType &&
-                BoundNode.GetConversion(leftConversion, leftPlaceholder) is { IsImplicit: true, IsUserDefined: false })
+                BoundNode.GetConversion(leftConversion, leftPlaceholder) is { IsImplicit: true, IsUserDefined: false, IsSpan: false })
             {
                 rewrittenLeft = ApplyConversionIfNotIdentity(leftConversion, leftPlaceholder, rewrittenLeft);
 

--- a/src/Compilers/Test/Utilities/CSharp/TestSources.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestSources.cs
@@ -45,6 +45,8 @@ namespace System
             this.Length = length;
         }
 
+        public static Span<T> Empty => default;
+
         public void CopyTo(Span<T> other)
         {
             Array.Copy(arr, start, other.arr, other.start, Length);
@@ -129,6 +131,8 @@ namespace System
             this.start = start;
             this.Length = length;
         }
+
+        public static ReadOnlySpan<T> Empty => default;
 
         public void CopyTo(Span<T> other)
         {


### PR DESCRIPTION
A bug discovered while running runtime tests (would be also discovered by building runtime with Debug version of roslyn but currently there are other unrelated asserts so I haven't tried that).

Test plan: https://github.com/dotnet/roslyn/issues/73445