### PR TITLE
Fix endianness issues to fix failures in Emit testsuite

### DIFF
--- a/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs
+++ b/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             byte* resourceStart = peImage.Pointer + start;
-            BlobReader tmpresource = peImage.GetReader(start , peImage.Length-start);
+            BlobReader tmpresource = peImage.GetReader(start, peImage.Length-start);
             int resourceSize = tmpresource.ReadInt32();
             if (resourceSize > resourcesDir.Size - sizeof(int))
             {

--- a/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs
+++ b/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             byte* resourceStart = peImage.Pointer + start;
-            BlobReader tmpresource = peImage.GetReader(start, peImage.Length-start);
+            BlobReader tmpresource = peImage.GetReader(start, peImage.Length - start);
             int resourceSize = tmpresource.ReadInt32();
             if (resourceSize > resourcesDir.Size - sizeof(int))
             {

--- a/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs
+++ b/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs
@@ -179,7 +179,8 @@ namespace Microsoft.CodeAnalysis
             }
 
             byte* resourceStart = peImage.Pointer + start;
-            int resourceSize = *(int*)resourceStart;
+            BlobReader tmpresource = peImage.GetReader(start , peImage.Length-start);
+            int resourceSize = tmpresource.ReadInt32();
             if (resourceSize > resourcesDir.Size - sizeof(int))
             {
                 throw new BadImageFormatException();


### PR DESCRIPTION
Test cases in Emit test suite are failing when run on s390x architecture. 
They are failing while reading the size. The length fetched is out of range on s390x due to an endianness issue. 
This fix will take care of reading the size irrespective of the endianness. 

The stack trace of the failures is as below for reference. 
```
Microsoft.CodeAnalysis.CSharp.Emit.UnitTests test net8.0 failed with 2 error(s) (4.1s)
   /dotnet-s390x/sdk/9.0.100-preview.5.24307.3/Microsoft.TestPlatform.targets(46,5): error : [xUnit.net 00:00:02.48]     Microsoft.CodeAnalysis.CSharp.DynamicAnalysis.UnitTests.DynamicAnalysisResourceTests.TestDeconstructionSpans [FAIL]
  /roslyn/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs(75): error VSTEST1: 
      Microsoft.CodeAnalysis.CSharp.DynamicAnalysis.UnitTests.DynamicAnalysisResourceTests.TestDeconstructionSpans (1s 262ms): Error Message: System
      .ArgumentOutOfRangeException : Specified argument was out of the range of valid values. (Parameter 'length')
      Stack Trace:
         at System.Reflection.Internal.MemoryBlock.CreateChecked(Byte* buffer, Int32 length)
         at System.Reflection.Metadata.BlobReader..ctor(Byte* buffer, Int32 length)
         at Microsoft.CodeAnalysis.DynamicAnalysisDataReader..ctor(Byte* buffer, Int32 size) in /roslyn/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs:line 75
         at Microsoft.CodeAnalysis.DynamicAnalysisDataReader.TryCreateFromPE(PEReader peReader, String resourceName) in /roslyn/src/Compilers/Test/Core/Metadata/DynamicAnalysisDataReader.cs:line 190
         at Microsoft.CodeAnalysis.CSharp.DynamicAnalysis.UnitTests.DynamicAnalysisResourceTests.TestDeconstructionSpans() in /roslyn/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs:line 533
         at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

Test summary: total: 1, failed: 1, succeeded: 0, skipped: 0, duration: 4.1s
Build failed with 2 error(s) in 27.8s
```