### PR TITLE
Reduce allocations during typing

### DIFF
--- a/src/Compilers/Core/Portable/Text/TextChangeRangeExtensions.cs
+++ b/src/Compilers/Core/Portable/Text/TextChangeRangeExtensions.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
@@ -14,9 +13,9 @@ namespace Roslyn.Utilities
 {
     internal static class TextChangeRangeExtensions
     {
-        public static TextChangeRange? Accumulate(this TextChangeRange? accumulatedTextChangeSoFar, IEnumerable<TextChangeRange> changesInNextVersion)
+        public static TextChangeRange? Accumulate(this TextChangeRange? accumulatedTextChangeSoFar, IReadOnlyList<TextChangeRange> changesInNextVersion)
         {
-            if (!changesInNextVersion.Any())
+            if (changesInNextVersion.Count == 0)
             {
                 return accumulatedTextChangeSoFar;
             }
@@ -25,7 +24,9 @@ namespace Roslyn.Utilities
             // we could apply each one individually like we do in SyntaxDiff::ComputeSpansInNew by calculating delta
             // between each change in changesInNextVersion which is already sorted in its textual position ascending order.
             // but end result will be same as just applying it once with encompassed text change range.
-            var newChange = TextChangeRange.Collapse(changesInNextVersion);
+            var newChange = changesInNextVersion.Count == 1
+                ? changesInNextVersion[0]
+                : TextChangeRange.Collapse(changesInNextVersion);
 
             // no previous accumulated change, return the new value.
             if (accumulatedTextChangeSoFar == null)

--- a/src/EditorFeatures/Text/ITextImageHelpers.cs
+++ b/src/EditorFeatures/Text/ITextImageHelpers.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
@@ -51,35 +52,54 @@ internal static class ITextImageHelpers
         }
 
         if (changes == null)
-        {
             return [];
-        }
-        else
+
+        var builder = ArrayBuilder<TextChangeRange>.GetInstance(changes.Count);
+        for (var i = 0; i < changes.Count; i++)
         {
-            return ImmutableArray.CreateRange(changes.Select(forward ? s_forwardTextChangeRange : s_backwardTextChangeRange));
+            var change = changes[i];
+            builder.Add(forward ? s_forwardTextChangeRange(change) : s_backwardTextChangeRange(change));
         }
+
+        return builder.ToImmutableAndFree();
     }
 
     private static TextChangeRange GetChangeRanges(ITextImageVersion oldVersion, ITextImageVersion newVersion, bool forward)
     {
         TextChangeRange? range = null;
-        var iterator = GetMultipleVersionTextChanges(oldVersion, newVersion, forward);
-        foreach (var changes in forward ? iterator : iterator.Reverse())
+        using var _ = ArrayBuilder<ArrayBuilder<TextChangeRange>>.GetInstance(out var builder);
+
+        GetMultipleVersionTextChanges(oldVersion, newVersion, forward, builder);
+        foreach (var changes in builder)
         {
             range = range.Accumulate(changes);
+            changes.Free();
         }
 
         RoslynDebug.Assert(range.HasValue);
         return range.Value;
     }
 
-    private static IEnumerable<IEnumerable<TextChangeRange>> GetMultipleVersionTextChanges(
-        ITextImageVersion oldVersion, ITextImageVersion newVersion, bool forward)
+    private static void GetMultipleVersionTextChanges(
+        ITextImageVersion oldVersion,
+        ITextImageVersion newVersion,
+        bool forward,
+        ArrayBuilder<ArrayBuilder<TextChangeRange>> builder)
     {
         for (var version = oldVersion; version != newVersion; version = version.Next)
         {
-            yield return version.Changes.Select(forward ? s_forwardTextChangeRange : s_backwardTextChangeRange);
+            var changes = ArrayBuilder<TextChangeRange>.GetInstance(version.Changes.Count);
+            for (var i = 0; i < version.Changes.Count; i++)
+            {
+                var change = version.Changes[i];
+                changes.Add(forward ? s_forwardTextChangeRange(change) : s_backwardTextChangeRange(change));
+            }
+
+            builder.Add(changes);
         }
+
+        if (!forward)
+            builder.ReverseContents();
     }
 
     private static TextChangeRange CreateTextChangeRange(ITextChange change, bool forward)

--- a/src/EditorFeatures/Text/ITextImageHelpers.cs
+++ b/src/EditorFeatures/Text/ITextImageHelpers.cs
@@ -54,14 +54,14 @@ internal static class ITextImageHelpers
         if (changes == null)
             return [];
 
-        var builder = ArrayBuilder<TextChangeRange>.GetInstance(changes.Count);
+        var builder = new FixedSizeArrayBuilder<TextChangeRange>(changes.Count);
         for (var i = 0; i < changes.Count; i++)
         {
             var change = changes[i];
             builder.Add(forward ? s_forwardTextChangeRange(change) : s_backwardTextChangeRange(change));
         }
 
-        return builder.ToImmutableAndFree();
+        return builder.MoveToImmutable();
     }
 
     private static TextChangeRange GetChangeRanges(ITextImageVersion oldVersion, ITextImageVersion newVersion, bool forward)


### PR DESCRIPTION
During typing, various codepaths attempt to find the set of changes between two text images. Note that while this change will get rid of the allocations, I'm not certain it makes sense for that codepath to be getting executed so frequently and am following up elsewhere. This should reduce allocations in the profile that I'm looking at by around 1.4% during typing.

*** allocations from the typing scenario in the new csharp editing speedometer that should be alleviated **
![image](https://github.com/user-attachments/assets/ea9796f5-b192-4316-b1cf-80ed6a67121d)