### PR TITLE
Use MSBuild globs to determine which file changes are relevant

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -173,6 +173,7 @@
     <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="1.7.0-beta-21528-01" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,6 +45,7 @@
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftExtensionsConfigurationVersion>8.0.0</MicrosoftExtensionsConfigurationVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>8.0.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsFileSystemGlobbingVersion>8.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftExtensionsLoggingVersion>8.0.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>8.0.0</MicrosoftExtensionsLoggingConsoleVersion>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using Roslyn.Utilities;
 
@@ -19,6 +20,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 /// </summary>
 internal sealed class LoadedProject : IDisposable
 {
+    private readonly string _projectFilePath;
+    private readonly string _projectDirectory;
+
     private readonly ProjectSystemProject _projectSystemProject;
     private readonly ProjectSystemProjectOptionsProcessor _optionsProcessor;
     private readonly IFileChangeContext _fileChangeContext;
@@ -28,6 +32,10 @@ internal sealed class LoadedProject : IDisposable
     /// The most recent version of the project design time build information; held onto so the next reload we can diff against this.
     /// </summary>
     private ProjectFileInfo? _mostRecentFileInfo;
+    /// <summary>
+    /// The most recent version of the file glob matcher.  Held onto 
+    /// </summary>
+    private Lazy<ImmutableArray<Matcher>>? _mostRecentFileMatchers;
     private IWatchedFile? _mostRecentProjectAssetsFileWatcher;
     private ImmutableArray<CommandLineReference> _mostRecentMetadataReferences = ImmutableArray<CommandLineReference>.Empty;
     private ImmutableArray<CommandLineAnalyzerReference> _mostRecentAnalyzerReferences = ImmutableArray<CommandLineAnalyzerReference>.Empty;
@@ -35,6 +43,7 @@ internal sealed class LoadedProject : IDisposable
     public LoadedProject(ProjectSystemProject projectSystemProject, SolutionServices solutionServices, IFileChangeWatcher fileWatcher, ProjectTargetFrameworkManager targetFrameworkManager)
     {
         Contract.ThrowIfNull(projectSystemProject.FilePath);
+        _projectFilePath = projectSystemProject.FilePath;
 
         _projectSystemProject = projectSystemProject;
         _optionsProcessor = new ProjectSystemProjectOptionsProcessor(projectSystemProject, solutionServices);
@@ -42,12 +51,12 @@ internal sealed class LoadedProject : IDisposable
 
         // We'll watch the directory for all source file changes
         // TODO: we only should listen for add/removals here, but we can't specify such a filter now
-        var projectDirectory = Path.GetDirectoryName(projectSystemProject.FilePath)!;
+        _projectDirectory = Path.GetDirectoryName(_projectFilePath)!;
 
         _fileChangeContext = fileWatcher.CreateContext([
-            new(projectDirectory, ".cs"),
-            new(projectDirectory, ".cshtml"),
-            new(projectDirectory, ".razor")
+            new(_projectDirectory, ".cs"),
+            new(_projectDirectory, ".cshtml"),
+            new(_projectDirectory, ".razor")
         ]);
         _fileChangeContext.FileChanged += FileChangedContext_FileChanged;
 
@@ -57,7 +66,34 @@ internal sealed class LoadedProject : IDisposable
 
     private void FileChangedContext_FileChanged(object? sender, string filePath)
     {
-        NeedsReload?.Invoke(this, EventArgs.Empty);
+        // If the project file itself changed, we almost certainly need to reload the project.
+        if (string.Equals(filePath, _projectFilePath, StringComparison.OrdinalIgnoreCase))
+        {
+            NeedsReload?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        var matchers = _mostRecentFileMatchers?.Value;
+        if (matchers is null)
+        {
+            return;
+        }
+
+        // Check if the file path matches any of the globs in the project file.
+        foreach (var matcher in matchers)
+        {
+            // CPS re-creates the msbuild globs from the includes/excludes/removes and the project XML directory and
+            // ignores the MSBuildGlob.FixedDirectoryPart.  We'll do the same here and match using the project directory as the relative path.
+            // See https://devdiv.visualstudio.com/DevDiv/_git/CPS?path=/src/Microsoft.VisualStudio.ProjectSystem/Build/MsBuildGlobFactory.cs
+            var relativeDirectory = _projectDirectory;
+
+            var matches = matcher.Match(relativeDirectory, filePath);
+            if (matches.HasMatches)
+            {
+                NeedsReload?.Invoke(this, EventArgs.Empty);
+                return;
+            }
+        }
     }
 
     public event EventHandler? NeedsReload;
@@ -186,6 +222,17 @@ internal sealed class LoadedProject : IDisposable
 
         var needsRestore = ProjectDependencyHelper.NeedsRestore(newProjectInfo, _mostRecentFileInfo, logger);
 
+        _mostRecentFileMatchers = new Lazy<ImmutableArray<Matcher>>(() =>
+        {
+            return newProjectInfo.FileGlobs.Select(glob =>
+            {
+                var matcher = new Matcher();
+                matcher.AddIncludePatterns(glob.Includes);
+                matcher.AddExcludePatterns(glob.Excludes);
+                matcher.AddExcludePatterns(glob.Removes);
+                return matcher;
+            }).ToImmutableArray();
+        });
         _mostRecentFileInfo = newProjectInfo;
 
         Contract.ThrowIfNull(_projectSystemProject.CompilationOptions, "Compilation options cannot be null for C#/VB project");

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -61,7 +61,7 @@ internal sealed class LoadedProject : IDisposable
         _fileChangeContext.FileChanged += FileChangedContext_FileChanged;
 
         // Start watching for file changes for the project file as well
-        _fileChangeContext.EnqueueWatchingFile(projectSystemProject.FilePath);
+        _fileChangeContext.EnqueueWatchingFile(_projectFilePath);
     }
 
     private void FileChangedContext_FileChanged(object? sender, string filePath)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -82,6 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -9,6 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Globbing;
+using Microsoft.Build.Globbing.Extensions;
 using Roslyn.Utilities;
 using MSB = Microsoft.Build;
 
@@ -171,6 +174,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
             var projectCapabilities = project.GetItems(ItemNames.ProjectCapability).SelectAsArray(item => item.ToString());
             var contentFileInfo = GetContentFiles(project);
 
+            var fileGlobs = _loadedProject?.GetAllGlobs().Select(GetFileGlobs).ToImmutableArray() ?? [];
+
             return ProjectFileInfo.Create(
                 Language,
                 project.FullPath,
@@ -189,7 +194,17 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 project.GetProjectReferences().ToImmutableArray(),
                 packageReferences,
                 projectCapabilities,
-                contentFileInfo);
+                contentFileInfo,
+                fileGlobs);
+
+            static FileGlobs GetFileGlobs(GlobResult g)
+            {
+                var includes = g.IncludeGlobs.ToImmutableArray();
+                var excludes = g.Excludes.ToImmutableArray();
+                var removes = g.Removes.ToImmutableArray();
+
+                return new FileGlobs(g.IncludeGlobs.ToImmutableArray(), g.Excludes.ToImmutableArray(), g.Removes.ToImmutableArray());
+            }
         }
 
         private static ImmutableArray<string> GetContentFiles(MSB.Execution.ProjectInstance project)

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -199,10 +199,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             static FileGlobs GetFileGlobs(GlobResult g)
             {
-                var includes = g.IncludeGlobs.ToImmutableArray();
-                var excludes = g.Excludes.ToImmutableArray();
-                var removes = g.Removes.ToImmutableArray();
-
                 return new FileGlobs(g.IncludeGlobs.ToImmutableArray(), g.Excludes.ToImmutableArray(), g.Removes.ToImmutableArray());
             }
         }

--- a/src/Workspaces/Core/MSBuild.BuildHost/Rpc/Contracts/FileGlobs.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Rpc/Contracts/FileGlobs.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.MSBuild;
+
+[DataContract]
+internal record FileGlobs(
+    [property: DataMember(Order = 0)] ImmutableArray<string> Includes,
+    [property: DataMember(Order = 1)] ImmutableArray<string> Excludes,
+    [property: DataMember(Order = 2)] ImmutableArray<string> Removes
+);

--- a/src/Workspaces/Core/MSBuild.BuildHost/Rpc/Contracts/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Rpc/Contracts/ProjectFileInfo.cs
@@ -137,6 +137,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
         [DataMember(Order = 18)]
         public string? TargetFrameworkVersion { get; }
 
+        [DataMember(Order = 19)]
+        public ImmutableArray<FileGlobs> FileGlobs { get; }
+
         public override string ToString()
             => RoslynString.IsNullOrWhiteSpace(TargetFramework)
                 ? FilePath ?? string.Empty
@@ -161,7 +164,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
             ImmutableArray<ProjectFileReference> projectReferences,
             ImmutableArray<PackageReference> packageReferences,
             ImmutableArray<string> projectCapabilities,
-            ImmutableArray<string> contentFilePaths)
+            ImmutableArray<string> contentFilePaths,
+            ImmutableArray<FileGlobs> fileGlobs)
         {
             RoslynDebug.Assert(filePath != null);
 
@@ -184,6 +188,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             this.PackageReferences = packageReferences;
             this.ProjectCapabilities = projectCapabilities;
             this.ContentFilePaths = contentFilePaths;
+            this.FileGlobs = fileGlobs;
         }
 
         public static ProjectFileInfo Create(
@@ -204,7 +209,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
             ImmutableArray<ProjectFileReference> projectReferences,
             ImmutableArray<PackageReference> packageReferences,
             ImmutableArray<string> projectCapabilities,
-            ImmutableArray<string> contentFilePaths)
+            ImmutableArray<string> contentFilePaths,
+            ImmutableArray<FileGlobs> fileGlobs)
             => new(
                 isEmpty: false,
                 language,
@@ -224,7 +230,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 projectReferences,
                 packageReferences,
                 projectCapabilities,
-                contentFilePaths);
+                contentFilePaths,
+                fileGlobs);
 
         public static ProjectFileInfo CreateEmpty(string language, string? filePath)
             => new(
@@ -246,6 +253,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 projectReferences: [],
                 packageReferences: [],
                 projectCapabilities: [],
-                contentFilePaths: []);
+                contentFilePaths: [],
+                fileGlobs: []);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6985

The approach I took was to serialize glob information over to the host process, and use MS.Extensions.FileGlobbing to match files against the globs.

Unfortunately it is quite difficult to get full fidelity matching - ideally we would be able to call `IsMatch` on a `CompositeGlob` built from all the project globs - however we do not want to load MSBuild in the host process.

Instead, we serialize the set of `Includes`, `Excludes`, and `Removes` from the evaluated `GlobResult`.  This roughly should be the correct set of globs and matches how CPS recreates globs, see https://devdiv.visualstudio.com/DevDiv/_git/CPS?path=/src/Microsoft.VisualStudio.ProjectSystem/Build/MsBuildGlobFactory.cs&version=GBmain&line=34&lineEnd=35&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents

We then match using the project directory as the relative directory (also matches CPS).  However our matching is a bit simpler as we don't currently even get file watcher notifications for anything outside the project cone.
