### PR TITLE
Add telemetry to track the rename option used.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -9,8 +9,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.InlineRename;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.EditorFeatures.Lightup;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text.Classification;
@@ -117,6 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
 
             var useInlineAdornment = _globalOptionService.GetOption(InlineRenameUIOptionsStorage.UseInlineAdornment);
+            LogAdornmentChoice(useInlineAdornment);
             if (useInlineAdornment)
             {
                 if (!_textView.HasAggregateFocus)
@@ -180,6 +183,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             Workspace.TryGetWorkspace(textContainer, out var workspace);
             return workspace;
+        }
+
+        private static void LogAdornmentChoice(bool useInlineAdornment)
+        {
+            TelemetryLogging.Log(FunctionId.InlineRenameAdornmentChoice, KeyValueLogMessage.Create(m =>
+            {
+                m[nameof(useInlineAdornment)] = useInlineAdornment;
+            }));
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -633,5 +633,7 @@ internal enum FunctionId
     Copilot_On_The_Fly_Docs_Results_Canceled = 814,
     Copilot_On_The_Fly_Docs_Get_Counts = 815,
     Copilot_On_The_Fly_Docs_Content_Excluded = 816,
-    Copilot_Rename = 851
+    Copilot_Rename = 851,
+
+    InlineRenameAdornmentChoice = 852
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -634,5 +634,5 @@ internal enum FunctionId
     Copilot_On_The_Fly_Docs_Results_Canceled = 814,
     Copilot_On_The_Fly_Docs_Get_Counts = 815,
     Copilot_On_The_Fly_Docs_Content_Excluded = 816,
-    Copilot_Rename = 851,
+    Copilot_Rename = 851
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -592,6 +592,7 @@ internal enum FunctionId
     // 670-680 for newer rename ids
     Rename_TryApplyRename_WorkspaceChanged = 670,
     Rename_InlineSession_Cancel_NonDocumentChangedWorkspaceChange = 671,
+    InlineRenameAdornmentChoice = 672,
 
     // 680-690 LSP Initialization info ids.
     LSP_Initialize = 680,
@@ -634,6 +635,4 @@ internal enum FunctionId
     Copilot_On_The_Fly_Docs_Get_Counts = 815,
     Copilot_On_The_Fly_Docs_Content_Excluded = 816,
     Copilot_Rename = 851,
-
-    InlineRenameAdornmentChoice = 852
 }


### PR DESCRIPTION
Collect the telemetry to deprecate the old inline rename UI, 