### PR TITLE
Fixing the OOM in scripting

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3206,10 +3206,12 @@ class C { }
 class C { }
 ";
             var parseOptions = TestOptions.RegularPreview;
-            var metadataRefs = new[] {
+            PortableExecutableReference[] metadataRefs =
+            [
                 MetadataReference.CreateFromAssemblyInternal(this.GetType().Assembly),
                 MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly)
-            };
+            ];
+
             Compilation compilation = CreateEmptyCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions, references: metadataRefs);
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -210,7 +211,7 @@ namespace Microsoft.CodeAnalysis
             return (path, properties) =>
             {
                 var peStream = FileSystem.OpenFileWithNormalizedException(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-                return MetadataReference.CreateFromFile(peStream, path, properties, documentation: null);
+                return MetadataReference.CreateFromFile(peStream, path, PEStreamOptions.PrefetchEntireImage, properties, documentation: null);
             };
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis
             return (path, properties) =>
             {
                 var peStream = FileSystem.OpenFileWithNormalizedException(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-                return MetadataReference.CreateFromFile(peStream, path, properties);
+                return MetadataReference.CreateFromFile(peStream, path, properties, documentation: null);
             };
         }
 

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -252,19 +252,8 @@ namespace Microsoft.CodeAnalysis
         internal static MetadataImageReference CreateFromFile(
             string path,
             PEStreamOptions options,
-            MetadataReferenceProperties properties) =>
-            CreateFromFile(
-                StandardFileSystem.Instance.OpenFileWithNormalizedException(path, FileMode.Open, FileAccess.Read, FileShare.Read),
-                path,
-                options,
-                properties,
-                documentation: null);
-
-        internal static MetadataImageReference CreateFromFile(
-            string path,
-            PEStreamOptions options,
             MetadataReferenceProperties properties,
-            DocumentationProvider? documentation) =>
+            DocumentationProvider? documentation = null) =>
             CreateFromFile(
                 StandardFileSystem.Instance.OpenFileWithNormalizedException(path, FileMode.Open, FileAccess.Read, FileShare.Read),
                 path,
@@ -275,20 +264,8 @@ namespace Microsoft.CodeAnalysis
         internal static MetadataImageReference CreateFromFile(
             Stream peStream,
             string path,
-            MetadataReferenceProperties properties,
-            DocumentationProvider? documentation) =>
-            CreateFromFile(
-                peStream,
-                path,
-                PEStreamOptions.PrefetchEntireImage,
-                properties,
-                documentation);
-
-        internal static MetadataImageReference CreateFromFile(
-            Stream peStream,
-            string path,
             PEStreamOptions options,
-            MetadataReferenceProperties properties = default,
+            MetadataReferenceProperties properties,
             DocumentationProvider? documentation = null)
         {
             // prefetch image, close stream to avoid locking it:
@@ -389,9 +366,11 @@ namespace Microsoft.CodeAnalysis
             DocumentationProvider? documentation = null)
         {
             var filePath = GetAssemblyFilePath(assembly, properties);
+            var peStream = StandardFileSystem.Instance.OpenFileWithNormalizedException(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
             // The file is locked by the CLR assembly loader, so we can create a lazily read metadata, 
             // which might also lock the file until the reference is GC'd.
-            return CreateFromFile(filePath, PEStreamOptions.Default, properties, documentation);
+            return CreateFromFile(peStream, filePath, PEStreamOptions.Default, properties, documentation);
         }
 
         internal static bool HasMetadata(Assembly assembly)

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -272,7 +272,6 @@ namespace Microsoft.CodeAnalysis
                 properties,
                 documentation);
 
-
         internal static MetadataImageReference CreateFromFile(
             Stream peStream,
             string path,

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -320,17 +320,9 @@ namespace Microsoft.CodeAnalysis
 
         internal static MetadataImageReference CreateFromAssemblyInternal(
             Assembly assembly,
-            MetadataReferenceProperties properties) =>
-            CreateFromAssemblyInternal(assembly, properties, documentation: null);
-
-        internal static MetadataImageReference CreateFromAssemblyInternal(
-            Assembly assembly,
             MetadataReferenceProperties properties,
             DocumentationProvider? documentation = null)
         {
-            // Note: returns MetadataReference and not PortableExecutableReference so that we can in future support assemblies that
-            // which are not backed by PE image.
-
             if (assembly == null)
             {
                 throw new ArgumentNullException(nameof(assembly));

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis
             return CreateFromAssemblyInternal(assembly);
         }
 
-        internal static MetadataReference CreateFromAssemblyInternal(Assembly assembly)
+        internal static MetadataImageReference CreateFromAssemblyInternal(Assembly assembly)
         {
             return CreateFromAssemblyInternal(assembly, default(MetadataReferenceProperties));
         }
@@ -318,7 +318,12 @@ namespace Microsoft.CodeAnalysis
             return CreateFromAssemblyInternal(assembly, properties, documentation);
         }
 
-        internal static PortableExecutableReference CreateFromAssemblyInternal(
+        internal static MetadataImageReference CreateFromAssemblyInternal(
+            Assembly assembly,
+            MetadataReferenceProperties properties) =>
+            CreateFromAssemblyInternal(assembly, properties, documentation: null);
+
+        internal static MetadataImageReference CreateFromAssemblyInternal(
             Assembly assembly,
             MetadataReferenceProperties properties,
             DocumentationProvider? documentation = null)

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -44,6 +44,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ExpressionCompiler.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider.UnitTests" />
     <InternalsVisibleTo Include="InteractiveHost.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Scripting.TestUtilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Scripting.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Scripting.Desktop.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests" />

--- a/src/EditorFeatures/Core/Interactive/InteractiveSession.cs
+++ b/src/EditorFeatures/Core/Interactive/InteractiveSession.cs
@@ -369,7 +369,7 @@ internal sealed class InteractiveSession : IDisposable
             baseDirectory,
             gacFileResolver: platformInfo.HasGlobalAssemblyCache ? new GacFileResolver(preferredCulture: CultureInfo.CurrentCulture) : null,
             platformAssemblyPaths: platformInfo.PlatformAssemblyPaths,
-            fileReferenceProvider: (path, properties) => metadataService.GetReference(path, properties));
+            createFromFileFunc: metadataService.GetReference);
     }
 
     private static SourceReferenceResolver CreateSourceReferenceResolver(ImmutableArray<string> searchPaths, string baseDirectory)

--- a/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
+++ b/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
@@ -93,7 +93,7 @@ internal static class MiscellaneousFileUtilities
         var referenceResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
             searchPaths: [RuntimeEnvironment.GetRuntimeDirectory()],
             baseDirectory: baseDirectory,
-            fileReferenceProvider: metadataService.GetReference);
+            createFromFileFunc: metadataService.GetReference);
 
         return compilationOptions
             .WithMetadataReferenceResolver(referenceResolver)

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Scripting;
@@ -14,14 +15,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 {
     internal sealed class CSharpInteractiveCompiler : CSharpCompiler
     {
-        private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _createFromFileFunc;
+        private readonly Func<string, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference> _createFromFileFunc;
 
         internal CSharpInteractiveCompiler(
             string? responseFile,
             BuildPaths buildPaths,
             string[] args,
             IAnalyzerAssemblyLoader analyzerLoader,
-            Func<string, MetadataReferenceProperties, PortableExecutableReference>? createFromFileFunc = null)
+            Func<string, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference>? createFromFileFunc = null)
             // Unlike C# compiler we do not use LIB environment variable. It's only supported for historical reasons.
             : base(CSharpCommandLineParser.Script, responseFile, args, buildPaths, additionalReferenceDirectories: null, analyzerLoader)
         {

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -14,24 +14,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 {
     internal sealed class CSharpInteractiveCompiler : CSharpCompiler
     {
-        private readonly Func<CSharpCommandLineArguments, TouchedFileLogger?, MetadataReferenceResolver> _createResolverFunc;
+        private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _createFromFileFunc;
 
         internal CSharpInteractiveCompiler(
             string? responseFile,
             BuildPaths buildPaths,
             string[] args,
             IAnalyzerAssemblyLoader analyzerLoader,
-            Func<CSharpCommandLineArguments, TouchedFileLogger?, MetadataReferenceResolver>? createResolverFunc = null)
+            Func<string, MetadataReferenceProperties, PortableExecutableReference>? createFromFileFunc = null)
             // Unlike C# compiler we do not use LIB environment variable. It's only supported for historical reasons.
             : base(CSharpCommandLineParser.Script, responseFile, args, buildPaths, additionalReferenceDirectories: null, analyzerLoader)
         {
-            _createResolverFunc = createResolverFunc ?? CommandLineRunner.GetMetadataReferenceResolver;
+            _createFromFileFunc = createFromFileFunc ?? RuntimeMetadataReferenceResolver.CreateFromFile;
         }
 
         internal override Type Type => typeof(CSharpInteractiveCompiler);
 
         internal override MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger? loggerOpt) =>
-           _createResolverFunc(Arguments, loggerOpt);
+           CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt, _createFromFileFunc);
 
         public override void PrintLogo(TextWriter consoleOutput)
         {

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
             // Unlike C# compiler we do not use LIB environment variable. It's only supported for historical reasons.
             : base(CSharpCommandLineParser.Script, responseFile, args, buildPaths, additionalReferenceDirectories: null, analyzerLoader)
         {
-            _createFromFileFunc = createFromFileFunc ?? RuntimeMetadataReferenceResolver.CreateFromFile;
+            _createFromFileFunc = createFromFileFunc ?? Script.CreateFromFile;
         }
 
         internal override Type Type => typeof(CSharpInteractiveCompiler);

--- a/src/Scripting/CSharpTest.Desktop/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/ObjectFormatterTests.cs
@@ -90,6 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
         [Fact]
         public void VBBackingFields_DebuggerBrowsable()
         {
+            var reference = MetadataReference.CreateFromAssemblyInternal(typeof(object).GetTypeInfo().Assembly);
             string source = @"
 Imports System
 
@@ -102,7 +103,7 @@ End Class
             var compilation = VB.VisualBasicCompilation.Create(
                 "goo",
                 new[] { VB.VisualBasicSyntaxTree.ParseText(source) },
-                new[] { MetadataReference.CreateFromAssemblyInternal(typeof(object).GetTypeInfo().Assembly) },
+                new[] { reference },
                 new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug));
 
             Assembly a;
@@ -128,6 +129,7 @@ End Class
             Assert.Equal(1, attrsA.Length);
             Assert.Equal(1, attrsWE.Length);
             Assert.Equal(1, attrsE.Length);
+            reference.GetMetadataNoCopy().Dispose();
         }
     }
 }

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting.Test;
+using Microsoft.CodeAnalysis.Scripting.TestUtilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 {
     using static TestCompilationFactory;
 
-    public class CommandLineRunnerTests : TestBase
+    public class CommandLineRunnerTests : CSharpScriptTestBase
     {
         private static readonly string s_compilerVersion = CommonCompiler.GetProductVersion(typeof(CSharpInteractiveCompiler));
 
@@ -31,80 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 {CSharpScriptingResources.LogoLine2}
 
 {ScriptingResources.HelpPrompt}";
-
-        // default csi.rsp
-        private static readonly string[] s_defaultArgs =
-        [
-            "/r:" + string.Join(";", GetReferences()),
-            "/u:System;System.IO;System.Collections.Generic;System.Diagnostics;System.Dynamic;System.Linq;System.Linq.Expressions;System.Text;System.Threading.Tasks",
-        ];
-
-        private static IEnumerable<string> GetReferences()
-        {
-            if (GacFileResolver.IsAvailable)
-            {
-                // keep in sync with list in csi.rsp
-                yield return "System";
-                yield return "System.Core";
-                yield return "Microsoft.CSharp";
-            }
-            else
-            {
-                // keep in sync with list in core csi.rsp
-                yield return "System.Collections";
-                yield return "System.Collections.Concurrent";
-                yield return "System.Console";
-                yield return "System.Diagnostics.Debug";
-                yield return "System.Diagnostics.Process";
-                yield return "System.Diagnostics.StackTrace";
-                yield return "System.Globalization";
-                yield return "System.IO";
-                yield return "System.IO.FileSystem";
-                yield return "System.IO.FileSystem.Primitives";
-                yield return "System.Reflection";
-                yield return "System.Reflection.Extensions";
-                yield return "System.Reflection.Primitives";
-                yield return "System.Runtime";
-                yield return "System.Runtime.Extensions";
-                yield return "System.Runtime.InteropServices";
-                yield return "System.Text.Encoding";
-                yield return "System.Text.Encoding.CodePages";
-                yield return "System.Text.Encoding.Extensions";
-                yield return "System.Text.RegularExpressions";
-                yield return "System.Threading";
-                yield return "System.Threading.Tasks";
-                yield return "System.Threading.Tasks.Parallel";
-                yield return "System.Threading.Thread";
-                yield return "System.Linq";
-                yield return "System.Linq.Expressions";
-                yield return "System.Runtime.Numerics";
-                yield return "System.Dynamic.Runtime";
-                yield return "Microsoft.CSharp";
-            }
-        }
-
-        private static CommandLineRunner CreateRunner(
-            string[] args = null,
-            string input = "",
-            string responseFile = null,
-            string workingDirectory = null)
-        {
-            var io = new TestConsoleIO(input);
-            var clientDir = Path.GetDirectoryName(RuntimeUtilities.GetAssemblyLocation(typeof(CommandLineRunnerTests)));
-            var buildPaths = new BuildPaths(
-                clientDir: clientDir,
-                workingDir: workingDirectory ?? clientDir,
-                sdkDir: null,
-                tempDir: Path.GetTempPath());
-
-            var compiler = new CSharpInteractiveCompiler(
-                responseFile,
-                buildPaths,
-                args?.Where(a => a != null).ToArray() ?? s_defaultArgs,
-                new NotImplementedAnalyzerLoader());
-
-            return new CommandLineRunner(io, compiler, CSharpScriptCompiler.Instance, CSharpObjectFormatter.Instance);
-        }
 
         [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30303")]
         public void Await()

--- a/src/Scripting/CSharpTest/InteractiveSessionReferencesTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionReferencesTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.TestUtilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -17,7 +18,7 @@ using static Microsoft.CodeAnalysis.Scripting.TestCompilationFactory;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Test
 {
-    public class InteractiveSessionReferencesTests : TestBase
+    public class InteractiveSessionReferencesTests : CSharpScriptTestBase
     {
         /// <summary>
         /// Test adding a reference to NetStandard 2.0 library.
@@ -40,7 +41,7 @@ public class C
             var s0 = CSharpScript.Create($@"
 #r ""{libFile.Path}""
 int F(C c) => c.X;
-");
+", ScriptOptions);
             var s1 = s0.ContinueWith($@"
 F(new C())
 ");
@@ -99,7 +100,7 @@ public class D
 #r ""{r1}""
 #r ""{r2}""
 new A().X + new B().X
-");
+", ScriptOptions);
             var diagnostics0 = s0.Compile();
             Assert.Empty(diagnostics0);
 
@@ -137,7 +138,7 @@ public class D
             var s0 = CSharpScript.Create($@"
 #r ""{libAFile.Path}""
 int F(C c) => c.X;
-");
+", ScriptOptions);
             var diagnostics0 = s0.Compile();
             Assert.Empty(diagnostics0);
 

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting.Test;
+using Microsoft.CodeAnalysis.Scripting.TestUtilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -32,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         public readonly int Goo;
     }
 
-    public class InteractiveSessionTests : TestBase
+    public class InteractiveSessionTests : CSharpScriptTestBase
     {
         internal static readonly Assembly HostAssembly = typeof(InteractiveSessionTests).GetTypeInfo().Assembly;
 
@@ -49,7 +50,7 @@ class InnerClass
    public string innerStr = null;
    public void Goo() { Goo(""test""); innerStr = outerStr; }       
 }
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 InnerClass iC = new InnerClass();
 iC.Goo();
 ").ContinueWith(@"
@@ -70,7 +71,7 @@ struct InnerStruct
    public string innerStr;
    public void Goo() { Goo(""test""); innerStr = outerStr; }            
 }
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 InnerStruct iS = new InnerStruct();     
 iS.Goo();
 ").ContinueWith(@"
@@ -88,7 +89,7 @@ interface I1 { int Goo();}
 class InnerClass : I1
 {
   public int Goo() { return 1; }
-}").ContinueWith(@"
+}", ScriptOptions).ContinueWith(@"
 I1 iC = new InnerClass();
 ").ContinueWith(@"
 iC.Goo()
@@ -104,7 +105,7 @@ iC.Goo()
 object field;
 object Property { get; set; }
 void Method() { }
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 class C 
 {
     public void Goo() 
@@ -132,7 +133,7 @@ class C
         {
             var script = CSharpScript.Create(@"
 var a = new { f = 1 };
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 var b = new { g = 1 };
 ").ContinueWith<Array>(@"
 var c = new { f = 1 };
@@ -152,7 +153,7 @@ new object[] { new[] { a, c }, new[] { b, d } }
         {
             var script = CSharpScript.Create(@"
 var a = new { f = 1 };
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 var b = new { g = 1 };
 ").ContinueWith(@"
 var c = new { f = 1 };
@@ -171,7 +172,7 @@ object.ReferenceEquals(a.GetType(), c.GetType()).ToString() + "" "" +
         {
             var script = CSharpScript.Create(@"
 var x = new { Goo = ""goo"" };
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 var x = new { Goo = ""goo"" };
 ").ContinueWith(@"
 x.Goo
@@ -186,7 +187,7 @@ x.Goo
         {
             var script = CSharpScript.Create(@"
 var a = new { };
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 var b = new { };
 ").ContinueWith<Array>(@"
 var c = new { };
@@ -207,7 +208,7 @@ new object[] { new[] { a, c }, new[] { b, d } }
         [Fact]
         public void Dynamic_Expando()
         {
-            var options = ScriptOptions.Default.
+            var options = ScriptOptions.
                 AddReferences(
                     typeof(Microsoft.CSharp.RuntimeBinder.RuntimeBinderException).GetTypeInfo().Assembly,
                     typeof(System.Dynamic.ExpandoObject).GetTypeInfo().Assembly).
@@ -238,7 +239,7 @@ public enum Enum1
 Enum1 E = Enum1.C;
 
 E
-");
+", ScriptOptions);
             var e = script.EvaluateAsync().Result;
 
             Assert.True(e.GetType().GetTypeInfo().IsEnum, "Expected enum");
@@ -271,7 +272,7 @@ class C { }
 
 typeof(C)
 ";
-            Type c = CSharpScript.EvaluateAsync<Type>(source).Result;
+            Type c = CSharpScript.EvaluateAsync<Type>(source, ScriptOptions).Result;
             var m = c.DeclaringType.GetTypeInfo().GetDeclaredMethod("M");
             Assert.Equal(MethodImplAttributes.PreserveSig, m.MethodImplementationFlags);
 
@@ -303,7 +304,7 @@ private static int bar() { return 10; }
 private static int f = 100;
 
 goo() + bar() + f
-");
+", ScriptOptions);
             Assert.Equal(111, script.EvaluateAsync().Result);
 
             script = script.ContinueWith<int>(@"
@@ -347,7 +348,7 @@ private class C
         internal static int goo() { return 1; } 
     }
 }
-");
+", ScriptOptions);
             Assert.Equal(1, script.ContinueWith<int>("C.D.goo()").EvaluateAsync().Result);
             Assert.Equal(1, script.ContinueWith<int>("C.F.goo()").EvaluateAsync().Result);
             Assert.Equal(1, script.ContinueWith<int>("C.G.goo()").EvaluateAsync().Result);
@@ -366,7 +367,7 @@ public int j = 2;
 protected int k = 2;
 internal protected int l = 2;
 internal int pi = 2;
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 i = i + i;
 j = j + j;
 k = k + k;
@@ -389,7 +390,7 @@ pi = i + j + k + l;
 @"class C
 {
     extern ~C();
-}");
+}", ScriptOptions);
             Assert.Null(script.EvaluateAsync().Result);
         }
 
@@ -400,7 +401,7 @@ pi = i + j + k + l;
         [Fact]
         public void CompilationChain_BasicFields()
         {
-            var script = CSharpScript.Create("var x = 1;").ContinueWith("x");
+            var script = CSharpScript.Create("var x = 1;", ScriptOptions).ContinueWith("x");
             Assert.Equal(1, script.EvaluateAsync().Result);
         }
 
@@ -408,7 +409,7 @@ pi = i + j + k + l;
         public void CompilationChain_GlobalNamespaceAndUsings()
         {
             var result =
-                CSharpScript.Create("using InteractiveFixtures.C;", ScriptOptions.Default.AddReferences(HostAssembly)).
+                CSharpScript.Create("using InteractiveFixtures.C;", ScriptOptions.AddReferences(HostAssembly)).
                 ContinueWith("using InteractiveFixtures.C;").
                 ContinueWith("System.Environment.ProcessorCount").
                 EvaluateAsync().Result;
@@ -419,7 +420,7 @@ pi = i + j + k + l;
         [Fact]
         public void CompilationChain_CurrentSubmissionUsings()
         {
-            var s0 = CSharpScript.RunAsync("", ScriptOptions.Default.AddReferences(HostAssembly));
+            var s0 = CSharpScript.RunAsync("", ScriptOptions.AddReferences(HostAssembly));
 
             var state = s0.
                 ContinueWith("class X { public int goo() { return 1; } }").
@@ -446,7 +447,7 @@ new X().goo()
             var script = CSharpScript.Create(@"
 using System;
 using System;
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 using System;
 using System;
 ").ContinueWith(@"
@@ -459,7 +460,7 @@ Environment.ProcessorCount
         [Fact]
         public void CompilationChain_GlobalImports()
         {
-            var options = ScriptOptions.Default.AddImports("System");
+            var options = ScriptOptions.AddImports("System");
 
             var state = CSharpScript.RunAsync("Environment.ProcessorCount", options);
             Assert.Equal(Environment.ProcessorCount, state.Result.ReturnValue);
@@ -472,7 +473,7 @@ Environment.ProcessorCount
         public void CompilationChain_Accessibility()
         {
             // Submissions have internal and protected access to one another.
-            var state1 = CSharpScript.RunAsync("internal class C1 { }   protected int X;   1");
+            var state1 = CSharpScript.RunAsync("internal class C1 { }   protected int X;   1", ScriptOptions);
             var compilation1 = state1.Result.Script.GetCompilation();
             compilation1.VerifyDiagnostics(
                 // (1,39): warning CS0628: 'X': new protected member declared in sealed type
@@ -514,7 +515,7 @@ Environment.ProcessorCount
         [Fact]
         public void CompilationChain_SubmissionSlotResize()
         {
-            var state = CSharpScript.RunAsync("");
+            var state = CSharpScript.RunAsync("", ScriptOptions);
 
             for (int i = 0; i < 17; i++)
             {
@@ -528,7 +529,7 @@ Environment.ProcessorCount
         public void CompilationChain_UsingNotHidingPreviousSubmission()
         {
             int result1 =
-                CSharpScript.Create("using System;").
+                CSharpScript.Create("using System;", ScriptOptions).
                 ContinueWith("int Environment = 1;").
                 ContinueWith<int>("Environment").
                 EvaluateAsync().Result;
@@ -536,7 +537,7 @@ Environment.ProcessorCount
             Assert.Equal(1, result1);
 
             int result2 =
-                CSharpScript.Create("int Environment = 1;").
+                CSharpScript.Create("int Environment = 1;", ScriptOptions).
                 ContinueWith("using System;").
                 ContinueWith<int>("Environment").
                 EvaluateAsync().Result;
@@ -548,7 +549,7 @@ Environment.ProcessorCount
         public void CompilationChain_DefinitionHidesGlobal()
         {
             var result =
-                CSharpScript.Create("int System = 1;").
+                CSharpScript.Create("int System = 1;", ScriptOptions).
                 ContinueWith("System").
                 EvaluateAsync().Result;
 
@@ -568,7 +569,7 @@ Environment.ProcessorCount
         public void CompilationChain_HostObjectMembersHidesGlobal()
         {
             var result =
-                CSharpScript.RunAsync("System", globals: new C1()).
+                CSharpScript.RunAsync("System", options: ScriptOptions, globals: new C1()).
                 Result.ReturnValue;
 
             Assert.Equal(1, result);
@@ -578,7 +579,7 @@ Environment.ProcessorCount
         public void CompilationChain_UsingNotHidingHostObjectMembers()
         {
             var result =
-                CSharpScript.RunAsync("using System;", globals: new C1()).
+                CSharpScript.RunAsync("using System;", options: ScriptOptions, globals: new C1()).
                 ContinueWith("Environment").
                 Result.ReturnValue;
 
@@ -589,7 +590,7 @@ Environment.ProcessorCount
         public void CompilationChain_DefinitionHidesHostObjectMembers()
         {
             var result =
-                CSharpScript.RunAsync("int System = 2;", globals: new C1()).
+                CSharpScript.RunAsync("int System = 2;", options: ScriptOptions, globals: new C1()).
                 ContinueWith("System").
                 Result.ReturnValue;
 
@@ -599,7 +600,7 @@ Environment.ProcessorCount
         [Fact]
         public void Submissions_ExecutionOrder1()
         {
-            var s0 = CSharpScript.Create("int x = 1;");
+            var s0 = CSharpScript.Create("int x = 1;", ScriptOptions);
             var s1 = s0.ContinueWith("int y = 2;");
             var s2 = s1.ContinueWith<int>("x + y");
 
@@ -618,7 +619,7 @@ Environment.ProcessorCount
         [Fact]
         public async Task Submissions_ExecutionOrder2()
         {
-            var s0 = await CSharpScript.RunAsync("int x = 1;");
+            var s0 = await CSharpScript.RunAsync("int x = 1;", ScriptOptions);
 
             Assert.Throws<CompilationErrorException>(() => s0.ContinueWithAsync("invalid$syntax").Result);
 
@@ -645,7 +646,7 @@ Environment.ProcessorCount
         [Fact]
         public async Task ObjectOverrides1()
         {
-            var state0 = await CSharpScript.RunAsync("", globals: new HostObjectWithOverrides());
+            var state0 = await CSharpScript.RunAsync("", options: ScriptOptions, globals: new HostObjectWithOverrides());
 
             var state1 = await state0.ContinueWithAsync<bool>("Equals(null)");
             Assert.True(state1.ReturnValue);
@@ -660,7 +661,7 @@ Environment.ProcessorCount
         [Fact]
         public async Task ObjectOverrides2()
         {
-            var state0 = await CSharpScript.RunAsync("", globals: new object());
+            var state0 = await CSharpScript.RunAsync("", options: ScriptOptions, globals: new object());
             var state1 = await state0.ContinueWithAsync<bool>(@"
 object x = 1;
 object y = x;
@@ -678,7 +679,7 @@ ReferenceEquals(x, y)");
         [Fact]
         public void ObjectOverrides3()
         {
-            var state0 = CSharpScript.RunAsync("");
+            var state0 = CSharpScript.RunAsync("", ScriptOptions);
 
             var src1 = @"
 Equals(null);
@@ -717,7 +718,7 @@ class InnerClass<T>
 {
     public int method(int value) { return value + 1; }            
     public int field = 2;
-}").ContinueWith(@"
+}", ScriptOptions).ContinueWith(@"
 InnerClass<int> iC = new InnerClass<int>();
 ").ContinueWith(@"
 iC.method(iC.field)
@@ -732,7 +733,7 @@ iC.method(iC.field)
             CSharpScript.EvaluateAsync(@"
 class A<T> { }
 class B<T> : A<B<B<T>>> { }
-");
+", ScriptOptions);
         }
 
         [Fact, WorkItem(5378, "DevDiv_Projects/Roslyn")]
@@ -745,7 +746,7 @@ public static T bar<T>(T i)
 {
    return i;
 }
-");
+", ScriptOptions);
 
             Assert.Equal(1, s0.ContinueWith(@"goo<int, int>(1)").EvaluateAsync().Result);
             Assert.Equal(5, s0.ContinueWith(@"bar(5)").EvaluateAsync().Result);
@@ -768,7 +769,7 @@ public class C
    public int gg<T>() { return 20; }
    public virtual int gh<T>() { return 200; }
 }
-");
+", ScriptOptions);
             state = state.ContinueWith(@"
 new System.Func<int>(C.f)() +
 new System.Func<int>(new C().g)() +
@@ -801,7 +802,7 @@ public class C<S>
    public int gg<T>() { return 20; }
    public virtual int gh<T>() { return 200; }
 }
-");
+", ScriptOptions);
             state = state.ContinueWith(@"
 new System.Func<int>(C<byte>.f)() +
 new System.Func<int>(new C<byte>().g)() +
@@ -839,7 +840,7 @@ else
 }
 
 x
-").Result;
+", ScriptOptions).Result;
 
             Assert.Equal(5, result);
         }
@@ -847,8 +848,8 @@ x
         [Fact]
         public void ExprStmtParenthesesUsedToOverrideDefaultEval()
         {
-            Assert.Equal(18, CSharpScript.EvaluateAsync<int>("(4 + 5) * 2").Result);
-            Assert.Equal(1, CSharpScript.EvaluateAsync<long>("6 / (2 * 3)").Result);
+            Assert.Equal(18, CSharpScript.EvaluateAsync<int>("(4 + 5) * 2", ScriptOptions).Result);
+            Assert.Equal(1, CSharpScript.EvaluateAsync<long>("6 / (2 * 3)", ScriptOptions).Result);
         }
 
         [Fact, WorkItem(5397, "DevDiv_Projects/Roslyn")]
@@ -857,7 +858,7 @@ x
             var s = CSharpScript.RunAsync(@"
 using System;
 delegate void TestDelegate(string s);
-");
+", ScriptOptions);
 
             s = s.ContinueWith(@"
 TestDelegate testDelB = delegate (string s) { Console.WriteLine(s); };
@@ -878,7 +879,7 @@ System.Func<int, int> f = (arg) =>
 };
 
 f
-").Result;
+", ScriptOptions).Result;
             Assert.Equal(3, f(2));
         }
 
@@ -895,14 +896,14 @@ List<string> result = new List<string>();
 string s = ""hello"";
 Enumerable.ToList(Enumerable.Range(1, 2)).ForEach(x => result.Add(s));
 result
-").Result;
+", ScriptOptions).Result;
             AssertEx.Equal(new[] { "hello", "hello" }, result);
         }
 
         [Fact]
         public void UseDelegateMixStaticAndDynamic()
         {
-            var f = CSharpScript.RunAsync("using System;").
+            var f = CSharpScript.RunAsync("using System;", ScriptOptions).
                 ContinueWith("int Sqr(int x) {return x*x;}").
                 ContinueWith<Func<int, int>>("new Func<int,int>(Sqr)").Result.ReturnValue;
 
@@ -916,7 +917,7 @@ result
 int[] arr_1 = { 1, 2, 3 };
 int[] arr_2 = new int[] { 1, 2, 3 };
 int[] arr_3 = new int[5];
-").ContinueWith(@"
+", ScriptOptions).ContinueWith(@"
 arr_2[0] = 5;
 ");
 
@@ -942,7 +943,7 @@ int z = 4 + f;
 result.Add(z);
 result.Add(a * z);
 result
-").Result;
+", ScriptOptions).Result;
             Assert.Equal(3, result.Count);
             Assert.Equal(3, result[0]);
             Assert.Equal(6, result[1]);
@@ -968,7 +969,7 @@ int field = 2;
 result.Add(constant);
 result.Add(field);
 result
-").Result;
+", ScriptOptions).Result;
             Assert.Equal(4, result.Count);
             Assert.Equal(1, result[0]);
             Assert.Equal(2, result[1]);
@@ -981,7 +982,7 @@ result
         {
             var result = CSharpScript.RunAsync(@"
 using System.Collections.Generic;
-static List<int> result = new List<int>();").
+static List<int> result = new List<int>();", ScriptOptions).
             ContinueWith("int x = 1;").
             ContinueWith("System.Func<int> f = () => x++;").
             ContinueWith("result.Add(f());").
@@ -996,7 +997,7 @@ static List<int> result = new List<int>();").
         [Fact]
         public void ExtensionMethods()
         {
-            var options = ScriptOptions.Default.AddReferences(
+            var options = ScriptOptions.AddReferences(
                 typeof(Enumerable).GetTypeInfo().Assembly);
 
             var result = CSharpScript.EvaluateAsync<int>(@"
@@ -1019,7 +1020,7 @@ string goo(int a) { return null; }
 int goo(string a) { return 0; }
 
 new object[] { x, y, z }
-").Result;
+", ScriptOptions).Result;
             AssertEx.Equal(new object[] { 1, 1, null }, result);
         }
 
@@ -1033,19 +1034,19 @@ new object[] { x, y, z }
         [WorkItem(9229, "DevDiv_Projects/Roslyn")]
         public async Task PrivateImplementationDetailsType()
         {
-            var result1 = await CSharpScript.EvaluateAsync<int[]>("new int[] { 1,2,3,4 }");
+            var result1 = await CSharpScript.EvaluateAsync<int[]>("new int[] { 1,2,3,4 }", ScriptOptions);
             AssertEx.Equal(new[] { 1, 2, 3, 4 }, result1);
 
-            var result2 = await CSharpScript.EvaluateAsync<int[]>("new int[] { 1,2,3,4,5  }");
+            var result2 = await CSharpScript.EvaluateAsync<int[]>("new int[] { 1,2,3,4,5  }", ScriptOptions);
             AssertEx.Equal(new[] { 1, 2, 3, 4, 5 }, result2);
 
-            var s1 = await CSharpScript.RunAsync<int[]>("new int[] { 1,2,3,4,5,6  }");
+            var s1 = await CSharpScript.RunAsync<int[]>("new int[] { 1,2,3,4,5,6  }", ScriptOptions);
             AssertEx.Equal(new[] { 1, 2, 3, 4, 5, 6 }, s1.ReturnValue);
 
-            var s2 = await s1.ContinueWithAsync<int[]>("new int[] { 1,2,3,4,5,6,7  }");
+            var s2 = await s1.ContinueWithAsync<int[]>("new int[] { 1,2,3,4,5,6,7  }", ScriptOptions);
             AssertEx.Equal(new[] { 1, 2, 3, 4, 5, 6, 7 }, s2.ReturnValue);
 
-            var s3 = await s2.ContinueWithAsync<int[]>("new int[] { 1,2,3,4,5,6,7,8  }");
+            var s3 = await s2.ContinueWithAsync<int[]>("new int[] { 1,2,3,4,5,6,7,8  }", ScriptOptions);
             AssertEx.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8 }, s3.ReturnValue);
         }
 
@@ -1053,7 +1054,7 @@ new object[] { x, y, z }
         public void NoAwait()
         {
             // No await. The return value is Task<int> rather than int.
-            var result = CSharpScript.EvaluateAsync("System.Threading.Tasks.Task.FromResult(1)").Result;
+            var result = CSharpScript.EvaluateAsync("System.Threading.Tasks.Task.FromResult(1)", ScriptOptions).Result;
             Assert.Equal(1, ((Task<int>)result).Result);
         }
 
@@ -1063,7 +1064,7 @@ new object[] { x, y, z }
         [Fact]
         public void Await()
         {
-            Assert.Equal(2, CSharpScript.EvaluateAsync("await System.Threading.Tasks.Task.FromResult(2)").Result);
+            Assert.Equal(2, CSharpScript.EvaluateAsync("await System.Threading.Tasks.Task.FromResult(2)", ScriptOptions).Result);
         }
 
         /// <summary>
@@ -1072,13 +1073,13 @@ new object[] { x, y, z }
         [Fact]
         public void AwaitSubExpression()
         {
-            Assert.Equal(3, CSharpScript.EvaluateAsync<int>("0 + await System.Threading.Tasks.Task.FromResult(3)").Result);
+            Assert.Equal(3, CSharpScript.EvaluateAsync<int>("0 + await System.Threading.Tasks.Task.FromResult(3)", ScriptOptions).Result);
         }
 
         [Fact]
         public void AwaitVoid()
         {
-            var task = CSharpScript.EvaluateAsync<object>("await System.Threading.Tasks.Task.Run(() => { })");
+            var task = CSharpScript.EvaluateAsync<object>("await System.Threading.Tasks.Task.Run(() => { })", ScriptOptions);
             Assert.Null(task.Result);
             Assert.Equal(TaskStatus.RanToCompletion, task.Status);
         }
@@ -1099,7 +1100,7 @@ static T F<T>(Func<Task<T>> f)
 static T G<T>(T t, Func<T, Task<T>> f)
 {
     return f(t).Result;
-}");
+}", ScriptOptions);
 
             var s1 = await s0.ContinueWithAsync("F(async () => await Task.FromResult(4))");
             Assert.Equal(4, s1.ReturnValue);
@@ -1111,7 +1112,7 @@ static T G<T>(T t, Func<T, Task<T>> f)
         [Fact]
         public void AwaitChain1()
         {
-            var options = ScriptOptions.Default.
+            var options = ScriptOptions.
                 AddReferences(typeof(Task).GetTypeInfo().Assembly).
                 AddImports("System.Threading.Tasks");
 
@@ -1129,7 +1130,7 @@ static T G<T>(T t, Func<T, Task<T>> f)
         [Fact]
         public void AwaitChain2()
         {
-            var options = ScriptOptions.Default.
+            var options = ScriptOptions.
                 AddReferences(typeof(Task).GetTypeInfo().Assembly).
                 AddImports("System.Threading.Tasks");
 
@@ -1148,7 +1149,7 @@ static T G<T>(T t, Func<T, Task<T>> f)
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/39548")]
         public async Task PatternVariableDeclaration()
         {
-            var state = await CSharpScript.RunAsync("var x = (false, 4);");
+            var state = await CSharpScript.RunAsync("var x = (false, 4);", ScriptOptions);
             state = await state.ContinueWithAsync("x is (false, var y)");
             Assert.Equal(true, state.ReturnValue);
         }
@@ -1156,7 +1157,7 @@ static T G<T>(T t, Func<T, Task<T>> f)
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42368")]
         public async Task CSharp9PatternForms()
         {
-            var options = ScriptOptions.Default.WithLanguageVersion(MessageID.IDS_FeatureAndPattern.RequiredVersion());
+            var options = ScriptOptions.WithLanguageVersion(MessageID.IDS_FeatureAndPattern.RequiredVersion());
             var state = await CSharpScript.RunAsync("object x = 1;", options: options);
             state = await state.ContinueWithAsync("x is long or int", options: options);
             Assert.Equal(true, state.ReturnValue);
@@ -1172,7 +1173,7 @@ static T G<T>(T t, Func<T, Task<T>> f)
         public void InteractiveSession_ImportScopes()
         {
             var script = CSharpScript.Create(@"
-1 + 1", ScriptOptions.Default.WithImports("System"));
+1 + 1", ScriptOptions.WithImports("System"));
 
             var compilation = script.GetCompilation();
             var tree = compilation.SyntaxTrees.Single();
@@ -1223,7 +1224,7 @@ public class C : I
 #r ""{file1.Path}""
 #r ""{file2.Path}""
 new C()
-").Result;
+", ScriptOptions).Result;
             Assert.NotNull(result);
         }
 
@@ -1240,7 +1241,7 @@ new C()
 
             var script = CSharpScript.Create(
                 $@"#r ""{Path.Combine("..", libFileName)}""",
-                ScriptOptions.Default.WithFilePath(scriptPath));
+                ScriptOptions.WithFilePath(scriptPath));
 
             script.GetCompilation().VerifyDiagnostics();
         }
@@ -1260,7 +1261,7 @@ new C()
 
             var script = CSharpScript.Create(
                 $@"#r ""\{unrooted}""",
-                ScriptOptions.Default.WithFilePath(scriptPath));
+                ScriptOptions.WithFilePath(scriptPath));
 
             script.GetCompilation().VerifyDiagnostics();
         }
@@ -1291,7 +1292,7 @@ new C()
             dir.CreateFile(libName + ".exe").WriteAllBytes(exeImage);
             dir.CreateFile(libName + ".winmd").WriteAllBytes(winmdImage);
 
-            var r2 = CSharpScript.Create($@"#r ""{fileMain.Path}""").ContinueWith($@"M.X.F").RunAsync().Result.ReturnValue;
+            var r2 = CSharpScript.Create($@"#r ""{fileMain.Path}""", ScriptOptions).ContinueWith($@"M.X.F").RunAsync().Result.ReturnValue;
             Assert.Equal("exe", r2);
         }
 
@@ -1322,7 +1323,7 @@ new C()
             dir.CreateFile(libName + ".dll").WriteAllBytes(dllImage);
             dir.CreateFile(libName + ".winmd").WriteAllBytes(winmdImage);
 
-            var r2 = CSharpScript.Create($@"#r ""{fileMain.Path}""").ContinueWith($@"M.X.F").RunAsync().Result.ReturnValue;
+            var r2 = CSharpScript.Create($@"#r ""{fileMain.Path}""", ScriptOptions).ContinueWith($@"M.X.F").RunAsync().Result.ReturnValue;
             Assert.Equal("dll", r2);
         }
 
@@ -1338,7 +1339,7 @@ public class E { }
             var libRef = CreateCSharpCompilationWithCorlib(source, "lib").EmitToImageReference();
 
             var script = CSharpScript.Create(@"new C()",
-                ScriptOptions.Default.WithReferences(libRef.WithAliases(new[] { "Hidden" })).WithImports("Hidden::N"));
+                ScriptOptions.WithReferences(libRef.WithAliases(new[] { "Hidden" })).WithImports("Hidden::N"));
 
             script.Compile().Verify();
         }
@@ -1355,14 +1356,14 @@ using D = System.Collections.Generic.Dictionary<string, int>;
 D d = new D();
 
 d
-").Result;
+", ScriptOptions).Result;
             Assert.True(result is Dictionary<string, int>, "Expected Dictionary<string, int>");
         }
 
         [Fact, WorkItem(9229, "DevDiv_Projects/Roslyn")]
         public void Usings1()
         {
-            var options = ScriptOptions.Default.
+            var options = ScriptOptions.
                 AddImports("System", "System.Linq").
                 AddReferences(typeof(Enumerable).GetTypeInfo().Assembly);
 
@@ -1373,7 +1374,7 @@ d
         [Fact, WorkItem(9229, "DevDiv_Projects/Roslyn")]
         public void Usings2()
         {
-            var options = ScriptOptions.Default.
+            var options = ScriptOptions.
                  AddImports("System", "System.Linq").
                  AddReferences(typeof(Enumerable).GetTypeInfo().Assembly);
 
@@ -1388,7 +1389,7 @@ d
         public void AddNamespaces_Errors()
         {
             // no immediate error, error is reported if the namespace can't be found when compiling:
-            var options = ScriptOptions.Default.AddImports("?1", "?2");
+            var options = ScriptOptions.AddImports("?1", "?2");
 
             ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("1", options),
                 // error CS0246: The type or namespace name '?1' could not be found (are you missing a using directive or an assembly reference?)
@@ -1396,19 +1397,19 @@ d
                 // error CS0246: The type or namespace name '?2' could not be found (are you missing a using directive or an assembly reference?)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("?2"));
 
-            options = ScriptOptions.Default.AddImports("");
+            options = ScriptOptions.AddImports("");
 
             ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("1", options),
                 // error CS7088: Invalid 'Usings' value: ''.
                 Diagnostic(ErrorCode.ERR_BadCompilationOptionValue).WithArguments("Usings", ""));
 
-            options = ScriptOptions.Default.AddImports(".abc");
+            options = ScriptOptions.AddImports(".abc");
 
             ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("1", options),
                 // error CS7088: Invalid 'Usings' value: '.abc'.
                 Diagnostic(ErrorCode.ERR_BadCompilationOptionValue).WithArguments("Usings", ".abc"));
 
-            options = ScriptOptions.Default.AddImports("a\0bc");
+            options = ScriptOptions.AddImports("a\0bc");
 
             ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("1", options),
                 // error CS7088: Invalid 'Usings' value: '.abc'.
@@ -1426,13 +1427,13 @@ d
         [Fact]
         public void Submission_HostConversions()
         {
-            Assert.Equal(2, CSharpScript.EvaluateAsync<int>("1+1").Result);
+            Assert.Equal(2, CSharpScript.EvaluateAsync<int>("1+1", ScriptOptions).Result);
 
-            Assert.Null(CSharpScript.EvaluateAsync<string>("null").Result);
+            Assert.Null(CSharpScript.EvaluateAsync<string>("null", ScriptOptions).Result);
 
             try
             {
-                CSharpScript.RunAsync<C<int>>("null");
+                CSharpScript.RunAsync<C<int>>("null", ScriptOptions);
                 Assert.True(false, "Expected an exception");
             }
             catch (CompilationErrorException e)
@@ -1442,7 +1443,7 @@ d
                 // Can't use Verify() because the version number of the test dll is different in the build lab.
             }
 
-            var options = ScriptOptions.Default.AddReferences(HostAssembly);
+            var options = ScriptOptions.AddReferences(HostAssembly);
 
             var cint = CSharpScript.EvaluateAsync<C<int>>("null", options).Result;
             Assert.Null(cint);
@@ -1451,7 +1452,7 @@ d
 
             try
             {
-                CSharpScript.RunAsync<int>("null");
+                CSharpScript.RunAsync<int>("null", ScriptOptions);
                 Assert.True(false, "Expected an exception");
             }
             catch (CompilationErrorException e)
@@ -1464,7 +1465,7 @@ d
 
             try
             {
-                CSharpScript.RunAsync<string>("1+1");
+                CSharpScript.RunAsync<string>("1+1", ScriptOptions);
                 Assert.True(false, "Expected an exception");
             }
             catch (CompilationErrorException e)
@@ -1483,7 +1484,7 @@ d
 using System;
 using System.Collections.Generic;
 new List<ArgumentException>()
-").Result;
+", ScriptOptions).Result;
 
             Assert.Null(value.FirstOrDefault());
         }
@@ -1527,7 +1528,7 @@ new List<ArgumentException>()
         {
             var c = new C();
 
-            var s0 = CSharpScript.RunAsync<int>("x + Y + Z()", globals: c);
+            var s0 = CSharpScript.RunAsync<int>("x + Y + Z()", options: ScriptOptions, globals: c);
             Assert.Equal(6, s0.Result.ReturnValue);
 
             var s1 = s0.ContinueWith<int>("x");
@@ -1543,7 +1544,7 @@ new List<ArgumentException>()
         public void HostObjectBinding_PublicGenericClassMembers()
         {
             var m = new M<string>();
-            var result = CSharpScript.EvaluateAsync<string>("G()", globals: m);
+            var result = CSharpScript.EvaluateAsync<string>("G()", options: ScriptOptions, globals: m);
             Assert.Null(result.Result);
         }
 
@@ -1552,7 +1553,7 @@ new List<ArgumentException>()
         {
             var c = new C();
 
-            var s0 = await CSharpScript.RunAsync<int>("Z()", globals: c, globalsType: typeof(I));
+            var s0 = await CSharpScript.RunAsync<int>("Z()", options: ScriptOptions, globals: c, globalsType: typeof(I));
             Assert.Equal(3, s0.ReturnValue);
 
             ScriptingTestHelpers.AssertCompilationError(s0, @"x + Y",
@@ -1569,7 +1570,7 @@ new List<ArgumentException>()
         {
             var c = new PrivateClass();
 
-            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", globals: c),
+            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", options: ScriptOptions, globals: c),
                 // (1,1): error CS0122: '<Fully Qualified Name of PrivateClass>.Z()' is inaccessible due to its protection level
                 Diagnostic(ErrorCode.ERR_BadAccess, "Z").WithArguments(typeof(PrivateClass).FullName.Replace("+", ".") + ".Z()"));
         }
@@ -1579,7 +1580,7 @@ new List<ArgumentException>()
         {
             object c = new M<int>();
 
-            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", globals: c),
+            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", options: ScriptOptions, globals: c),
                 // (1,1): error CS0103: The name 'z' does not exist in the current context
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "Z").WithArguments("Z"));
         }
@@ -1588,14 +1589,14 @@ new List<ArgumentException>()
         public void HostObjectBinding_PrivateClassImplementingPublicInterface()
         {
             var c = new PrivateClass();
-            var result = CSharpScript.EvaluateAsync<int>("Z()", globals: c, globalsType: typeof(I));
+            var result = CSharpScript.EvaluateAsync<int>("Z()", options: ScriptOptions, globals: c, globalsType: typeof(I));
             Assert.Equal(3, result.Result);
         }
 
         [Fact]
         public void HostObjectBinding_StaticMembers()
         {
-            var s0 = CSharpScript.RunAsync("static int goo = StaticField;", globals: new C());
+            var s0 = CSharpScript.RunAsync("static int goo = StaticField;", options: ScriptOptions, globals: new C());
             var s1 = s0.ContinueWith("static int bar { get { return goo; } }");
             var s2 = s1.ContinueWith("class C { public static int baz() { return bar; } }");
             var s3 = s2.ContinueWith("C.baz()");
@@ -1614,7 +1615,7 @@ new List<ArgumentException>()
         [Fact]
         public void HostObjectBinding_Overloads()
         {
-            var s0 = CSharpScript.RunAsync("int goo(double a) { return 2; }", globals: new D());
+            var s0 = CSharpScript.RunAsync("int goo(double a) { return 2; }", options: ScriptOptions, globals: new D());
             var s1 = s0.ContinueWith("goo(1)");
             Assert.Equal(2, s1.Result.ReturnValue);
 
@@ -1626,11 +1627,11 @@ new List<ArgumentException>()
         public void HostObjectInRootNamespace()
         {
             var obj = new InteractiveFixtures_TopLevelHostObject { X = 1, Y = 2, Z = 3 };
-            var r0 = CSharpScript.EvaluateAsync<int>("X + Y + Z", globals: obj);
+            var r0 = CSharpScript.EvaluateAsync<int>("X + Y + Z", options: ScriptOptions, globals: obj);
             Assert.Equal(6, r0.Result);
 
             obj = new InteractiveFixtures_TopLevelHostObject { X = 1, Y = 2, Z = 3 };
-            var r1 = CSharpScript.EvaluateAsync<int>("X", globals: obj);
+            var r1 = CSharpScript.EvaluateAsync<int>("X", options: ScriptOptions, globals: obj);
             Assert.Equal(1, r1.Result);
         }
 
@@ -1639,7 +1640,7 @@ new List<ArgumentException>()
         {
             var scriptCompilation = CSharpScript.Create(
                 "nameof(Microsoft.CodeAnalysis.Scripting)",
-                ScriptOptions.Default.WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance),
+                ScriptOptions.WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance),
                 globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
 
             scriptCompilation.VerifyDiagnostics(
@@ -1696,7 +1697,7 @@ new List<ArgumentException>()
         {
             var scriptCompilation = CSharpScript.Create(
                 "typeof(Microsoft.CodeAnalysis.Scripting.Script)",
-                options: ScriptOptions.Default.
+                options: ScriptOptions.
                     WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance).
                     WithReferences(typeof(CSharpScript).GetTypeInfo().Assembly),
                 globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
@@ -1764,7 +1765,7 @@ typeof(Microsoft.CodeAnalysis.Scripting.Script)
 ";
             var scriptCompilation = CSharpScript.Create(
                 source,
-                ScriptOptions.Default.WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance),
+                ScriptOptions.WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance),
                 globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
 
             scriptCompilation.VerifyDiagnostics();
@@ -1840,7 +1841,7 @@ if(TryGetValue(out var result)){
 return true;
 ";
 
-            var result = await CSharpScript.EvaluateAsync<bool>(code, globalsType: typeof(E), globals: new E());
+            var result = await CSharpScript.EvaluateAsync<bool>(code, options: ScriptOptions, globalsType: typeof(E), globals: new E());
             Assert.True(result);
         }
 
@@ -1860,7 +1861,7 @@ static bool M()
 return M();
 ";
 
-            var script = CSharpScript.Create<bool>(code, globalsType: typeof(F));
+            var script = CSharpScript.Create<bool>(code, options: ScriptOptions, globalsType: typeof(F));
             ScriptingTestHelpers.AssertCompilationError(() => script.RunAsync(new F()).Wait(),
                     // (4,9): error CS0120: An object reference is required for the non-static field, method, or property 'InteractiveSessionTests.F.Value'
                     // 				return Value;
@@ -1882,7 +1883,7 @@ bool M()
 return M();
 ";
 
-            var script = CSharpScript.Create<bool>(code, globalsType: typeof(F));
+            var script = CSharpScript.Create<bool>(code, options: ScriptOptions, globalsType: typeof(F));
             ScriptingTestHelpers.AssertCompilationError(() => script.RunAsync(new F()).Wait(),
                     // (7,10): error CS0120: An object reference is required for the non-static field, method, or property 'InteractiveSessionTests.F.Value'
                     // 					return Value;
@@ -1904,7 +1905,7 @@ bool M()
 return M();
 ";
 
-            var result = await CSharpScript.EvaluateAsync<bool>(code, globalsType: typeof(F), globals: new F());
+            var result = await CSharpScript.EvaluateAsync<bool>(code, options: ScriptOptions, globalsType: typeof(F), globals: new F());
             Assert.True(result);
         }
 
@@ -1920,7 +1921,7 @@ return M();
 int i = 10;
 throw new System.Exception(""Bang!"");
 int j = 2;
-");
+", ScriptOptions);
 
             var s1 = s0.ContinueWith(@"
 int F() => i + j;
@@ -1941,7 +1942,7 @@ int F() => i + j;
         {
             var s0 = CSharpScript.Create(@"
 int i = 100;
-");
+", ScriptOptions);
 
             var s1 = s0.ContinueWith(@"
 int j = 20;
@@ -1968,7 +1969,7 @@ int F() => i + j + k;
         {
             var s0 = CSharpScript.Create(@"
 int i = 1000;
-");
+", ScriptOptions);
             var s1 = s0.ContinueWith(@"
 int j = 200;
 throw new System.Exception(""Bang!"");
@@ -1996,7 +1997,7 @@ int F() => i + j + k + l;
         {
             var state0 = await CSharpScript.RunAsync(@"
 int i = 1000;
-");
+", ScriptOptions);
             var state1 = await state0.ContinueWithAsync(@"
 int j = 200;
 throw new System.Exception(""Bang 1!"");
@@ -2029,7 +2030,7 @@ i + j + k + l
 
             var s0 = CSharpScript.Create(@"
 int i = 1000;
-", globalsType: globals.GetType());
+", options: ScriptOptions, globalsType: globals.GetType());
 
             var s1 = s0.ContinueWith(@"
 int j = 200;
@@ -2063,7 +2064,7 @@ int F() => i + j + k + l;
 
             var s0 = CSharpScript.Create(@"
 int i = 1000;
-", globalsType: globals.GetType());
+", options: ScriptOptions, globalsType: globals.GetType());
 
             var s1 = s0.ContinueWith(@"
 int j = 200;
@@ -2097,7 +2098,7 @@ int F() => i + j + k + l;
 
             var s0 = CSharpScript.Create(@"
 int i = 1000;
-", globalsType: globals.GetType());
+", options: ScriptOptions, globalsType: globals.GetType());
 
             var s1 = s0.ContinueWith(@"
 int j = 200;
@@ -2129,7 +2130,7 @@ int F() => i + j + k + l;
 {
     return LocalFunction();
     int LocalFunction() => Y;
-}", globals: new C()).
+}", options: ScriptOptions, globals: new C()).
                 ContinueWith(
 @"var lambda = new System.Func<int>(() =>
 {

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -11,9 +11,12 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting.Test;
+using Microsoft.CodeAnalysis.Scripting.TestUtilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -22,7 +25,7 @@ using KeyValuePairUtil = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 {
-    public class ScriptTests : TestBase
+    public class ScriptTests : CSharpScriptTestBase
     {
         public class Globals
         {
@@ -33,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         [Fact]
         public void TestCreateScript()
         {
-            var script = CSharpScript.Create("1 + 2");
+            var script = CSharpScript.Create("1 + 2", ScriptOptions);
             Assert.Equal("1 + 2", script.Code);
         }
 
@@ -46,20 +49,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         [Fact]
         public void TestCreateFromStreamScript()
         {
-            var script = CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("1 + 2")));
+            var script = CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("1 + 2")), ScriptOptions);
             Assert.Equal("1 + 2", script.Code);
         }
 
         [Fact]
         public void TestCreateFromStreamScript_StreamIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => CSharpScript.Create((Stream)null));
+            Assert.Throws<ArgumentNullException>(() => CSharpScript.Create((Stream)null, ScriptOptions));
         }
 
         [Fact]
         public async Task TestGetCompilation()
         {
-            var state = await CSharpScript.RunAsync("1 + 2", globals: new ScriptTests());
+            var state = await CSharpScript.RunAsync("1 + 2", options: ScriptOptions, globals: new ScriptTests());
             var compilation = state.Script.GetCompilation();
             Assert.Equal(state.Script.Code, compilation.SyntaxTrees.First().GetText().ToString());
         }
@@ -67,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         [Fact]
         public async Task TestGetCompilationSourceText()
         {
-            var state = await CSharpScript.RunAsync("1 + 2", globals: new ScriptTests());
+            var state = await CSharpScript.RunAsync("1 + 2", options: ScriptOptions, globals: new ScriptTests());
             var compilation = state.Script.GetCompilation();
             Assert.Equal(state.Script.SourceText, compilation.SyntaxTrees.First().GetText());
         }
@@ -80,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 
         private void TestEmit(DebugInformationFormat format)
         {
-            var script = CSharpScript.Create("1 + 2", options: ScriptOptions.Default.WithEmitDebugInformation(true));
+            var script = CSharpScript.Create("1 + 2", options: ScriptOptions.WithEmitDebugInformation(true));
             var compilation = script.GetCompilation();
             var emitOptions = ScriptBuilder.GetEmitOptions(emitDebugInformation: true).WithDebugInformationFormat(format);
 
@@ -104,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         public async Task TestCreateScriptDelegate()
         {
             // create a delegate for the entire script
-            var script = CSharpScript.Create("1 + 2");
+            var script = CSharpScript.Create("1 + 2", ScriptOptions);
             var fn = script.CreateDelegate();
 
             Assert.Equal(3, fn().Result);
@@ -115,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         public async Task TestCreateScriptDelegateWithGlobals()
         {
             // create a delegate for the entire script
-            var script = CSharpScript.Create<int>("X + Y", globalsType: typeof(Globals));
+            var script = CSharpScript.Create<int>("X + Y", options: ScriptOptions, globalsType: typeof(Globals));
             var fn = script.CreateDelegate();
 
             await Assert.ThrowsAsync<ArgumentException>("globals", () => fn());
@@ -126,14 +129,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         [Fact]
         public async Task TestRunScript()
         {
-            var state = await CSharpScript.RunAsync("1 + 2");
+            var state = await CSharpScript.RunAsync("1 + 2", ScriptOptions);
             Assert.Equal(3, state.ReturnValue);
         }
 
         [Fact]
         public async Task TestCreateAndRunScript()
         {
-            var script = CSharpScript.Create("1 + 2");
+            var script = CSharpScript.Create("1 + 2", ScriptOptions);
             var state = await script.RunAsync();
             Assert.Same(script, state.Script);
             Assert.Equal(3, state.ReturnValue);
@@ -142,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         [Fact]
         public async Task TestCreateFromStreamAndRunScript()
         {
-            var script = CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("1 + 2")));
+            var script = CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("1 + 2")), ScriptOptions);
             var state = await script.RunAsync();
             Assert.Same(script, state.Script);
             Assert.Equal(3, state.ReturnValue);
@@ -151,14 +154,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         [Fact]
         public async Task TestEvalScript()
         {
-            var value = await CSharpScript.EvaluateAsync("1 + 2");
+            var value = await CSharpScript.EvaluateAsync("1 + 2", ScriptOptions);
             Assert.Equal(3, value);
         }
 
         [Fact]
         public async Task TestRunScriptWithSpecifiedReturnType()
         {
-            var state = await CSharpScript.RunAsync("1 + 2");
+            var state = await CSharpScript.RunAsync("1 + 2", ScriptOptions);
             Assert.Equal(3, state.ReturnValue);
         }
 
@@ -166,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         public void TestRunVoidScript()
         {
             var state = ScriptingTestHelpers.RunScriptWithOutput(
-                CSharpScript.Create("System.Console.WriteLine(0);"),
+                CSharpScript.Create("System.Console.WriteLine(0);", ScriptOptions),
                 "0");
             Assert.Null(state.ReturnValue);
         }
@@ -176,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         {
             var state = await CSharpScript.RunAsync(
 @"int F() { return 1; }
-F();");
+F();", ScriptOptions);
             Assert.Null(state.ReturnValue);
         }
 
@@ -192,7 +195,7 @@ class SomeClass
 }
 dynamic d = new SomeClass();
 d.Do();"
-, ScriptOptions.Default.WithReferences(MscorlibRef, SystemRef, SystemCoreRef, CSharpRef));
+, ScriptOptions.WithReferences(MscorlibRef, SystemRef, SystemCoreRef, CSharpRef));
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/170")]
@@ -207,7 +210,7 @@ class SomeClass
 }
 dynamic d = new SomeClass();
 d.Do()"
-, ScriptOptions.Default.WithReferences(MscorlibRef, SystemRef, SystemCoreRef, CSharpRef));
+, ScriptOptions.WithReferences(MscorlibRef, SystemRef, SystemCoreRef, CSharpRef));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/6676")]
@@ -218,7 +221,7 @@ d.Do()"
             try
             {
                 var state = CSharpScript.RunAsync(@"if (true)
- System.Console.WriteLine(true)", globals: new ScriptTests());
+ System.Console.WriteLine(true)", options: ScriptOptions, globals: new ScriptTests());
             }
             catch (CompilationErrorException ex)
             {
@@ -236,14 +239,14 @@ d.Do()"
         public void TestRunEmbeddedStatementFollowedBySemicolon()
         {
             var state = CSharpScript.RunAsync(@"if (true)
-System.Console.WriteLine(true);", globals: new ScriptTests());
+System.Console.WriteLine(true);", options: ScriptOptions, globals: new ScriptTests());
             Assert.Null(state.Exception);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/6676")]
         public void TestRunStatementFollowedBySpace()
         {
-            var state = CSharpScript.RunAsync(@"System.Console.WriteLine(true) ", globals: new ScriptTests());
+            var state = CSharpScript.RunAsync(@"System.Console.WriteLine(true) ", options: ScriptOptions, globals: new ScriptTests());
             Assert.Null(state.Exception);
         }
 
@@ -253,7 +256,7 @@ System.Console.WriteLine(true);", globals: new ScriptTests());
             var state = CSharpScript.RunAsync(@"
 System.Console.WriteLine(true)
 
-", globals: new ScriptTests());
+", options: ScriptOptions, globals: new ScriptTests());
             Assert.Null(state.Exception);
         }
 
@@ -265,7 +268,7 @@ System.Console.WriteLine(true)
             try
             {
                 var state = CSharpScript.RunAsync(@"if (e) a = b 
-throw e;", globals: new ScriptTests());
+throw e;", options: ScriptOptions, globals: new ScriptTests());
             }
             catch (CompilationErrorException ex)
             {
@@ -284,14 +287,14 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task TestRunScriptWithGlobals()
         {
-            var state = await CSharpScript.RunAsync("X + Y", globals: new Globals { X = 1, Y = 2 });
+            var state = await CSharpScript.RunAsync("X + Y", options: ScriptOptions, globals: new Globals { X = 1, Y = 2 });
             Assert.Equal(3, state.ReturnValue);
         }
 
         [Fact]
         public async Task TestRunCreatedScriptWithExpectedGlobals()
         {
-            var script = CSharpScript.Create("X + Y", globalsType: typeof(Globals));
+            var script = CSharpScript.Create("X + Y", options: ScriptOptions, globalsType: typeof(Globals));
             var state = await script.RunAsync(new Globals { X = 1, Y = 2 });
             Assert.Equal(3, state.ReturnValue);
             Assert.Same(script, state.Script);
@@ -300,7 +303,7 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task TestRunCreatedScriptWithUnexpectedGlobals()
         {
-            var script = CSharpScript.Create("X + Y");
+            var script = CSharpScript.Create("X + Y", ScriptOptions);
 
             // Global variables passed to a script without a global type
             await Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new Globals { X = 1, Y = 2 }));
@@ -309,7 +312,7 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task TestRunCreatedScriptWithoutGlobals()
         {
-            var script = CSharpScript.Create("X + Y", globalsType: typeof(Globals));
+            var script = CSharpScript.Create("X + Y", options: ScriptOptions, globalsType: typeof(Globals));
 
             //  The script requires access to global variables but none were given
             await Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync());
@@ -318,7 +321,7 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task TestRunCreatedScriptWithMismatchedGlobals()
         {
-            var script = CSharpScript.Create("X + Y", globalsType: typeof(Globals));
+            var script = CSharpScript.Create("X + Y", options: ScriptOptions, globalsType: typeof(Globals));
 
             //  The globals of type 'System.Object' is not assignable to 'Microsoft.CodeAnalysis.CSharp.Scripting.Test.ScriptTests+Globals'
             await Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new object()));
@@ -327,7 +330,7 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task ContinueAsync_Error1()
         {
-            var state = await CSharpScript.RunAsync("X + Y", globals: new Globals());
+            var state = await CSharpScript.RunAsync("X + Y", options: ScriptOptions, globals: new Globals());
 
             await Assert.ThrowsAsync<ArgumentNullException>("previousState", () => state.Script.RunFromAsync(null));
         }
@@ -335,8 +338,8 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task ContinueAsync_Error2()
         {
-            var state1 = await CSharpScript.RunAsync("X + Y + 1", globals: new Globals());
-            var state2 = await CSharpScript.RunAsync("X + Y + 2", globals: new Globals());
+            var state1 = await CSharpScript.RunAsync("X + Y + 1", options: ScriptOptions, globals: new Globals());
+            var state2 = await CSharpScript.RunAsync("X + Y + 2", options: ScriptOptions, globals: new Globals());
 
             await Assert.ThrowsAsync<ArgumentException>("previousState", () => state1.Script.RunFromAsync(state2));
         }
@@ -345,7 +348,7 @@ throw e;", globals: new ScriptTests());
         public async Task TestRunScriptWithScriptState()
         {
             // run a script using another scripts end state as the starting state (globals)
-            var state = await CSharpScript.RunAsync("int X = 100;").ContinueWith("X + X");
+            var state = await CSharpScript.RunAsync("int X = 100;", ScriptOptions).ContinueWith("X + X");
             Assert.Equal(200, state.ReturnValue);
         }
 
@@ -359,7 +362,7 @@ throw e;", globals: new ScriptTests());
                 "x + y"
             };
 
-            var state = await CSharpScript.RunAsync("");
+            var state = await CSharpScript.RunAsync("", ScriptOptions);
             foreach (var submission in submissions)
             {
                 state = await state.ContinueWithAsync(submission);
@@ -388,6 +391,7 @@ throw e;", globals: new ScriptTests());
             var script =
                 CSharpScript.Create(
                     "var a = '1';",
+                    options: ScriptOptions,
                     globalsType: globals.GetType()).
                 ContinueWith("var b = 2u;").
                 ContinueWith("var a = 3m;").
@@ -412,7 +416,7 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task ScriptVariable_SetValue()
         {
-            var script = CSharpScript.Create("var x = 1;");
+            var script = CSharpScript.Create("var x = 1;", ScriptOptions);
 
             var s1 = await script.RunAsync();
             s1.GetVariable("x").Value = 2;
@@ -435,7 +439,7 @@ throw e;", globals: new ScriptTests());
 var x = 1;
 readonly var y = 2;
 const int z = 3;
-");
+", ScriptOptions);
 
             Assert.False(state.GetVariable("x").IsReadOnly);
             Assert.True(state.GetVariable("y").IsReadOnly);
@@ -452,7 +456,7 @@ const int z = 3;
         public async Task TestBranchingSubscripts()
         {
             // run script to create declaration of M
-            var state1 = await CSharpScript.RunAsync("int M(int x) { return x + x; }");
+            var state1 = await CSharpScript.RunAsync("int M(int x) { return x + x; }", ScriptOptions);
 
             // run second script starting from first script's end state
             // this script's new declaration should hide the old declaration
@@ -468,7 +472,7 @@ const int z = 3;
         [Fact]
         public async Task StaticDelegate0()
         {
-            var state0 = await CSharpScript.RunAsync("static int Add(int x, int y) => x + y;", options: ScriptOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var state0 = await CSharpScript.RunAsync("static int Add(int x, int y) => x + y;", options: ScriptOptions.WithLanguageVersion(LanguageVersion.Preview));
             var state1 = await state0.ContinueWithAsync("System.Func<int, int, int> adder = Add;");
             var state2 = await state1.ContinueWithAsync("adder(1, 1)");
             Assert.Equal(2, state2.ReturnValue);
@@ -477,7 +481,7 @@ const int z = 3;
         [Fact]
         public async Task StaticDelegate1()
         {
-            var state0 = await CSharpScript.RunAsync("class Id<T> { static T Core(T t) => t; public static System.Func<T, T> Get => Core; }");
+            var state0 = await CSharpScript.RunAsync("class Id<T> { static T Core(T t) => t; public static System.Func<T, T> Get => Core; }", ScriptOptions);
             var state1 = await state0.ContinueWithAsync("Id<int>.Get(1)");
             Assert.Equal(1, state1.ReturnValue);
         }
@@ -485,7 +489,7 @@ const int z = 3;
         [Fact]
         public async Task StaticDelegate2()
         {
-            var state0 = await CSharpScript.RunAsync("class Id { static T Core<T>(T t) => t; public static System.Func<T, T> Get<T>() => Core; }");
+            var state0 = await CSharpScript.RunAsync("class Id { static T Core<T>(T t) => t; public static System.Func<T, T> Get<T>() => Core; }", ScriptOptions);
             var state1 = await state0.ContinueWithAsync("Id.Get<int>()(1)");
             Assert.Equal(1, state1.ReturnValue);
         }
@@ -494,7 +498,7 @@ const int z = 3;
         public async Task ReturnIntAsObject()
         {
             var expected = 42;
-            var script = CSharpScript.Create<object>($"return {expected};");
+            var script = CSharpScript.Create<object>($"return {expected};", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Equal(expected, result);
         }
@@ -503,13 +507,13 @@ const int z = 3;
         public void NoReturn()
         {
             Assert.Null(ScriptingTestHelpers.EvaluateScriptWithOutput(
-                CSharpScript.Create("System.Console.WriteLine();"), ""));
+                CSharpScript.Create("System.Console.WriteLine();", ScriptOptions), ""));
         }
 
         [Fact]
         public async Task ReturnAwait()
         {
-            var script = CSharpScript.Create<int>("return await System.Threading.Tasks.Task.FromResult(42);");
+            var script = CSharpScript.Create<int>("return await System.Threading.Tasks.Task.FromResult(42);", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Equal(42, result);
         }
@@ -522,7 +526,7 @@ bool condition = false;
 if (condition)
 {
     return 1;
-}");
+}", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Null(result);
         }
@@ -536,7 +540,7 @@ if (condition)
 {
     return 1;
 }
-System.Console.WriteLine();");
+System.Console.WriteLine();", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Null(result);
 
@@ -546,7 +550,7 @@ if (condition)
 {
     return 1;
 }
-System.Console.WriteLine();");
+System.Console.WriteLine();", ScriptOptions);
 
             Assert.Equal(1, ScriptingTestHelpers.EvaluateScriptWithOutput(script, ""));
         }
@@ -560,7 +564,7 @@ if (condition)
 {
     return 1;
 }
-System.Console.WriteLine();");
+System.Console.WriteLine();", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Equal(0, result);
 
@@ -570,7 +574,7 @@ if (condition)
 {
     return 1;
 }
-System.Console.WriteLine()");
+System.Console.WriteLine()", ScriptOptions);
 
             Assert.Equal(0, ScriptingTestHelpers.EvaluateScriptWithOutput(script, ""));
         }
@@ -584,7 +588,7 @@ if (condition)
 {
     return 1;
 }
-1.1");
+1.1", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Equal(1.1, result);
 
@@ -594,7 +598,7 @@ if (condition)
 {
     return 1;
 }
-1.1");
+1.1", ScriptOptions);
             result = await script.EvaluateAsync();
             Assert.Equal(1, result);
         }
@@ -606,7 +610,7 @@ if (condition)
 if (false)
 {
     return new System.Collections.Generic.List<int> { 1, 2, 3 };
-}");
+}", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Null(result);
 
@@ -614,7 +618,7 @@ if (false)
 if (true)
 {
     return new System.Collections.Generic.List<int> { 1, 2, 3 };
-}");
+}", ScriptOptions);
             result = await script.EvaluateAsync();
             Assert.Equal(new List<int> { 1, 2, 3 }, result);
         }
@@ -626,7 +630,7 @@ if (true)
 if (false)
 {
     return 42;
-}");
+}", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.False(result.HasValue);
 
@@ -634,7 +638,7 @@ if (false)
 if (true)
 {
     return 42;
-}");
+}", ScriptOptions);
             result = await script.EvaluateAsync();
             Assert.Equal(42, result);
         }
@@ -644,7 +648,7 @@ if (true)
         {
             var resolver = TestSourceReferenceResolver.Create(
                 KeyValuePairUtil.Create("a.csx", "return 42;"));
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
 
             var script = CSharpScript.Create("#load \"a.csx\"", options);
             var result = await script.EvaluateAsync();
@@ -667,7 +671,7 @@ if (false)
     return 42;
 }
 1"));
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
 
             var script = CSharpScript.Create("#load \"a.csx\"", options);
             var result = await script.EvaluateAsync();
@@ -690,7 +694,7 @@ if (false)
     return 1;
 }
 System.Console.WriteLine(42)"));
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
 
             var script = CSharpScript.Create("#load \"a.csx\"", options);
             var result = ScriptingTestHelpers.EvaluateScriptWithOutput(script, "42");
@@ -711,7 +715,7 @@ System.Console.WriteLine(42)"));
                 KeyValuePairUtil.Create("b.csx", @"
 #load ""a.csx""
 2"));
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
             var script = CSharpScript.Create("#load \"b.csx\"", options);
             var result = await script.EvaluateAsync();
             Assert.Null(result);
@@ -719,7 +723,7 @@ System.Console.WriteLine(42)"));
             resolver = TestSourceReferenceResolver.Create(
                 KeyValuePairUtil.Create("a.csx", "1"),
                 KeyValuePairUtil.Create("b.csx", "2"));
-            options = ScriptOptions.Default.WithSourceResolver(resolver);
+            options = ScriptOptions.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
 #load ""b.csx""", options);
@@ -729,7 +733,7 @@ System.Console.WriteLine(42)"));
             resolver = TestSourceReferenceResolver.Create(
                 KeyValuePairUtil.Create("a.csx", "1"),
                 KeyValuePairUtil.Create("b.csx", "2"));
-            options = ScriptOptions.Default.WithSourceResolver(resolver);
+            options = ScriptOptions.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
 #load ""b.csx""
@@ -746,7 +750,7 @@ System.Console.WriteLine(42)"));
                 KeyValuePairUtil.Create("b.csx", @"
 #load ""a.csx""
 2"));
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
             var script = CSharpScript.Create("#load \"b.csx\"", options);
             var result = await script.EvaluateAsync();
             Assert.Equal(1, result);
@@ -754,7 +758,7 @@ System.Console.WriteLine(42)"));
             resolver = TestSourceReferenceResolver.Create(
                 KeyValuePairUtil.Create("a.csx", "return 1;"),
                 KeyValuePairUtil.Create("b.csx", "2"));
-            options = ScriptOptions.Default.WithSourceResolver(resolver);
+            options = ScriptOptions.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
 #load ""b.csx""", options);
@@ -764,7 +768,7 @@ System.Console.WriteLine(42)"));
             resolver = TestSourceReferenceResolver.Create(
                 KeyValuePairUtil.Create("a.csx", "return 1;"),
                 KeyValuePairUtil.Create("b.csx", "2"));
-            options = ScriptOptions.Default.WithSourceResolver(resolver);
+            options = ScriptOptions.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
 #load ""b.csx""
@@ -783,7 +787,7 @@ NEXT:
 return 1;
 EOF:;
 2"));
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
 
             var script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -807,7 +811,7 @@ EOF2: ;
         [Fact]
         public async Task VoidReturn()
         {
-            var script = CSharpScript.Create("return;");
+            var script = CSharpScript.Create("return;", ScriptOptions);
             var result = await script.EvaluateAsync();
             Assert.Null(result);
 
@@ -817,7 +821,7 @@ if (b)
 {
     return;
 }
-b");
+b", ScriptOptions);
             result = await script.EvaluateAsync();
             Assert.Null(result);
         }
@@ -830,7 +834,7 @@ b");
 var i = 42;
 return;
 i = -1;"));
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
             var script = CSharpScript.Create<int>(@"
 #load ""a.csx""
 i", options);
@@ -844,7 +848,7 @@ i", options);
             var code = "throw new System.Exception();";
             try
             {
-                var opts = ScriptOptions.Default.WithEmitDebugInformation(true).WithFilePath("debug.csx").WithFileEncoding(null);
+                var opts = ScriptOptions.WithEmitDebugInformation(true).WithFilePath("debug.csx").WithFileEncoding(null);
                 var script = await CSharpScript.RunAsync(code, opts);
             }
             catch (CompilationErrorException ex)
@@ -858,21 +862,21 @@ i", options);
         [WorkItem("https://github.com/dotnet/roslyn/issues/19027")]
         public Task Pdb_CreateFromString_CodeFromFile_WithEmitDebugInformation_WithFileEncoding_ResultInPdbEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(true).WithFilePath("debug.csx").WithFileEncoding(Encoding.UTF8);
+            var opts = ScriptOptions.WithEmitDebugInformation(true).WithFilePath("debug.csx").WithFileEncoding(Encoding.UTF8);
             return VerifyStackTraceAsync(() => CSharpScript.Create("throw new System.Exception();", opts), line: 1, column: 1, filename: "debug.csx");
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public Task Pdb_CreateFromString_CodeFromFile_WithoutEmitDebugInformation_WithoutFileEncoding_ResultInPdbNotEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(false).WithFilePath(null).WithFileEncoding(null);
+            var opts = ScriptOptions.WithEmitDebugInformation(false).WithFilePath(null).WithFileEncoding(null);
             return VerifyStackTraceAsync(() => CSharpScript.Create("throw new System.Exception();", opts));
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public Task Pdb_CreateFromString_CodeFromFile_WithoutEmitDebugInformation_WithFileEncoding_ResultInPdbNotEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(false).WithFilePath("debug.csx").WithFileEncoding(Encoding.UTF8);
+            var opts = ScriptOptions.WithEmitDebugInformation(false).WithFilePath("debug.csx").WithFileEncoding(Encoding.UTF8);
             return VerifyStackTraceAsync(() => CSharpScript.Create("throw new System.Exception();", opts));
         }
 
@@ -880,14 +884,14 @@ i", options);
         [WorkItem("https://github.com/dotnet/roslyn/issues/19027")]
         public Task Pdb_CreateFromStream_CodeFromFile_WithEmitDebugInformation_ResultInPdbEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(true).WithFilePath("debug.csx");
+            var opts = ScriptOptions.WithEmitDebugInformation(true).WithFilePath("debug.csx");
             return VerifyStackTraceAsync(() => CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("throw new System.Exception();")), opts), line: 1, column: 1, filename: "debug.csx");
         }
 
         [Fact]
         public Task Pdb_CreateFromStream_CodeFromFile_WithoutEmitDebugInformation_ResultInPdbNotEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(false).WithFilePath("debug.csx");
+            var opts = ScriptOptions.WithEmitDebugInformation(false).WithFilePath("debug.csx");
             return VerifyStackTraceAsync(() => CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("throw new System.Exception();")), opts));
         }
 
@@ -895,7 +899,7 @@ i", options);
         [WorkItem("https://github.com/dotnet/roslyn/issues/19027")]
         public Task Pdb_CreateFromString_InlineCode_WithEmitDebugInformation_WithoutFileEncoding_ResultInPdbEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(true).WithFileEncoding(null);
+            var opts = ScriptOptions.WithEmitDebugInformation(true).WithFileEncoding(null);
             return VerifyStackTraceAsync(() => CSharpScript.Create("throw new System.Exception();", opts), line: 1, column: 1, filename: "");
         }
 
@@ -903,21 +907,21 @@ i", options);
         [WorkItem("https://github.com/dotnet/roslyn/issues/19027")]
         public Task Pdb_CreateFromString_InlineCode_WithEmitDebugInformation_WithFileEncoding_ResultInPdbEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(true).WithFileEncoding(Encoding.UTF8);
+            var opts = ScriptOptions.WithEmitDebugInformation(true).WithFileEncoding(Encoding.UTF8);
             return VerifyStackTraceAsync(() => CSharpScript.Create("throw new System.Exception();", opts), line: 1, column: 1, filename: "");
         }
 
         [Fact]
         public Task Pdb_CreateFromString_InlineCode_WithoutEmitDebugInformation_WithoutFileEncoding_ResultInPdbNotEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(false).WithFileEncoding(null);
+            var opts = ScriptOptions.WithEmitDebugInformation(false).WithFileEncoding(null);
             return VerifyStackTraceAsync(() => CSharpScript.Create("throw new System.Exception();", opts));
         }
 
         [Fact]
         public Task Pdb_CreateFromString_InlineCode_WithoutEmitDebugInformation_WithFileEncoding_ResultInPdbNotEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(false).WithFileEncoding(Encoding.UTF8);
+            var opts = ScriptOptions.WithEmitDebugInformation(false).WithFileEncoding(Encoding.UTF8);
             return VerifyStackTraceAsync(() => CSharpScript.Create("throw new System.Exception();", opts));
         }
 
@@ -925,14 +929,14 @@ i", options);
         [WorkItem("https://github.com/dotnet/roslyn/issues/19027")]
         public Task Pdb_CreateFromStream_InlineCode_WithEmitDebugInformation_ResultInPdbEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(true);
+            var opts = ScriptOptions.WithEmitDebugInformation(true);
             return VerifyStackTraceAsync(() => CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("throw new System.Exception();")), opts), line: 1, column: 1, filename: "");
         }
 
         [Fact]
         public Task Pdb_CreateFromStream_InlineCode_WithoutEmitDebugInformation_ResultInPdbNotEmitted()
         {
-            var opts = ScriptOptions.Default.WithEmitDebugInformation(false);
+            var opts = ScriptOptions.WithEmitDebugInformation(false);
             return VerifyStackTraceAsync(() => CSharpScript.Create(new MemoryStream(Encoding.UTF8.GetBytes("throw new System.Exception();")), opts));
         }
 
@@ -940,7 +944,7 @@ i", options);
         public void StreamWithOffset()
         {
             var resolver = new StreamOffsetResolver();
-            var options = ScriptOptions.Default.WithSourceResolver(resolver);
+            var options = ScriptOptions.WithSourceResolver(resolver);
             var script = CSharpScript.Create(@"#load ""a.csx""", options);
             ScriptingTestHelpers.EvaluateScriptWithOutput(script, "Hello World!");
         }
@@ -948,7 +952,7 @@ i", options);
         [Fact]
         public void CreateScriptWithFeatureThatIsNotSupportedInTheSelectedLanguageVersion()
         {
-            var script = CSharpScript.Create(@"string x = default;", ScriptOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7));
+            var script = CSharpScript.Create(@"string x = default;", ScriptOptions.WithLanguageVersion(LanguageVersion.CSharp7));
             var compilation = script.GetCompilation();
 
             compilation.VerifyDiagnostics(
@@ -962,7 +966,7 @@ i", options);
         public void CreateScriptWithNullableContextWithCSharp8()
         {
             var script = CSharpScript.Create(@"#nullable enable
-                string x = null;", ScriptOptions.Default.WithLanguageVersion(LanguageVersion.CSharp8));
+                string x = null;", ScriptOptions.WithLanguageVersion(LanguageVersion.CSharp8));
             var compilation = script.GetCompilation();
 
             compilation.VerifyDiagnostics(
@@ -984,7 +988,7 @@ var reply = data switch {
 
 return reply;
 ";
-            var script = CSharpScript.Create(code, ScriptOptions.Default.WithLanguageVersion(LanguageVersion.CSharp8));
+            var script = CSharpScript.Create(code, ScriptOptions.WithLanguageVersion(LanguageVersion.CSharp8));
             var compilation = script.GetCompilation();
             compilation.VerifyDiagnostics();
 
@@ -1000,7 +1004,7 @@ return reply;
 
             try
             {
-                await CSharpScript.RunAsync(@"var data = notExistentVariable switch { _ => null };", globals: new ScriptTests());
+                await CSharpScript.RunAsync(@"var data = notExistentVariable switch { _ => null };", options: ScriptOptions, globals: new ScriptTests());
             }
             catch (CompilationErrorException ex)
             {
@@ -1022,7 +1026,7 @@ return reply;
 
             try
             {
-                await CSharpScript.RunAsync(@"var data = ""data"" switch { < 5 => null };", globals: new ScriptTests());
+                await CSharpScript.RunAsync(@"var data = ""data"" switch { < 5 => null };", options: ScriptOptions, globals: new ScriptTests());
             }
             catch (CompilationErrorException ex)
             {
@@ -1047,7 +1051,7 @@ return reply;
 
             try
             {
-                await CSharpScript.RunAsync(@"var data = ""test"" switch { _ => armError };", globals: new ScriptTests());
+                await CSharpScript.RunAsync(@"var data = ""test"" switch { _ => armError };", options: ScriptOptions, globals: new ScriptTests());
             }
             catch (CompilationErrorException ex)
             {

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             Compiler = compiler;
             _scriptCompiler = scriptCompiler;
             _objectFormatter = objectFormatter;
-            _createFromFileFunc = createFromFileFunc ?? MetadataReference.CreateFromFile;
+            _createFromFileFunc = createFromFileFunc ?? Script.CreateFromFile;
         }
 
         // for testing:

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -137,6 +137,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
 
             var cancellationToken = new CancellationToken();
 
+            Debug.Assert(scriptOptions is not null);
             if (Compiler.Arguments.InteractiveMode)
             {
                 RunInteractiveLoop(scriptOptions, code?.ToString(), cancellationToken);
@@ -193,12 +194,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 });
         }
 
-        internal static SourceReferenceResolver GetSourceReferenceResolver(CommandLineArguments arguments, TouchedFileLogger loggerOpt)
+        internal static SourceReferenceResolver GetSourceReferenceResolver(CommandLineArguments arguments, TouchedFileLogger? loggerOpt)
         {
             return new CommonCompiler.LoggingSourceFileResolver(arguments.SourcePaths, arguments.BaseDirectory, ImmutableArray<KeyValuePair<string, string>>.Empty, loggerOpt);
         }
 
-        private int RunScript(ScriptOptions options, SourceText code, ErrorLogger errorLogger, CancellationToken cancellationToken)
+        private int RunScript(ScriptOptions? options, SourceText? code, ErrorLogger? errorLogger, CancellationToken cancellationToken)
         {
             var globals = new CommandLineScriptGlobals(Console.Out, _objectFormatter);
             globals.Args.AddRange(Compiler.Arguments.ScriptArguments);
@@ -220,12 +221,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             }
         }
 
-        private void RunInteractiveLoop(ScriptOptions options, string initialScriptCodeOpt, CancellationToken cancellationToken)
+        private void RunInteractiveLoop(ScriptOptions options, string? initialScriptCodeOpt, CancellationToken cancellationToken)
         {
             var globals = new InteractiveScriptGlobals(Console.Out, _objectFormatter);
             globals.Args.AddRange(Compiler.Arguments.ScriptArguments);
 
-            ScriptState<object> state = null;
+            ScriptState<object>? state = null;
 
             if (initialScriptCodeOpt != null)
             {
@@ -237,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             {
                 Console.Out.Write("> ");
                 var input = new StringBuilder();
-                string line;
+                string? line;
                 bool cancelSubmission = false;
 
                 while (true)
@@ -292,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             }
         }
 
-        private void BuildAndRun(Script<object> newScript, InteractiveScriptGlobals globals, ref ScriptState<object> state, ref ScriptOptions options, bool displayResult, CancellationToken cancellationToken)
+        private void BuildAndRun(Script<object> newScript, InteractiveScriptGlobals globals, ref ScriptState<object>? state, ref ScriptOptions options, bool displayResult, CancellationToken cancellationToken)
         {
             var diagnostics = newScript.Compile(cancellationToken);
             DisplayDiagnostics(diagnostics);

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -178,8 +178,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 createFromFileFunc: _createFromFileFunc);
         }
 
-#nullable enable
-
         internal static MetadataReferenceResolver GetMetadataReferenceResolver(
             CommandLineArguments arguments,
             TouchedFileLogger? loggerOpt,
@@ -194,8 +192,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                     return createFromFileFunc(path, PEStreamOptions.PrefetchEntireImage, properties);
                 });
         }
-
-#nullable disable
 
         internal static SourceReferenceResolver GetSourceReferenceResolver(CommandLineArguments arguments, TouchedFileLogger loggerOpt)
         {

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -188,10 +188,10 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             return RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
                 arguments.ReferencePaths,
                 arguments.BaseDirectory,
-                createFromFileFunc: (path, options, properties) =>
+                createFromFileFunc: (path, properties) =>
                 {
                     loggerOpt?.AddRead(path);
-                    return createFromFileFunc(path, options, properties);
+                    return createFromFileFunc(path, PEStreamOptions.PrefetchEntireImage, properties);
                 });
         }
 

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -83,12 +83,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             NuGetPackageResolver? packageResolver,
             GacFileResolver? gacFileResolver,
             ImmutableDictionary<string, string> trustedPlatformAssemblies,
-            Func<string,  MetadataReferenceProperties, PortableExecutableReference>? createFromfileFunc = null)
+            Func<string, MetadataReferenceProperties, PortableExecutableReference>? createFromfileFunc = null)
         {
             PathResolver = pathResolver;
             PackageResolver = packageResolver;
             GacFileResolver = gacFileResolver;
-            _createFromFileFunc = createFromfileFunc ?? CreateFromFile;
+            _createFromFileFunc = createFromfileFunc ?? ((path, properties) => Script.CreateFromFile(path, PEStreamOptions.PrefetchEntireImage, properties));
             TrustedPlatformAssemblies = trustedPlatformAssemblies;
         }
 

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         internal readonly RelativePathResolver PathResolver;
         internal readonly NuGetPackageResolver? PackageResolver;
         internal readonly GacFileResolver? GacFileResolver;
-        private readonly Func<string, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference> _createFromFileFunc;
+        private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _createFromFileFunc;
 
         // TODO: Look for .winmd, but only if the identity has content WindowsRuntime (https://github.com/dotnet/roslyn/issues/6483)
         // The extensions are in order in which the CLR loader looks for assembly files.
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         internal static RuntimeMetadataReferenceResolver CreateCurrentPlatformResolver(
             ImmutableArray<string> searchPaths = default,
             string? baseDirectory = null,
-            Func<string, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference>? createFromFileFunc = null)
+            Func<string, MetadataReferenceProperties, PortableExecutableReference>? createFromFileFunc = null)
         {
             return new RuntimeMetadataReferenceResolver(
                 searchPaths,
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             NuGetPackageResolver? packageResolver = null,
             GacFileResolver? gacFileResolver = null,
             ImmutableArray<string> platformAssemblyPaths = default,
-            Func<string, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference>? createFromFileFunc = null)
+            Func<string,  MetadataReferenceProperties, PortableExecutableReference>? createFromFileFunc = null)
             : this(new RelativePathResolver(searchPaths.NullToEmpty(), baseDirectory),
                    packageResolver,
                    gacFileResolver,
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             NuGetPackageResolver? packageResolver,
             GacFileResolver? gacFileResolver,
             ImmutableDictionary<string, string> trustedPlatformAssemblies,
-            Func<string, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference>? createFromfileFunc = null)
+            Func<string,  MetadataReferenceProperties, PortableExecutableReference>? createFromfileFunc = null)
         {
             PathResolver = pathResolver;
             PackageResolver = packageResolver;
@@ -135,13 +135,10 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         }
 
         private PortableExecutableReference CreateFromFile(string filePath, MetadataReferenceProperties properties) =>
-            _createFromFileFunc(filePath, PEStreamOptions.PrefetchEntireImage, properties);
-
-        internal static MetadataImageReference CreateFromFile(string filePath, PEStreamOptions options, MetadataReferenceProperties properties)
-            => MetadataReference.CreateFromFile(filePath, options, properties);
+            _createFromFileFunc(filePath, properties);
 
         private PortableExecutableReference CreateResolvedMissingReference(string fullPath) =>
-            _createFromFileFunc(fullPath, PEStreamOptions.PrefetchEntireImage, s_resolvedMissingAssemblyReferenceProperties);
+            _createFromFileFunc(fullPath, s_resolvedMissingAssemblyReferenceProperties);
 
         public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string? baseFilePath, MetadataReferenceProperties properties)
         {

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             NuGetPackageResolver? packageResolver = null,
             GacFileResolver? gacFileResolver = null,
             ImmutableArray<string> platformAssemblyPaths = default,
-            Func<string,  MetadataReferenceProperties, PortableExecutableReference>? createFromFileFunc = null)
+            Func<string, MetadataReferenceProperties, PortableExecutableReference>? createFromFileFunc = null)
             : this(new RelativePathResolver(searchPaths.NullToEmpty(), baseDirectory),
                    packageResolver,
                    gacFileResolver,

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -136,6 +136,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             return null;
         }
 
+        internal static PortableExecutableReference CreateFromFile(string filePath, MetadataReferenceProperties properties)
+            => MetadataReference.CreateFromFile(filePath, properties);
+
+        internal static MetadataImageReference CreateFromAssembly(Assembly assembly, MetadataReferenceProperties properties)
+            => MetadataReference.CreateFromAssemblyInternal(assembly, properties);
+
         private PortableExecutableReference CreateResolvedMissingReference(string fullPath)
         {
             return _fileReferenceProvider(fullPath, s_resolvedMissingAssemblyReferenceProperties);

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// <remarks>
         /// This API exists as the default for reading <see cref="MetadataReference"/> from files. It is handy 
         /// to have this separate method when trying to track down unit tests that aren't going through the 
-        /// proper heplers in ScriptTestBase to hook loading from file. Can set a breakpoint here, debug the 
+        /// proper helpers in ScriptTestBase to hook loading from file. Can set a breakpoint here, debug the 
         /// tests and fix any hits.
         /// </remarks>
         internal static MetadataImageReference CreateFromFile(

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -320,6 +320,21 @@ namespace Microsoft.CodeAnalysis.Scripting
             var filePath = MetadataReference.GetAssemblyFilePath(assembly, properties);
             return createFromFileFunc(filePath, PEStreamOptions.Default, properties);
         }
+
+        /// <summary>
+        /// <see cref="MetadataReference.CreateFromFile(string, PEStreamOptions, MetadataReferenceProperties)"/>
+        /// </summary>
+        /// <remarks>
+        /// This API exists as the default for reading <see cref="MetadataReference"/> from files. It is handy 
+        /// to have this separate method when trying to track down unit tests that aren't going through the 
+        /// proper heplers in ScriptTestBase to hook loading from file. Can set a breakpoint here, debug the 
+        /// tests and fix any hits.
+        /// </remarks>
+        internal static MetadataImageReference CreateFromFile(
+            string filePath,
+            PEStreamOptions options,
+            MetadataReferenceProperties properties) =>
+            MetadataReference.CreateFromFile(filePath, options, properties);
     }
 
     public sealed class Script<T> : Script

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             {
                 if (Previous == null)
                 {
-                    var corLib = MetadataReference.CreateFromAssemblyInternal(typeof(object).GetTypeInfo().Assembly);
+                    var corLib = Options.CreateFromAssemblyFunc(typeof(object).GetTypeInfo().Assembly, default);
                     references.Add(corLib);
 
                     if (GlobalsType != null)
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Scripting
                         // the host has to add reference to the metadata where globals type is located explicitly.
                         if (MetadataReference.HasMetadata(globalsAssembly))
                         {
-                            references.Add(MetadataReference.CreateFromAssemblyInternal(globalsAssembly, HostAssemblyReferenceProperties));
+                            references.Add(Options.CreateFromAssemblyFunc(globalsAssembly, HostAssemblyReferenceProperties));
                         }
                     }
 

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         }
 
         /// <summary>
-        /// <see cref="MetadataReference.CreateFromFile(string, PEStreamOptions, MetadataReferenceProperties)"/>
+        /// <see cref="MetadataReference.CreateFromFile(string, PEStreamOptions, MetadataReferenceProperties, DocumentationProvider)"/>
         /// </summary>
         /// <remarks>
         /// This API exists as the default for reading <see cref="MetadataReference"/> from files. It is handy 

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -174,18 +174,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             AllowUnsafe = allowUnsafe;
             WarningLevel = warningLevel;
             ParseOptions = parseOptions;
-            CreateFromAssemblyFunc = createFromAssemblyFunc ?? createFromAssemblyDefault;
-
-            // Having a local function makes it much easier to identify cases in our unit tests
-            // that are implicitly using ScriptOptions.Default. Doing so leads to pressure on the
-            // finalizer queue because CreateFromAssemblyInternal passively frees resources. Tests
-            // should use a version of ScriptOptions that hook this member and actively free
-            // the resources.
-            //
-            // This local function lets us set a breakpoint, run tests under the debugger and
-            // identify places the hook was not set.
-            static MetadataImageReference createFromAssemblyDefault(Assembly assembly, MetadataReferenceProperties metadataReferenceProperties) =>
-                MetadataReference.CreateFromAssemblyInternal(assembly, metadataReferenceProperties);
+            CreateFromAssemblyFunc = createFromAssemblyFunc ?? RuntimeMetadataReferenceResolver.CreateFromAssembly;
         }
 
         private ScriptOptions(ScriptOptions other)

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             AllowUnsafe = allowUnsafe;
             WarningLevel = warningLevel;
             ParseOptions = parseOptions;
-            CreateFromFileFunc = createFromFileFunc ?? RuntimeMetadataReferenceResolver.CreateFromFile;
+            CreateFromFileFunc = createFromFileFunc ?? Script.CreateFromFile;
         }
 
         private ScriptOptions(ScriptOptions other)

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// <summary>
         /// Creates a new <see cref="ScriptOptions"/> with the <see cref="FilePath"/> changed.
         /// </summary>
-        public ScriptOptions WithFilePath(string filePath)
+        public ScriptOptions WithFilePath(string? filePath)
             => (FilePath == filePath) ? this : new ScriptOptions(this) { FilePath = filePath ?? "" };
 
         private static MetadataReference CreateUnresolvedReference(string reference)

--- a/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
+++ b/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.Test;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Scripting.TestUtilities;
+
+public class CSharpScriptTestBase : TestBase
+{
+    // default csi.rsp
+    private static readonly string[] s_defaultArgs =
+    [
+        "/r:" + string.Join(";", GetReferences()),
+        "/u:System;System.IO;System.Collections.Generic;System.Diagnostics;System.Dynamic;System.Linq;System.Linq.Expressions;System.Text;System.Threading.Tasks",
+    ];
+
+    private readonly List<MetadataImageReference> _referenceList = new List<MetadataImageReference>();
+    public ScriptOptions ScriptOptions { get; }
+    public ScriptMetadataResolver ScriptMetadataResolver { get; }
+
+    protected CSharpScriptTestBase()
+    {
+        var runtimeMetadataReferenceResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
+            searchPaths: [],
+            baseDirectory: null,
+            CreateFromFilePath);
+        ScriptMetadataResolver = new ScriptMetadataResolver(runtimeMetadataReferenceResolver);
+        ScriptOptions = ScriptOptions.Default
+            .WithMetadataResolver(ScriptMetadataResolver)
+            .WithCreateAssemblyFunc(CreateFromAssembly);
+    }
+
+    private PortableExecutableReference CreateFromFilePath(string filePath, MetadataReferenceProperties properties)
+    {
+        var reference = MetadataReference.CreateFromFile(filePath, properties);
+        Debug.Assert(reference is MetadataImageReference);
+        _referenceList.Add((MetadataImageReference)reference);
+        return reference;
+    }
+
+    private MetadataImageReference CreateFromAssembly(Assembly assembly, MetadataReferenceProperties metadataReferenceProperties)
+    {
+        var reference = MetadataReference.CreateFromAssemblyInternal(assembly, metadataReferenceProperties);
+        _referenceList.Add(reference);
+        return reference;
+    }
+
+    private protected CommandLineRunner CreateRunner(
+        string[]? args = null,
+        string input = "",
+        string? responseFile = null,
+        string? workingDirectory = null)
+    {
+        var io = new TestConsoleIO(input);
+        var clientDir = Path.GetDirectoryName(RuntimeUtilities.GetAssemblyLocation(typeof(CSharpScriptTestBase)))!;
+        var buildPaths = new BuildPaths(
+            clientDir: clientDir,
+            workingDir: workingDirectory ?? clientDir,
+            sdkDir: null,
+            tempDir: Path.GetTempPath());
+
+        var compiler = new CSharpInteractiveCompiler(
+            responseFile,
+            buildPaths,
+            args?.Where(a => a != null).ToArray() ?? s_defaultArgs,
+            new NotImplementedAnalyzerLoader(),
+            createResolverFunc: (args, logger) => RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
+                args.ReferencePaths,
+                args.BaseDirectory,
+                fileReferenceProvider: (path, properties) =>
+                {
+                    logger?.AddRead(path);
+                    return CreateFromFilePath(path, properties);
+                }));
+
+        return new CommandLineRunner(io, compiler, CSharpScriptCompiler.Instance, CSharpObjectFormatter.Instance, CreateFromAssembly);
+    }
+
+    private static IEnumerable<string> GetReferences()
+    {
+        if (GacFileResolver.IsAvailable)
+        {
+            // keep in sync with list in csi.rsp
+            yield return "System";
+            yield return "System.Core";
+            yield return "Microsoft.CSharp";
+        }
+        else
+        {
+            // keep in sync with list in core csi.rsp
+            yield return "System.Collections";
+            yield return "System.Collections.Concurrent";
+            yield return "System.Console";
+            yield return "System.Diagnostics.Debug";
+            yield return "System.Diagnostics.Process";
+            yield return "System.Diagnostics.StackTrace";
+            yield return "System.Globalization";
+            yield return "System.IO";
+            yield return "System.IO.FileSystem";
+            yield return "System.IO.FileSystem.Primitives";
+            yield return "System.Reflection";
+            yield return "System.Reflection.Extensions";
+            yield return "System.Reflection.Primitives";
+            yield return "System.Runtime";
+            yield return "System.Runtime.Extensions";
+            yield return "System.Runtime.InteropServices";
+            yield return "System.Text.Encoding";
+            yield return "System.Text.Encoding.CodePages";
+            yield return "System.Text.Encoding.Extensions";
+            yield return "System.Text.RegularExpressions";
+            yield return "System.Threading";
+            yield return "System.Threading.Tasks";
+            yield return "System.Threading.Tasks.Parallel";
+            yield return "System.Threading.Thread";
+            yield return "System.Linq";
+            yield return "System.Linq.Expressions";
+            yield return "System.Runtime.Numerics";
+            yield return "System.Dynamic.Runtime";
+            yield return "Microsoft.CSharp";
+        }
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        foreach (var pe in _referenceList)
+        {
+            if (pe is MetadataImageReference me)
+            {
+                me.GetMetadataNoCopy().Dispose();
+            }
+        }
+    }
+}

--- a/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
+++ b/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
@@ -20,7 +20,7 @@ using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.Scripting.TestUtilities;
 
-public class CSharpScriptTestBase : TestBase
+public class CSharpScriptTestBase : ScriptTestBase
 {
     // default csi.rsp
     private static readonly string[] s_defaultArgs =
@@ -28,29 +28,6 @@ public class CSharpScriptTestBase : TestBase
         "/r:" + string.Join(";", GetReferences()),
         "/u:System;System.IO;System.Collections.Generic;System.Diagnostics;System.Dynamic;System.Linq;System.Linq.Expressions;System.Text;System.Threading.Tasks",
     ];
-
-    private readonly List<MetadataImageReference> _referenceList = new List<MetadataImageReference>();
-    public ScriptOptions ScriptOptions { get; }
-    public ScriptMetadataResolver ScriptMetadataResolver { get; }
-
-    protected CSharpScriptTestBase()
-    {
-        var runtimeMetadataReferenceResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
-            searchPaths: [],
-            baseDirectory: null,
-            CreateFromFile);
-        ScriptMetadataResolver = new ScriptMetadataResolver(runtimeMetadataReferenceResolver);
-        ScriptOptions = ScriptOptions.Default
-            .WithMetadataResolver(ScriptMetadataResolver)
-            .WithCreateFromFileFunc(CreateFromFile);
-    }
-
-    private MetadataImageReference CreateFromFile(string filePath, PEStreamOptions options, MetadataReferenceProperties properties)
-    {
-        var reference = MetadataReference.CreateFromFile(filePath, options, properties);
-        _referenceList.Add(reference);
-        return reference;
-    }
 
     private protected CommandLineRunner CreateRunner(
         string[]? args = null,
@@ -116,15 +93,6 @@ public class CSharpScriptTestBase : TestBase
             yield return "System.Runtime.Numerics";
             yield return "System.Dynamic.Runtime";
             yield return "Microsoft.CSharp";
-        }
-    }
-
-    public override void Dispose()
-    {
-        base.Dispose();
-        foreach (var reference in _referenceList)
-        {
-            reference.GetMetadataNoCopy().Dispose();
         }
     }
 }

--- a/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
+++ b/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
@@ -37,14 +37,14 @@ public class CSharpScriptTestBase : TestBase
         var runtimeMetadataReferenceResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
             searchPaths: [],
             baseDirectory: null,
-            CreateFromFilePath);
+            CreateFromFile);
         ScriptMetadataResolver = new ScriptMetadataResolver(runtimeMetadataReferenceResolver);
         ScriptOptions = ScriptOptions.Default
             .WithMetadataResolver(ScriptMetadataResolver)
             .WithCreateAssemblyFunc(CreateFromAssembly);
     }
 
-    private PortableExecutableReference CreateFromFilePath(string filePath, MetadataReferenceProperties properties)
+    private PortableExecutableReference CreateFromFile(string filePath, MetadataReferenceProperties properties)
     {
         var reference = MetadataReference.CreateFromFile(filePath, properties);
         Debug.Assert(reference is MetadataImageReference);
@@ -78,16 +78,8 @@ public class CSharpScriptTestBase : TestBase
             buildPaths,
             args?.Where(a => a != null).ToArray() ?? s_defaultArgs,
             new NotImplementedAnalyzerLoader(),
-            createResolverFunc: (args, logger) => RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
-                args.ReferencePaths,
-                args.BaseDirectory,
-                fileReferenceProvider: (path, properties) =>
-                {
-                    logger?.AddRead(path);
-                    return CreateFromFilePath(path, properties);
-                }));
-
-        return new CommandLineRunner(io, compiler, CSharpScriptCompiler.Instance, CSharpObjectFormatter.Instance, CreateFromAssembly);
+            CreateFromFile);
+        return new CommandLineRunner(io, compiler, CSharpScriptCompiler.Instance, CSharpObjectFormatter.Instance, CreateFromAssembly, CreateFromFile);
     }
 
     private static IEnumerable<string> GetReferences()

--- a/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
+++ b/src/Scripting/CoreTestUtilities/CSharpScriptTestBase.cs
@@ -122,12 +122,9 @@ public class CSharpScriptTestBase : TestBase
     public override void Dispose()
     {
         base.Dispose();
-        foreach (var pe in _referenceList)
+        foreach (var reference in _referenceList)
         {
-            if (pe is MetadataImageReference me)
-            {
-                me.GetMetadataNoCopy().Dispose();
-            }
+            reference.GetMetadataNoCopy().Dispose();
         }
     }
 }

--- a/src/Scripting/CoreTestUtilities/README.md
+++ b/src/Scripting/CoreTestUtilities/README.md
@@ -1,0 +1,15 @@
+# Scripting Unit Tests
+
+## Native Memory Pressure
+
+The scripting engine in Roslyn makes heavy use of creating `MetadatImageReference` over a `Stream`. That is the way in which runtime assembly references are added. This form of `MetadataReference` results in a lot of native allocations as opposed to using an `ImmutableArray<byte>` which has none. By default these native allocations are collected by the finalizer as `MetadadataImageReference` is not disposable.
+
+For production code this dependency on the finalizer is largely fine. An application generally creates a fixed set of `MetadataReferences` and operates on them. For our unit tests the finalizer is not sufficient. Virtually every scripting test creates a new instance of the scripting engine, that in turns loads a set of references from `Stream` and allocates a significant amount of native memory. The number of tests mean that we end up allocating a significant amount of native memory and it can lead to tests OOMing in CI if the finalizer isn't running often enough. Particularly when run on x86 environments.
+
+To address this we strive to have the individual unit tests in scripting aggressively free the native memory that they allocate. This is done by:
+
+1. Deriving scripting tests from `ScriptTestBase`
+2. Using `ScriptTestBase.ScriptOptions` as the basis for all options used in testing
+3. Ensuring every scripting test passes `ScriptTestBase.ScriptOptions`
+
+The logic in `ScriptTestBase` hooks the core scripting engine functions for loading off of disk and ensures the native resources are freed when the test case is disposed

--- a/src/Scripting/CoreTestUtilities/README.md
+++ b/src/Scripting/CoreTestUtilities/README.md
@@ -2,7 +2,7 @@
 
 ## Native Memory Pressure
 
-The scripting engine in Roslyn makes heavy use of creating `MetadatImageReference` over a `Stream`. That is the way in which runtime assembly references are added. This form of `MetadataReference` results in a lot of native allocations as opposed to using an `ImmutableArray<byte>` which has none. By default these native allocations are collected by the finalizer as `MetadadataImageReference` is not disposable.
+The scripting engine in Roslyn makes heavy use of creating `MetadataImageReference` over a `Stream`. That is the way in which runtime assembly references are added. This form of `MetadataReference` results in a lot of native allocations as opposed to using an `ImmutableArray<byte>` which has none. By default these native allocations are collected by the finalizer as `MetadadataImageReference` is not disposable.
 
 For production code this dependency on the finalizer is largely fine. An application generally creates a fixed set of `MetadataReferences` and operates on them. For our unit tests the finalizer is not sufficient. Virtually every scripting test creates a new instance of the scripting engine, that in turns loads a set of references from `Stream` and allocates a significant amount of native memory. The number of tests mean that we end up allocating a significant amount of native memory and it can lead to tests OOMing in CI if the finalizer isn't running often enough. Particularly when run on x86 environments.
 

--- a/src/Scripting/CoreTestUtilities/ScriptTestBase.cs
+++ b/src/Scripting/CoreTestUtilities/ScriptTestBase.cs
@@ -32,7 +32,7 @@ public class ScriptTestBase : TestBase
         var runtimeMetadataReferenceResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
             searchPaths: [],
             baseDirectory: null,
-            CreateFromFile);
+            (path, properties) => CreateFromFile(path, PEStreamOptions.PrefetchEntireImage, properties));
         ScriptMetadataResolver = new ScriptMetadataResolver(runtimeMetadataReferenceResolver);
         ScriptOptions = ScriptOptions.Default
             .WithMetadataResolver(ScriptMetadataResolver)

--- a/src/Scripting/CoreTestUtilities/ScriptTestBase.cs
+++ b/src/Scripting/CoreTestUtilities/ScriptTestBase.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.VisualBasic.Scripting;
+using Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.Test;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Scripting.TestUtilities;
+
+public class ScriptTestBase : TestBase
+{
+    private readonly List<MetadataImageReference> _referenceList = new List<MetadataImageReference>();
+
+    public ScriptOptions ScriptOptions { get; }
+    public ScriptMetadataResolver ScriptMetadataResolver { get; }
+
+    protected ScriptTestBase()
+    {
+        var runtimeMetadataReferenceResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(
+            searchPaths: [],
+            baseDirectory: null,
+            CreateFromFile);
+        ScriptMetadataResolver = new ScriptMetadataResolver(runtimeMetadataReferenceResolver);
+        ScriptOptions = ScriptOptions.Default
+            .WithMetadataResolver(ScriptMetadataResolver)
+            .WithCreateFromFileFunc(CreateFromFile);
+    }
+
+    private protected MetadataImageReference CreateFromFile(string filePath, PEStreamOptions options, MetadataReferenceProperties properties)
+    {
+        var reference = MetadataReference.CreateFromFile(filePath, options, properties);
+        _referenceList.Add(reference);
+        return reference;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        foreach (var reference in _referenceList)
+        {
+            reference.GetMetadataNoCopy().Dispose();
+        }
+    }
+}

--- a/src/Scripting/CoreTestUtilities/VisualBasicScriptTestBase.cs
+++ b/src/Scripting/CoreTestUtilities/VisualBasicScriptTestBase.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.VisualBasic.Scripting;
+using Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.Test;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Scripting.TestUtilities;
+
+public class VisualBasicScriptTestBase : ScriptTestBase
+{
+    private static readonly string[] s_defaultArgs = ["/R:System"];
+
+    private protected CommandLineRunner CreateRunner(
+        string[]? args = null,
+        string input = "",
+        string? responseFile = null,
+        string? workingDirectory = null)
+    {
+        var io = new TestConsoleIO(input);
+
+        var buildPaths = new BuildPaths(
+            clientDir: AppContext.BaseDirectory,
+            workingDir: workingDirectory ?? AppContext.BaseDirectory,
+            sdkDir: RuntimeMetadataReferenceResolver.GetDesktopFrameworkDirectory(),
+            tempDir: Path.GetTempPath());
+
+        var compiler = new VisualBasicInteractiveCompiler(
+            responseFile,
+            buildPaths,
+            args ?? s_defaultArgs,
+            new NotImplementedAnalyzerLoader(),
+            CreateFromFile);
+
+        return new CommandLineRunner(
+            io,
+            compiler,
+            VisualBasicScriptCompiler.Instance,
+            VisualBasicObjectFormatter.Instance);
+    }
+}

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -6,6 +6,7 @@ Imports System.IO
 Imports System.Reflection
 Imports System.Reflection.PortableExecutable
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Scripting
 Imports Microsoft.CodeAnalysis.Scripting.Hosting
 Imports Microsoft.CodeAnalysis.VisualBasic
 
@@ -19,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         Friend Sub New(responseFile As String, buildPaths As BuildPaths, args As String(), analyzerLoader As IAnalyzerAssemblyLoader, Optional createFromFileFunc As Func(Of String, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference) = Nothing)
             MyBase.New(VisualBasicCommandLineParser.Script, responseFile, args, buildPaths, Nothing, analyzerLoader)
             If createFromFileFunc Is Nothing Then
-                createFromFileFunc = AddressOf RuntimeMetadataReferenceResolver.CreateFromFile
+                createFromFileFunc = AddressOf Script.CreateFromFile
             End If
             _createFromFileFunc = createFromFileFunc
         End Sub

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -4,6 +4,7 @@
 
 Imports System.IO
 Imports System.Reflection
+Imports System.Reflection.PortableExecutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Scripting.Hosting
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -13,12 +14,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
     Friend NotInheritable Class VisualBasicInteractiveCompiler
         Inherits VisualBasicCompiler
 
-        Friend Sub New(responseFile As String, buildPaths As BuildPaths, args As String(), analyzerLoader As IAnalyzerAssemblyLoader)
+        Private ReadOnly _createFromFileFunc As Func(Of String, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference)
+
+        Friend Sub New(responseFile As String, buildPaths As BuildPaths, args As String(), analyzerLoader As IAnalyzerAssemblyLoader, Optional createFromFileFunc As Func(Of String, PEStreamOptions, MetadataReferenceProperties, MetadataImageReference) = Nothing)
             MyBase.New(VisualBasicCommandLineParser.Script, responseFile, args, buildPaths, Nothing, analyzerLoader)
+            If createFromFileFunc Is Nothing Then
+                createFromFileFunc = AddressOf RuntimeMetadataReferenceResolver.CreateFromFile
+            End If
+            _createFromFileFunc = createFromFileFunc
         End Sub
 
         Friend Overrides Function GetCommandLineMetadataReferenceResolver(loggerOpt As TouchedFileLogger) As MetadataReferenceResolver
-            Return CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt, AddressOf RuntimeMetadataReferenceResolver.CreateFromFile)
+            Return CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt, _createFromFileFunc)
         End Function
 
         Friend Overrides ReadOnly Property Type As Type

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Sub
 
         Friend Overrides Function GetCommandLineMetadataReferenceResolver(loggerOpt As TouchedFileLogger) As MetadataReferenceResolver
-            Return CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt)
+            Return CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt, AddressOf RuntimeMetadataReferenceResolver.CreateFromFile)
         End Function
 
         Friend Overrides ReadOnly Property Type As Type

--- a/src/Scripting/VisualBasic/VisualBasicScript.vb
+++ b/src/Scripting/VisualBasic/VisualBasicScript.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting
                                              Optional options As ScriptOptions = Nothing,
                                              Optional globals As Object = Nothing,
                                              Optional cancellationToken As CancellationToken = Nothing) As Task(Of Object)
-            Return EvaluateAsync(Of Object)(code, Nothing, globals, cancellationToken)
+            Return EvaluateAsync(Of Object)(code, options, globals, cancellationToken)
         End Function
     End Class
 

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -8,6 +8,7 @@ Imports System.Reflection
 Imports Microsoft.CodeAnalysis.Scripting
 Imports Microsoft.CodeAnalysis.Scripting.Hosting
 Imports Microsoft.CodeAnalysis.Scripting.Test
+Imports Microsoft.CodeAnalysis.Scripting.TestUtilities
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
 Imports Roslyn.Test.Utilities
@@ -16,7 +17,7 @@ Imports Xunit
 Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 
     Public Class CommandLineRunnerTests
-        Inherits TestBase
+        Inherits VisualBasicScriptTestBase
 
         Private Shared ReadOnly s_compilerVersion As String =
             CommonCompiler.GetProductVersion(GetType(VisualBasicInteractiveCompiler))
@@ -25,35 +26,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             String.Format(VBScriptingResources.LogoLine1, s_compilerVersion) + vbNewLine + VBScriptingResources.LogoLine2 + "
 
 " + ScriptingResources.HelpPrompt
-
-        Private Shared ReadOnly s_defaultArgs As String() = {"/R:System"}
-
-        Private Shared Function CreateRunner(
-            Optional args As String() = Nothing,
-            Optional input As String = "",
-            Optional responseFile As String = Nothing,
-            Optional workingDirectory As String = Nothing
-        ) As CommandLineRunner
-            Dim io = New TestConsoleIO(input)
-
-            Dim buildPaths = New BuildPaths(
-                clientDir:=AppContext.BaseDirectory,
-                workingDir:=If(workingDirectory, AppContext.BaseDirectory),
-                sdkDir:=RuntimeMetadataReferenceResolver.GetDesktopFrameworkDirectory(),
-                tempDir:=Path.GetTempPath())
-
-            Dim compiler = New VisualBasicInteractiveCompiler(
-                responseFile,
-                buildPaths,
-                If(args, s_defaultArgs),
-                New NotImplementedAnalyzerLoader())
-
-            Return New CommandLineRunner(
-                io,
-                compiler,
-                VisualBasicScriptCompiler.Instance,
-                VisualBasicObjectFormatter.Instance)
-        End Function
 
         <Fact>
         Public Sub TestPrint()

--- a/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
+++ b/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
@@ -4,7 +4,9 @@
 
 Imports System.Reflection
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Scripting
 Imports Microsoft.CodeAnalysis.Scripting.Test
+Imports Microsoft.CodeAnalysis.Scripting.TestUtilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Roslyn.Test.Utilities
 Imports Xunit
@@ -12,12 +14,12 @@ Imports Xunit
 Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 
     Public Class InteractiveSessionTests
-        Inherits TestBase
+        Inherits VisualBasicScriptTestBase
 
         <Fact>
         Public Async Function Fields() As Task
             Dim s = Await VisualBasicScript.
-                RunAsync("Dim x As Integer = 1").
+                RunAsync("Dim x As Integer = 1", ScriptOptions).
                 ContinueWith("Dim y As Integer = 2").
                 ContinueWith("?x + y")
 
@@ -29,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim source = "
 ?1 _
 "
-            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source).Result)
+            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source, ScriptOptions).Result)
         End Sub
 
         <Fact>
@@ -37,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim source = "
 ?1
 "
-            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source).Result)
+            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source, ScriptOptions).Result)
         End Sub
 
         <Fact>
@@ -46,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 ?  Nothing
 "
 
-            Assert.Null(VisualBasicScript.EvaluateAsync(source).Result)
+            Assert.Null(VisualBasicScript.EvaluateAsync(source, ScriptOptions).Result)
         End Sub
 
         <Fact, WorkItem(10856, "DevDiv_Projects/Roslyn")>
@@ -62,7 +64,7 @@ End If
 ?x + 1
 "
 
-            Assert.Equal(6, VisualBasicScript.EvaluateAsync(source).Result)
+            Assert.Equal(6, VisualBasicScript.EvaluateAsync(source, ScriptOptions).Result)
         End Sub
 
         <Fact>
@@ -70,7 +72,7 @@ End If
             Dim script = VisualBasicScript.Create("
 Option Infer On
 Dim a = New With { .f = 1 }
-").ContinueWith("
+", ScriptOptions).ContinueWith("
 Option Infer On
 Dim b = New With { Key .f = 1 }
 ").ContinueWith("
@@ -91,7 +93,7 @@ Dim d = New With { Key .F = 777 }
 Option Infer On
 Dim a = Sub()
         End Sub
-").ContinueWith("
+", ScriptOptions).ContinueWith("
 Option Infer On
 Dim b = Function () As Integer
             Return 0
@@ -118,7 +120,7 @@ Dim d = Function () As Integer
 "Friend Class C1
 End Class
 Protected X As Integer
-")
+", ScriptOptions)
             Dim compilation1 = state1.Result.Script.GetCompilation()
             compilation1.VerifyDiagnostics()
 

--- a/src/Scripting/VisualBasicTest/ScriptTests.vb
+++ b/src/Scripting/VisualBasicTest/ScriptTests.vb
@@ -5,13 +5,14 @@
 Imports System.Threading.Tasks
 Imports Basic.Reference.Assemblies
 Imports Microsoft.CodeAnalysis.Scripting
+Imports Microsoft.CodeAnalysis.Scripting.TestUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 
     Public Class ScriptTests
-        Inherits TestBase
+        Inherits VisualBasicScriptTestBase
 
         ''' <summary>
         ''' Need to create a <see cref="PortableExecutableReference"/> without a file path here. Scripting
@@ -22,29 +23,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 
         ' It shouldn't be necessary to include VB runtime assembly
         ' explicitly in VisualBasicScript.Create.
-        Private Shared ReadOnly s_defaultOptions As ScriptOptions = ScriptOptions.Default.AddReferences(s_msvbReference)
+        Private ReadOnly DefaultOptions As ScriptOptions = ScriptOptions.AddReferences(s_msvbReference)
 
         <Fact>
         Public Sub TestCreateScript()
-            Dim script = VisualBasicScript.Create("? 1 + 2")
+            Dim script = VisualBasicScript.Create("? 1 + 2", ScriptOptions)
             Assert.Equal("? 1 + 2", script.Code)
         End Sub
 
         <Fact>
         Public Sub TestEvalScript()
-            Dim value = VisualBasicScript.EvaluateAsync("? 1 + 2", s_defaultOptions)
+            Dim value = VisualBasicScript.EvaluateAsync("? 1 + 2", DefaultOptions)
             Assert.Equal(3, value.Result)
         End Sub
 
         <Fact>
         Public Async Function TestRunScript() As Task
-            Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", s_defaultOptions)
+            Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", DefaultOptions)
             Assert.Equal(3, state.ReturnValue)
         End Function
 
         <Fact>
         Public Async Function TestCreateAndRunScript() As Task
-            Dim script = VisualBasicScript.Create("? 1 + 2", s_defaultOptions)
+            Dim script = VisualBasicScript.Create("? 1 + 2", DefaultOptions)
             Dim state = Await script.RunAsync()
             Assert.Same(script, state.Script)
             Assert.Equal(3, state.ReturnValue)
@@ -52,20 +53,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 
         <Fact>
         Public Async Function TestRunScriptWithSpecifiedReturnType() As Task
-            Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", s_defaultOptions)
+            Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", DefaultOptions)
             Assert.Equal(3, state.ReturnValue)
         End Function
 
         <Fact>
         Public Sub TestGetCompilation()
-            Dim script = VisualBasicScript.Create("? 1 + 2")
+            Dim script = VisualBasicScript.Create("? 1 + 2", ScriptOptions)
             Dim compilation = script.GetCompilation()
             Assert.Equal(script.Code, compilation.SyntaxTrees.First().GetText().ToString())
         End Sub
 
         <Fact>
         Public Async Function TestRunVoidScript() As Task
-            Dim state = Await VisualBasicScript.RunAsync("System.Console.WriteLine(0)", s_defaultOptions)
+            Dim state = Await VisualBasicScript.RunAsync("System.Console.WriteLine(0)", DefaultOptions)
             Assert.Null(state.ReturnValue)
         End Function
 

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
@@ -768,7 +768,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 }
 
                 var metadataService = Services.GetRequiredService<IMetadataService>();
-                var metadataResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(fileReferenceProvider: metadataService.GetReference);
+                var metadataResolver = RuntimeMetadataReferenceResolver.CreateCurrentPlatformResolver(createFromFileFunc: metadataService.GetReference);
                 var syntaxFactory = languageServices.GetRequiredService<ISyntaxTreeFactoryService>();
                 var compilationFactory = languageServices.GetRequiredService<ICompilationFactoryService>();
                 var compilationOptions = compilationFactory.GetDefaultCompilationOptions()


### PR DESCRIPTION
Dug into the Scripting OOM tests more and figured out what was going on. The scripting tests predominantly create `PortableExecutableReference` instances using `Stream` as the source. Under the hood this creates a lot of native allocations in the form of memory mapped files and `AllocHGlobal` memory. As `PortableExecutableReference` is not disposable, these allocations are cleaned up passively in finalizers.

This means that our tests rely on the finalizer running fast enough that it frees up enough native memory for the next scripting test that allocates native memory to succeed. When the scripting tests are run in isolation or in an x64 process this works out just fine. But when we run the tests on x86 and in combination with other test assemblies this can break down and lead to OOM situations.

This fix approaches the problem from three directions:

1. Scripting had an existing mechanism for intercepting files being converted to `PortableExecutableReference`. This change expands on that to make it more thoroughly plumbed through the scripting code base and to have a single place, `ScriptOptions`, where the intercept can be hooked up.
2. Creating a `ScriptTestBase` type which sets up the intercepting of file loads and then actively disposing the resulting `MetadataImageReference` on `Dispose`. This means the native memory is actively freed at the end of each test. It also provides a `ScriptOptions` value that derived tests can leverage.
3. Plumbing through `ScriptOptions` to the individual tests. 

After doing this I ran the script tests under PerfView in a number of configurations and verified that the memory was being actively freed and the heap size of the process was reduced as expected.
