### PR TITLE
Only provide fallback options for host analyzers

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
+++ b/src/Analyzers/CSharp/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
@@ -30,7 +30,7 @@ internal partial class HideBaseCodeFixProvider
         protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
         {
             var root = await _document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var configOptions = await _document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var configOptions = await _document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             var newNode = GetNewNode(_node, configOptions.GetOption(CSharpCodeStyleOptions.PreferredModifierOrder).Value);
             var newRoot = root.ReplaceNode(_node, newNode);

--- a/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
@@ -60,7 +60,7 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
         var syntaxRoot = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var compilationUnit = (CompilationUnitSyntax)syntaxRoot;
 
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         var simplifierOptions = new CSharpSimplifierOptions(configOptions);
 
         // Read the preferred placement option and verify if it can be applied to this code file. There are cases

--- a/src/Analyzers/Core/CodeFixes/ImplementType/ImplementTypeOptions.cs
+++ b/src/Analyzers/Core/CodeFixes/ImplementType/ImplementTypeOptions.cs
@@ -76,7 +76,7 @@ internal static class ImplementTypeOptionsProviders
 
     public static async ValueTask<ImplementTypeOptions> GetImplementTypeOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetImplementTypeOptions(document.Project.Language);
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -656,21 +656,28 @@ public class DiagnosticAnalyzerDriverTests
         //   1) No duplicate diagnostics
         //   2) Both NuGet and Vsix analyzers execute
         //   3) Appropriate diagnostic filtering is done - Nuget suppressor suppresses VSIX analyzer.
+        //
+        // 🐛 After splitting fallback options into separate CompilationWithAnalyzers for project and host analyzers,
+        // NuGet-installed suppressors no longer act on VSIX-installed analyzer diagnostics. Fixing this requires us to
+        // add NuGet-installed analyzer references to the host CompilationWithAnalyzers, with an additional flag
+        // indicating that only suppressors should run for these references.
+        // https://github.com/dotnet/roslyn/issues/75399
+        const bool FalseButShouldBeTrue = false;
         await TestNuGetAndVsixAnalyzerCoreAsync(
             nugetAnalyzers: ImmutableArray.Create(firstNugetAnalyzer),
             expectedNugetAnalyzersExecuted: true,
             vsixAnalyzers: ImmutableArray.Create(vsixAnalyzer),
             expectedVsixAnalyzersExecuted: true,
             nugetSuppressors: ImmutableArray.Create(nugetSuppressor),
-            expectedNugetSuppressorsExecuted: true,
+            expectedNugetSuppressorsExecuted: FalseButShouldBeTrue,
             vsixSuppressors: ImmutableArray<VsixSuppressor>.Empty,
             expectedVsixSuppressorsExecuted: false,
             new[]
             {
                 (Diagnostic("A", "Class").WithLocation(1, 7), nameof(NuGetAnalyzer)),
-                (Diagnostic("X", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer)),
-                (Diagnostic("Y", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer)),
-                (Diagnostic("Z", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer))
+                (Diagnostic("X", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer)),
+                (Diagnostic("Y", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer)),
+                (Diagnostic("Z", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer))
             });
 
         // Suppressors with duplicate support for VsixAnalyzer, but not 100% overlap. Verify the following:
@@ -684,15 +691,15 @@ public class DiagnosticAnalyzerDriverTests
             vsixAnalyzers: ImmutableArray.Create(vsixAnalyzer),
             expectedVsixAnalyzersExecuted: true,
             nugetSuppressors: ImmutableArray.Create(partialNugetSuppressor),
-            expectedNugetSuppressorsExecuted: true,
+            expectedNugetSuppressorsExecuted: FalseButShouldBeTrue,
             vsixSuppressors: ImmutableArray.Create(vsixSuppressor),
             expectedVsixSuppressorsExecuted: false,
             new[]
             {
                 (Diagnostic("A", "Class").WithLocation(1, 7), nameof(NuGetAnalyzer)),
                 (Diagnostic("X", "Class", isSuppressed: false).WithLocation(1, 7), nameof(VsixAnalyzer)),
-                (Diagnostic("Y", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer)),
-                (Diagnostic("Z", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer))
+                (Diagnostic("Y", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer)),
+                (Diagnostic("Z", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer))
             });
 
         // Suppressors with duplicate support for VsixAnalyzer, with 100% overlap. Verify the following:
@@ -706,15 +713,15 @@ public class DiagnosticAnalyzerDriverTests
             vsixAnalyzers: ImmutableArray.Create(vsixAnalyzer),
             expectedVsixAnalyzersExecuted: true,
             nugetSuppressors: ImmutableArray.Create(nugetSuppressor),
-            expectedNugetSuppressorsExecuted: true,
+            expectedNugetSuppressorsExecuted: FalseButShouldBeTrue,
             vsixSuppressors: ImmutableArray.Create(vsixSuppressor),
             expectedVsixSuppressorsExecuted: false,
             new[]
             {
                 (Diagnostic("A", "Class").WithLocation(1, 7), nameof(NuGetAnalyzer)),
-                (Diagnostic("X", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer)),
-                (Diagnostic("Y", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer)),
-                (Diagnostic("Z", "Class", isSuppressed: true).WithLocation(1, 7), nameof(VsixAnalyzer))
+                (Diagnostic("X", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer)),
+                (Diagnostic("Y", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer)),
+                (Diagnostic("Z", "Class", isSuppressed: FalseButShouldBeTrue).WithLocation(1, 7), nameof(VsixAnalyzer))
             });
     }
 

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
@@ -112,10 +112,10 @@ internal abstract class SettingsProviderBase<TData, TOptionsUpdater, TOption, TV
 
         public override NamingStylePreferences GetNamingStylePreferences()
         {
-            var preferences = _fileDirectoryConfigData.ConfigOptions.GetNamingStylePreferences();
+            var preferences = _fileDirectoryConfigData.ConfigOptionsWithoutFallback.GetNamingStylePreferences();
             if (preferences.IsEmpty && _projectDirectoryConfigData.HasValue)
             {
-                preferences = _projectDirectoryConfigData.Value.ConfigOptions.GetNamingStylePreferences();
+                preferences = _projectDirectoryConfigData.Value.ConfigOptionsWithoutFallback.GetNamingStylePreferences();
             }
 
             return preferences;
@@ -123,7 +123,7 @@ internal abstract class SettingsProviderBase<TData, TOptionsUpdater, TOption, TV
 
         public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
         {
-            if (_fileDirectoryConfigData.ConfigOptions.TryGetValue(key, out value))
+            if (_fileDirectoryConfigData.ConfigOptionsWithoutFallback.TryGetValue(key, out value))
             {
                 return true;
             }
@@ -134,7 +134,7 @@ internal abstract class SettingsProviderBase<TData, TOptionsUpdater, TOption, TV
                 return false;
             }
 
-            if (_projectDirectoryConfigData.Value.ConfigOptions.TryGetValue(key, out value))
+            if (_projectDirectoryConfigData.Value.ConfigOptionsWithoutFallback.TryGetValue(key, out value))
             {
                 return true;
             }
@@ -156,23 +156,23 @@ internal abstract class SettingsProviderBase<TData, TOptionsUpdater, TOption, TV
         {
             get
             {
-                foreach (var key in _fileDirectoryConfigData.ConfigOptions.Keys)
+                foreach (var key in _fileDirectoryConfigData.ConfigOptionsWithoutFallback.Keys)
                     yield return key;
 
                 if (!_projectDirectoryConfigData.HasValue)
                     yield break;
 
-                foreach (var key in _projectDirectoryConfigData.Value.ConfigOptions.Keys)
+                foreach (var key in _projectDirectoryConfigData.Value.ConfigOptionsWithoutFallback.Keys)
                 {
-                    if (!_fileDirectoryConfigData.ConfigOptions.TryGetValue(key, out _))
+                    if (!_fileDirectoryConfigData.ConfigOptionsWithoutFallback.TryGetValue(key, out _))
                         yield return key;
                 }
 
                 foreach (var (key, severity) in _projectDirectoryConfigData.Value.TreeOptions)
                 {
                     var diagnosticKey = "dotnet_diagnostic." + key + ".severity";
-                    if (!_fileDirectoryConfigData.ConfigOptions.TryGetValue(diagnosticKey, out _) &&
-                        !_projectDirectoryConfigData.Value.ConfigOptions.TryGetValue(diagnosticKey, out _))
+                    if (!_fileDirectoryConfigData.ConfigOptionsWithoutFallback.TryGetValue(diagnosticKey, out _) &&
+                        !_projectDirectoryConfigData.Value.ConfigOptionsWithoutFallback.TryGetValue(diagnosticKey, out _))
                     {
                         yield return diagnosticKey;
                     }

--- a/src/Features/CSharp/Portable/SyncNamespaces/CSharpSyncNamespacesService.cs
+++ b/src/Features/CSharp/Portable/SyncNamespaces/CSharpSyncNamespacesService.cs
@@ -23,5 +23,7 @@ internal sealed class CSharpSyncNamespacesService(
 {
     public override AbstractMatchFolderAndNamespaceDiagnosticAnalyzer<SyntaxKind, BaseNamespaceDeclarationSyntax> DiagnosticAnalyzer { get; } = diagnosticAnalyzer;
 
+    public override bool IsHostAnalyzer => false;
+
     public override AbstractChangeNamespaceToMatchFolderCodeFixProvider CodeFixProvider { get; } = codeFixProvider;
 }

--- a/src/Features/Core/Portable/AddImport/AddImportOptions.cs
+++ b/src/Features/Core/Portable/AddImport/AddImportOptions.cs
@@ -30,7 +30,7 @@ internal static class AddImportOptionsProviders
 
     public static async ValueTask<AddImportOptions> GetAddImportOptionsAsync(this Document document, SymbolSearchOptions searchOptions, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetAddImportOptions(document.Project.Services, searchOptions, document.AllowImportsInHiddenRegions());
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -51,7 +52,7 @@ internal static class DiagnosticAnalyzerExtensions
     public static string GetAnalyzerAssemblyName(this DiagnosticAnalyzer analyzer)
         => analyzer.GetType().Assembly.GetName().Name ?? throw ExceptionUtilities.Unreachable();
 
-    public static void AppendAnalyzerMap(this Dictionary<string, DiagnosticAnalyzer> analyzerMap, IEnumerable<DiagnosticAnalyzer> analyzers)
+    public static void AppendAnalyzerMap(this Dictionary<string, DiagnosticAnalyzer> analyzerMap, ImmutableArray<DiagnosticAnalyzer> analyzers)
     {
         foreach (var analyzer in analyzers)
         {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Text;
@@ -66,7 +67,13 @@ internal class DiagnosticArguments
     /// Array of analyzer IDs for analyzers that need to be executed for computing diagnostics.
     /// </summary>
     [DataMember(Order = 7)]
-    public string[] AnalyzerIds;
+    public ImmutableArray<string> ProjectAnalyzerIds;
+
+    /// <summary>
+    /// Array of analyzer IDs for analyzers that need to be executed for computing diagnostics.
+    /// </summary>
+    [DataMember(Order = 8)]
+    public ImmutableArray<string> HostAnalyzerIds;
 
     /// <summary>
     /// Indicates diagnostic computation for an explicit user-invoked request,
@@ -83,14 +90,15 @@ internal class DiagnosticArguments
         TextSpan? documentSpan,
         AnalysisKind? documentAnalysisKind,
         ProjectId projectId,
-        string[] analyzerIds,
+        ImmutableArray<string> projectAnalyzerIds,
+        ImmutableArray<string> hostAnalyzerIds,
         bool isExplicit)
     {
         Debug.Assert(documentId != null || documentSpan == null);
         Debug.Assert(documentId != null || documentAnalysisKind == null);
         Debug.Assert(documentAnalysisKind is null or
             (AnalysisKind?)AnalysisKind.Syntax or (AnalysisKind?)AnalysisKind.Semantic);
-        Debug.Assert(analyzerIds.Length > 0);
+        Debug.Assert(projectAnalyzerIds.Length > 0 || hostAnalyzerIds.Length > 0);
 
         ReportSuppressedDiagnostics = reportSuppressedDiagnostics;
         LogPerformanceInfo = logPerformanceInfo;
@@ -99,7 +107,8 @@ internal class DiagnosticArguments
         DocumentSpan = documentSpan;
         DocumentAnalysisKind = documentAnalysisKind;
         ProjectId = projectId;
-        AnalyzerIds = analyzerIds;
+        ProjectAnalyzerIds = projectAnalyzerIds;
+        HostAnalyzerIds = hostAnalyzerIds;
         IsExplicit = isExplicit;
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.cs
@@ -439,6 +439,7 @@ internal partial class UnitTestingSolutionCrawlerRegistrationService
                 !object.Equals(oldProject.AssemblyName, newProject.AssemblyName) ||
                 !object.Equals(oldProject.Name, newProject.Name) ||
                 !object.Equals(oldProject.AnalyzerOptions, newProject.AnalyzerOptions) ||
+                !object.Equals(oldProject.HostAnalyzerOptions, newProject.HostAnalyzerOptions) ||
                 !object.Equals(oldProject.DefaultNamespace, newProject.DefaultNamespace) ||
                 !object.Equals(oldProject.OutputFilePath, newProject.OutputFilePath) ||
                 !object.Equals(oldProject.OutputRefFilePath, newProject.OutputRefFilePath) ||

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
@@ -41,7 +41,7 @@ internal abstract class AbstractTypeSnippetProvider<TTypeDeclarationSyntax> : Ab
 
     protected static async Task<bool> AreAccessibilityModifiersRequiredAsync(Document document, CancellationToken cancellationToken)
     {
-        var options = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var options = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         var accessibilityModifiersRequired = options.GetEditorConfigOptionValue(CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.Never);
         return accessibilityModifiersRequired is AccessibilityModifiersRequired.ForNonInterfaceMembers or AccessibilityModifiersRequired.Always;
     }

--- a/src/Features/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
+++ b/src/Features/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
@@ -53,7 +53,7 @@ internal static class SymbolSearchOptionsProviders
 
     public static async ValueTask<SymbolSearchOptions> GetSymbolSearchOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetSymbolSearchOptions(document.Project.Language);
     }
 }

--- a/src/Features/Core/Portable/Wrapping/AbstractWrappingCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractWrappingCodeRefactoringProvider.cs
@@ -43,7 +43,7 @@ internal abstract class AbstractWrappingCodeRefactoringProvider : CodeRefactorin
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var token = root.FindToken(position);
 
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         var options = GetWrappingOptions(configOptions);
 
         foreach (var node in token.GetRequiredParent().AncestorsAndSelf())

--- a/src/Features/ExternalAccess/OmniSharp/Formatting/OmniSharpSyntaxFormattingOptionsWrapper.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Formatting/OmniSharpSyntaxFormattingOptionsWrapper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Formatting
 
         public static async ValueTask<OmniSharpSyntaxFormattingOptionsWrapper> FromDocumentAsync(Document document, OmniSharpLineFormattingOptions fallbackLineFormattingOptions, CancellationToken cancellationToken)
         {
-            var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             var optionsWithFallback = StructuredAnalyzerConfigOptions.Create(configOptions,
                 StructuredAnalyzerConfigOptions.Create(new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty

--- a/src/LanguageServer/Protocol/ExternalAccess/Razor/SimplifyMethodHandler.cs
+++ b/src/LanguageServer/Protocol/ExternalAccess/Razor/SimplifyMethodHandler.cs
@@ -57,7 +57,7 @@ internal class SimplifyMethodHandler : ILspServiceDocumentRequestHandler<Simplif
         var annotatedDocument = originalDocument.WithSyntaxRoot(annotatedSyntaxRoot);
 
         // Call to the Simplifier and pass back the edits.
-        var configOptions = await originalDocument.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await originalDocument.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         var simplificationService = originalDocument.Project.Services.GetRequiredService<ISimplificationService>();
         var options = simplificationService.GetSimplifierOptions(configOptions);
         var newDocument = await Simplifier.ReduceAsync(annotatedDocument, options, cancellationToken).ConfigureAwait(false);

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
@@ -25,20 +25,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// </summary>
     internal sealed partial class DocumentAnalysisExecutor
     {
-        private readonly CompilationWithAnalyzers? _compilationWithAnalyzers;
+        private readonly CompilationWithAnalyzersPair? _compilationWithAnalyzers;
         private readonly InProcOrRemoteHostAnalyzerRunner _diagnosticAnalyzerRunner;
         private readonly bool _isExplicit;
         private readonly bool _logPerformanceInfo;
         private readonly Action? _onAnalysisException;
 
-        private readonly ImmutableArray<DiagnosticAnalyzer> _compilationBasedAnalyzersInAnalysisScope;
+        private readonly ImmutableArray<DiagnosticAnalyzer> _compilationBasedProjectAnalyzersInAnalysisScope;
+        private readonly ImmutableArray<DiagnosticAnalyzer> _compilationBasedHostAnalyzersInAnalysisScope;
 
         private ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>? _lazySyntaxDiagnostics;
         private ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>? _lazySemanticDiagnostics;
 
         public DocumentAnalysisExecutor(
             DocumentAnalysisScope analysisScope,
-            CompilationWithAnalyzers? compilationWithAnalyzers,
+            CompilationWithAnalyzersPair? compilationWithAnalyzers,
             InProcOrRemoteHostAnalyzerRunner diagnosticAnalyzerRunner,
             bool isExplicit,
             bool logPerformanceInfo,
@@ -51,9 +52,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _logPerformanceInfo = logPerformanceInfo;
             _onAnalysisException = onAnalysisException;
 
-            var compilationBasedAnalyzers = compilationWithAnalyzers?.Analyzers.ToImmutableHashSet();
-            _compilationBasedAnalyzersInAnalysisScope = compilationBasedAnalyzers != null
-                ? analysisScope.Analyzers.WhereAsArray(compilationBasedAnalyzers.Contains)
+            var compilationBasedProjectAnalyzers = compilationWithAnalyzers?.ProjectAnalyzers.ToImmutableHashSet();
+            _compilationBasedProjectAnalyzersInAnalysisScope = compilationBasedProjectAnalyzers != null
+                ? analysisScope.ProjectAnalyzers.WhereAsArray(compilationBasedProjectAnalyzers.Contains)
+                : [];
+
+            var compilationBasedHostAnalyzers = compilationWithAnalyzers?.HostAnalyzers.ToImmutableHashSet();
+            _compilationBasedHostAnalyzersInAnalysisScope = compilationBasedHostAnalyzers != null
+                ? analysisScope.HostAnalyzers.WhereAsArray(compilationBasedHostAnalyzers.Contains)
                 : [];
         }
 
@@ -67,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public async Task<IEnumerable<DiagnosticData>> ComputeDiagnosticsAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfFalse(AnalysisScope.Analyzers.Contains(analyzer));
+            Contract.ThrowIfFalse(AnalysisScope.ProjectAnalyzers.Contains(analyzer) || AnalysisScope.HostAnalyzers.Contains(analyzer));
 
             var textDocument = AnalysisScope.TextDocument;
             var span = AnalysisScope.Span;
@@ -107,8 +113,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (document == null)
                     return [];
 
+                // DocumentDiagnosticAnalyzer is a host-only analyzer
                 var documentDiagnostics = await ComputeDocumentDiagnosticAnalyzerDiagnosticsAsync(
-                    documentAnalyzer, document, kind, _compilationWithAnalyzers?.Compilation, cancellationToken).ConfigureAwait(false);
+                    documentAnalyzer, document, kind, _compilationWithAnalyzers?.HostCompilation, cancellationToken).ConfigureAwait(false);
 
                 return ConvertToLocalDiagnostics(documentDiagnostics, document, span);
             }
@@ -163,7 +170,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
 #if DEBUG
             var diags = await diagnostics.ToDiagnosticsAsync(textDocument.Project, cancellationToken).ConfigureAwait(false);
-            Debug.Assert(diags.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diags, _compilationWithAnalyzers.Compilation).Count());
+            var compilation = _compilationBasedProjectAnalyzersInAnalysisScope.Contains(analyzer) ? _compilationWithAnalyzers.ProjectCompilation : _compilationWithAnalyzers.HostCompilation;
+            RoslynDebug.AssertNotNull(compilation);
+            Debug.Assert(diags.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diags, compilation).Count());
             Debug.Assert(diagnostics.Length == ConvertToLocalDiagnostics(diags, textDocument, span).Count());
 #endif
 
@@ -204,10 +213,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             RoslynDebug.Assert(analyzer.IsCompilerAnalyzer());
             RoslynDebug.Assert(_compilationWithAnalyzers != null);
-            RoslynDebug.Assert(_compilationBasedAnalyzersInAnalysisScope.Contains(analyzer));
+            RoslynDebug.Assert(_compilationBasedProjectAnalyzersInAnalysisScope.Contains(analyzer) || _compilationBasedHostAnalyzersInAnalysisScope.Contains(analyzer));
             RoslynDebug.Assert(AnalysisScope.TextDocument is Document);
 
-            var analysisScope = AnalysisScope.WithAnalyzers([analyzer]).WithSpan(span);
+            var analysisScope = _compilationBasedProjectAnalyzersInAnalysisScope.Contains(analyzer)
+                ? AnalysisScope.WithAnalyzers([analyzer], []).WithSpan(span)
+                : AnalysisScope.WithAnalyzers([], [analyzer]).WithSpan(span);
             var analysisResult = await GetAnalysisResultAsync(analysisScope, cancellationToken).ConfigureAwait(false);
             if (!analysisResult.TryGetValue(analyzer, out var result))
             {
@@ -226,7 +237,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             //     for rest of the analyzers. This is needed to ensure faster refresh for compiler diagnostics while typing.
 
             RoslynDebug.Assert(_compilationWithAnalyzers != null);
-            RoslynDebug.Assert(_compilationBasedAnalyzersInAnalysisScope.Contains(analyzer));
+            RoslynDebug.Assert(_compilationBasedProjectAnalyzersInAnalysisScope.Contains(analyzer) || _compilationBasedHostAnalyzersInAnalysisScope.Contains(analyzer));
 
             if (isCompilerAnalyzer)
             {
@@ -242,7 +253,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.RequestDiagnostics_Summary, $"{nameof(GetSyntaxDiagnosticsAsync)}.{nameof(GetAnalysisResultAsync)}");
 
-                var analysisScope = AnalysisScope.WithAnalyzers(_compilationBasedAnalyzersInAnalysisScope);
+                var analysisScope = AnalysisScope.WithAnalyzers(_compilationBasedProjectAnalyzersInAnalysisScope, _compilationBasedHostAnalyzersInAnalysisScope);
                 var syntaxDiagnostics = await GetAnalysisResultAsync(analysisScope, cancellationToken).ConfigureAwait(false);
                 Interlocked.CompareExchange(ref _lazySyntaxDiagnostics, syntaxDiagnostics, null);
             }
@@ -278,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.RequestDiagnostics_Summary, $"{nameof(GetSemanticDiagnosticsAsync)}.{nameof(GetAnalysisResultAsync)}");
 
-                var analysisScope = AnalysisScope.WithAnalyzers(_compilationBasedAnalyzersInAnalysisScope);
+                var analysisScope = AnalysisScope.WithAnalyzers(_compilationBasedProjectAnalyzersInAnalysisScope, _compilationBasedHostAnalyzersInAnalysisScope);
                 var semanticDiagnostics = await GetAnalysisResultAsync(analysisScope, cancellationToken).ConfigureAwait(false);
                 Interlocked.CompareExchange(ref _lazySemanticDiagnostics, semanticDiagnostics, null);
             }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics.EngineV2;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -127,9 +128,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 language: language);
         }
 
-        public static async Task<CompilationWithAnalyzers?> CreateCompilationWithAnalyzersAsync(
+        public static async Task<CompilationWithAnalyzersPair?> CreateCompilationWithAnalyzersAsync(
             Project project,
-            ImmutableArray<DiagnosticAnalyzer> analyzers,
+            ImmutableArray<DiagnosticAnalyzer> projectAnalyzers,
+            ImmutableArray<DiagnosticAnalyzer> hostAnalyzers,
             bool includeSuppressedDiagnostics,
             bool crashOnAnalyzerException,
             CancellationToken cancellationToken)
@@ -142,11 +144,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             // Create driver that holds onto compilation and associated analyzers
-            var filteredAnalyzers = analyzers.WhereAsArray(a => !a.IsWorkspaceDiagnosticAnalyzer());
+            var filteredProjectAnalyzers = projectAnalyzers.WhereAsArray(static a => !a.IsWorkspaceDiagnosticAnalyzer());
+            var filteredHostAnalyzers = hostAnalyzers.WhereAsArray(static a => !a.IsWorkspaceDiagnosticAnalyzer());
 
             // PERF: there is no analyzers for this compilation.
             //       compilationWithAnalyzer will throw if it is created with no analyzers which is perf optimization.
-            if (filteredAnalyzers.IsEmpty)
+            if (filteredProjectAnalyzers.IsEmpty && filteredHostAnalyzers.IsEmpty)
             {
                 return null;
             }
@@ -156,8 +159,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             // in IDE, we always set concurrentAnalysis == false otherwise, we can get into thread starvation due to
             // async being used with synchronous blocking concurrency.
-            var analyzerOptions = new CompilationWithAnalyzersOptions(
+            var projectAnalyzerOptions = new CompilationWithAnalyzersOptions(
                 options: project.AnalyzerOptions,
+                onAnalyzerException: null,
+                analyzerExceptionFilter: GetAnalyzerExceptionFilter(),
+                concurrentAnalysis: false,
+                logAnalyzerExecutionTime: true,
+                reportSuppressedDiagnostics: includeSuppressedDiagnostics);
+            var hostAnalyzerOptions = new CompilationWithAnalyzersOptions(
+                options: project.HostAnalyzerOptions,
                 onAnalyzerException: null,
                 analyzerExceptionFilter: GetAnalyzerExceptionFilter(),
                 concurrentAnalysis: false,
@@ -165,7 +175,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 reportSuppressedDiagnostics: includeSuppressedDiagnostics);
 
             // Create driver that holds onto compilation and associated analyzers
-            return compilation.WithAnalyzers(filteredAnalyzers, analyzerOptions);
+            return new CompilationWithAnalyzersPair(
+                filteredProjectAnalyzers.Any() ? compilation.WithAnalyzers(filteredProjectAnalyzers, projectAnalyzerOptions) : null,
+                filteredHostAnalyzers.Any() ? compilation.WithAnalyzers(filteredHostAnalyzers, hostAnalyzerOptions) : null);
 
             Func<Exception, bool> GetAnalyzerExceptionFilter()
             {

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -2,16 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
     internal partial class DiagnosticIncrementalAnalyzer
     {
-        private static Task<CompilationWithAnalyzers?> CreateCompilationWithAnalyzersAsync(Project project, IEnumerable<StateSet> stateSets, bool includeSuppressedDiagnostics, bool crashOnAnalyzerException, CancellationToken cancellationToken)
-            => DocumentAnalysisExecutor.CreateCompilationWithAnalyzersAsync(project, stateSets.SelectAsArray(s => s.Analyzer), includeSuppressedDiagnostics, crashOnAnalyzerException, cancellationToken);
+        private static Task<CompilationWithAnalyzersPair?> CreateCompilationWithAnalyzersAsync(Project project, ImmutableArray<StateSet> stateSets, bool includeSuppressedDiagnostics, bool crashOnAnalyzerException, CancellationToken cancellationToken)
+            => DocumentAnalysisExecutor.CreateCompilationWithAnalyzersAsync(project, stateSets.SelectAsArray(s => !s.IsHostAnalyzer, s => s.Analyzer), stateSets.SelectAsArray(s => s.IsHostAnalyzer, s => s.Analyzer), includeSuppressedDiagnostics, crashOnAnalyzerException, cancellationToken);
     }
 }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// Return all diagnostics that belong to given project for the given StateSets (analyzers) either from cache or by calculating them
         /// </summary>
         private async Task<ProjectAnalysisData> GetProjectAnalysisDataAsync(
-            CompilationWithAnalyzers? compilationWithAnalyzers, Project project, ImmutableArray<StateSet> stateSets, CancellationToken cancellationToken)
+            CompilationWithAnalyzersPair? compilationWithAnalyzers, Project project, ImmutableArray<StateSet> stateSets, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.Diagnostics_ProjectDiagnostic, GetProjectLogMessage, project, stateSets, cancellationToken))
             {
@@ -88,14 +89,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// Calculate all diagnostics for a given project using analyzers referenced by the project and specified IDE analyzers.
         /// </summary>
         private async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> ComputeDiagnosticsAsync(
-            CompilationWithAnalyzers? compilationWithAnalyzers, Project project, ImmutableArray<DiagnosticAnalyzer> ideAnalyzers, CancellationToken cancellationToken)
+            CompilationWithAnalyzersPair? compilationWithAnalyzers, Project project, ImmutableArray<DiagnosticAnalyzer> ideAnalyzers, CancellationToken cancellationToken)
         {
             try
             {
                 var result = ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty;
 
                 // can be null if given project doesn't support compilation.
-                if (compilationWithAnalyzers?.Analyzers.Length > 0)
+                if (compilationWithAnalyzers?.ProjectAnalyzers.Length > 0
+                    || compilationWithAnalyzers?.HostAnalyzers.Length > 0)
                 {
                     // calculate regular diagnostic analyzers diagnostics
                     var resultMap = await _diagnosticAnalyzerRunner.AnalyzeProjectAsync(
@@ -108,7 +110,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 // check whether there is IDE specific project diagnostic analyzer
-                return await MergeProjectDiagnosticAnalyzerDiagnosticsAsync(project, ideAnalyzers, compilationWithAnalyzers?.Compilation, result, cancellationToken).ConfigureAwait(false);
+                Debug.Assert(ideAnalyzers.All(a => a is ProjectDiagnosticAnalyzer or DocumentDiagnosticAnalyzer));
+                return await MergeProjectDiagnosticAnalyzerDiagnosticsAsync(project, ideAnalyzers, compilationWithAnalyzers?.HostCompilation, result, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
@@ -117,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> ComputeDiagnosticsAsync(
-            CompilationWithAnalyzers? compilationWithAnalyzers, Project project, ImmutableArray<StateSet> stateSets,
+            CompilationWithAnalyzersPair? compilationWithAnalyzers, Project project, ImmutableArray<StateSet> stateSets,
             ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> existing, CancellationToken cancellationToken)
         {
             try
@@ -129,18 +132,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 var ideAnalyzers = stateSets.Select(s => s.Analyzer).Where(a => a is ProjectDiagnosticAnalyzer or DocumentDiagnosticAnalyzer).ToImmutableArrayOrEmpty();
 
-                if (compilationWithAnalyzers != null && TryReduceAnalyzersToRun(compilationWithAnalyzers, version, existing, out var analyzersToRun))
+                if (compilationWithAnalyzers != null && TryReduceAnalyzersToRun(compilationWithAnalyzers, version, existing, out var projectAnalyzersToRun, out var hostAnalyzersToRun))
                 {
                     // it looks like we can reduce the set. create new CompilationWithAnalyzer.
                     // if we reduced to 0, we just pass in null for analyzer drvier. it could be reduced to 0
                     // since we might have up to date results for analyzers from compiler but not for 
                     // workspace analyzers.
 
-                    var compilationWithReducedAnalyzers = (analyzersToRun.Length == 0) ? null :
+                    var compilationWithReducedAnalyzers = (projectAnalyzersToRun.Length == 0 && hostAnalyzersToRun.Length == 0) ? null :
                         await DocumentAnalysisExecutor.CreateCompilationWithAnalyzersAsync(
                             project,
-                            analyzersToRun,
-                            compilationWithAnalyzers.AnalysisOptions.ReportSuppressedDiagnostics,
+                            projectAnalyzersToRun,
+                            hostAnalyzersToRun,
+                            compilationWithAnalyzers.ReportSuppressedDiagnostics,
                             AnalyzerService.CrashOnAnalyzerException,
                             cancellationToken).ConfigureAwait(false);
 
@@ -180,35 +184,52 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private static bool TryReduceAnalyzersToRun(
-            CompilationWithAnalyzers compilationWithAnalyzers, VersionStamp version,
+            CompilationWithAnalyzersPair compilationWithAnalyzers, VersionStamp version,
             ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> existing,
-            out ImmutableArray<DiagnosticAnalyzer> analyzers)
+            out ImmutableArray<DiagnosticAnalyzer> projectAnalyzers,
+            out ImmutableArray<DiagnosticAnalyzer> hostAnalyzers)
         {
-            analyzers = default;
-
-            var existingAnalyzers = compilationWithAnalyzers.Analyzers;
-            var builder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
-            foreach (var analyzer in existingAnalyzers)
-            {
-                if (existing.TryGetValue(analyzer, out var analysisResult) &&
-                    analysisResult.Version == version)
+            projectAnalyzers = compilationWithAnalyzers.ProjectAnalyzers.WhereAsArray(
+                static (analyzer, arg) =>
                 {
-                    // we already have up to date result.
-                    continue;
-                }
+                    if (arg.existing.TryGetValue(analyzer, out var analysisResult) &&
+                        analysisResult.Version == arg.version)
+                    {
+                        // we already have up to date result.
+                        return false;
+                    }
 
-                // analyzer that is out of date.
-                // open file only analyzer is always out of date for project wide data
-                builder.Add(analyzer);
-            }
+                    // analyzer that is out of date.
+                    // open file only analyzer is always out of date for project wide data
+                    return true;
+                },
+                (existing, version));
 
-            // all of analyzers are out of date.
-            if (builder.Count == existingAnalyzers.Length)
+            hostAnalyzers = compilationWithAnalyzers.HostAnalyzers.WhereAsArray(
+                static (analyzer, arg) =>
+                {
+                    if (arg.existing.TryGetValue(analyzer, out var analysisResult) &&
+                        analysisResult.Version == arg.version)
+                    {
+                        // we already have up to date result.
+                        return false;
+                    }
+
+                    // analyzer that is out of date.
+                    // open file only analyzer is always out of date for project wide data
+                    return true;
+                },
+                (existing, version));
+
+            if (projectAnalyzers.Length == compilationWithAnalyzers.ProjectAnalyzers.Length
+                && hostAnalyzers.Length == compilationWithAnalyzers.HostAnalyzers.Length)
             {
+                // all of analyzers are out of date.
+                projectAnalyzers = default;
+                hostAnalyzers = default;
                 return false;
             }
 
-            analyzers = builder.ToImmutable();
             return true;
         }
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeDocumentAsync(
             DocumentAnalysisScope documentAnalysisScope,
-            CompilationWithAnalyzers compilationWithAnalyzers,
+            CompilationWithAnalyzersPair compilationWithAnalyzers,
             bool isExplicit,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeProjectAsync(
             Project project,
-            CompilationWithAnalyzers compilationWithAnalyzers,
+            CompilationWithAnalyzersPair compilationWithAnalyzers,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeAsync(
             DocumentAnalysisScope? documentAnalysisScope,
             Project project,
-            CompilationWithAnalyzers compilationWithAnalyzers,
+            CompilationWithAnalyzersPair compilationWithAnalyzers,
             bool isExplicit,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeCoreAsync()
             {
-                Contract.ThrowIfFalse(!compilationWithAnalyzers.Analyzers.IsEmpty);
+                Contract.ThrowIfFalse(compilationWithAnalyzers.HasAnalyzers);
 
                 var remoteHostClient = await RemoteHostClient.TryGetClientAsync(project, cancellationToken).ConfigureAwait(false);
                 if (remoteHostClient != null)
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeInProcAsync(
             DocumentAnalysisScope? documentAnalysisScope,
             Project project,
-            CompilationWithAnalyzers compilationWithAnalyzers,
+            CompilationWithAnalyzersPair compilationWithAnalyzers,
             RemoteHostClient? client,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
@@ -122,29 +122,55 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             var version = await DiagnosticIncrementalAnalyzer.GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
 
-            var (analysisResult, additionalPragmaSuppressionDiagnostics) = await compilationWithAnalyzers.GetAnalysisResultAsync(
+            var (projectAnalysisResult, hostAnalysisResult, additionalPragmaSuppressionDiagnostics) = await compilationWithAnalyzers.GetAnalysisResultAsync(
                 documentAnalysisScope, project, AnalyzerInfoCache, cancellationToken).ConfigureAwait(false);
 
             if (logPerformanceInfo)
             {
                 // if remote host is there, report performance data
                 var asyncToken = _asyncOperationListener.BeginAsyncOperation(nameof(AnalyzeInProcAsync));
-                var _ = FireAndForgetReportAnalyzerPerformanceAsync(documentAnalysisScope, project, client, analysisResult, cancellationToken).CompletesAsyncOperation(asyncToken);
+                var _ = FireAndForgetReportAnalyzerPerformanceAsync(documentAnalysisScope, project, client, projectAnalysisResult, hostAnalysisResult, cancellationToken).CompletesAsyncOperation(asyncToken);
             }
 
-            var analyzers = documentAnalysisScope?.Analyzers ?? compilationWithAnalyzers.Analyzers;
+            var projectAnalyzers = documentAnalysisScope?.ProjectAnalyzers ?? compilationWithAnalyzers.ProjectAnalyzers;
+            var hostAnalyzers = documentAnalysisScope?.HostAnalyzers ?? compilationWithAnalyzers.HostAnalyzers;
             var skippedAnalyzersInfo = project.GetSkippedAnalyzersInfo(AnalyzerInfoCache);
 
             // get compiler result builder map
-            var builderMap = await analysisResult.ToResultBuilderMapAsync(
-                additionalPragmaSuppressionDiagnostics, documentAnalysisScope, project, version,
-                compilationWithAnalyzers.Compilation, analyzers, skippedAnalyzersInfo,
-                compilationWithAnalyzers.AnalysisOptions.ReportSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
+            var builderMap = ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResultBuilder>.Empty;
+            if (projectAnalysisResult is not null)
+            {
+                var map = await projectAnalysisResult.ToResultBuilderMapAsync(
+                    additionalPragmaSuppressionDiagnostics, documentAnalysisScope, project, version,
+                    compilationWithAnalyzers.ProjectCompilation!, projectAnalyzers, skippedAnalyzersInfo,
+                    compilationWithAnalyzers.ReportSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
+                builderMap = builderMap.AddRange(map);
+            }
+
+            if (hostAnalysisResult is not null)
+            {
+                var map = await hostAnalysisResult.ToResultBuilderMapAsync(
+                    additionalPragmaSuppressionDiagnostics, documentAnalysisScope, project, version,
+                    compilationWithAnalyzers.HostCompilation!, hostAnalyzers, skippedAnalyzersInfo,
+                    compilationWithAnalyzers.ReportSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
+                builderMap = builderMap.AddRange(map);
+            }
 
             var result = builderMap.ToImmutableDictionary(kv => kv.Key, kv => DiagnosticAnalysisResult.CreateFromBuilder(kv.Value));
-            var telemetry = getTelemetryInfo
-                ? analysisResult.AnalyzerTelemetryInfo
-                : ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo>.Empty;
+            var telemetry = ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo>.Empty;
+            if (getTelemetryInfo)
+            {
+                if (projectAnalysisResult is not null)
+                {
+                    telemetry = telemetry.AddRange(projectAnalysisResult.AnalyzerTelemetryInfo);
+                }
+
+                if (hostAnalysisResult is not null)
+                {
+                    telemetry = telemetry.AddRange(hostAnalysisResult.AnalyzerTelemetryInfo);
+                }
+            }
+
             return DiagnosticAnalysisResultMap.Create(result, telemetry);
         }
 
@@ -152,7 +178,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DocumentAnalysisScope? documentAnalysisScope,
             Project project,
             RemoteHostClient? client,
-            AnalysisResult analysisResult,
+            AnalysisResult? projectAnalysisResult,
+            AnalysisResult? hostAnalysisResult,
             CancellationToken cancellationToken)
         {
             if (client == null)
@@ -166,7 +193,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var count = documentAnalysisScope != null ? 1 : project.DocumentIds.Count + 1;
                 var forSpanAnalysis = documentAnalysisScope?.Span.HasValue ?? false;
 
-                var performanceInfo = analysisResult.AnalyzerTelemetryInfo.ToAnalyzerPerformanceInfo(AnalyzerInfoCache).ToImmutableArray();
+                ImmutableArray<AnalyzerPerformanceInfo> performanceInfo = [];
+                if (projectAnalysisResult is not null)
+                {
+                    performanceInfo = performanceInfo.AddRange(projectAnalysisResult.AnalyzerTelemetryInfo.ToAnalyzerPerformanceInfo(AnalyzerInfoCache));
+                }
+
+                if (hostAnalysisResult is not null)
+                {
+                    performanceInfo = performanceInfo.AddRange(hostAnalysisResult.AnalyzerTelemetryInfo.ToAnalyzerPerformanceInfo(AnalyzerInfoCache));
+                }
 
                 _ = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService>(
                     (service, cancellationToken) => service.ReportAnalyzerPerformanceAsync(performanceInfo, count, forSpanAnalysis, cancellationToken),
@@ -181,34 +217,39 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeOutOfProcAsync(
             DocumentAnalysisScope? documentAnalysisScope,
             Project project,
-            CompilationWithAnalyzers compilationWithAnalyzers,
+            CompilationWithAnalyzersPair compilationWithAnalyzers,
             RemoteHostClient client,
             bool isExplicit,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
         {
-            using var pooledObject = SharedPools.Default<Dictionary<string, DiagnosticAnalyzer>>().GetPooledObject();
-            var analyzerMap = pooledObject.Object;
+            using var pooledObject1 = SharedPools.Default<Dictionary<string, DiagnosticAnalyzer>>().GetPooledObject();
+            using var pooledObject2 = SharedPools.Default<Dictionary<string, DiagnosticAnalyzer>>().GetPooledObject();
+            var projectAnalyzerMap = pooledObject1.Object;
+            var hostAnalyzerMap = pooledObject2.Object;
 
-            var analyzers = documentAnalysisScope?.Analyzers ?? compilationWithAnalyzers.Analyzers;
+            var projectAnalyzers = documentAnalysisScope?.ProjectAnalyzers ?? compilationWithAnalyzers.ProjectAnalyzers;
+            var hostAnalyzers = documentAnalysisScope?.HostAnalyzers ?? compilationWithAnalyzers.HostAnalyzers;
 
-            analyzerMap.AppendAnalyzerMap(analyzers);
+            projectAnalyzerMap.AppendAnalyzerMap(projectAnalyzers);
+            hostAnalyzerMap.AppendAnalyzerMap(hostAnalyzers);
 
-            if (analyzerMap.Count == 0)
+            if (projectAnalyzerMap.Count == 0 && hostAnalyzerMap.Count == 0)
             {
                 return DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty;
             }
 
             var argument = new DiagnosticArguments(
-                compilationWithAnalyzers.AnalysisOptions.ReportSuppressedDiagnostics,
+                compilationWithAnalyzers.ReportSuppressedDiagnostics,
                 logPerformanceInfo,
                 getTelemetryInfo,
                 documentAnalysisScope?.TextDocument.Id,
                 documentAnalysisScope?.Span,
                 documentAnalysisScope?.Kind,
                 project.Id,
-                [.. analyzerMap.Keys],
+                [.. projectAnalyzerMap.Keys],
+                [.. hostAnalyzerMap.Keys],
                 isExplicit);
 
             var result = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, SerializableDiagnosticAnalysisResults>(
@@ -228,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             return new DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>(
                 result.Value.Diagnostics.ToImmutableDictionary(
-                    entry => analyzerMap[entry.analyzerId],
+                    entry => IReadOnlyDictionaryExtensions.GetValueOrDefault(projectAnalyzerMap, entry.analyzerId) ?? hostAnalyzerMap[entry.analyzerId],
                     entry => DiagnosticAnalysisResult.Create(
                         project,
                         version,
@@ -237,7 +278,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         nonLocalMap: Hydrate(entry.diagnosticMap.NonLocal, project),
                         others: entry.diagnosticMap.Other,
                         documentIds)),
-                result.Value.Telemetry.ToImmutableDictionary(entry => analyzerMap[entry.analyzerId], entry => entry.telemetry));
+                result.Value.Telemetry.ToImmutableDictionary(
+                    entry => IReadOnlyDictionaryExtensions.GetValueOrDefault(projectAnalyzerMap, entry.analyzerId) ?? hostAnalyzerMap[entry.analyzerId],
+                    entry => entry.telemetry));
         }
 
         // TODO: filter in OOP https://github.com/dotnet/roslyn/issues/47859

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         }
                         else
                         {
-                            var analyzerWithStateAndEmptyData = new AnalyzerWithState(analyzerWithState.Analyzer, analyzerWithState.State, DocumentAnalysisData.Empty);
+                            var analyzerWithStateAndEmptyData = new AnalyzerWithState(analyzerWithState.Analyzer, analyzerWithState.IsHostAnalyzer, analyzerWithState.State, DocumentAnalysisData.Empty);
                             if (!compilerAnalyzerData.HasValue && analyzerWithState.Analyzer.IsCompilerAnalyzer())
                                 compilerAnalyzerData = (analyzerWithStateAndEmptyData, spanBased: false);
                             else

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var language = arg.Language;
                     var analyzersPerReference = hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
 
-                    var analyzerMap = CreateStateSetMap(language, analyzersPerReference.Values, includeWorkspacePlaceholderAnalyzers: true);
+                    var analyzerMap = CreateStateSetMap(language, [], analyzersPerReference.Values, includeWorkspacePlaceholderAnalyzers: true);
 
                     return new HostAnalyzerStateSets(analyzerMap);
                 }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return ProjectAnalyzerStateSets.Default;
                 }
 
-                var newMap = CreateStateSetMap(project.Language, analyzersPerReference.Values, includeWorkspacePlaceholderAnalyzers: false);
+                var newMap = CreateStateSetMap(project.Language, analyzersPerReference.Values, [], includeWorkspacePlaceholderAnalyzers: false);
                 var skippedAnalyzersInfo = project.GetSkippedAnalyzersInfo(_analyzerInfoCache);
                 return new ProjectAnalyzerStateSets(project.AnalyzerReferences, analyzersPerReference, newMap, skippedAnalyzersInfo);
             }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -23,14 +23,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             public readonly string Language;
             public readonly DiagnosticAnalyzer Analyzer;
+            public readonly bool IsHostAnalyzer;
 
             private readonly ConcurrentDictionary<DocumentId, ActiveFileState> _activeFileStates;
             private readonly ConcurrentDictionary<ProjectId, ProjectState> _projectStates;
 
-            public StateSet(string language, DiagnosticAnalyzer analyzer)
+            public StateSet(string language, DiagnosticAnalyzer analyzer, bool isHostAnalyzer)
             {
                 Language = language;
                 Analyzer = analyzer;
+                IsHostAnalyzer = isHostAnalyzer;
 
                 _activeFileStates = new ConcurrentDictionary<DocumentId, ActiveFileState>(concurrencyLevel: 2, capacity: 10);
                 _projectStates = new ConcurrentDictionary<ProjectId, ProjectState>(concurrencyLevel: 2, capacity: 1);

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.ProjectAndCompilationWithAnalyzers.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.ProjectAndCompilationWithAnalyzers.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private sealed class ProjectAndCompilationWithAnalyzers
         {
             public Project Project { get; }
-            public CompilationWithAnalyzers? CompilationWithAnalyzers { get; }
+            public CompilationWithAnalyzersPair? CompilationWithAnalyzers { get; }
 
-            public ProjectAndCompilationWithAnalyzers(Project project, CompilationWithAnalyzers? compilationWithAnalyzers)
+            public ProjectAndCompilationWithAnalyzers(Project project, CompilationWithAnalyzersPair? compilationWithAnalyzers)
             {
                 Project = project;
                 CompilationWithAnalyzers = compilationWithAnalyzers;

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
@@ -287,7 +287,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
                 foreach (var diagnosticItem in group)
                 {
-                    var severity = diagnosticItem.Descriptor.GetEffectiveSeverity(project.CompilationOptions, analyzerConfigOptions?.ConfigOptions, analyzerConfigOptions?.TreeOptions);
+                    // Currently only project analyzers show in Solution Explorer, so we never need to consider fallback options.
+                    var severity = diagnosticItem.Descriptor.GetEffectiveSeverity(project.CompilationOptions, analyzerConfigOptions?.ConfigOptionsWithoutFallback, analyzerConfigOptions?.TreeOptions);
                     selectedItemSeverities.Add(severity);
                 }
             }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
@@ -116,7 +116,8 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
             return;
         }
 
-        var newDiagnosticItems = GenerateDiagnosticItems(project, analyzerReference);
+        // Currently only project analyzers show in Solution Explorer, so isHostAnalyzer is always false.
+        var newDiagnosticItems = GenerateDiagnosticItems(project, analyzerReference, isHostAnalyzer: false);
         var newSourceGeneratorItems = await GenerateSourceGeneratorItemsAsync(
             project, analyzerReference).ConfigureAwait(false);
 
@@ -143,7 +144,8 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
 
         ImmutableArray<BaseItem> GenerateDiagnosticItems(
             Project project,
-            AnalyzerReference analyzerReference)
+            AnalyzerReference analyzerReference,
+            bool isHostAnalyzer)
         {
             var generalDiagnosticOption = project.CompilationOptions!.GeneralDiagnosticOption;
             var specificDiagnosticOptions = project.CompilationOptions!.SpecificDiagnosticOptions;
@@ -158,7 +160,7 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
                     var selectedDiagnostic = g.OrderBy(d => d, s_comparer).First();
                     var effectiveSeverity = selectedDiagnostic.GetEffectiveSeverity(
                         project.CompilationOptions!,
-                        analyzerConfigOptions?.ConfigOptions,
+                        isHostAnalyzer ? analyzerConfigOptions?.ConfigOptionsWithFallback : analyzerConfigOptions?.ConfigOptionsWithoutFallback,
                         analyzerConfigOptions?.TreeOptions);
                     return (BaseItem)new DiagnosticItem(project.Id, analyzerReference, selectedDiagnostic, effectiveSeverity, CommandHandler);
                 });

--- a/src/Workspaces/Core/Portable/Diagnostics/CompilationWithAnalyzersPair.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/CompilationWithAnalyzersPair.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics;
+
+internal sealed class CompilationWithAnalyzersPair
+{
+    private readonly CompilationWithAnalyzers? _projectCompilationWithAnalyzers;
+    private readonly CompilationWithAnalyzers? _hostCompilationWithAnalyzers;
+
+    public CompilationWithAnalyzersPair(CompilationWithAnalyzers? projectCompilationWithAnalyzers, CompilationWithAnalyzers? hostCompilationWithAnalyzers)
+    {
+        if (projectCompilationWithAnalyzers is not null && hostCompilationWithAnalyzers is not null)
+        {
+            Contract.ThrowIfFalse(projectCompilationWithAnalyzers.AnalysisOptions.ReportSuppressedDiagnostics == hostCompilationWithAnalyzers.AnalysisOptions.ReportSuppressedDiagnostics);
+            Contract.ThrowIfFalse(projectCompilationWithAnalyzers.AnalysisOptions.ConcurrentAnalysis == hostCompilationWithAnalyzers.AnalysisOptions.ConcurrentAnalysis);
+        }
+        else
+        {
+            Contract.ThrowIfTrue(projectCompilationWithAnalyzers is null && hostCompilationWithAnalyzers is null);
+        }
+
+        _projectCompilationWithAnalyzers = projectCompilationWithAnalyzers;
+        _hostCompilationWithAnalyzers = hostCompilationWithAnalyzers;
+    }
+
+    public Compilation? ProjectCompilation => _projectCompilationWithAnalyzers?.Compilation;
+
+    public Compilation? HostCompilation => _hostCompilationWithAnalyzers?.Compilation;
+
+    public CompilationWithAnalyzers? ProjectCompilationWithAnalyzers => _projectCompilationWithAnalyzers;
+
+    public CompilationWithAnalyzers? HostCompilationWithAnalyzers => _hostCompilationWithAnalyzers;
+
+    public bool ReportSuppressedDiagnostics => _projectCompilationWithAnalyzers?.AnalysisOptions.ReportSuppressedDiagnostics ?? _hostCompilationWithAnalyzers!.AnalysisOptions.ReportSuppressedDiagnostics;
+
+    public bool ConcurrentAnalysis => _projectCompilationWithAnalyzers?.AnalysisOptions.ConcurrentAnalysis ?? _hostCompilationWithAnalyzers!.AnalysisOptions.ConcurrentAnalysis;
+
+    public bool HasAnalyzers => ProjectAnalyzers.Any() || HostAnalyzers.Any();
+
+    public ImmutableArray<DiagnosticAnalyzer> ProjectAnalyzers => _projectCompilationWithAnalyzers?.Analyzers ?? [];
+
+    public ImmutableArray<DiagnosticAnalyzer> HostAnalyzers => _hostCompilationWithAnalyzers?.Analyzers ?? [];
+
+    public Task<AnalyzerTelemetryInfo> GetAnalyzerTelemetryInfoAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
+    {
+        if (ProjectAnalyzers.Contains(analyzer))
+        {
+            return ProjectCompilationWithAnalyzers!.GetAnalyzerTelemetryInfoAsync(analyzer, cancellationToken);
+        }
+        else
+        {
+            Debug.Assert(HostAnalyzers.Contains(analyzer));
+            return HostCompilationWithAnalyzers!.GetAnalyzerTelemetryInfoAsync(analyzer, cancellationToken);
+        }
+    }
+
+    public async Task<(AnalysisResult? projectAnalysisResult, AnalysisResult? hostAnalysisResult)> GetAnalysisResultAsync(CancellationToken cancellationToken)
+    {
+        var projectAnalysisResult = ProjectCompilationWithAnalyzers is not null
+            ? await ProjectCompilationWithAnalyzers.GetAnalysisResultAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+        var hostAnalysisResult = HostCompilationWithAnalyzers is not null
+            ? await HostCompilationWithAnalyzers.GetAnalysisResultAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+
+        return (projectAnalysisResult, hostAnalysisResult);
+    }
+
+    public async Task<(AnalysisResult? projectAnalysisResult, AnalysisResult? hostAnalysisResult)> GetAnalysisResultAsync(SyntaxTree tree, TextSpan? filterSpan, ImmutableArray<DiagnosticAnalyzer> projectAnalyzers, ImmutableArray<DiagnosticAnalyzer> hostAnalyzers, CancellationToken cancellationToken)
+    {
+        var projectAnalysisResult = projectAnalyzers.Any()
+            ? await ProjectCompilationWithAnalyzers!.GetAnalysisResultAsync(tree, filterSpan, projectAnalyzers, cancellationToken).ConfigureAwait(false)
+            : null;
+        var hostAnalysisResult = hostAnalyzers.Any()
+            ? await HostCompilationWithAnalyzers!.GetAnalysisResultAsync(tree, filterSpan, hostAnalyzers, cancellationToken).ConfigureAwait(false)
+            : null;
+
+        return (projectAnalysisResult, hostAnalysisResult);
+    }
+
+    public async Task<(AnalysisResult? projectAnalysisResult, AnalysisResult? hostAnalysisResult)> GetAnalysisResultAsync(AdditionalText file, TextSpan? filterSpan, ImmutableArray<DiagnosticAnalyzer> projectAnalyzers, ImmutableArray<DiagnosticAnalyzer> hostAnalyzers, CancellationToken cancellationToken)
+    {
+        var projectAnalysisResult = projectAnalyzers.Any()
+            ? await ProjectCompilationWithAnalyzers!.GetAnalysisResultAsync(file, filterSpan, projectAnalyzers, cancellationToken).ConfigureAwait(false)
+            : null;
+        var hostAnalysisResult = hostAnalyzers.Any()
+            ? await HostCompilationWithAnalyzers!.GetAnalysisResultAsync(file, filterSpan, hostAnalyzers, cancellationToken).ConfigureAwait(false)
+            : null;
+
+        return (projectAnalysisResult, hostAnalysisResult);
+    }
+
+    public async Task<(AnalysisResult? projectAnalysisResult, AnalysisResult? hostAnalysisResult)> GetAnalysisResultAsync(SemanticModel model, TextSpan? filterSpan, ImmutableArray<DiagnosticAnalyzer> projectAnalyzers, ImmutableArray<DiagnosticAnalyzer> hostAnalyzers, CancellationToken cancellationToken)
+    {
+        var projectAnalysisResult = projectAnalyzers.Any()
+            ? await ProjectCompilationWithAnalyzers!.GetAnalysisResultAsync(model, filterSpan, projectAnalyzers, cancellationToken).ConfigureAwait(false)
+            : null;
+        var hostAnalysisResult = hostAnalyzers.Any()
+            ? await HostCompilationWithAnalyzers!.GetAnalysisResultAsync(model, filterSpan, hostAnalyzers, cancellationToken).ConfigureAwait(false)
+            : null;
+
+        return (projectAnalysisResult, hostAnalysisResult);
+    }
+}

--- a/src/Workspaces/Core/Portable/Diagnostics/DocumentAnalysisScope.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DocumentAnalysisScope.cs
@@ -21,15 +21,19 @@ internal sealed class DocumentAnalysisScope
     public DocumentAnalysisScope(
         TextDocument document,
         TextSpan? span,
-        ImmutableArray<DiagnosticAnalyzer> analyzers,
+        ImmutableArray<DiagnosticAnalyzer> projectAnalyzers,
+        ImmutableArray<DiagnosticAnalyzer> hostAnalyzers,
         AnalysisKind kind)
     {
         Debug.Assert(kind is AnalysisKind.Syntax or AnalysisKind.Semantic);
-        Debug.Assert(!analyzers.IsDefaultOrEmpty);
+        Debug.Assert(!projectAnalyzers.IsDefault);
+        Debug.Assert(!hostAnalyzers.IsDefault);
+        Debug.Assert(!projectAnalyzers.IsEmpty || !hostAnalyzers.IsEmpty);
 
         TextDocument = document;
         Span = span;
-        Analyzers = analyzers;
+        ProjectAnalyzers = projectAnalyzers;
+        HostAnalyzers = hostAnalyzers;
         Kind = kind;
 
         _lazyAdditionalFile = new Lazy<AdditionalText>(ComputeAdditionalFile);
@@ -37,7 +41,8 @@ internal sealed class DocumentAnalysisScope
 
     public TextDocument TextDocument { get; }
     public TextSpan? Span { get; }
-    public ImmutableArray<DiagnosticAnalyzer> Analyzers { get; }
+    public ImmutableArray<DiagnosticAnalyzer> ProjectAnalyzers { get; }
+    public ImmutableArray<DiagnosticAnalyzer> HostAnalyzers { get; }
     public AnalysisKind Kind { get; }
 
     /// <summary>
@@ -55,8 +60,8 @@ internal sealed class DocumentAnalysisScope
     }
 
     public DocumentAnalysisScope WithSpan(TextSpan? span)
-        => new(TextDocument, span, Analyzers, Kind);
+        => new(TextDocument, span, ProjectAnalyzers, HostAnalyzers, Kind);
 
-    public DocumentAnalysisScope WithAnalyzers(ImmutableArray<DiagnosticAnalyzer> analyzers)
-        => new(TextDocument, Span, analyzers, Kind);
+    public DocumentAnalysisScope WithAnalyzers(ImmutableArray<DiagnosticAnalyzer> projectAnalyzers, ImmutableArray<DiagnosticAnalyzer> hostAnalyzers)
+        => new(TextDocument, Span, projectAnalyzers, hostAnalyzers, Kind);
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -96,7 +96,7 @@ internal static partial class Extensions
         Project project,
         VersionStamp version,
         Compilation compilation,
-        IEnumerable<DiagnosticAnalyzer> analyzers,
+        ImmutableArray<DiagnosticAnalyzer> analyzers,
         SkippedHostAnalyzersInfo skippedAnalyzersInfo,
         bool includeSuppressedDiagnostics,
         CancellationToken cancellationToken)
@@ -205,7 +205,7 @@ internal static partial class Extensions
                     {
                         var diagnostics = additionalPragmaSuppressionDiagnostics.WhereAsArray(d => d.Location.SourceTree == treeToAnalyze);
                         AddDiagnosticsToResult(diagnostics, ref result, compilation, treeToAnalyze, additionalDocumentId: null,
-                            documentAnalysisScope!.Span, AnalysisKind.Semantic, diagnosticIdsToFilter, includeSuppressedDiagnostics);
+                            documentAnalysisScope.Span, AnalysisKind.Semantic, diagnosticIdsToFilter, includeSuppressedDiagnostics);
                     }
                 }
                 else
@@ -313,8 +313,8 @@ internal static partial class Extensions
             filterSpan.HasValue && !filterSpan.Value.IntersectsWith(diagnostic.Location.SourceSpan));
     }
 
-    public static async Task<(AnalysisResult result, ImmutableArray<Diagnostic> additionalDiagnostics)> GetAnalysisResultAsync(
-        this CompilationWithAnalyzers compilationWithAnalyzers,
+    public static async Task<(AnalysisResult? projectAnalysisResult, AnalysisResult? hostAnalysisResult, ImmutableArray<Diagnostic> additionalDiagnostics)> GetAnalysisResultAsync(
+        this CompilationWithAnalyzersPair compilationWithAnalyzers,
         DocumentAnalysisScope? documentAnalysisScope,
         Project project,
         DiagnosticAnalyzerInfoCache analyzerInfoCache,
@@ -323,11 +323,11 @@ internal static partial class Extensions
         var result = await GetAnalysisResultAsync(compilationWithAnalyzers, documentAnalysisScope, cancellationToken).ConfigureAwait(false);
         var additionalDiagnostics = await compilationWithAnalyzers.GetPragmaSuppressionAnalyzerDiagnosticsAsync(
             documentAnalysisScope, project, analyzerInfoCache, cancellationToken).ConfigureAwait(false);
-        return (result, additionalDiagnostics);
+        return (result.projectAnalysisResult, result.hostAnalysisResult, additionalDiagnostics);
     }
 
-    private static async Task<AnalysisResult> GetAnalysisResultAsync(
-        CompilationWithAnalyzers compilationWithAnalyzers,
+    private static async Task<(AnalysisResult? projectAnalysisResult, AnalysisResult? hostAnalysisResult)> GetAnalysisResultAsync(
+        CompilationWithAnalyzersPair compilationWithAnalyzers,
         DocumentAnalysisScope? documentAnalysisScope,
         CancellationToken cancellationToken)
     {
@@ -336,7 +336,8 @@ internal static partial class Extensions
             return await compilationWithAnalyzers.GetAnalysisResultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        Debug.Assert(documentAnalysisScope.Analyzers.ToSet().IsSubsetOf(compilationWithAnalyzers.Analyzers));
+        Debug.Assert(documentAnalysisScope.ProjectAnalyzers.ToSet().IsSubsetOf(compilationWithAnalyzers.ProjectAnalyzers));
+        Debug.Assert(documentAnalysisScope.HostAnalyzers.ToSet().IsSubsetOf(compilationWithAnalyzers.HostAnalyzers));
 
         switch (documentAnalysisScope.Kind)
         {
@@ -344,16 +345,16 @@ internal static partial class Extensions
                 if (documentAnalysisScope.TextDocument is Document document)
                 {
                     var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                    return await compilationWithAnalyzers.GetAnalysisResultAsync(tree, documentAnalysisScope.Span, documentAnalysisScope.Analyzers, cancellationToken).ConfigureAwait(false);
+                    return await compilationWithAnalyzers.GetAnalysisResultAsync(tree, documentAnalysisScope.Span, documentAnalysisScope.ProjectAnalyzers, documentAnalysisScope.HostAnalyzers, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    return await compilationWithAnalyzers.GetAnalysisResultAsync(documentAnalysisScope.AdditionalFile, documentAnalysisScope.Span, documentAnalysisScope.Analyzers, cancellationToken).ConfigureAwait(false);
+                    return await compilationWithAnalyzers.GetAnalysisResultAsync(documentAnalysisScope.AdditionalFile, documentAnalysisScope.Span, documentAnalysisScope.ProjectAnalyzers, documentAnalysisScope.HostAnalyzers, cancellationToken).ConfigureAwait(false);
                 }
 
             case AnalysisKind.Semantic:
                 var model = await ((Document)documentAnalysisScope.TextDocument).GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                return await compilationWithAnalyzers.GetAnalysisResultAsync(model, documentAnalysisScope.Span, documentAnalysisScope.Analyzers, cancellationToken).ConfigureAwait(false);
+                return await compilationWithAnalyzers.GetAnalysisResultAsync(model, documentAnalysisScope.Span, documentAnalysisScope.ProjectAnalyzers, documentAnalysisScope.HostAnalyzers, cancellationToken).ConfigureAwait(false);
 
             default:
                 throw ExceptionUtilities.UnexpectedValue(documentAnalysisScope.Kind);
@@ -361,16 +362,18 @@ internal static partial class Extensions
     }
 
     private static async Task<ImmutableArray<Diagnostic>> GetPragmaSuppressionAnalyzerDiagnosticsAsync(
-        this CompilationWithAnalyzers compilationWithAnalyzers,
+        this CompilationWithAnalyzersPair compilationWithAnalyzers,
         DocumentAnalysisScope? documentAnalysisScope,
         Project project,
         DiagnosticAnalyzerInfoCache analyzerInfoCache,
         CancellationToken cancellationToken)
     {
-        var analyzers = documentAnalysisScope?.Analyzers ?? compilationWithAnalyzers.Analyzers;
-        var suppressionAnalyzer = analyzers.OfType<IPragmaSuppressionsAnalyzer>().FirstOrDefault();
+        var hostAnalyzers = documentAnalysisScope?.HostAnalyzers ?? compilationWithAnalyzers.HostAnalyzers;
+        var suppressionAnalyzer = hostAnalyzers.OfType<IPragmaSuppressionsAnalyzer>().FirstOrDefault();
         if (suppressionAnalyzer == null)
             return [];
+
+        RoslynDebug.AssertNotNull(compilationWithAnalyzers.HostCompilationWithAnalyzers);
 
         if (documentAnalysisScope != null)
         {
@@ -379,24 +382,24 @@ internal static partial class Extensions
 
             using var _ = ArrayBuilder<Diagnostic>.GetInstance(out var diagnosticsBuilder);
             await AnalyzeDocumentAsync(
-                compilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer,
+                compilationWithAnalyzers.HostCompilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer,
                 document, documentAnalysisScope.Span, diagnosticsBuilder.Add, cancellationToken).ConfigureAwait(false);
             return diagnosticsBuilder.ToImmutableAndClear();
         }
         else
         {
-            if (compilationWithAnalyzers.AnalysisOptions.ConcurrentAnalysis)
+            if (compilationWithAnalyzers.ConcurrentAnalysis)
             {
                 return await ProducerConsumer<Diagnostic>.RunParallelAsync(
                     source: project.GetAllRegularAndSourceGeneratedDocumentsAsync(cancellationToken),
                     produceItems: static async (document, callback, args, cancellationToken) =>
                     {
-                        var (compilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer) = args;
+                        var (hostCompilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer) = args;
                         await AnalyzeDocumentAsync(
-                            compilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer,
+                            hostCompilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer,
                             document, span: null, callback, cancellationToken).ConfigureAwait(false);
                     },
-                    args: (compilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer),
+                    args: (compilationWithAnalyzers.HostCompilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer),
                     cancellationToken).ConfigureAwait(false);
             }
             else
@@ -405,7 +408,7 @@ internal static partial class Extensions
                 await foreach (var document in project.GetAllRegularAndSourceGeneratedDocumentsAsync(cancellationToken))
                 {
                     await AnalyzeDocumentAsync(
-                        compilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer,
+                        compilationWithAnalyzers.HostCompilationWithAnalyzers, analyzerInfoCache, suppressionAnalyzer,
                         document, span: null, diagnosticsBuilder.Add, cancellationToken).ConfigureAwait(false);
                 }
 
@@ -414,7 +417,7 @@ internal static partial class Extensions
         }
 
         static async Task AnalyzeDocumentAsync(
-            CompilationWithAnalyzers compilationWithAnalyzers,
+            CompilationWithAnalyzers hostCompilationWithAnalyzers,
             DiagnosticAnalyzerInfoCache analyzerInfoCache,
             IPragmaSuppressionsAnalyzer suppressionAnalyzer,
             Document document,
@@ -424,7 +427,7 @@ internal static partial class Extensions
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             await suppressionAnalyzer.AnalyzeAsync(
-                semanticModel, span, compilationWithAnalyzers, analyzerInfoCache.GetDiagnosticDescriptors, reportDiagnostic, cancellationToken).ConfigureAwait(false);
+                semanticModel, span, hostCompilationWithAnalyzers, analyzerInfoCache.GetDiagnosticDescriptors, reportDiagnostic, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/OrganizeImports/OrganizeImportsOptionsProviders.cs
+++ b/src/Workspaces/Core/Portable/OrganizeImports/OrganizeImportsOptionsProviders.cs
@@ -22,7 +22,7 @@ internal static class OrganizeImportsOptionsProviders
 
     public static async ValueTask<OrganizeImportsOptions> GetOrganizeImportsOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetOrganizeImportsOptions(document.Project.Language);
     }
 }

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.CodeAnalysis.Project.HostAnalyzerOptions.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
 Microsoft.CodeAnalysis.ProjectInfo.WithId(Microsoft.CodeAnalysis.ProjectId id) -> Microsoft.CodeAnalysis.ProjectInfo
 virtual Microsoft.CodeAnalysis.Host.HostLanguageServices.Dispose() -> void
 virtual Microsoft.CodeAnalysis.Host.HostWorkspaceServices.Dispose() -> void

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigData.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigData.cs
@@ -10,13 +10,24 @@ namespace Microsoft.CodeAnalysis;
 /// <summary>
 /// Aggregate analyzer config options for a specific path.
 /// </summary>
-internal readonly struct AnalyzerConfigData(AnalyzerConfigOptionsResult result, StructuredAnalyzerConfigOptions fallbackOptions)
+internal readonly struct AnalyzerConfigData
 {
-    public readonly StructuredAnalyzerConfigOptions ConfigOptions = StructuredAnalyzerConfigOptions.Create(
-        new DictionaryAnalyzerConfigOptions(result.AnalyzerOptions), fallbackOptions);
+    private readonly AnalyzerConfigOptions _dictionaryConfigOptions;
+
+    public readonly StructuredAnalyzerConfigOptions ConfigOptionsWithoutFallback;
+
+    public readonly StructuredAnalyzerConfigOptions ConfigOptionsWithFallback;
 
     /// <summary>
     /// These options do not fall back.
     /// </summary>
-    public readonly ImmutableDictionary<string, ReportDiagnostic> TreeOptions = result.TreeOptions;
+    public readonly ImmutableDictionary<string, ReportDiagnostic> TreeOptions;
+
+    public AnalyzerConfigData(AnalyzerConfigOptionsResult result, StructuredAnalyzerConfigOptions fallbackOptions)
+    {
+        _dictionaryConfigOptions = new DictionaryAnalyzerConfigOptions(result.AnalyzerOptions);
+        ConfigOptionsWithoutFallback = StructuredAnalyzerConfigOptions.Create(_dictionaryConfigOptions, StructuredAnalyzerConfigOptions.Empty);
+        ConfigOptionsWithFallback = StructuredAnalyzerConfigOptions.Create(_dictionaryConfigOptions, fallbackOptions);
+        TreeOptions = result.TreeOptions;
+    }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -546,7 +546,7 @@ public class Document : TextDocument
     {
         var newAsyncLazy = AsyncLazy.Create(static async (arg, cancellationToken) =>
         {
-            var options = await arg.self.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var options = await arg.self.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
             return new DocumentOptionSet(options, arg.solutionOptions, arg.self.Project.Language);
         },
         arg: (self: this, solutionOptions));
@@ -555,9 +555,9 @@ public class Document : TextDocument
     }
 #pragma warning restore
 
-    internal async ValueTask<StructuredAnalyzerConfigOptions> GetAnalyzerConfigOptionsAsync(CancellationToken cancellationToken)
+    internal async ValueTask<StructuredAnalyzerConfigOptions> GetHostAnalyzerConfigOptionsAsync(CancellationToken cancellationToken)
     {
-        var provider = (ProjectState.ProjectAnalyzerConfigOptionsProvider)Project.State.AnalyzerOptions.AnalyzerConfigOptionsProvider;
+        var provider = (ProjectState.ProjectHostAnalyzerConfigOptionsProvider)Project.State.HostAnalyzerOptions.AnalyzerConfigOptionsProvider;
         return await provider.GetOptionsAsync(DocumentState, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -147,7 +147,12 @@ public partial class Project
     /// <summary>
     /// The options used by analyzers for this project.
     /// </summary>
-    public AnalyzerOptions AnalyzerOptions => State.AnalyzerOptions;
+    public AnalyzerOptions AnalyzerOptions => State.ProjectAnalyzerOptions;
+
+    /// <summary>
+    /// The options used by analyzers for this project.
+    /// </summary>
+    public AnalyzerOptions HostAnalyzerOptions => State.HostAnalyzerOptions;
 
     /// <summary>
     /// The options used when building the compilation for this project.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Host;
@@ -58,7 +59,11 @@ internal partial class ProjectState
     /// </summary>
     private readonly AnalyzerConfigOptionsCache _analyzerConfigOptionsCache;
 
-    private AnalyzerOptions? _lazyAnalyzerOptions;
+    private ImmutableArray<AdditionalText> _lazyAdditionalFiles;
+
+    private AnalyzerOptions? _lazyProjectAnalyzerOptions;
+
+    private AnalyzerOptions? _lazyHostAnalyzerOptions;
 
     private ProjectState(
         ProjectInfo projectInfo,
@@ -291,10 +296,32 @@ internal partial class ProjectState
             typeof(TDocumentState) == typeof(AnalyzerConfigDocumentState) ? new AnalyzerConfigDocumentState(LanguageServices.SolutionServices, documentInfo, new LoadTextOptions(ChecksumAlgorithm)) :
             throw ExceptionUtilities.UnexpectedValue(typeof(TDocumentState)));
 
-    public AnalyzerOptions AnalyzerOptions
-        => _lazyAnalyzerOptions ??= new AnalyzerOptions(
-            additionalFiles: AdditionalDocumentStates.SelectAsArray(static documentState => documentState.AdditionalText),
-            optionsProvider: new ProjectAnalyzerConfigOptionsProvider(this));
+    private ImmutableArray<AdditionalText> AdditionalFiles
+    {
+        get
+        {
+            return InterlockedOperations.Initialize(
+                ref _lazyAdditionalFiles,
+                static self => self.AdditionalDocumentStates.SelectAsArray(static documentState => documentState.AdditionalText),
+                this);
+        }
+    }
+
+    public AnalyzerOptions ProjectAnalyzerOptions
+        => InterlockedOperations.Initialize(
+            ref _lazyProjectAnalyzerOptions,
+            static self => new AnalyzerOptions(
+                additionalFiles: self.AdditionalFiles,
+                optionsProvider: new ProjectAnalyzerConfigOptionsProvider(self)),
+            this);
+
+    public AnalyzerOptions HostAnalyzerOptions
+        => InterlockedOperations.Initialize(
+            ref _lazyHostAnalyzerOptions,
+            static self => new AnalyzerOptions(
+                additionalFiles: self.AdditionalFiles,
+                optionsProvider: new ProjectHostAnalyzerConfigOptionsProvider(self)),
+            this);
 
     public AnalyzerConfigData GetAnalyzerOptionsForPath(string path, CancellationToken cancellationToken)
         => _analyzerConfigOptionsCache.Lazy.GetValue(cancellationToken).GetOptionsForSourcePath(path);
@@ -334,13 +361,83 @@ internal partial class ProjectState
 
     internal sealed class ProjectAnalyzerConfigOptionsProvider(ProjectState projectState) : AnalyzerConfigOptionsProvider
     {
+        private AnalyzerConfigOptionsCache.Value GetCache()
+            => projectState._analyzerConfigOptionsCache.Lazy.GetValue(CancellationToken.None);
+
+        public override AnalyzerConfigOptions GlobalOptions
+            => GetCache().GlobalConfigOptions.ConfigOptionsWithoutFallback;
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
+        {
+            var documentId = DocumentState.GetDocumentIdForTree(tree);
+            var cache = GetCache();
+            if (documentId != null && projectState.DocumentStates.TryGetState(documentId, out var documentState))
+            {
+                return GetOptions(cache, documentState);
+            }
+
+            return GetOptionsForSourcePath(cache, tree.FilePath);
+        }
+
+        internal async ValueTask<StructuredAnalyzerConfigOptions> GetOptionsAsync(DocumentState documentState, CancellationToken cancellationToken)
+        {
+            var cache = await projectState._analyzerConfigOptionsCache.Lazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            return GetOptions(cache, documentState);
+        }
+
+        private StructuredAnalyzerConfigOptions GetOptions(in AnalyzerConfigOptionsCache.Value cache, DocumentState documentState)
+        {
+            var filePath = GetEffectiveFilePath(documentState);
+            return filePath == null
+                ? StructuredAnalyzerConfigOptions.Empty
+                : GetOptionsForSourcePath(cache, filePath);
+        }
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
+        {
+            // TODO: correctly find the file path, since it looks like we give this the document's .Name under the covers if we don't have one
+            return GetOptionsForSourcePath(GetCache(), textFile.Path);
+        }
+
+        private static StructuredAnalyzerConfigOptions GetOptionsForSourcePath(in AnalyzerConfigOptionsCache.Value cache, string path)
+            => cache.GetOptionsForSourcePath(path).ConfigOptionsWithoutFallback;
+
+        private string? GetEffectiveFilePath(DocumentState documentState)
+        {
+            if (!string.IsNullOrEmpty(documentState.FilePath))
+            {
+                return documentState.FilePath;
+            }
+
+            // We need to work out path to this document. Documents may not have a "real" file path if they're something created
+            // as a part of a code action, but haven't been written to disk yet.
+
+            var projectFilePath = projectState.FilePath;
+
+            if (documentState.Name != null && projectFilePath != null)
+            {
+                var projectPath = PathUtilities.GetDirectoryName(projectFilePath);
+
+                if (!RoslynString.IsNullOrEmpty(projectPath) &&
+                    PathUtilities.GetDirectoryName(projectFilePath) is string directory)
+                {
+                    return PathUtilities.CombinePathsUnchecked(directory, documentState.Name);
+                }
+            }
+
+            return null;
+        }
+    }
+
+    internal sealed class ProjectHostAnalyzerConfigOptionsProvider(ProjectState projectState) : AnalyzerConfigOptionsProvider
+    {
         private RazorDesignTimeAnalyzerConfigOptions? _lazyRazorDesignTimeOptions = null;
 
         private AnalyzerConfigOptionsCache.Value GetCache()
             => projectState._analyzerConfigOptionsCache.Lazy.GetValue(CancellationToken.None);
 
         public override AnalyzerConfigOptions GlobalOptions
-            => GetCache().GlobalConfigOptions.ConfigOptions;
+            => GetCache().GlobalConfigOptions.ConfigOptionsWithoutFallback;
 
         public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
         {
@@ -382,7 +479,7 @@ internal partial class ProjectState
         }
 
         private static StructuredAnalyzerConfigOptions GetOptionsForSourcePath(in AnalyzerConfigOptionsCache.Value cache, string path)
-            => cache.GetOptionsForSourcePath(path).ConfigOptions;
+            => cache.GetOptionsForSourcePath(path).ConfigOptionsWithFallback;
 
         private string? GetEffectiveFilePath(DocumentState documentState)
         {
@@ -467,7 +564,7 @@ internal partial class ProjectState
         {
             var options = _lazyAnalyzerConfigSet.Lazy
                 .GetValue(cancellationToken).GetOptionsForSourcePath(tree.FilePath);
-            return GeneratedCodeUtilities.GetGeneratedCodeKindFromOptions(options.ConfigOptions);
+            return GeneratedCodeUtilities.GetGeneratedCodeKindFromOptions(options.ConfigOptionsWithoutFallback);
         }
 
         public override bool TryGetDiagnosticValue(SyntaxTree tree, string diagnosticId, CancellationToken cancellationToken, out ReportDiagnostic severity)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker_Generators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker_Generators.cs
@@ -396,7 +396,7 @@ internal partial class SolutionCompilationState
                 return compilationFactory.CreateGeneratorDriver(
                     projectState.ParseOptions!,
                     GetSourceGenerators(projectState),
-                    projectState.AnalyzerOptions.AnalyzerConfigOptionsProvider,
+                    projectState.ProjectAnalyzerOptions.AnalyzerConfigOptionsProvider,
                     additionalTexts);
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
@@ -127,7 +127,7 @@ internal partial class SolutionCompilationState
             public override bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput => true;
 
             public override GeneratorDriver TransformGeneratorDriver(GeneratorDriver generatorDriver)
-                => generatorDriver.WithUpdatedAnalyzerConfigOptions(NewProjectState.AnalyzerOptions.AnalyzerConfigOptionsProvider);
+                => generatorDriver.WithUpdatedAnalyzerConfigOptions(NewProjectState.ProjectAnalyzerOptions.AnalyzerConfigOptionsProvider);
         }
 
         internal sealed class RemoveDocumentsAction(
@@ -364,7 +364,7 @@ internal partial class SolutionCompilationState
                 var generatorDriver = oldGeneratorDriver
                     .ReplaceAdditionalTexts(this.NewProjectState.AdditionalDocumentStates.SelectAsArray(static documentState => documentState.AdditionalText))
                     .WithUpdatedParseOptions(this.NewProjectState.ParseOptions!)
-                    .WithUpdatedAnalyzerConfigOptions(this.NewProjectState.AnalyzerOptions.AnalyzerConfigOptionsProvider)
+                    .WithUpdatedAnalyzerConfigOptions(this.NewProjectState.ProjectAnalyzerOptions.AnalyzerConfigOptionsProvider)
                     .ReplaceGenerators(GetSourceGenerators(this.NewProjectState));
 
                 return generatorDriver;

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2154,8 +2154,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void FallbackAnalyzerOptions(bool isRoot)
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments(editorConfig: $"""
-                [*]
                 {(isRoot ? "root = true" : "")}
+                [*]
                 optionA = A
                 """);
             var solution = workspace.CurrentSolution;
@@ -2167,46 +2167,65 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     .Add("optionA", "fallbackA")
                     .Add("optionB", "fallbackB")))));
 
-            TestOptionValues(solution2, expectedA: "A", expectedB: "fallbackB");
+            TestOptionValues(solution2, expectedA: "A", hasBWithoutFallback: false, expectedB: "fallbackB", expectedBFile: "fallbackB");
 
             var solution3 = solution2.WithFallbackAnalyzerOptions(ImmutableDictionary<string, StructuredAnalyzerConfigOptions>.Empty
                .Add(LanguageNames.CSharp, StructuredAnalyzerConfigOptions.Create(new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty
                    .Add("optionA", "fallbackX")
                    .Add("optionB", "fallbackY")))));
 
-            TestOptionValues(solution3, expectedA: "A", expectedB: "fallbackY");
+            TestOptionValues(solution3, expectedA: "A", hasBWithoutFallback: false, expectedB: "fallbackY", expectedBFile: "fallbackY");
 
             Assert.True(workspace.TryApplyChanges(solution3));
-            TestOptionValues(workspace.CurrentSolution, expectedA: "A", expectedB: "fallbackY");
+            TestOptionValues(workspace.CurrentSolution, expectedA: "A", hasBWithoutFallback: false, expectedB: "fallbackY", expectedBFile: "fallbackY");
 
             var editorConfigContent = """
                 [*]
                 optionB = ec2
                 """;
             var editorConfigId = DocumentId.CreateNewId(solution3.Projects.Single().Id);
-            var solution4 = solution3.AddAnalyzerConfigDocument(editorConfigId, "editorconfig2", SourceText.From(editorConfigContent), filePath: Path.Combine(s_projectDir, "editorconfig2"));
+            var solution4 = solution3.AddAnalyzerConfigDocument(editorConfigId, ".editorconfig", SourceText.From(editorConfigContent), filePath: Path.Combine(s_projectDir, "subfolder", ".editorconfig"));
 
-            TestOptionValues(solution4, expectedA: "A", expectedB: "ec2");
+            TestOptionValues(solution4, expectedA: "A", hasBWithoutFallback: true, expectedB: "fallbackY", expectedBFile: "ec2");
 
-            static void TestOptionValues(Solution solution, string expectedA, string expectedB)
+            static void TestOptionValues(Solution solution, string expectedA, bool hasBWithoutFallback, string expectedB, string expectedBFile)
             {
                 var project2 = solution.Projects.Single();
 
                 var projectOptions = project2.GetAnalyzerConfigOptions();
                 Assert.NotNull(projectOptions);
 
-                Assert.True(projectOptions!.Value.ConfigOptions.TryGetValue("optionA", out var value1));
+                Assert.True(projectOptions!.Value.ConfigOptionsWithoutFallback.TryGetValue("optionA", out var value1));
+                Assert.Equal(expectedA, value1);
+                Assert.True(projectOptions!.Value.ConfigOptionsWithFallback.TryGetValue("optionA", out value1));
                 Assert.Equal(expectedA, value1);
 
-                Assert.True(projectOptions!.Value.ConfigOptions.TryGetValue("optionB", out var value2));
+                Assert.False(projectOptions!.Value.ConfigOptionsWithoutFallback.TryGetValue("optionB", out var value2));
+                Assert.Null(value2);
+                Assert.True(projectOptions!.Value.ConfigOptionsWithFallback.TryGetValue("optionB", out value2));
                 Assert.Equal(expectedB, value2);
 
                 var sourcePathOptions = project2.State.GetAnalyzerOptionsForPath(Path.Combine(s_projectDir, "x.cs"), CancellationToken.None);
-                Assert.True(sourcePathOptions.ConfigOptions.TryGetValue("optionA", out var value3));
+                Assert.True(sourcePathOptions.ConfigOptionsWithoutFallback.TryGetValue("optionA", out var value3));
+                Assert.Equal(expectedA, value3);
+                Assert.True(sourcePathOptions.ConfigOptionsWithFallback.TryGetValue("optionA", out value3));
                 Assert.Equal(expectedA, value3);
 
-                Assert.True(sourcePathOptions.ConfigOptions.TryGetValue("optionB", out var value4));
+                Assert.False(sourcePathOptions.ConfigOptionsWithoutFallback.TryGetValue("optionB", out var value4));
+                Assert.Null(value4);
+                Assert.True(sourcePathOptions.ConfigOptionsWithFallback.TryGetValue("optionB", out value4));
                 Assert.Equal(expectedB, value4);
+
+                sourcePathOptions = project2.State.GetAnalyzerOptionsForPath(Path.Combine(s_projectDir, "subfolder", "x.cs"), CancellationToken.None);
+                Assert.True(sourcePathOptions.ConfigOptionsWithoutFallback.TryGetValue("optionA", out var value5));
+                Assert.Equal(expectedA, value5);
+                Assert.True(sourcePathOptions.ConfigOptionsWithFallback.TryGetValue("optionA", out value5));
+                Assert.Equal(expectedA, value5);
+
+                Assert.Equal(hasBWithoutFallback, sourcePathOptions.ConfigOptionsWithoutFallback.TryGetValue("optionB", out var value6));
+                Assert.Equal(hasBWithoutFallback ? expectedBFile : null, value6);
+                Assert.True(sourcePathOptions.ConfigOptionsWithFallback.TryGetValue("optionB", out value6));
+                Assert.Equal(expectedBFile, value6);
             }
         }
 
@@ -5382,11 +5401,12 @@ class C
 #pragma warning restore
 
             var syntaxTree = await document.GetSyntaxTreeAsync();
-            var documentOptionsViaSyntaxTree = document.Project.State.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+            var documentOptionsViaSyntaxTree = document.Project.State.ProjectAnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
             Assert.Equal(appliedToDocument, documentOptionsViaSyntaxTree.TryGetValue("indent_style", out var value) == true && value == "tab");
 
             var projectOptions = document.Project.GetAnalyzerConfigOptions();
-            Assert.Equal(appliedToEntireProject, projectOptions?.ConfigOptions.TryGetValue("indent_style", out value) == true && value == "tab");
+            Assert.Equal(appliedToEntireProject, projectOptions?.ConfigOptionsWithoutFallback.TryGetValue("indent_style", out value) == true && value == "tab");
+            Assert.Equal(appliedToEntireProject, projectOptions?.ConfigOptionsWithFallback.TryGetValue("indent_style", out value) == true && value == "tab");
         }
 
         [Fact]

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -64,7 +64,7 @@ internal sealed class RemoteDiagnosticAnalyzerService : BrokeredServiceBase, IRe
                     var result = await DiagnosticComputer.GetDiagnosticsAsync(
                         document, project, solutionChecksum,
                         documentSpan,
-                        arguments.AnalyzerIds, documentAnalysisKind,
+                        arguments.ProjectAnalyzerIds, arguments.HostAnalyzerIds, documentAnalysisKind,
                         _analyzerInfoCache, hostWorkspaceServices,
                         isExplicit: arguments.IsExplicit,
                         reportSuppressedDiagnostics: arguments.ReportSuppressedDiagnostics,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IPragmaSuppressionsAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IPragmaSuppressionsAnalyzer.cs
@@ -22,7 +22,7 @@ internal interface IPragmaSuppressionsAnalyzer
     Task AnalyzeAsync(
         SemanticModel semanticModel,
         TextSpan? span,
-        CompilationWithAnalyzers compilationWithAnalyzers,
+        CompilationWithAnalyzers hostCompilationWithAnalyzers,
         Func<DiagnosticAnalyzer, ImmutableArray<DiagnosticDescriptor>> getSupportedDiagnostics,
         Action<Diagnostic> reportDiagnostic,
         CancellationToken cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Formatting/CSharpSyntaxFormattingOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Formatting/CSharpSyntaxFormattingOptionsProviders.cs
@@ -13,7 +13,7 @@ internal static class CSharpSyntaxFormattingOptionsProviders
 {
     public static async ValueTask<CSharpSyntaxFormattingOptions> GetCSharpSyntaxFormattingOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return new CSharpSyntaxFormattingOptions(configOptions);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Simplification/CSharpSimplifierOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Simplification/CSharpSimplifierOptionsProviders.cs
@@ -13,7 +13,7 @@ internal static class CSharpSimplifierOptionsProviders
 {
     public static async ValueTask<CSharpSimplifierOptions> GetCSharpSimplifierOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return new CSharpSimplifierOptions(configOptions);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/AddImport/AddImportPlacementOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/AddImport/AddImportPlacementOptionsProviders.cs
@@ -26,7 +26,7 @@ internal static class AddImportPlacementOptionsProviders
 
     public static async ValueTask<AddImportPlacementOptions> GetAddImportPlacementOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         var service = document.GetRequiredLanguageService<IAddImportsService>();
         return service.GetAddImportOptions(configOptions, document.AllowImportsInHiddenRegions());
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeCleanup/CodeCleanupOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeCleanup/CodeCleanupOptionsProviders.cs
@@ -26,7 +26,7 @@ internal static class CodeCleanupOptionsProviders
 
     public static async ValueTask<CodeCleanupOptions> GetCodeCleanupOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetCodeCleanupOptions(document.Project.GetExtendedLanguageServices().LanguageServices, document.AllowImportsInHiddenRegions());
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationOptionsProviders.cs
@@ -34,7 +34,7 @@ internal static class CodeGenerationOptionsProviders
 
     public static async ValueTask<CodeGenerationOptions> GetCodeGenerationOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetCodeGenerationOptions(document.Project.GetExtendedLanguageServices().LanguageServices);
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
@@ -225,7 +225,7 @@ internal static partial class DocumentExtensions
     }
 
 #if CODE_STYLE
-    public static async ValueTask<IOptionsReader> GetAnalyzerConfigOptionsAsync(this Document document, CancellationToken cancellationToken)
+    public static async ValueTask<IOptionsReader> GetHostAnalyzerConfigOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
         var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
         return document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree).GetOptionsReader();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
@@ -228,6 +228,9 @@ internal static partial class DocumentExtensions
     public static async ValueTask<IOptionsReader> GetHostAnalyzerConfigOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
         var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+
+        // Code style layer (which is always NuGet-installed) does not use host options, but we keep the method name to
+        // reduce the number of instances where code needs to be conditionally included.
         return document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree).GetOptionsReader();
     }
 #endif

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Formatting/DocumentFormattingOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Formatting/DocumentFormattingOptionsProviders.cs
@@ -21,7 +21,7 @@ internal static class DocumentFormattingOptionsProviders
 
     public static async ValueTask<DocumentFormattingOptions> GetDocumentFormattingOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetDocumentFormattingOptions();
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Formatting/LineFormattingOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Formatting/LineFormattingOptionsProviders.cs
@@ -16,7 +16,7 @@ internal static class LineFormattingOptionsProviders
 
     public static async ValueTask<LineFormattingOptions> GetLineFormattingOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetLineFormattingOptions(document.Project.Language);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Formatting/SyntaxFormattingOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Formatting/SyntaxFormattingOptionsProviders.cs
@@ -19,7 +19,7 @@ internal static class SyntaxFormattingOptionsProviders
 
     public static async ValueTask<SyntaxFormattingOptions> GetSyntaxFormattingOptionsAsync(this Document document, ISyntaxFormatting formatting, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return formatting.GetFormattingOptions(configOptions);
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/NamingStyles/NamingStylePreferencesProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/NamingStyles/NamingStylePreferencesProviders.cs
@@ -14,7 +14,7 @@ internal static class NamingStylePreferencesProviders
 {
     public static async ValueTask<NamingStylePreferences> GetNamingStylePreferencesAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetOption(NamingStyleOptions.NamingPreferences, document.Project.Language);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Options/MemberDisplayOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Options/MemberDisplayOptions.cs
@@ -49,7 +49,7 @@ internal static class MemberDisplayOptionsProviders
 
     public static async ValueTask<MemberDisplayOptions> GetMemberDisplayOptionsAsync(this Document document, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return configOptions.GetMemberDisplayOptions(document.Project.Language);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/SimplifierOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/SimplifierOptionsProviders.cs
@@ -19,7 +19,7 @@ internal static class SimplifierOptionsProviders
 
     public static async ValueTask<SimplifierOptions> GetSimplifierOptionsAsync(this Document document, ISimplification simplification, CancellationToken cancellationToken)
     {
-        var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
+        var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
         return simplification.GetSimplifierOptions(configOptions);
     }
 


### PR DESCRIPTION
* Separate analysis passes into "project" analyzers (aka NuGet-installed analyzers) and "solution" analyzers (aka host- or VSIX-installed analyzers)
* Only provide fallback options from the host for host-installed analyzers

### Items not covered by this pull request

* Redirect Code Style analyzers to Features analyzers when loaded in Visual Studio. This is addressed separately by #75250.
* Treat Features analyzers as project analyzers when they are being used in place of Code Style analyzers.
* NuGet-installed code fixes and refactorings should not use host options, but currently they do. Only source generators and analyzers are corrected by this pull request.

### Known issues introduced by this change

* Prior to this change, NuGet-installed diagnostic suppressors were able to suppress diagnostics reported by VSIX-installed analyzers. This is no longer possible. To resolve this issue, NuGet-installed analyzers need to be added to _both_ `CompilationWithAnalyzers` instances, but for the host instance, only the diagnostic suppressors should run. #75399