### PR TITLE
Respect [MemberNotNull] on local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3258,9 +3258,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var oldPending = SavePending();
 
                 EnterParameters();
-                bool isLocalFunction = lambdaOrFunctionSymbol is LocalFunctionSymbol;
-                SyntaxNode? localFunctionSyntax = isLocalFunction ? ((LocalFunctionSymbol)lambdaOrFunctionSymbol).Syntax : null;
 
+                bool isLocalFunction = lambdaOrFunctionSymbol is LocalFunctionSymbol;
                 if (isLocalFunction)
                 {
                     MakeMembersMaybeNull(lambdaOrFunctionSymbol, lambdaOrFunctionSymbol.NotNullMembers);
@@ -3281,7 +3280,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 EnforceDoesNotReturn(syntaxOpt: null);
                 if (isLocalFunction)
                 {
-                    enforceMemberNotNull(localFunctionSyntax, this.State);
+                    enforceMemberNotNull(((LocalFunctionSymbol)lambdaOrFunctionSymbol).Syntax, this.State);
                 }
                 EnforceParameterNotNullOnExit(null, this.State);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2092,7 +2092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        static MethodSymbol? GetTopLevelMethod(MethodSymbol? method)
+        private static MethodSymbol? GetTopLevelMethod(MethodSymbol? method)
         {
             while (method is object)
             {
@@ -7015,6 +7015,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (method.MethodKind == MethodKind.LocalFunction
                 && GetTopLevelMethod(method) is { ThisParameter: { } thisParameter })
             {
+                Debug.Assert(receiverSlot == -1);
                 receiverSlot = GetOrCreateSlot(thisParameter);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7015,7 +7015,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (method.MethodKind == MethodKind.LocalFunction
                 && GetTopLevelMethod(method) is { ThisParameter: { } thisParameter })
             {
-                Debug.Assert(receiverSlot is 0 or -1);
                 receiverSlot = GetOrCreateSlot(thisParameter);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7015,7 +7015,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (method.MethodKind == MethodKind.LocalFunction
                 && GetTopLevelMethod(method) is { ThisParameter: { } thisParameter })
             {
-                Debug.Assert(receiverSlot == -1);
+                Debug.Assert(receiverSlot is 0 or -1);
                 receiverSlot = GetOrCreateSlot(thisParameter);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7072,17 +7072,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return -1;
             }
 
+            if (method.IsStatic)
+            {
+                return 0;
+            }
+
             MethodSymbol? current = method;
-            bool anyStatic = current.IsStatic;
             while (current.ContainingSymbol is MethodSymbol container)
             {
                 current = container;
-                anyStatic |= container.IsStatic;
-            }
-
-            if (anyStatic)
-            {
-                return 0;
+                if (container.IsStatic)
+                {
+                    return 0;
+                }
             }
 
             if (current.TryGetThisParameter(out var thisParameter) && thisParameter is not null)

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
@@ -447,7 +447,7 @@ lSelect:
             Debug.Assert(node.MethodGroupOpt Is Nothing)
 
             Dim delegateType As NamedTypeSymbol = DirectCast(node.Type, NamedTypeSymbol)
-            Debug.Assert(delegateType.TypeKind = TYPEKIND.Delegate)
+            Debug.Assert(delegateType.TypeKind = TypeKind.Delegate)
 
             Dim method As MethodSymbol = node.Method
             Dim receiverOpt As BoundExpression = node.ReceiverOpt

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
@@ -447,7 +447,7 @@ lSelect:
             Debug.Assert(node.MethodGroupOpt Is Nothing)
 
             Dim delegateType As NamedTypeSymbol = DirectCast(node.Type, NamedTypeSymbol)
-            Debug.Assert(delegateType.TypeKind = TypeKind.Delegate)
+            Debug.Assert(delegateType.TypeKind = TYPEKIND.Delegate)
 
             Dim method As MethodSymbol = node.Method
             Dim receiverOpt As BoundExpression = node.ReceiverOpt


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/56256

The `MemberNotNull` attribute takes effect if either:
- the context is non-static (ie. the containing method and the nested local functions are not static). The target member can be static or not
- the context is static (ie. either the containing method or the local function is static) and the target member is static

When the `MemberNotNull` takes effect, three things happen:
1. after the local function is called, the state of the target member is changed to not-null
2. when entering the local function, the state of the target member is changed to maybe-null
3. when existing the local function, we warn if the target member isn't not-null

Note: I didn't gate this change behind LangVer as it seems small and only affects nullability warnings, but I'm open to it.