### PR TITLE
Handle span conversions in `is` operator

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3439,6 +3439,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             switch (conversionKind)
             {
+                case ConversionKind.ImplicitSpan:
+                case ConversionKind.ExplicitSpan:
                 case ConversionKind.NoConversion:
                     // Oddly enough, "x is T" can be true even if there is no conversion from x to T!
                     //


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/73445

These scenarios previously failed with "unexpected value" exception.