### PR TITLE
Remove LittleEndian asserts

### DIFF
--- a/src/Compilers/Core/Portable/CodeGen/BasicBlock.cs
+++ b/src/Compilers/Core/Portable/CodeGen/BasicBlock.cs
@@ -65,7 +65,6 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
             internal BasicBlock(ILBuilder builder)
             {
-                Debug.Assert(BitConverter.IsLittleEndian);
                 Initialize(builder);
             }
 

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -71,8 +71,6 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         internal ILBuilder(ITokenDeferral module, LocalSlotManager localSlotManager, OptimizationLevel optimizations, bool areLocalsZeroed)
         {
-            Debug.Assert(BitConverter.IsLittleEndian);
-
             this.module = module;
             this.LocalSlotManager = localSlotManager;
             _emitState = default(EmitState);

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -367,8 +367,6 @@ namespace Microsoft.CodeAnalysis
 
         public static ConstantValue Create(object value, ConstantValueTypeDiscriminator discriminator)
         {
-            Debug.Assert(BitConverter.IsLittleEndian);
-
             switch (discriminator)
             {
                 case ConstantValueTypeDiscriminator.Null: return Null;


### PR DESCRIPTION
The functionality work both on little endian and bigendian architecture. Hence removing the assert statements. These can be verified by running CommandLine test suite.