### PR TITLE
Allow <code> in DocComments to render as a block in Hover response

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -424,6 +424,48 @@ void A.AMethod(int i)
             Assert.Equal(expectedMarkdown, results.Contents.Fourth.Value);
         }
 
+        [Theory, CombinatorialData]
+        public async Task TestGetHoverAsync_UsingMarkupContentDoesNotEscapeCodeBlock(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"class A
+{
+    /// <summary>
+    /// <code>
+    /// if (true) {
+    ///     Console.WriteLine(""hello"");
+    /// }
+    /// </code>
+    /// </summary>
+    void {|caret:AMethod|}(int i)
+    {
+    }
+}";
+            var clientCapabilities = new LSP.ClientCapabilities
+            {
+                TextDocument = new LSP.TextDocumentClientCapabilities { Hover = new LSP.HoverSetting { ContentFormat = [LSP.MarkupKind.Markdown] } }
+            };
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, clientCapabilities);
+            var expectedLocation = testLspServer.GetLocations("caret").Single();
+
+            var expectedMarkdown = @"```csharp
+void A.AMethod(int i)
+```
+  
+
+```text
+if (true) {
+    Console.WriteLine(""hello"");
+}
+```  
+";
+
+            var results = await RunGetHoverAsync(
+                testLspServer,
+                expectedLocation).ConfigureAwait(false);
+            Assert.Equal(expectedMarkdown, results.Contents.Fourth.Value);
+        }
+
         [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/6577")]
         public async Task TestGetHoverAsync_UsesInlineCodeFencesInAwaitReturn(bool mutatingLspWorkspace)
         {

--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -424,7 +424,7 @@ void A.AMethod(int i)
             Assert.Equal(expectedMarkdown, results.Contents.Fourth.Value);
         }
 
-        [Theory, CombinatorialData]
+        [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/75181")]
         public async Task TestGetHoverAsync_UsingMarkupContentDoesNotEscapeCodeBlock(bool mutatingLspWorkspace)
         {
             var markup =


### PR DESCRIPTION
As noticed in #75181, `<code>` from DocComment always renders inline even if it represents a block of code.

Before:
![image](https://github.com/user-attachments/assets/f425c386-7e35-4f48-8b49-a22b12de2ee4)

After:
<img width="542" alt="image" src="https://github.com/user-attachments/assets/6a68c9ef-2635-45e0-8ea3-985e081762dc">

In order to have highlighting, we will need to pass along the code blocks `lang` attribute with the TaggedText.