### PR TITLE
Do not simplify type name to a type with the EditorBrowsable attribute on it.

### DIFF
--- a/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -7304,39 +7304,63 @@ namespace N
             """, new TestParameters(options: featureOptions));
     }
 
+    [Fact]
+    public async Task TestEditorBrowsable1()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            using System.ComponentModel;
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            class Base
+            {
+                public static void Method() { }
+            }
+
+            class Derived : Base { }
+
+            class Test
+            {
+                void M()
+                {
+                    [|Derived|].Method();
+                }
+            }
+            """);
+    }
+
     private async Task TestWithPredefinedTypeOptionsAsync(string code, string expected, int index = 0)
         => await TestInRegularAndScript1Async(code, expected, index, new TestParameters(options: PreferIntrinsicTypeEverywhere));
 
     private OptionsCollection PreferIntrinsicTypeEverywhere
-        => new OptionsCollection(GetLanguage())
+        => new(GetLanguage())
         {
             { CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration, true, NotificationOption2.Error },
             { CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, this.onWithError },
         };
 
     private OptionsCollection PreferIntrinsicTypeInDeclaration
-        => new OptionsCollection(GetLanguage())
+        => new(GetLanguage())
         {
             { CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration, true, NotificationOption2.Error },
             { CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, this.offWithSilent },
         };
 
     private OptionsCollection PreferIntrinsicTypeInMemberAccess
-        => new OptionsCollection(GetLanguage())
+        => new(GetLanguage())
         {
             { CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, true, NotificationOption2.Error },
             { CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration, this.offWithSilent },
         };
 
     private OptionsCollection PreferImplicitTypeEverywhere
-        => new OptionsCollection(GetLanguage())
+        => new(GetLanguage())
         {
             { CSharpCodeStyleOptions.VarElsewhere, onWithInfo },
             { CSharpCodeStyleOptions.VarWhenTypeIsApparent, onWithInfo },
             { CSharpCodeStyleOptions.VarForBuiltInTypes, onWithInfo },
         };
 
-    private readonly CodeStyleOption2<bool> offWithSilent = new CodeStyleOption2<bool>(false, NotificationOption2.Silent);
-    private readonly CodeStyleOption2<bool> onWithInfo = new CodeStyleOption2<bool>(true, NotificationOption2.Suggestion);
-    private readonly CodeStyleOption2<bool> onWithError = new CodeStyleOption2<bool>(true, NotificationOption2.Error);
+    private readonly CodeStyleOption2<bool> offWithSilent = new(false, NotificationOption2.Silent);
+    private readonly CodeStyleOption2<bool> onWithInfo = new(true, NotificationOption2.Suggestion);
+    private readonly CodeStyleOption2<bool> onWithError = new(true, NotificationOption2.Error);
 }

--- a/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -7304,7 +7304,7 @@ namespace N
             """, new TestParameters(options: featureOptions));
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75162")]
     public async Task TestEditorBrowsable1()
     {
         await TestMissingInRegularAndScriptAsync("""

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
@@ -40,7 +40,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
         replacementNode = null;
         issueSpan = default;
 
-        if (expression is MemberAccessExpressionSyntax(SyntaxKind.ThisExpression) memberAccessExpression)
+        if (expression is MemberAccessExpressionSyntax { Expression.RawKind: (int)SyntaxKind.ThisExpression } memberAccessExpression)
         {
             if (!MemberAccessExpressionSimplifier.Instance.ShouldSimplifyThisMemberAccessExpression(
                     memberAccessExpression, semanticModel, options, out _, out _, cancellationToken))

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -33,7 +31,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
         ExpressionSyntax expression,
         SemanticModel semanticModel,
         CSharpSimplifierOptions options,
-        out ExpressionSyntax replacementNode,
+        [NotNullWhen(true)] out ExpressionSyntax? replacementNode,
         out TextSpan issueSpan,
         CancellationToken cancellationToken)
     {
@@ -65,7 +63,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
     private static bool TryReduceExplicitName(
         ExpressionSyntax expression,
         SemanticModel semanticModel,
-        out TypeSyntax replacementNode,
+        [NotNullWhen(true)] out TypeSyntax? replacementNode,
         out TextSpan issueSpan,
         CSharpSimplifierOptions options,
         CancellationToken cancellationToken)
@@ -88,7 +86,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
     private static bool TryReduceMemberAccessExpression(
         MemberAccessExpressionSyntax memberAccess,
         SemanticModel semanticModel,
-        out TypeSyntax replacementNode,
+        [NotNullWhen(true)] out TypeSyntax? replacementNode,
         out TextSpan issueSpan,
         CSharpSimplifierOptions options,
         CancellationToken cancellationToken)
@@ -147,7 +145,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
 
                 if (syntaxRef != null)
                 {
-                    var declIdentifier = ((UsingDirectiveSyntax)syntaxRef.GetSyntax(cancellationToken)).Alias.Name.Identifier;
+                    var declIdentifier = ((UsingDirectiveSyntax)syntaxRef.GetSyntax(cancellationToken)).Alias!.Name.Identifier;
                     text = declIdentifier.IsVerbatimIdentifier() ? declIdentifier.ToString()[1..] : declIdentifier.ToString();
                 }
 
@@ -259,7 +257,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
     private static bool TrySimplify(
         ExpressionSyntax expression,
         SemanticModel semanticModel,
-        out ExpressionSyntax replacementNode,
+        [NotNullWhen(true)] out ExpressionSyntax? replacementNode,
         out TextSpan issueSpan,
         CancellationToken cancellationToken)
     {
@@ -273,7 +271,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
         static bool TrySimplifyWorker(
             ExpressionSyntax expression,
             SemanticModel semanticModel,
-            out ExpressionSyntax replacementNode,
+            [NotNullWhen(true)] out ExpressionSyntax? replacementNode,
             out TextSpan issueSpan,
             CancellationToken cancellationToken)
         {
@@ -374,7 +372,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
             var leftSymbol = semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).GetAnySymbol();
             if (leftSymbol is INamedTypeSymbol)
             {
-                var type = semanticModel.GetTypeInfo(memberAccess.Parent, cancellationToken).Type;
+                var type = semanticModel.GetTypeInfo(memberAccess.GetRequiredParent(), cancellationToken).Type;
                 if (type?.Kind == SymbolKind.DynamicType)
                 {
                     return true;
@@ -394,7 +392,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
     {
         var constructor = memberAccess.Ancestors().OfType<ConstructorDeclarationSyntax>().SingleOrDefault();
 
-        if (constructor == null || constructor.Parent.Kind() is not (SyntaxKind.StructDeclaration or SyntaxKind.RecordStructDeclaration))
+        if (constructor == null || constructor.GetRequiredParent().Kind() is not (SyntaxKind.StructDeclaration or SyntaxKind.RecordStructDeclaration))
         {
             return false;
         }
@@ -407,7 +405,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
         ExpressionSyntax left,
         ExpressionSyntax right,
         SemanticModel semanticModel,
-        out ExpressionSyntax replacementNode,
+        [NotNullWhen(true)] out ExpressionSyntax? replacementNode,
         out TextSpan issueSpan)
     {
         replacementNode = null;

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
@@ -40,7 +40,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
         replacementNode = null;
         issueSpan = default;
 
-        if (expression is MemberAccessExpressionSyntax { Expression.RawKind: (int)SyntaxKind.ThisExpression } memberAccessExpression)
+        if (expression is MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax } memberAccessExpression)
         {
             if (!MemberAccessExpressionSimplifier.Instance.ShouldSimplifyThisMemberAccessExpression(
                     memberAccessExpression, semanticModel, options, out _, out _, cancellationToken))

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
@@ -428,7 +428,7 @@ internal sealed partial class ExpressionSimplifier : AbstractCSharpSimplifier<Ex
                         // Don't simplify to a base type if it has the EditorBrowsable attribute on it.  This is
                         // occasionally done in some APIs to have a 'pseudo internal' base type that has functionality,
                         // which a user is supposed to only access through some 'pseudo public' derived type instead.
-                        if (!containingType.IsEditorBrowsable(hideAdvancedMembers: true, semanticModel.Compilation))
+                        if (!containingType.IsEditorBrowsable(hideAdvancedMembers: true, semanticModel.Compilation, includingSourceSymbols: true))
                             return false;
 
                         // We have a static member access or a nested type member access using a more derived type.

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -26,24 +26,25 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions;
 internal static partial class ISymbolExtensions
 {
     /// <summary>
-    /// Checks a given symbol for browsability based on its declaration location, attributes 
-    /// explicitly limiting browsability, and whether showing of advanced members is enabled. 
-    /// The optional editorBrowsableInfo parameters may be used to specify the symbols of the
-    /// constructors of the various browsability limiting attributes because finding these 
-    /// repeatedly over a large list of symbols can be slow. If these are not provided,
-    /// they will be found in the compilation.
+    /// Checks a given symbol for browsability based on its declaration location, attributes explicitly limiting
+    /// browsability, and whether showing of advanced members is enabled. The optional editorBrowsableInfo parameters
+    /// may be used to specify the symbols of the constructors of the various browsability limiting attributes because
+    /// finding these repeatedly over a large list of symbols can be slow. If these are not provided, they will be found
+    /// in the compilation.
     /// </summary>
     public static bool IsEditorBrowsable(
         this ISymbol symbol,
         bool hideAdvancedMembers,
         Compilation compilation,
-        EditorBrowsableInfo editorBrowsableInfo = default)
+        EditorBrowsableInfo editorBrowsableInfo = default,
+        bool includingSourceSymbols = false)
     {
         return IsEditorBrowsableWithState(
             symbol,
             hideAdvancedMembers,
             compilation,
-            editorBrowsableInfo).isBrowsable;
+            editorBrowsableInfo,
+            includingSourceSymbols).isBrowsable;
     }
 
     // In addition to given symbol's browsability, also returns its EditorBrowsableState if it contains EditorBrowsableAttribute.
@@ -51,40 +52,34 @@ internal static partial class ISymbolExtensions
         this ISymbol symbol,
         bool hideAdvancedMembers,
         Compilation compilation,
-        EditorBrowsableInfo editorBrowsableInfo = default)
+        EditorBrowsableInfo editorBrowsableInfo = default,
+        bool includingSourceSymbols = false)
     {
         // Namespaces can't have attributes, so just return true here.  This also saves us a 
         // costly check if this namespace has any locations in source (since a merged namespace
         // needs to go collect all the locations).
         if (symbol.Kind == SymbolKind.Namespace)
-        {
             return (isBrowsable: true, isEditorBrowsableStateAdvanced: false);
-        }
 
         // check for IsImplicitlyDeclared so we don't spend time examining VB's embedded types.
         // This saves a few percent in typing scenarios.  An implicitly declared symbol can't
         // have attributes, so it can't be hidden by them.
         if (symbol.IsImplicitlyDeclared)
-        {
             return (isBrowsable: true, isEditorBrowsableStateAdvanced: false);
-        }
 
         if (editorBrowsableInfo.IsDefault)
-        {
             editorBrowsableInfo = new EditorBrowsableInfo(compilation);
-        }
 
         // Ignore browsability limiting attributes if the symbol is declared in source.
         // Check all locations since some of VB's embedded My symbols are declared in 
         // both source and the MyTemplateLocation.
-        if (symbol.Locations.All(loc => loc.IsInSource))
+        if (!includingSourceSymbols && symbol.Locations.All(loc => loc.IsInSource))
         {
             // The HideModuleNameAttribute still applies to Modules defined in source
             return (!IsBrowsingProhibitedByHideModuleNameAttribute(symbol, editorBrowsableInfo.HideModuleNameAttribute), isEditorBrowsableStateAdvanced: false);
         }
 
         var (isProhibited, isEditorBrowsableStateAdvanced) = IsBrowsingProhibited(symbol, hideAdvancedMembers, editorBrowsableInfo);
-
         return (!isProhibited, isEditorBrowsableStateAdvanced);
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/Simplifiers/AbstractSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/Simplifiers/AbstractSimplifier.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;
 
@@ -18,7 +17,7 @@ internal abstract class AbstractSimplifier<TSyntax, TSimplifiedSyntax, TSimplifi
         TSyntax syntax,
         SemanticModel semanticModel,
         TSimplifierOptions options,
-        out TSimplifiedSyntax replacementNode,
+        [NotNullWhen(true)] out TSimplifiedSyntax? replacementNode,
         out TextSpan issueSpan,
         CancellationToken cancellationToken);
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/75162