### PR TITLE
Improve error recovery for `with` expression statement

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -8110,7 +8109,8 @@ done:
             {
                 return this.ParseYieldStatement(attributes);
             }
-            else if (this.IsPossibleAwaitExpressionStatement())
+            else if (this.IsPossibleAwaitExpressionStatement() ||
+                     this.IsPossibleWithExpressionStatement())
             {
                 return this.ParseExpressionStatement(attributes);
             }
@@ -10862,6 +10862,12 @@ done:
         private bool IsPossibleAwaitExpressionStatement()
         {
             return (this.IsScript || this.IsInAsync) && this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword;
+        }
+
+        private bool IsPossibleWithExpressionStatement()
+        {
+            Debug.Assert(CurrentToken.Kind == SyntaxKind.IdentifierToken);
+            return PeekToken(1).ContextualKind == SyntaxKind.WithKeyword && PeekToken(2).Kind == SyntaxKind.OpenBraceToken;
         }
 
         private bool IsAwaitExpression()

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
@@ -2492,39 +2492,27 @@ record R(int X);
             Assert.Equal("System.Int32 R.X { get; init; }", symbol.ToTestDisplayString());
         }
 
-        [Fact, WorkItem(46465, "https://github.com/dotnet/roslyn/issues/46465")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/44688")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/46465")]
         public void WithExpr29_DisallowedAsExpressionStatement()
         {
-            var src = @"
-record R(int X)
-{
-    void M()
-    {
-        var r = new R(1);
-        r with { X = 2 };
-    }
-}
-";
-            // Note: we didn't parse the `with` as a `with` expression, but as a broken local declaration
-            // Tracked by https://github.com/dotnet/roslyn/issues/46465
+            var src = """
+                record R(int X)
+                {
+                    void M()
+                    {
+                        var r = new R(1);
+                        r with { X = 2 };
+                    }
+                }
+                """;
+
             var comp = CreateCompilation(src);
             comp.VerifyEmitDiagnostics(
-                // (7,9): error CS0118: 'r' is a variable but is used like a type
+                // (6,9): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
                 //         r with { X = 2 };
-                Diagnostic(ErrorCode.ERR_BadSKknown, "r").WithArguments("r", "variable", "type").WithLocation(7, 9),
-                // (7,11): warning CS0168: The variable 'with' is declared but never used
-                //         r with { X = 2 };
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "with").WithArguments("with").WithLocation(7, 11),
-                // (7,16): error CS1002: ; expected
-                //         r with { X = 2 };
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(7, 16),
-                // (7,18): error CS8852: Init-only property or indexer 'R.X' can only be assigned in an object initializer, or on 'this' or 'base' in an instance constructor or an 'init' accessor.
-                //         r with { X = 2 };
-                Diagnostic(ErrorCode.ERR_AssignmentInitOnly, "X").WithArguments("R.X").WithLocation(7, 18),
-                // (7,24): error CS1002: ; expected
-                //         r with { X = 2 };
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(7, 24)
-                );
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "r with { X = 2 }").WithLocation(6, 9));
         }
 
         [Fact]


### PR DESCRIPTION
Closes: https://github.com/dotnet/roslyn/issues/44688
Closes: https://github.com/dotnet/roslyn/issues/46465