### PR TITLE
Use manual recursion for binary patterns

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -676,6 +676,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitBinaryPattern(BoundBinaryPattern node)
+        {
+            // Do not use left recursion because we can have many nested binary patterns.
+
+            BoundBinaryPattern current = node;
+            while (true)
+            {
+                Visit(current.Right);
+                if (current.Left is BoundBinaryPattern left)
+                {
+                    current = left;
+                }
+                else
+                {
+                    Visit(current.Left);
+                    break;
+                }
+            }
+
+            return null;
+        }
+
         public override BoundNode VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
         {
             CheckLiftedUserDefinedConditionalLogicalOperator(node);


### PR DESCRIPTION
Much like binary operators, we can have deeply-nested binary patterns. An example of this is our own IsBuildOnlyDiagnostic, which has ~2500 binary patterns in a single arm, and growing every release. To avoid stack depth issues, I took the same approach we do for binary operators; rewrite recursion to use a manual stack for these cases. Fixes https://github.com/dotnet/roslyn/issues/73439.
