### PR TITLE
Don't update xaml tool

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -372,6 +372,7 @@ extends:
             publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-roslyn/items?path=eng/config/PublishData.json&api-version=6.0"
             publishDataAccessToken: "$(System.AccessToken)"
             dropPath: '$(Pipeline.Workspace)\VSSetup'
+            updateXamlRoslynVersion: false
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -46,6 +46,9 @@ parameters:
   - name: dropPath
     type: string
     default: ''
+  - name: updateXamlRoslynVersion
+    type: boolean
+    default: true
 
 steps:
   - checkout: none
@@ -208,6 +211,7 @@ steps:
         -visualStudioBranchName "$(Template.VSBranchName)" `
         -writePullRequest "prid.txt" `
         -queueSpeedometerValidation "${{ parameters.queueSpeedometerValidation }}"
+        -updatexamlroslynversion "${{ parameters.updateXamlRoslynVersion }}"
     displayName: 'Run OneOffInsertion.ps1'
 
   - script: 'echo. && echo. && type "prid.txt" && echo. && echo.'


### PR DESCRIPTION
https://github.com/dotnet/roslyn-tools/pull/1430 set updateXamlRoslynVersion default to be true.
It should fix https://dev.azure.com/dnceng/internal/_build/results?buildId=2550417&view=results
In old release branch this `/src/Xaml/Versions.props` doesn't exist.
So we need to pass that parameter.