### PR TITLE
Avoid linking back to the original TreeSource in document state updates if the associated lazy is already completed

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -24,7 +24,9 @@ internal partial class DocumentState
         ITreeAndVersionSource originalTreeSource,
         AsyncLazy<TreeAndVersion> lazyComputation) : ITreeAndVersionSource
     {
-        // Used as a fallback value in GetComputedTreeAndVersionSource to avoid long lazy chain evaluations.
+        /// <summary>
+        /// Used as a fallback value in GetComputedTreeAndVersionSource to avoid long lazy chain evaluations.
+        /// </summary>
         private readonly ITreeAndVersionSource _originalTreeSource = originalTreeSource;
 
         /// <summary>
@@ -37,13 +39,8 @@ internal partial class DocumentState
         /// If the lazy computation has not completed, we don't wish to pass back an object using it, as doing so might
         /// lead to a long chain of lazy evaluations. Instead, use the originalTreeSource passed into this object.
         /// </remarks>
-        public ITreeAndVersionSource GetNonChainedTreeAndVersionSource()
-        {
-            if (TryGetValue(out _))
-                return this;
-
-            return _originalTreeSource;
-        }
+        public ITreeAndVersionSource GetNonChainedTreeAndVersionSource() 
+            => TryGetValue(out _) ? this : _originalTreeSource;
 
         public Task<TreeAndVersion> GetValueAsync(CancellationToken cancellationToken)
             => lazyComputation.GetValueAsync(cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -69,8 +69,11 @@ internal partial class DocumentState
         // We only need to look one deep here as we'll pull that tree source forward to our level.  If another link is
         // later added to us, it will do the same thing.
         var originalTreeSource = this.TreeSource;
-        if (originalTreeSource is LinkedFileReuseTreeAndVersionSource linkedFileTreeAndVersionSource)
+        if (originalTreeSource is LinkedFileReuseTreeAndVersionSource linkedFileTreeAndVersionSource
+            && !linkedFileTreeAndVersionSource.TryGetValue(out var _))
+        {
             originalTreeSource = linkedFileTreeAndVersionSource.OriginalTreeSource;
+        }
 
         // Always pass along the sibling text.  We will always be in sync with that.
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -39,7 +39,7 @@ internal partial class DocumentState
         /// If the lazy computation has not completed, we don't wish to pass back an object using it, as doing so might
         /// lead to a long chain of lazy evaluations. Instead, use the originalTreeSource passed into this object.
         /// </remarks>
-        public ITreeAndVersionSource GetNonChainedTreeAndVersionSource() 
+        public ITreeAndVersionSource GetNonChainedTreeAndVersionSource()
             => TryGetValue(out _) ? this : _originalTreeSource;
 
         public Task<TreeAndVersion> GetValueAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Previously, I was seeing pull diagnostics requests for linked documents as computing the changes between the original and current version of the file. Instead, change the code where we determine the tree source to use the latest tree source if it's been calculated.