### PR TITLE
Add `Enumerable.Reverse(this T[])` polyfill

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -879,6 +879,9 @@ namespace System.Linq
             }
         }
 
+        // https://github.com/dotnet/runtime/issues/107723
+        public static IEnumerable<T> Reverse<T>(this T[] source) => Enumerable.Reverse(source);
+
 #if NETSTANDARD
 
         // Copied from https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq/src/System/Linq/Chunk.cs

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -880,7 +880,11 @@ namespace System.Linq
         }
 
         // https://github.com/dotnet/runtime/issues/107723
+#if NET10_0_OR_GREATER
+        public static IEnumerable<T> Reverse<T>(T[] source) => Enumerable.Reverse(source);
+#else
         public static IEnumerable<T> Reverse<T>(this T[] source) => Enumerable.Reverse(source);
+#endif
 
 #if NETSTANDARD
 

--- a/src/Features/CSharp/Portable/CodeRefactorings/UseRecursivePatterns/UseRecursivePatternsCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseRecursivePatterns/UseRecursivePatternsCodeRefactoringProvider.cs
@@ -600,7 +600,7 @@ internal sealed class UseRecursivePatternsCodeRefactoringProvider : SyntaxEditor
 
         // Process all nodes to refactor in reverse to ensure nested nodes
         // are processed before the outer nodes to refactor.
-        foreach (var originalNode in Enumerable.Reverse(nodes))
+        foreach (var originalNode in nodes.Reverse())
         {
             // Only process nodes fully within a fixAllSpan
             if (!fixAllSpans.Any(fixAllSpan => fixAllSpan.Contains(originalNode.Span)))


### PR DESCRIPTION
To avoid needing to fixup more locations when merging main into the feature branch. See also https://github.com/dotnet/roslyn/pull/75077#discussion_r1757047047.

Test plan: https://github.com/dotnet/roslyn/issues/73445