### PR TITLE
Fix crash with Dispose method with params

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1141,6 +1141,9 @@ outerDefault:
                     }
 
                     break;
+
+                case MemberResolutionKind.None:
+                    return true;
             }
             return false;
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -940,6 +940,7 @@ outerDefault:
             where TMember : Symbol
         {
             Debug.Assert(checkOverriddenOrHidden || containingTypeMapOpt is null);
+            Debug.Assert((options & Options.IgnoreNormalFormIfHasValidParamsParameter) == 0 || (options & Options.IsMethodGroupConversion) == 0);
 
             // SPEC VIOLATION:
             //
@@ -1064,7 +1065,6 @@ outerDefault:
                 // tricks you can pull to make overriding methods [indexers] inconsistent with overridden
                 // methods [indexers] (or implementing methods [indexers] inconsistent with interfaces). 
 
-                Debug.Assert((options & Options.IgnoreNormalFormIfHasValidParamsParameter) == 0 || (options & Options.IsMethodGroupConversion) == 0);
                 if ((options & Options.IsMethodGroupConversion) == 0 && IsValidParams(_binder, leastOverriddenMember, disallowExpandedNonArrayParams, out TypeWithAnnotations definitionElementType))
                 {
                     var expandedResult = IsMemberApplicableInExpandedForm(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -5576,5 +5576,22 @@ public static class Extensions
                 //     r.S.F++;
                 Diagnostic(ErrorCode.ERR_AssgReadonlyLocal2Cause, "r.S.F").WithArguments("r", "foreach iteration variable").WithLocation(7, 5));
         }
+
+        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2187060")]
+        public void ExtensionDisposeMethodWithParams()
+        {
+            var source = """
+System.ReadOnlySpan<int> values = [4, 2];
+foreach (int value in values) { System.Console.Write(value); }
+
+public static class C
+{
+    public static void Dispose(this int i, params int[] other) { }
+}
+""";
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "42" : null, verify: Verification.Skipped)
+                .VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2187060

The issue is in `OverloadResolution.AddMemberToCandidateSet` which may or may not compute a normal result (`normalResult`) on line 1047, then decides whether to keep the normal or expanded result on line 1079 (`PreferExpandedFormOverNormalForm`).
In the failing scenario, we skip computing a normal result but end up preferring the normal result (which is `default`) which then would crash in `OverloadResolutionResult.ReportDiagnostics` (assertion in debug mode in `AssertNone(MemberResolutionKind.None)` and throwing `UnexpectedValue` at line 457 in release mode).
The fix is to prefer the expanded result since we didn't compute a normal result.