### PR TITLE
Fix circularity issue with binding const local

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal virtual LocalSymbol LocalInProgress
+        internal virtual LocalSymbol? LocalInProgress
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal virtual LocalSymbol? LocalInProgress
+        internal virtual LocalSymbol LocalInProgress
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -949,13 +949,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (node.Initializer is { } initializer)
             {
-                var oldEnclosing = _enclosing;
-                var localInProgressBinder = new LocalInProgressBinder(initializer, _enclosing);
-                AddToMap(initializer, localInProgressBinder);
+                var enclosing = _enclosing;
+                if (node.Parent is VariableDeclarationSyntax { Parent: LocalDeclarationStatementSyntax { IsConst: true } })
+                {
+                    enclosing = new LocalInProgressBinder(initializer, _enclosing);
+                    AddToMap(initializer, enclosing);
+                }
 
-                _enclosing = localInProgressBinder;
-                Visit(initializer.Value);
-                _enclosing = oldEnclosing;
+                Visit(initializer.Value, enclosing);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -946,7 +946,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitVariableDeclarator(VariableDeclaratorSyntax node)
         {
             Visit(node.ArgumentList);
-            Visit(node.Initializer?.Value);
+
+            if (node.Initializer is { } initializer)
+            {
+                var oldEnclosing = _enclosing;
+                var localInProgressBinder = new LocalInProgressBinder(initializer, _enclosing);
+                AddToMap(initializer, localInProgressBinder);
+
+                _enclosing = localInProgressBinder;
+                Visit(initializer.Value);
+                _enclosing = oldEnclosing;
+            }
         }
 
         public override void VisitReturnStatement(ReturnStatementSyntax node)

--- a/src/Compilers/CSharp/Portable/Binder/LocalInProgressBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalInProgressBinder.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
+using System.Diagnostics;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -17,20 +18,26 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal sealed class LocalInProgressBinder : Binder
     {
-        private readonly LocalSymbol _inProgress;
+        public readonly EqualsValueClauseSyntax InitializerSyntax;
+        private LocalSymbol? _localSymbol;
 
-        internal LocalInProgressBinder(LocalSymbol inProgress, Binder next)
+        internal LocalInProgressBinder(EqualsValueClauseSyntax initializerSyntax, Binder next)
             : base(next)
         {
-            _inProgress = inProgress;
+            InitializerSyntax = initializerSyntax;
         }
 
-        internal override LocalSymbol LocalInProgress
+        internal override LocalSymbol? LocalInProgress
         {
             get
             {
-                return _inProgress;
+                return _localSymbol;
             }
+        }
+
+        internal void SetLocalSymbol(LocalSymbol local)
+        {
+            Interlocked.CompareExchange(ref _localSymbol, local, null);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/LocalInProgressBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalInProgressBinder.cs
@@ -27,10 +27,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             InitializerSyntax = initializerSyntax;
         }
 
-        internal override LocalSymbol? LocalInProgress
+        internal override LocalSymbol LocalInProgress
         {
             get
             {
+                // The local symbol should have been initialized by now
+                Debug.Assert(_localSymbol is not null);
                 return _localSymbol;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -536,10 +536,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(initializer != null);
 
                 _initializer = initializer;
-                _initializerBinder = initializerBinder.GetBinder(initializer);
+                _initializerBinder = initializerBinder;
                 if (this.IsConst)
                 {
-                    _initializerBinder ??= new LocalInProgressBinder(_initializer, initializerBinder); // for error scenarios
+                    _initializerBinder = _initializerBinder.GetBinder(initializer) ?? new LocalInProgressBinder(_initializer, initializerBinder); // for error scenarios
                     recordConstInBinderChain();
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -536,9 +536,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(initializer != null);
 
                 _initializer = initializer;
-                _initializerBinder = initializerBinder.GetBinder(initializer) ?? new LocalInProgressBinder(_initializer, initializerBinder);
+                _initializerBinder = initializerBinder.GetBinder(initializer);
                 if (this.IsConst)
                 {
+                    _initializerBinder ??= new LocalInProgressBinder(_initializer, initializerBinder); // for error scenarios
                     recordConstInBinderChain();
                 }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -3309,9 +3309,28 @@ class C
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-    // (6,51): error CS0133: The expression being assigned to 'b' must be constant
-    //         const Func<int> a = () => { const int b = a(); return 1; };
-    Diagnostic(ErrorCode.ERR_NotConstantExpression, "a()").WithArguments("b").WithLocation(6, 51)
+                // (6,51): error CS0133: The expression being assigned to 'b' must be constant
+                //         const Func<int> a = () => { const int b = a(); return 1; };
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, "a()").WithArguments("b").WithLocation(6, 51)
+                );
+        }
+
+        [Fact]
+        public static void DoubleRecursiveConst_NotInvoked()
+        {
+            var source =
+@"using System;
+class C
+{
+    public static void Main()
+    {
+        const Func<int> a = () => { const Func<int> b = a; return 1; };
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (6,57): error CS0134: 'b' is of type 'Func<int>'. A const field of a reference type other than string can only be initialized with null.
+                //         const Func<int> a = () => { const Func<int> b = a; return 1; };
+                Diagnostic(ErrorCode.ERR_NotNullConstRefField, "a").WithArguments("b", "System.Func<int>").WithLocation(6, 57)
                 );
         }
 
@@ -4040,6 +4059,117 @@ public class C
 
             Assert.Equal("bad", badConst.ToString(null, CultureInfo.InvariantCulture));
             Assert.Equal("null", nullConst.ToString(null, CultureInfo.InvariantCulture));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75353")]
+        public void ConstLocalCircularity_SwitchOperand()
+        {
+            var source = """
+const string x = x switch { _ => "" };
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (1,18): error CS0110: The evaluation of the constant value for 'x' involves a circular definition
+                // const string x = x switch { _ => "" };
+                Diagnostic(ErrorCode.ERR_CircConstValue, "x").WithArguments("x").WithLocation(1, 18),
+                // (1,18): error CS0133: The expression being assigned to 'x' must be constant
+                // const string x = x switch { _ => "" };
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, @"x switch { _ => """" }").WithArguments("x").WithLocation(1, 18));
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var xDeclarator = GetSyntax<VariableDeclaratorSyntax>(tree, """x = x switch { _ => "" }""");
+            Assert.Equal("System.String x", model.GetDeclaredSymbol(xDeclarator).ToTestDisplayString(includeNonNullable: false));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75353")]
+        public void ConstLocalCircularity_SwitchOperand_Var()
+        {
+            var source = """
+const var x = x switch { _ => "" };
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (1,7): error CS0822: Implicitly-typed variables cannot be constant
+                // const var x = x switch { _ => "" };
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableCannotBeConst, @"var x = x switch { _ => """" }").WithLocation(1, 7),
+                // (1,15): error CS0841: Cannot use local variable 'x' before it is declared
+                // const var x = x switch { _ => "" };
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x").WithArguments("x").WithLocation(1, 15));
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var xDeclarator = GetSyntax<VariableDeclaratorSyntax>(tree, """x = x switch { _ => "" }""");
+            Assert.Equal("System.String x", model.GetDeclaredSymbol(xDeclarator).ToTestDisplayString(includeNonNullable: false));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75353")]
+        public void ConstLocalCircularity_SwitchArm()
+        {
+            var source = """
+const string x = 42 switch { _ => x };
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (1,18): error CS0133: The expression being assigned to 'x' must be constant
+                // const string x = 42 switch { _ => x };
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, "42 switch { _ => x }").WithArguments("x").WithLocation(1, 18),
+                // (1,35): error CS0110: The evaluation of the constant value for 'x' involves a circular definition
+                // const string x = 42 switch { _ => x };
+                Diagnostic(ErrorCode.ERR_CircConstValue, "x").WithArguments("x").WithLocation(1, 35));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75353")]
+        public void ConstLocalCircularity_Nameof()
+        {
+            var source = """
+const string x = nameof(x);
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75353")]
+        public void ConstLocalCircularity_Checked()
+        {
+            var source = """
+const int x = checked(x);
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (1,23): error CS0110: The evaluation of the constant value for 'x' involves a circular definition
+                // const int x = checked(x);
+                Diagnostic(ErrorCode.ERR_CircConstValue, "x").WithArguments("x").WithLocation(1, 23));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75353")]
+        public void ConstLocalCircularity_Checked_TwoConstDeclarations()
+        {
+            var source = """
+const int x = checked(y);
+const int y = checked(x);
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (1,23): error CS0841: Cannot use local variable 'y' before it is declared
+                // const int x = checked(y);
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "y").WithArguments("y").WithLocation(1, 23));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75353")]
+        public void ConstLocalCircularity_Checked_TwoConstDeclarators()
+        {
+            var source = """
+const int x = y switch { _ => 42 }, y = x switch { _ => 42 };
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (1,15): error CS0841: Cannot use local variable 'y' before it is declared
+                // const int x = y switch { _ => 42 }, y = x switch { _ => 42 };
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "y").WithArguments("y").WithLocation(1, 15),
+                // (1,41): error CS0133: The expression being assigned to 'y' must be constant
+                // const int x = y switch { _ => 42 }, y = x switch { _ => 42 };
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, "x switch { _ => 42 }").WithArguments("y").WithLocation(1, 41));
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/75353

Opened issue https://github.com/dotnet/roslyn/issues/75416 (wrong binder used in `switch` expression binding)
Opened issue https://github.com/dotnet/roslyn/issues/75437 (injected binders may get dropped by `GetBinder`) 