### PR TITLE
Reduce allocations in TypeSymbolExtensions.IsAtLeastAsVisibleAs

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -14,6 +14,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal static partial class TypeSymbolExtensions
     {
+        private sealed class VisitTypeData
+        {
+            public Symbol? Symbol;
+            public CompoundUseSiteInfo<AssemblySymbol> UseSiteInfo;
+        }
+
         private static readonly ObjectPool<VisitTypeData> s_visitTypeDataPool
             = new ObjectPool<VisitTypeData>(() => new VisitTypeData(), size: 4);
 
@@ -662,12 +668,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static SpecialType GetSpecialTypeSafe(this TypeSymbol? type)
         {
             return type is object ? type.SpecialType : SpecialType.None;
-        }
-
-        private class VisitTypeData
-        {
-            public Symbol? Symbol;
-            public CompoundUseSiteInfo<AssemblySymbol> UseSiteInfo;
         }
 
         public static bool IsAtLeastAsVisibleAs(this TypeSymbol type, Symbol sym, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal static partial class TypeSymbolExtensions
     {
+        private static readonly ObjectPool<VisitTypeData> s_visitTypeDataPool
+            = new ObjectPool<VisitTypeData>(() => new VisitTypeData(), size: 4);
+
         public static bool ImplementsInterface(this TypeSymbol subType, TypeSymbol superInterface, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             foreach (NamedTypeSymbol @interface in subType.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteInfo))
@@ -661,13 +664,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type is object ? type.SpecialType : SpecialType.None;
         }
 
+        private class VisitTypeData
+        {
+            public Symbol? Symbol;
+            public CompoundUseSiteInfo<AssemblySymbol> UseSiteInfo;
+        }
+
         public static bool IsAtLeastAsVisibleAs(this TypeSymbol type, Symbol sym, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            CompoundUseSiteInfo<AssemblySymbol> localUseSiteInfo = useSiteInfo;
-            var result = type.VisitType((type1, symbol, unused) => IsTypeLessVisibleThan(type1, symbol, ref localUseSiteInfo), sym,
-                                        canDigThroughNullable: true); // System.Nullable is public
-            useSiteInfo = localUseSiteInfo;
-            return result is null;
+            var visitTypeData = s_visitTypeDataPool.Allocate();
+
+            try
+            {
+                visitTypeData.UseSiteInfo = useSiteInfo;
+                visitTypeData.Symbol = sym;
+
+                var result = type.VisitType(static (type1, arg, unused) => IsTypeLessVisibleThan(type1, arg.Symbol!, ref arg.UseSiteInfo),
+                                            arg: visitTypeData,
+                                            canDigThroughNullable: true); // System.Nullable is public
+
+                useSiteInfo = visitTypeData.UseSiteInfo;
+                return result is null;
+            }
+            finally
+            {
+                visitTypeData.UseSiteInfo = default;
+                visitTypeData.Symbol = null;
+                s_visitTypeDataPool.Free(visitTypeData);
+            }
         }
 
         private static bool IsTypeLessVisibleThan(TypeSymbol type, Symbol sym, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)


### PR DESCRIPTION
This method showed up in multiple profiles as about 0.6% of allocations in the Roslyn CA process in the csharp editing speedometer test.

This simply avoids those allocations by switching to a static lambda using the arg data to pass in a pooled object. Note that the arg passed into VisitType needed to be a class to allow the ref parameter to change it's value.

*** old allocations ***
![image](https://github.com/user-attachments/assets/c039f2ce-9b10-4e4c-84f3-215772fb27d7)
