### PR TITLE
Reduce allocations from creating MissingTokenWithTrivia objects

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         internal static SyntaxToken MissingToken(SyntaxKind kind)
         {
-            return SyntaxToken.CreateMissing(kind, null, null);
+            return SyntaxToken.CreateMissing(kind);
         }
 
         internal static SyntaxToken MissingToken(GreenNode leading, SyntaxKind kind, GreenNode trailing)

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     throw new ArgumentException(string.Format(CSharpResources.ThisMethodCanOnlyBeUsedToCreateTokens, kind), nameof(kind));
                 }
 
-                return CreateMissing(kind, null, null);
+                return CreateMissing(kind);
             }
 
             return s_tokensWithNoTrivia[(int)kind].Value;
@@ -118,20 +118,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new SyntaxTokenWithTrivia(kind, leading, trailing);
         }
 
-        internal static SyntaxToken CreateMissing(SyntaxKind kind, GreenNode leading, GreenNode trailing)
+        internal static SyntaxToken CreateMissing(SyntaxKind kind)
         {
-            if (leading == null && trailing == null)
+            if (kind <= LastTokenWithWellKnownText)
             {
-                if (kind <= LastTokenWithWellKnownText)
-                {
-                    return s_missingTokensWithNoTrivia[(int)kind].Value;
-                }
-                else if (kind == SyntaxKind.IdentifierToken)
-                {
-                    return s_missingIdentifierTokenWithNoTrivia;
-                }
+                return s_missingTokensWithNoTrivia[(int)kind].Value;
+            }
+            else if (kind == SyntaxKind.IdentifierToken)
+            {
+                return s_missingIdentifierTokenWithNoTrivia;
             }
 
+            return new MissingTokenWithTrivia(kind, leading: null, trailing: null);
+        }
+
+        internal static SyntaxToken CreateMissing(SyntaxKind kind, GreenNode leading, GreenNode trailing)
+        {
             return new MissingTokenWithTrivia(kind, leading, trailing);
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
@@ -120,6 +120,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         internal static SyntaxToken CreateMissing(SyntaxKind kind, GreenNode leading, GreenNode trailing)
         {
+            if (leading == null && trailing == null)
+            {
+                if (kind <= LastTokenWithWellKnownText)
+                {
+                    return s_missingTokensWithNoTrivia[(int)kind].Value;
+                }
+                else if (kind == SyntaxKind.IdentifierToken)
+                {
+                    return s_missingIdentifierTokenWithNoTrivia;
+                }
+            }
+
             return new MissingTokenWithTrivia(kind, leading, trailing);
         }
 
@@ -131,6 +143,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private static readonly ArrayElement<SyntaxToken>[] s_tokensWithElasticTrivia = new ArrayElement<SyntaxToken>[(int)LastTokenWithWellKnownText + 1];
         private static readonly ArrayElement<SyntaxToken>[] s_tokensWithSingleTrailingSpace = new ArrayElement<SyntaxToken>[(int)LastTokenWithWellKnownText + 1];
         private static readonly ArrayElement<SyntaxToken>[] s_tokensWithSingleTrailingCRLF = new ArrayElement<SyntaxToken>[(int)LastTokenWithWellKnownText + 1];
+        private static readonly ArrayElement<SyntaxToken>[] s_missingTokensWithNoTrivia = new ArrayElement<SyntaxToken>[(int)LastTokenWithWellKnownText + 1];
+
+        private static readonly SyntaxToken s_missingIdentifierTokenWithNoTrivia = new MissingTokenWithTrivia(SyntaxKind.IdentifierToken, leading: null, trailing: null);
 
         static SyntaxToken()
         {
@@ -140,6 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 s_tokensWithElasticTrivia[(int)kind].Value = new SyntaxTokenWithTrivia(kind, SyntaxFactory.ElasticZeroSpace, SyntaxFactory.ElasticZeroSpace);
                 s_tokensWithSingleTrailingSpace[(int)kind].Value = new SyntaxTokenWithTrivia(kind, null, SyntaxFactory.Space);
                 s_tokensWithSingleTrailingCRLF[(int)kind].Value = new SyntaxTokenWithTrivia(kind, null, SyntaxFactory.CarriageReturnLineFeed);
+                s_missingTokensWithNoTrivia[(int)kind].Value = new MissingTokenWithTrivia(kind, leading: null, trailing: null);
             }
         }
 


### PR DESCRIPTION
This method accounts for 0.7% of allocations in the roslyn csharp editing speedometer test profile I'm looking at. In addition to caching tokens < LastTokenWithWellKnownText similar to what is already done, the SyntaxKind.IdentifierToken case is handled as it's very commonly hit too. Local testing of opening LanguageParser and typing in a new method reduced the number of MissingTokenWithTrivia from over 1 million to zero.

*** allocations in speedometer profile ***
![image](https://github.com/user-attachments/assets/eafd510a-d7d7-452e-9bf6-d0460e30f07f)