### PR TITLE
Check for source only properties before tool restore

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -339,7 +339,9 @@ if [[ "$restore" == true || "$test_core_clr" == true ]]; then
   install=true
 fi
 InitializeDotNetCli $install
-if [[ "$restore" == true && "$source_build" != true ]]; then
+# Check the dev switch --source-build as well as ensure that source only switches were not passed in via extra properties
+# Source only builds would not have 'dotnet' ambiently available.
+if [[ "$restore" == true && "$source_build" != true && $properties != *"DotNetBuildSourceOnly=true"* ]]; then
   dotnet tool restore
 fi
 


### PR DESCRIPTION
'dotnet' is not ambiently available, and we don't want the extra tool restore here (in case it brings in prebuilts). Check for passed in properties that would indicate a source only build from the VMR as well as the dev switch.