### PR TITLE
Clarify the bug template to request a code snippet

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ about: Report a bug in Roslyn
 2. 
 3. 
 
-A minimal repro, with source-code provided, is ideal.  Using [sharplab](https://sharplab.io/) is preferred for compiler/language issues whenever possible.
+A minimal repro, with source-code provided, is ideal.  Most compiler/language issues can be distilled into a snippet that can be pasted into [sharplab](https://sharplab.io/).
 
 **Diagnostic Id**:
 


### PR DESCRIPTION
 (rather than a sharplab link)
 
 @dotnet/roslyn-compiler This is a belated follow-up on a team discussion.