### PR TITLE
Add keyboard shortcut for 'Add null checks' in generate constructor

### DIFF
--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -948,7 +948,7 @@ This version used in: {2}</value>
     <value>Initialize property '{0}'</value>
   </data>
   <data name="Add_null_checks" xml:space="preserve">
-    <value>Add null checks</value>
+    <value>Add _null checks</value>
   </data>
   <data name="Generate_operators" xml:space="preserve">
     <value>Generate operators</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -4766,8 +4766,8 @@ Tato verze se používá zde: {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Přidat kontroly hodnot null</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Přidat kontroly hodnot null</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -4766,8 +4766,8 @@ Diese Version wird verwendet in: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">NULL-Überprüfungen hinzufügen</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">NULL-Überprüfungen hinzufügen</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -4766,8 +4766,8 @@ Esta versión se utiliza en: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Agregar comprobaciones de valores null</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Agregar comprobaciones de valores null</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -4766,8 +4766,8 @@ Version utilisée dans : {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Ajouter des contrôles de valeur null</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Ajouter des contrôles de valeur null</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -4766,8 +4766,8 @@ Questa versione è usata {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Aggiungi i controlli Null</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Aggiungi i controlli Null</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -4766,8 +4766,8 @@ This version used in: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">null チェックを追加する</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">null チェックを追加する</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -4766,8 +4766,8 @@ This version used in: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">null 검사 추가</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">null 검사 추가</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -4766,8 +4766,8 @@ Ta wersja jest używana wersja: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Dodaj sprawdzenia wartości null</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Dodaj sprawdzenia wartości null</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -4766,8 +4766,8 @@ Essa versão é usada no: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Adicionar verificações nulas</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Adicionar verificações nulas</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -4766,8 +4766,8 @@ This version used in: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Добавить проверки значений NULL</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Добавить проверки значений NULL</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -4766,8 +4766,8 @@ Bu sürüm şurada kullanılır: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">Null denetimleri ekle</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">Null denetimleri ekle</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -4766,8 +4766,8 @@ This version used in: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">添加 null 检查</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">添加 null 检查</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -4766,8 +4766,8 @@ This version used in: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="Add_null_checks">
-        <source>Add null checks</source>
-        <target state="translated">新增 null 檢查</target>
+        <source>Add _null checks</source>
+        <target state="needs-review-translation">新增 null 檢查</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_operators">

--- a/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
@@ -155,12 +155,11 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <CheckBox IsChecked="{Binding IsChecked}"
-                                      VerticalAlignment="Center"
-                                      VerticalContentAlignment="Center"
-                                      Margin="8,0,0,5">
-                                <TextBlock Text="{Binding Title}"
-                                           TextWrapping="Wrap" />
-                            </CheckBox>
+                                VerticalAlignment="Center"
+                                VerticalContentAlignment="Center"
+                                Margin="8,0,0,5" 
+                                AutomationProperties.LabeledBy="{Binding ElementName=OptionsLabel}"
+                                Content="{Binding Title}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>


### PR DESCRIPTION
Fixes #75320

![4f83d2a9-742a-48e0-9451-cc884c78231f](https://github.com/user-attachments/assets/06fd3988-5c56-4e88-bef9-245a08dfdc6c)
