### PR TITLE
Fix the OOM error in scripting tests

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -939,7 +939,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 default:
-                    Debug.Assert(expr is not BoundValuePlaceholderBase, $"Placeholder kind {expr.Kind} should be explicitly handled");
+                    RoslynDebug.Assert(expr is not BoundValuePlaceholderBase, $"Placeholder kind {expr.Kind} should be explicitly handled");
                     break;
             }
 
@@ -4492,7 +4492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // in error situations some unexpected nodes could make here
                     // returning "scopeOfTheContainingExpression" seems safer than throwing.
                     // we will still assert to make sure that all nodes are accounted for. 
-                    Debug.Assert(false, $"{expr.Kind} expression of {expr.Type} type");
+                    RoslynDebug.Assert(false, $"{expr.Kind} expression of {expr.Type} type");
                     return scopeOfTheContainingExpression;
             }
         }
@@ -5287,7 +5287,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // in error situations some unexpected nodes could make here
                     // returning "false" seems safer than throwing.
                     // we will still assert to make sure that all nodes are accounted for.
-                    Debug.Assert(false, $"{expr.Kind} expression of {expr.Type} type");
+                    RoslynDebug.Assert(false, $"{expr.Kind} expression of {expr.Type} type");
                     diagnostics.Add(ErrorCode.ERR_InternalError, node.Location);
                     return false;
 

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -63,11 +64,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? currentConversion,
             BinderFlags location)
         {
-            Debug.Assert((object)collectionType != null, $"Field '{nameof(collectionType)}' cannot be null");
-            Debug.Assert(elementType.HasType, $"Field '{nameof(elementType)}' cannot be null");
-            Debug.Assert((object)getEnumeratorInfo != null, $"Field '{nameof(getEnumeratorInfo)}' cannot be null");
-            Debug.Assert((object)currentPropertyGetter != null, $"Field '{nameof(currentPropertyGetter)}' cannot be null");
-            Debug.Assert((object)moveNextInfo != null, $"Field '{nameof(moveNextInfo)}' cannot be null");
+            RoslynDebug.Assert((object)collectionType != null, $"Field '{nameof(collectionType)}' cannot be null");
+            RoslynDebug.Assert(elementType.HasType, $"Field '{nameof(elementType)}' cannot be null");
+            RoslynDebug.Assert((object)getEnumeratorInfo != null, $"Field '{nameof(getEnumeratorInfo)}' cannot be null");
+            RoslynDebug.Assert((object)currentPropertyGetter != null, $"Field '{nameof(currentPropertyGetter)}' cannot be null");
+            RoslynDebug.Assert((object)moveNextInfo != null, $"Field '{nameof(moveNextInfo)}' cannot be null");
             Debug.Assert(patternDisposeInfo == null || needsDisposal);
             Debug.Assert(inlineArraySpanType is WellKnownType.Unknown or WellKnownType.System_Span_T or WellKnownType.System_ReadOnlySpan_T);
             Debug.Assert(inlineArraySpanType == WellKnownType.Unknown ||

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (_visited is { } && _visited.Count <= MaxTrackVisited)
                 {
                     bool added = _visited.Add(expr);
-                    Debug.Assert(added, $"Expression {expr} `{expr.Syntax}` visited more than once.");
+                    RoslynDebug.Assert(added, $"Expression {expr} `{expr.Syntax}` visited more than once.");
                 }
             }
         }
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (_visited is { } && _visited.Count <= MaxTrackVisited)
             {
-                Debug.Assert(_visited.Contains(expr), $"Expected {expr} `{expr.Syntax}` to be visited.");
+                RoslynDebug.Assert(_visited.Contains(expr), $"Expected {expr} `{expr.Syntax}` to be visited.");
             }
         }
 #endif

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
-            Debug.Assert(isTrivial, "this conversion needs additional data: " + kind);
+            RoslynDebug.Assert(isTrivial, $"this conversion needs additional data: {kind}");
         }
 
         internal static Conversion GetTrivialConversion(ConversionKind kind)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDagEvaluation.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDagEvaluation.cs
@@ -83,8 +83,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             internal set
             {
-                Debug.Assert(value > 0, "Id must be positive but was set to " + value);
-                Debug.Assert(_id == -1, $"Id was set to {_id} and set again to {value}");
+                RoslynDebug.Assert(value > 0, "Id must be positive but was set to " + value);
+                RoslynDebug.Assert(_id == -1, $"Id was set to {_id} and set again to {value}");
                 _id = value;
             }
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             protected set
             {
-                Debug.Assert((_attributes & BoundNodeAttributes.ParamsArrayOrCollection) == 0, $"{nameof(BoundNodeAttributes.ParamsArrayOrCollection)} flag should not be set twice or reset");
+                RoslynDebug.Assert((_attributes & BoundNodeAttributes.ParamsArrayOrCollection) == 0, $"{nameof(BoundNodeAttributes.ParamsArrayOrCollection)} flag should not be set twice or reset");
                 Debug.Assert(value || !IsParamsArrayOrCollection);
                 Debug.Assert(!value ||
                              this is BoundArrayCreation { Bounds: [BoundLiteral { WasCompilerGenerated: true }], InitializerOpt: BoundArrayInitialization { WasCompilerGenerated: true }, WasCompilerGenerated: true } or

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                Debug.Assert(this.Type is { }, $"Unexpected null type in {this.GetType().Name}");
+                RoslynDebug.Assert(this.Type is { }, $"Unexpected null type in {this.GetType().Name}");
                 return this.Type;
             }
         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // the null terminator off as part of creating the span instance.
 
             Debug.Assert(inPlaceTarget is null || TargetIsNotOnHeap(inPlaceTarget), "in-place construction target should not be on heap");
-            Debug.Assert(_diagnostics.DiagnosticBag is not null, $"Expected non-null {nameof(_diagnostics)}.{nameof(_diagnostics.DiagnosticBag)}");
+            RoslynDebug.Assert(_diagnostics.DiagnosticBag is not null, $"Expected non-null {nameof(_diagnostics)}.{nameof(_diagnostics.DiagnosticBag)}");
 
             if (start is null != length is null)
             {

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -1238,7 +1238,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private string GetAndEndTemporaryString()
         {
             TemporaryStringBuilder t = _temporaryStringBuilders.Pop();
-            Debug.Assert(_indentDepth == t.InitialIndentDepth, $"Temporary strings should be indent-neutral (was {t.InitialIndentDepth}, is {_indentDepth})");
+            RoslynDebug.Assert(_indentDepth == t.InitialIndentDepth, $"Temporary strings should be indent-neutral (was {t.InitialIndentDepth}, is {_indentDepth})");
             _indentDepth = t.InitialIndentDepth;
             return t.Pooled.ToStringAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -132,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static string GetMessage(MessageID code, CultureInfo culture)
         {
             string message = ResourceManager.GetString(code.ToString(), culture);
-            Debug.Assert(!string.IsNullOrEmpty(message), code.ToString());
+            RoslynDebug.Assert(!string.IsNullOrEmpty(message), $"{code}");
             return message;
         }
 
@@ -140,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static string GetMessage(ErrorCode code, CultureInfo culture)
         {
             string message = ResourceManager.GetString(code.ToString(), culture);
-            Debug.Assert(!string.IsNullOrEmpty(message), code.ToString());
+            RoslynDebug.Assert(!string.IsNullOrEmpty(message), $"{code}");
             return message;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -895,7 +895,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public override BoundNode DefaultVisit(BoundNode node)
         {
-            Debug.Assert(false, $"Should Visit{node.Kind} be overridden in {this.GetType().Name}?");
+            RoslynDebug.Assert(false, $"Should Visit{node.Kind} be overridden in {this.GetType().Name}?");
             Diagnostics.Add(ErrorCode.ERR_InternalError, node.Syntax.Location);
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (!verifier._visitedExpressions.Contains(analyzedNode))
                         {
-                            Debug.Assert(false, $"Analyzed {verifier._analyzedNullabilityMap.Count} nodes in NullableWalker, but DebugVerifier expects {verifier._visitedExpressions.Count}. Example of unverified node: {analyzedNode.GetDebuggerDisplay()}");
+                            RoslynDebug.Assert(false, $"Analyzed {verifier._analyzedNullabilityMap.Count} nodes in NullableWalker, but DebugVerifier expects {verifier._visitedExpressions.Count}. Example of unverified node: {analyzedNode.GetDebuggerDisplay()}");
                         }
                     }
                 }
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (!verifier._analyzedNullabilityMap.ContainsKey(verifiedNode))
                         {
-                            Debug.Assert(false, $"Analyzed {verifier._analyzedNullabilityMap.Count} nodes in NullableWalker, but DebugVerifier expects {verifier._visitedExpressions.Count}. Example of unanalyzed node: {verifiedNode.GetDebuggerDisplay()}");
+                            RoslynDebug.Assert(false, $"Analyzed {verifier._analyzedNullabilityMap.Count} nodes in NullableWalker, but DebugVerifier expects {verifier._visitedExpressions.Count}. Example of unanalyzed node: {verifiedNode.GetDebuggerDisplay()}");
                         }
                     }
                 }
@@ -67,11 +68,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (expression.IsParamsArrayOrCollection)
                 {
                     // Params collections are processed element wise. 
-                    Debug.Assert(!_analyzedNullabilityMap.ContainsKey(expression), $"Found unexpected {expression} `{expression.Syntax}` in the map.");
+                    RoslynDebug.Assert(!_analyzedNullabilityMap.ContainsKey(expression), $"Found unexpected {expression} `{expression.Syntax}` in the map.");
                 }
                 else if (overrideSkippedExpression || !s_skippedExpressions.Contains(expression.Kind))
                 {
-                    Debug.Assert(_analyzedNullabilityMap.ContainsKey(expression), $"Did not find {expression} `{expression.Syntax}` in the map.");
+                    RoslynDebug.Assert(_analyzedNullabilityMap.ContainsKey(expression), $"Did not find {expression} `{expression.Syntax}` in the map.");
                     _visitedExpressions.Add(expression);
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     Debug.Fail($"Did not find a snapshot for {node} `{node.Syntax}.`");
                 }
-                Debug.Assert(_walkerSharedStates.Length > _incrementalSnapshots[position].snapshot.SharedStateIndex, $"Did not find shared state for {node} `{node.Syntax}`.");
+                RoslynDebug.Assert(_walkerSharedStates.Length > _incrementalSnapshots[position].snapshot.SharedStateIndex, $"Did not find shared state for {node} `{node.Syntax}`.");
             }
 
             internal void VerifyUpdatedSymbols()
@@ -123,10 +123,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var ((expr, originalSymbol), updatedSymbol) in _updatedSymbolsMap)
                 {
                     var debugText = expr?.Syntax.ToFullString() ?? originalSymbol.ToDisplayString();
-                    Debug.Assert((object)originalSymbol != updatedSymbol, $"Recorded exact same symbol for {debugText}");
+                    RoslynDebug.Assert((object)originalSymbol != updatedSymbol, $"Recorded exact same symbol for {debugText}");
                     RoslynDebug.Assert(originalSymbol is object, $"Recorded null original symbol for {debugText}");
                     RoslynDebug.Assert(updatedSymbol is object, $"Recorded null updated symbol for {debugText}");
-                    Debug.Assert(AreCloseEnough(originalSymbol, updatedSymbol), @$"Symbol for `{debugText}` changed:
+                    RoslynDebug.Assert(AreCloseEnough(originalSymbol, updatedSymbol), @$"Symbol for `{debugText}` changed:
 Was {originalSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}
 Now {updatedSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1835,7 +1835,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             Debug.Assert(node is object);
-            Debug.Assert(AreCloseEnough(originalSymbol, updatedSymbol), $"Attempting to set {node.Syntax} from {originalSymbol.ToDisplayString()} to {updatedSymbol.ToDisplayString()}");
+            RoslynDebug.Assert(AreCloseEnough(originalSymbol, updatedSymbol), $"Attempting to set {node.Syntax} from {originalSymbol.ToDisplayString()} to {updatedSymbol.ToDisplayString()}");
 #endif
 
             if (lambdaIsExactMatch || Symbol.Equals(originalSymbol, updatedSymbol, TypeCompareKind.ConsiderEverything))

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.Analysis.Tree.cs
@@ -764,7 +764,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return;
                     }
 
-                    Debug.Assert(scope == _currentScope.Parent, $"{nameof(scope)} must be {nameof(_currentScope)} or {nameof(_currentScope)}.{nameof(_currentScope.Parent)}");
+                    RoslynDebug.Assert(scope == _currentScope.Parent, $"{nameof(scope)} must be {nameof(_currentScope)} or {nameof(_currentScope)}.{nameof(_currentScope.Parent)}");
 
                     // Since it is forbidden to jump into a scope, 
                     // we can forget all information we have about labels in the child scope

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -1117,7 +1117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return expr is BoundConversion { Conversion: { IsInterpolatedStringHandler: true }, Type: { IsValueType: true } };
             }
 
-            Debug.Assert(expr is not BoundValuePlaceholderBase, $"Placeholder kind {expr.Kind} must be handled explicitly");
+            RoslynDebug.Assert(expr is not BoundValuePlaceholderBase, $"Placeholder kind {expr.Kind} must be handled explicitly");
 
             return false;
         }
@@ -1250,7 +1250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private void Fail(BoundNode node)
             {
-                Debug.Assert(false, $"Bound nodes of kind {node.Kind} should not survive past local rewriting");
+                RoslynDebug.Assert(false, $"Bound nodes of kind {node.Kind} should not survive past local rewriting");
             }
         }
 #endif

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected void AddStateDebugInfo(SyntaxNode node, AwaitDebugId awaitId, StateMachineState state)
         {
-            Debug.Assert(SyntaxBindingUtilities.BindsToResumableStateMachineState(node) || SyntaxBindingUtilities.BindsToTryStatement(node), $"Unexpected syntax: {node.Kind()}");
+            RoslynDebug.Assert(SyntaxBindingUtilities.BindsToResumableStateMachineState(node) || SyntaxBindingUtilities.BindsToTryStatement(node), $"Unexpected syntax: {node.Kind()}");
 
             int syntaxOffset = CurrentMethod.CalculateLocalSyntaxOffset(node.SpanStart, node.SyntaxTree);
             _stateDebugInfoBuilder.Add(new StateMachineStateDebugInfo(syntaxOffset, awaitId, state));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                Debug.Assert(!_parameters.IsDefault, $"Expected {nameof(InitializeParameters)} prior to accessing this property.");
+                RoslynDebug.Assert(!_parameters.IsDefault, $"Expected {nameof(InitializeParameters)} prior to accessing this property.");
                 return _parameters.NullToEmpty();
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                Debug.Assert(!_typeParameters.IsDefault, $"Expected {nameof(SetTypeParameters)} prior to accessing this property.");
+                RoslynDebug.Assert(!_typeParameters.IsDefault, $"Expected {nameof(SetTypeParameters)} prior to accessing this property.");
                 if (_typeParameters.IsDefault)
                 {
                     return ImmutableArray<TypeParameterSymbol>.Empty;
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                Debug.Assert(!_parameters.IsDefault, $"Expected {nameof(SetParameters)} prior to accessing this property.");
+                RoslynDebug.Assert(!_parameters.IsDefault, $"Expected {nameof(SetParameters)} prior to accessing this property.");
                 if (_parameters.IsDefault)
                 {
                     return ImmutableArray<ParameterSymbol>.Empty;

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -59,6 +59,8 @@
     <Compile Include="..\Portable\InternalUtilities\ReflectionUtilities.cs" />
     <Compile Include="..\Portable\InternalUtilities\RoslynString.cs" />
     <Compile Include="..\Portable\InternalUtilities\UnicodeCharacterUtilities.cs" />
+    <Compile Include="..\Portable\InternalUtilities\InterpolatedStringHandlerAttribute.cs" />
+    <Compile Include="..\Portable\InternalUtilities\InterpolatedStringHandlerArgumentAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="ErrorString.resx" GenerateSource="true" />

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
                 // just use the hex value of the data hash.  For other alignments, tack on a '2', '4', or '8'
                 // accordingly.  As every byte will yield two chars, the odd number of chars used for 2/4/8
                 // alignments will never produce a name that conflicts with names for an alignment of 1.
-                Debug.Assert(alignment is 1 or 2 or 4 or 8, $"Unexpected alignment: {alignment}");
+                RoslynDebug.Assert(alignment is 1 or 2 or 4 or 8, $"Unexpected alignment: {alignment}");
                 string hex = DataToHex(key.Data);
                 string name = alignment switch
                 {
@@ -571,7 +571,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         internal ExplicitSizeStruct(uint size, ushort alignment, PrivateImplementationDetails containingType, Cci.ITypeReference sysValueType)
         {
-            Debug.Assert(alignment is 1 or 2 or 4 or 8, $"Unexpected alignment: {alignment}");
+            RoslynDebug.Assert(alignment is 1 or 2 or 4 or 8, $"Unexpected alignment: {alignment}");
 
             _size = size;
             _alignment = alignment;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1003,7 +1003,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // aggregate.
                 if (nodeActionsByKind.TryGetValue(getKind(node), out var actionsForKind))
                 {
-                    Debug.Assert(!actionsForKind.IsEmpty, $"Unexpected empty action collection in {nameof(nodeActionsByKind)}");
+                    RoslynDebug.Assert(!actionsForKind.IsEmpty, $"Unexpected empty action collection in {nameof(nodeActionsByKind)}");
                     if (ShouldExecuteNode(node, analyzer, cancellationToken))
                     {
                         // If analyzer hasn't registered any CodeBlockStart or SymbolStart actions, then update the filter span
@@ -1103,7 +1103,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // expensive in aggregate.
                 if (operationActionsByKind.TryGetValue(operation.Kind, out var actionsForKind))
                 {
-                    Debug.Assert(!actionsForKind.IsEmpty, $"Unexpected empty action collection in {nameof(operationActionsByKind)}");
+                    RoslynDebug.Assert(!actionsForKind.IsEmpty, $"Unexpected empty action collection in {nameof(operationActionsByKind)}");
                     if (ShouldExecuteOperation(operation, analyzer, cancellationToken))
                     {
                         // If analyzer hasn't registered any OperationBlockStart or SymbolStart actions, then update

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -222,18 +222,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             [Conditional("DEBUG")]
             private void VerifyNewEntryForPendingMemberSymbolsMap(ISymbol symbol, HashSet<ISymbol>? dependentSymbols)
             {
-                Debug.Assert(_lazyPendingMemberSymbolsMap != null, $"{nameof(_lazyPendingMemberSymbolsMap)} was expected to be a non-null value.");
+                RoslynDebug.Assert(_lazyPendingMemberSymbolsMap != null, $"{nameof(_lazyPendingMemberSymbolsMap)} was expected to be a non-null value.");
 
                 if (_lazyPendingMemberSymbolsMap.TryGetValue(symbol, out var existingDependentSymbols))
                 {
                     if (existingDependentSymbols == null)
                     {
-                        Debug.Assert(dependentSymbols == null, $"{nameof(dependentSymbols)} was expected to be null.");
+                        RoslynDebug.Assert(dependentSymbols == null, $"{nameof(dependentSymbols)} was expected to be null.");
                     }
                     else
                     {
-                        Debug.Assert(dependentSymbols != null, $"{nameof(dependentSymbols)} was expected to be a non-null value.");
-                        Debug.Assert(existingDependentSymbols.IsSubsetOf(dependentSymbols), $"{nameof(existingDependentSymbols)} was expected to be a subset of {nameof(dependentSymbols)}");
+                        RoslynDebug.Assert(dependentSymbols != null, $"{nameof(dependentSymbols)} was expected to be a non-null value.");
+                        RoslynDebug.Assert(existingDependentSymbols.IsSubsetOf(dependentSymbols), $"{nameof(existingDependentSymbols)} was expected to be a subset of {nameof(dependentSymbols)}");
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -990,7 +990,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         Cci.IFieldReference ITokenDeferral.GetFieldForData(ImmutableArray<byte> data, ushort alignment, SyntaxNode syntaxNode, DiagnosticBag diagnostics)
         {
-            Debug.Assert(alignment is 1 or 2 or 4 or 8, $"Unexpected alignment: {alignment}");
+            RoslynDebug.Assert(alignment is 1 or 2 or 4 or 8, $"Unexpected alignment: {alignment}");
 
             var privateImpl = GetPrivateImplClass((TSyntaxNode)syntaxNode, diagnostics);
 

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Roslyn.Utilities
 {
@@ -12,12 +14,22 @@ namespace Roslyn.Utilities
     {
         /// <inheritdoc cref="Debug.Assert(bool)"/>
         [Conditional("DEBUG")]
-        public static void Assert([DoesNotReturnIf(false)] bool b) => Debug.Assert(b);
+        public static void Assert([DoesNotReturnIf(false)] bool condition) => Debug.Assert(condition);
 
         /// <inheritdoc cref="Debug.Assert(bool, string)"/>
         [Conditional("DEBUG")]
-        public static void Assert([DoesNotReturnIf(false)] bool b, string message)
-            => Debug.Assert(b, message);
+        public static void Assert([DoesNotReturnIf(false)] bool condition, string message)
+            => Debug.Assert(condition, message);
+
+        /// <inheritdoc cref="Debug.Assert(bool, string)"/>
+        [Conditional("DEBUG")]
+        public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref AssertInterpolatedStringHandler message)
+        {
+            if (!condition)
+            {
+                Debug.Fail(message.ToStringAndClear());
+            }
+        }
 
         [Conditional("DEBUG")]
         public static void AssertNotNull<T>([NotNull] T value)
@@ -61,6 +73,31 @@ namespace Roslyn.Utilities
                 }
             }
 #endif
+        }
+
+        [InterpolatedStringHandler]
+        public struct AssertInterpolatedStringHandler
+        {
+            private readonly StringBuilder? _builder;
+
+            public AssertInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
+            {
+                shouldAppend = condition;
+                if (shouldAppend)
+                {
+                    _builder = new StringBuilder(literalLength + formattedCount);
+                }
+            }
+
+            internal string ToStringAndClear() => _builder is null
+                ? ""
+                : _builder.ToString();
+
+            public void AppendLiteral(string value) => _builder!.Append(value);
+
+            public void AppendFormatted<T>(T value) => _builder!.Append(value);
+
+            public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value.ToString());
         }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -82,7 +82,7 @@ namespace Roslyn.Utilities
 
             public AssertInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
             {
-                shouldAppend = condition;
+                shouldAppend = !condition;
                 if (shouldAppend)
                 {
                     _builder = new StringBuilder(literalLength + formattedCount);

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -89,9 +89,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            internal string ToStringAndClear() => _builder is null
-                ? ""
-                : _builder.ToString();
+            internal string ToStringAndClear() => _builder!.ToString();
 
             public void AppendLiteral(string value) => _builder!.Append(value);
 

--- a/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
@@ -727,7 +727,7 @@ foundIdx:
 #if DEBUG
             for (var i = 0; i < ascii.Length; i++)
             {
-                Debug.Assert((ascii[i] & 0x80) == 0, $"The {nameof(ascii)} input to this method must be valid ASCII.");
+                RoslynDebug.Assert((ascii[i] & 0x80) == 0, $"The {nameof(ascii)} input to this method must be valid ASCII.");
             }
 #endif
 

--- a/src/Compilers/Core/Portable/Operations/OperationMapBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationMapBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -65,8 +66,9 @@ namespace Microsoft.CodeAnalysis
                 if (!operation.IsImplicit)
                 {
                     // IOperation invariant is that all there is at most 1 non-implicit node per syntax node.
-                    Debug.Assert(!argument.ContainsKey(operation.Syntax),
-                        $"Duplicate operation node for {operation.Syntax}. Existing node is {(argument.TryGetValue(operation.Syntax, out var original) ? original.Kind : null)}, new node is {operation.Kind}.");
+                    RoslynDebug.Assert(
+                        !argument.ContainsKey(operation.Syntax),
+                        $"Duplicate operation node for {operation.Syntax}. Existing node is {(argument.TryGetValue(operation.Syntax, out var original) ? (OperationKind?)original.Kind : null)}, new node is {operation.Kind}.");
                     argument.Add(operation.Syntax, operation);
                 }
             }

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -710,7 +711,7 @@ namespace Microsoft.CodeAnalysis
                     typeIdName = typeIdName.Substring(0, separator);
                 }
 
-                Debug.Assert(name == typeIdName, $"Enum name ({typeIdName}) and type name ({name}) must match at {i}");
+                RoslynDebug.Assert(name == typeIdName, $"Enum name ({typeIdName}) and type name ({name}) must match at {i}");
             }
 
 #if DEBUG

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.TypeNames.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -155,7 +156,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return;
             }
 
-            Debug.Assert(!isDynamic, $"Dynamic should have been handled by {nameof(AppendSpecialTypeName)}");
+            RoslynDebug.Assert(!isDynamic, $"Dynamic should have been handled by {nameof(AppendSpecialTypeName)}");
             Debug.Assert(!IsPredefinedType(type));
 
             if (type.IsGenericParameter)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.ResultProvider.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.ResultProvider.csproj
@@ -37,6 +37,12 @@
     <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\InterpolatedStringHandlerAttribute.cs">
+      <Link>Compilers\InternalUtilities\InterpolatedStringHandlerAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\InterpolatedStringHandlerArgumentAttribute.cs">
+      <Link>Compilers\InternalUtilities\InterpolatedStringHandlerArgumentAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\..\..\Dependencies\PooledObjects\ObjectPool`1.cs">
       <Link>Compiler\InternalUtilities\ObjectPool`1.cs</Link>
     </Compile>

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
@@ -49,6 +49,12 @@
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\InterpolatedStringHandlerAttribute.cs">
+      <Link>Compilers\InternalUtilities\InterpolatedStringHandlerAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\InterpolatedStringHandlerArgumentAttribute.cs">
+      <Link>Compilers\InternalUtilities\InterpolatedStringHandlerArgumentAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\..\Dependencies\PooledObjects\ObjectPool`1.cs">
       <Link>Compiler\InternalUtilities\ObjectPool`1.cs</Link>
     </Compile>

--- a/src/Tools/Replay/Replay.csproj
+++ b/src/Tools/Replay/Replay.csproj
@@ -14,6 +14,8 @@
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\Debug.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\NullableAttributes.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\InterpolatedStringHandlerAttribute.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\InterpolatedStringHandlerArgumentAttribute.cs" />
     <Compile Include="..\..\Compilers\Shared\BuildServerConnection.cs" />
     <Compile Include="..\..\Compilers\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Compilers\Shared\RuntimeHostInfo.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.IndentationData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.IndentationData.cs
@@ -119,8 +119,8 @@ internal partial class FormattingContext
         public AdjustedIndentationData(TextSpan textSpan, IndentationData baseIndentationData, int adjustment)
             : base(textSpan)
         {
-            Debug.Assert(adjustment != 0, $"Indentation with no adjustment should be represented by {nameof(BaseIndentationData)} directly.");
-            Debug.Assert(baseIndentationData is not AdjustedIndentationData, $"Indentation data should only involve one layer of adjustment (multiples can be combined by adding the {nameof(Adjustment)} fields.");
+            RoslynDebug.Assert(adjustment != 0, $"Indentation with no adjustment should be represented by {nameof(BaseIndentationData)} directly.");
+            RoslynDebug.Assert(baseIndentationData is not AdjustedIndentationData, $"Indentation data should only involve one layer of adjustment (multiples can be combined by adding the {nameof(Adjustment)} fields.");
 
             BaseIndentationData = baseIndentationData;
             Adjustment = adjustment;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractDocumentationCommentService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractDocumentationCommentService.cs
@@ -139,7 +139,7 @@ internal abstract class AbstractDocumentationCommentService<
                         AppendTextTokens(sb, GetTextTokens(xmlTextAttribute));
                         break;
                     default:
-                        Debug.Assert(false, $"Unexpected XML syntax kind {attribute.RawKind}");
+                        RoslynDebug.Assert(false, $"Unexpected XML syntax kind {attribute.RawKind}");
                         break;
                 }
             }


### PR DESCRIPTION
Was able to reproduce the Scripting `OutOfMemoryException` issues on my local machine. After looking at the test run in PerfView it was clear that we were allocating a lot more memory than necessary and that was, likey, the cause of the OOM that we saw. Given that it was running under x86 this seems fairly likely.

The allocations were coming more from the ResultsProvider and IOperation test assemlbies. But given that scripting is small our scheduling algorithm often puts scripting into a slice that includes both these test assemblies. Their allocations are what is pushing us to OOM. That is also likely why we couldn't reproduce this by just running the scripting tests locally.

This PR attempts to address the cases that I saw. There are a few cases where I moved eager operations to lazy. The bigger change though is moving a to using an interpolated string handler for `RoslynDebug.Assert`. There are a number of cases where had roughly the following code:

```csharp
Debug.Assert(condition, $"... {syntaxNode} ...");
```

On net472 that is going to eagerly allocate the message string which realizes the entire syntax node. One assert alone was contributing 9GB of allocations all by itself. Did a simple regex search for `Debug.Assert` that had an interpolation and moved them in mass to `RoslynDebug.Assert`. Now the strings are only realized if the assert fails. Will discuss with the team if we want to think about an analyzer here

PS: if the scripting tests OOM on this PR I may take tomorrow off.