### PR TITLE
Collapse the rename UI when commit starts

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -20,6 +20,7 @@
              Focusable="False"
              UseLayoutRounding="True"
              Cursor="Arrow"
+             Visibility="{Binding Path=Visibility}"
              x:Name="control">
 
     <UserControl.Resources>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -65,8 +65,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             RegisterOleComponent();
         }
 
-        private void CommitStateChange(object sender, bool commitStarts)
-            => Visibility = commitStarts ? Visibility.Collapsed : Visibility.Visible;
+        private void CommitStateChange(object sender, EventArgs args)
+            => Visibility = this.Session.IsCommitInProgress ? Visibility.Collapsed : Visibility.Visible;
 
         public SmartRenameViewModel? SmartRenameViewModel { get; }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Windows;
 using System.Windows.Interop;
 using Microsoft.CodeAnalysis.Editor.InlineRename;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -52,6 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             Session.ReplacementTextChanged += OnReplacementTextChanged;
             Session.ReplacementsComputed += OnReplacementsComputed;
             Session.ReferenceLocationsChanged += OnReferenceLocationsChanged;
+            Session.CommitStateChange += CommitStateChange;
             StartingSelection = selectionSpan;
             InitialTrackingSpan = session.TriggerSpan.CreateTrackingSpan(SpanTrackingMode.EdgeInclusive);
             var smartRenameSession = smartRenameSessionFactory?.Value.CreateSmartRenameSession(Session.TriggerSpan);
@@ -62,6 +64,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             RegisterOleComponent();
         }
+
+        private void CommitStateChange(object sender, bool commitStarts)
+            => Visibility = commitStarts ? Visibility.Collapsed : Visibility.Visible;
 
         public SmartRenameViewModel? SmartRenameViewModel { get; }
 
@@ -208,6 +213,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         public TextSpan StartingSelection { get; }
 
+        private Visibility _visibility;
+        public Visibility Visibility
+        {
+            get => _visibility;
+            set => Set(ref _visibility, value);
+        }
+
         public bool Submit()
         {
             if (StatusSeverity == Severity.Error)
@@ -310,6 +322,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 {
                     Session.ReplacementTextChanged -= OnReplacementTextChanged;
                     Session.ReplacementsComputed -= OnReplacementsComputed;
+                    Session.CommitStateChange -= CommitStateChange;
 
                     if (SmartRenameViewModel is not null)
                     {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml
@@ -145,8 +145,8 @@
 
                 <CheckBox Content="{Binding ElementName=dashboard, Path=RenameOverloads}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameOverloadFlag, Mode=TwoWay}"
                       Name="OverloadsCheckbox" Visibility="{Binding ElementName=dashboard, Path=RenameOverloadsVisibility}" IsEnabled="{Binding ElementName=dashboard, Path=IsRenameOverloadsEditable}" />
-                <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInCommentsFlag, Mode=TwoWay}" />
-                <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInStringsFlag, Mode=TwoWay}" />
+                <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInCommentsFlag, Mode=TwoWay}" IsEnabled="{Binding Path=CommitNotStart}" />
+                <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInStringsFlag, Mode=TwoWay}" IsEnabled="{Binding Path=CommitNotStart}" />
                 <CheckBox Name="FileRenameCheckbox" 
                           Content="{Binding Path=FileRenameString}" 
                           Margin="0" 
@@ -154,7 +154,7 @@
                           IsEnabled="{Binding Path=AllowFileRename, Mode=OneWay}" 
                           Visibility="{Binding Path=ShowFileRename, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
 
-                <CheckBox Name="PreviewChangesCheckbox" Content="{Binding ElementName=dashboard, Path=PreviewChanges}" Margin="0,8,0,0" IsChecked="{Binding Path=DefaultPreviewChangesFlag, Mode=TwoWay}" />
+                <CheckBox Name="PreviewChangesCheckbox" Content="{Binding ElementName=dashboard, Path=PreviewChanges}" Margin="0,8,0,0" IsChecked="{Binding Path=DefaultPreviewChangesFlag, Mode=TwoWay}" IsEnabled="{Binding Path=CommitNotStart}" />
 
                 <!-- Summary: Includes the number of references to be updated and any conflict information -->
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml
@@ -13,6 +13,7 @@
              Focusable="True"
              x:Name="dashboard"
              AutomationProperties.AutomationId="Microsoft.CodeAnalysis.EditorFeatures.InlineRenameDialog" 
+             Visibility="{Binding Path=Visibility}"
              UseLayoutRounding="True">
     <!-- 
         !!!IMPORTANT!!! 
@@ -145,8 +146,8 @@
 
                 <CheckBox Content="{Binding ElementName=dashboard, Path=RenameOverloads}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameOverloadFlag, Mode=TwoWay}"
                       Name="OverloadsCheckbox" Visibility="{Binding ElementName=dashboard, Path=RenameOverloadsVisibility}" IsEnabled="{Binding ElementName=dashboard, Path=IsRenameOverloadsEditable}" />
-                <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInCommentsFlag, Mode=TwoWay}" IsEnabled="{Binding Path=CommitNotStart}" />
-                <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInStringsFlag, Mode=TwoWay}" IsEnabled="{Binding Path=CommitNotStart}" />
+                <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInCommentsFlag, Mode=TwoWay}" />
+                <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInStringsFlag, Mode=TwoWay}" />
                 <CheckBox Name="FileRenameCheckbox" 
                           Content="{Binding Path=FileRenameString}" 
                           Margin="0" 
@@ -154,7 +155,7 @@
                           IsEnabled="{Binding Path=AllowFileRename, Mode=OneWay}" 
                           Visibility="{Binding Path=ShowFileRename, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
 
-                <CheckBox Name="PreviewChangesCheckbox" Content="{Binding ElementName=dashboard, Path=PreviewChanges}" Margin="0,8,0,0" IsChecked="{Binding Path=DefaultPreviewChangesFlag, Mode=TwoWay}" IsEnabled="{Binding Path=CommitNotStart}" />
+                <CheckBox Name="PreviewChangesCheckbox" Content="{Binding ElementName=dashboard, Path=PreviewChanges}" Margin="0,8,0,0" IsChecked="{Binding Path=DefaultPreviewChangesFlag, Mode=TwoWay}" />
 
                 <!-- Summary: Includes the number of references to be updated and any conflict information -->
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml.cs
@@ -57,10 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _textView = textView;
             this.DataContext = model;
 
-            this.Visibility = textView.HasAggregateFocus ? Visibility.Visible : Visibility.Collapsed;
-
             _textView.GotAggregateFocus += OnTextViewGotAggregateFocus;
-            _textView.LostAggregateFocus += OnTextViewLostAggregateFocus;
             _textView.VisualElement.SizeChanged += OnElementSizeChanged;
             this.SizeChanged += OnElementSizeChanged;
 
@@ -311,12 +308,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         private void OnTextViewGotAggregateFocus(object sender, EventArgs e)
         {
-            this.Visibility = Visibility.Visible;
             PositionDashboard();
         }
-
-        private void OnTextViewLostAggregateFocus(object sender, EventArgs e)
-            => this.Visibility = Visibility.Collapsed;
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
@@ -365,7 +358,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public override void Dispose()
         {
             _textView.GotAggregateFocus -= OnTextViewGotAggregateFocus;
-            _textView.LostAggregateFocus -= OnTextViewLostAggregateFocus;
             _textView.VisualElement.SizeChanged -= OnElementSizeChanged;
             this.SizeChanged -= OnElementSizeChanged;
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             else
             {
                 var newAdornment = new RenameDashboard(
-                    (RenameDashboardViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameDashboardViewModel(session)),
+                    (RenameDashboardViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameDashboardViewModel(session, _threadingContext)),
                     _editorFormatMapService,
                     _textView);
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             else
             {
                 var newAdornment = new RenameDashboard(
-                    (RenameDashboardViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameDashboardViewModel(session, _threadingContext)),
+                    (RenameDashboardViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameDashboardViewModel(session, _threadingContext, _textView)),
                     _editorFormatMapService,
                     _textView);
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -340,6 +340,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
     public bool HasRenameOverloads => RenameInfo.HasOverloads;
     public bool MustRenameOverloads => RenameInfo.MustRenameOverloads;
     public IInlineRenameUndoManager UndoManager { get; }
+    public bool IsCommitInProgress { get; private set; } = false;
 
     public event EventHandler<ImmutableArray<InlineRenameLocation>> ReferenceLocationsChanged;
     public event EventHandler<IInlineRenameReplacementInfo> ReplacementsComputed;
@@ -348,7 +349,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
     /// <summary>
     /// True if commit operation starts, False if commit operation ends.
     /// </summary>
-    public event EventHandler<bool> CommitStateChange;
+    public event EventHandler CommitStateChange;
 
     internal OpenTextBufferManager GetBufferManager(ITextBuffer buffer)
         => _openTextBuffers[buffer];
@@ -797,7 +798,8 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         try
         {
             // Notify the UI commit starts.
-            this.CommitStateChange?.Invoke(this, true);
+            this.IsCommitInProgress = true;
+            this.CommitStateChange?.Invoke(this, EventArgs.Empty);
 
             if (canUseBackgroundWorkIndicator)
             {
@@ -836,7 +838,8 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         }
         finally
         {
-            this.CommitStateChange?.Invoke(this, false);
+            this.IsCommitInProgress = true;
+            this.CommitStateChange?.Invoke(this, EventArgs.Empty);
         }
 
         return true;

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -836,7 +836,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         }
         finally
         {
-            this.CommitStateChange.Invoke(this, false);
+            this.CommitStateChange?.Invoke(this, false);
         }
 
         return true;

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -345,10 +345,6 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
     public event EventHandler<ImmutableArray<InlineRenameLocation>> ReferenceLocationsChanged;
     public event EventHandler<IInlineRenameReplacementInfo> ReplacementsComputed;
     public event EventHandler ReplacementTextChanged;
-
-    /// <summary>
-    /// True if commit operation starts, False if commit operation ends.
-    /// </summary>
     public event EventHandler CommitStateChange;
 
     internal OpenTextBufferManager GetBufferManager(ITextBuffer buffer)
@@ -838,7 +834,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         }
         finally
         {
-            this.IsCommitInProgress = true;
+            this.IsCommitInProgress = false;
             this.CommitStateChange?.Invoke(this, EventArgs.Empty);
         }
 

--- a/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
@@ -585,8 +585,10 @@ class D : B
                     edit.Apply()
                 End Using
 
+                Dim threadingContext = workspace.ExportProvider.GetExport(Of IThreadingContext)().Value
+
                 Using dashboard = New RenameDashboard(
-                    New RenameDashboardViewModel(DirectCast(sessionInfo.Session, InlineRenameSession)),
+                    New RenameDashboardViewModel(DirectCast(sessionInfo.Session, InlineRenameSession), threadingContext),
                     editorFormatMapService:=Nothing,
                     textView:=cursorDocument.GetTextView())
 
@@ -624,7 +626,6 @@ class D : B
                 Dim TestQuickInfoBroker = New TestQuickInfoBroker()
                 Dim listenerProvider = workspace.ExportProvider.GetExport(Of IAsynchronousOperationListenerProvider)().Value
                 Dim editorFormatMapService = workspace.ExportProvider.GetExport(Of IEditorFormatMapService)().Value
-                Dim threadingContext = workspace.ExportProvider.GetExport(Of IThreadingContext)().Value
 
                 Using flyout = New RenameFlyout(
                     New RenameFlyoutViewModel(DirectCast(sessionInfo.Session, InlineRenameSession), selectionSpan:=Nothing, registerOleComponent:=False, globalOptions, threadingContext, listenerProvider, Nothing), ' Don't registerOleComponent in tests, it requires OleComponentManagers that don't exist in our host

--- a/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
@@ -587,8 +587,9 @@ class D : B
 
                 Dim threadingContext = workspace.ExportProvider.GetExport(Of IThreadingContext)().Value
 
+                Dim textView = cursorDocument.GetTextView()
                 Using dashboard = New RenameDashboard(
-                    New RenameDashboardViewModel(DirectCast(sessionInfo.Session, InlineRenameSession), threadingContext),
+                    New RenameDashboardViewModel(DirectCast(sessionInfo.Session, InlineRenameSession), threadingContext, textView),
                     editorFormatMapService:=Nothing,
                     textView:=cursorDocument.GetTextView())
 


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn/pull/74794

In inline rename UI, when rename commit is in progress, the UI is still there.
Existing behavior:
![image](https://github.com/user-attachments/assets/c09134dd-8052-427d-a582-b486827c2878)

This might not be a problem in the current rename experience since everything is sync, but when we moved to async rename it's needed, as we don't want user to change rename option when rename is in progress.
 
After this change:
![InlineRenameCollapseUI](https://github.com/user-attachments/assets/acba022e-21c6-45da-8b6d-0a059557ed9a)

Same concept also applies to the legacy UI.
