### PR TITLE
Improve performance on `SymbolCompletionProviderTests`

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -64,7 +64,7 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
 
     private protected override Task BaseVerifyWorkerAsync(
         string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
         List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
     {
         return base.VerifyWorkerAsync(

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -62,6 +62,16 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
             displayTextPrefix, inlineDescription, isComplexTextEdit, matchingFilters, flags, options, skipSpeculation: skipSpeculation);
     }
 
+    private protected override Task BaseVerifyWorkerAsync(
+        string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
+            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults,
+        List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
+    {
+        return base.VerifyWorkerAsync(
+            code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionItem, sourceCodeKind,
+            expectedResults, matchingFilters, flags, options, skipSpeculation);
+    }
+
     private protected override async Task VerifyWorkerAsync(
         string code, int position,
         string expectedItemOrNull, string expectedDescriptionOrNull,

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12584,10 +12584,12 @@ public static class Extension
     {
         var source = "enum E : $$";
 
-        await VerifyItemExistsAsync(source, "System");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("System"),
 
-        // Not accessible in the given context
-        await VerifyItemIsAbsentAsync(source, underlyingType);
+            // Not accessible in the given context
+            CompletionTestExpectedResult.Absent(underlyingType),
+        ]);
     }
 
     [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
@@ -12840,9 +12842,11 @@ public static class Extension
             }
             """;
 
-        await VerifyItemExistsAsync(source, "endIndex");
-        await VerifyItemExistsAsync(source, "Test");
-        await VerifyItemExistsAsync(source, "C");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("endIndex"),
+            CompletionTestExpectedResult.Exists("Test"),
+            CompletionTestExpectedResult.Exists("C"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66903")]
@@ -12861,9 +12865,11 @@ public static class Extension
             }
             """;
 
-        await VerifyItemExistsAsync(source, "endIndex");
-        await VerifyItemExistsAsync(source, "Test");
-        await VerifyItemExistsAsync(source, "C");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("endIndex"),
+            CompletionTestExpectedResult.Exists("Test"),
+            CompletionTestExpectedResult.Exists("C"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25572")]
@@ -12886,10 +12892,12 @@ public static class Extension
             }
             """;
 
-        await VerifyItemExistsAsync(source, "foo");
-        await VerifyItemExistsAsync(source, "M");
-        await VerifyItemExistsAsync(source, "System");
-        await VerifyItemIsAbsentAsync(source, "Int32");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("foo"),
+            CompletionTestExpectedResult.Exists("M"),
+            CompletionTestExpectedResult.Exists("System"),
+            CompletionTestExpectedResult.Absent("Int32"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25572")]
@@ -12910,9 +12918,11 @@ public static class Extension
             }
             """;
 
-        await VerifyItemExistsAsync(source, "System");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemIsAbsentAsync(source, "other");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("System"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Absent("other"),
+        ]);
     }
 
     public static readonly IEnumerable<object[]> PatternMatchingPrecedingPatterns = new object[][]
@@ -12945,12 +12955,14 @@ public static class Extension
         var expression = $"return input {precedingPattern} Constants.$$";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemIsAbsentAsync(source, "D");
-        await VerifyItemIsAbsentAsync(source, "M");
-        await VerifyItemExistsAsync(source, "R");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Absent("D"),
+            CompletionTestExpectedResult.Absent("M"),
+            CompletionTestExpectedResult.Exists("R"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -12960,12 +12972,14 @@ public static class Extension
         var expression = $"return input {precedingPattern} Constants.R.$$";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemIsAbsentAsync(source, "C");
-        await VerifyItemIsAbsentAsync(source, "D");
-        await VerifyItemIsAbsentAsync(source, "M");
-        await VerifyItemIsAbsentAsync(source, "R");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Absent("C"),
+            CompletionTestExpectedResult.Absent("D"),
+            CompletionTestExpectedResult.Absent("M"),
+            CompletionTestExpectedResult.Absent("R"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -12975,9 +12989,11 @@ public static class Extension
         var expression = $"return input {precedingPattern} $$";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemExistsAsync(source, "Constants");
-        await VerifyItemExistsAsync(source, "System");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("Constants"),
+            CompletionTestExpectedResult.Exists("System"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -12988,8 +13004,12 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         // In scripts, we also get a Script class containing our defined types
-        await VerifyItemExistsAsync(source, "C", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemExistsAsync(source, "Constants", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Exists("C"),
+                CompletionTestExpectedResult.Exists("Constants"),
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
         await VerifyItemExistsAsync(source, "System");
     }
 
@@ -12999,10 +13019,12 @@ public static class Extension
         var expression = $"return $$ is Constants.A";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "input");
-        await VerifyItemExistsAsync(source, "Constants");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemExistsAsync(source, "M");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("input"),
+            CompletionTestExpectedResult.Exists("Constants"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("M"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13012,12 +13034,14 @@ public static class Extension
         var expression = $"return input {precedingPattern} Constants.$$.A";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemIsAbsentAsync(source, "D");
-        await VerifyItemIsAbsentAsync(source, "M");
-        await VerifyItemExistsAsync(source, "R");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Absent("D"),
+            CompletionTestExpectedResult.Absent("M"),
+            CompletionTestExpectedResult.Exists("R"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13027,12 +13051,14 @@ public static class Extension
         var expression = $"return input {precedingPattern} Enum.$$";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemExistsAsync(source, "D");
-        await VerifyItemIsAbsentAsync(source, "M");
-        await VerifyItemIsAbsentAsync(source, "R");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("D"),
+            CompletionTestExpectedResult.Absent("M"),
+            CompletionTestExpectedResult.Absent("R"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13042,14 +13068,16 @@ public static class Extension
         var expression = $"return input {precedingPattern} nameof(Constants.$$";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemExistsAsync(source, "D");
-        await VerifyItemExistsAsync(source, "E");
-        await VerifyItemExistsAsync(source, "M");
-        await VerifyItemExistsAsync(source, "R");
-        await VerifyItemExistsAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("D"),
+            CompletionTestExpectedResult.Exists("E"),
+            CompletionTestExpectedResult.Exists("M"),
+            CompletionTestExpectedResult.Exists("R"),
+            CompletionTestExpectedResult.Exists("ToString"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13059,11 +13087,13 @@ public static class Extension
         var expression = $"return input {precedingPattern} nameof(Constants.R.$$";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "D");
-        await VerifyItemExistsAsync(source, "E");
-        await VerifyItemExistsAsync(source, "M");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("D"),
+            CompletionTestExpectedResult.Exists("E"),
+            CompletionTestExpectedResult.Exists("M"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13073,13 +13103,15 @@ public static class Extension
         var expression = $"return input {precedingPattern} nameof(Constants.$$.A";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemExistsAsync(source, "D");
-        await VerifyItemExistsAsync(source, "E");
-        await VerifyItemExistsAsync(source, "M");
-        await VerifyItemExistsAsync(source, "R");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("D"),
+            CompletionTestExpectedResult.Exists("E"),
+            CompletionTestExpectedResult.Exists("M"),
+            CompletionTestExpectedResult.Exists("R"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13089,12 +13121,14 @@ public static class Extension
         var expression = $"return input {precedingPattern} [Constants.R(Constants.$$, nameof(Constants.R))]";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemIsAbsentAsync(source, "D");
-        await VerifyItemIsAbsentAsync(source, "M");
-        await VerifyItemExistsAsync(source, "R");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Absent("D"),
+            CompletionTestExpectedResult.Absent("M"),
+            CompletionTestExpectedResult.Exists("R"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13104,12 +13138,14 @@ public static class Extension
         var expression = $"return input {precedingPattern} [Constants.R(Constants.$$), nameof(Constants.R)]";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "A");
-        await VerifyItemExistsAsync(source, "B");
-        await VerifyItemExistsAsync(source, "C");
-        await VerifyItemIsAbsentAsync(source, "D");
-        await VerifyItemIsAbsentAsync(source, "M");
-        await VerifyItemExistsAsync(source, "R");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Absent("D"),
+            CompletionTestExpectedResult.Absent("M"),
+            CompletionTestExpectedResult.Exists("R"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13119,8 +13155,10 @@ public static class Extension
         var expression = $"return input {precedingPattern} [Constants.R(Constants.A) {{ P.$$: Constants.A, InstanceProperty: 153 }}, nameof(Constants.R)]";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemExistsAsync(source, "Length");
-        await VerifyItemIsAbsentAsync(source, "Constants");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Length"),
+            CompletionTestExpectedResult.Absent("Constants"),
+        ]);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70226")]
@@ -13130,9 +13168,11 @@ public static class Extension
         var expression = $"return input {precedingPattern} [Constants.R(Constants.A) {{ P: $$ }}, nameof(Constants.R)]";
         var source = WrapPatternMatchingSource(expression);
 
-        await VerifyItemIsAbsentAsync(source, "InstanceProperty");
-        await VerifyItemIsAbsentAsync(source, "P");
-        await VerifyItemExistsAsync(source, "Constants");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Constants"),
+            CompletionTestExpectedResult.Absent("InstanceProperty"),
+            CompletionTestExpectedResult.Absent("P"),
+        ]);
     }
 
     private static string WrapPatternMatchingSource(string returnedExpression)

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -263,7 +263,7 @@ class C {
     [Fact]
     public async Task OpenStringLiteralInDirective()
     {
-        var code = "#r \"$$\"";
+        var code = "#r \"$$";
         await VerifyExpectedItemsAsync(
             code, [
                 CompletionTestExpectedResult.Absent("String"),
@@ -318,9 +318,10 @@ class C {
     public async Task AssemblyAttribute2()
     {
         var code = @"[assembly: $$]";
-        await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Exists("System")
+        var source = AddUsingDirectives("using System;", code);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("System"),
+            CompletionTestExpectedResult.Exists("AttributeUsage")
         ]);
     }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -1741,8 +1741,12 @@ class CL<T> where T : $$", @"Test");
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30784")]
     public async Task TypeParameterConstraintClause_StillShowStaticAndSealedTypesNotDirectlyInConstraint()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL<T> where T : IList<$$"), @"System");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL<T> where T : IList<$$"), @"String");
+        var content = @"class CL<T> where T : IList<$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30784")]
@@ -1790,15 +1794,23 @@ class CL<T> where T : A, $$", @"Test");
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30784")]
     public async Task TypeParameterConstraintClauseList_StillShowStaticAndSealedTypesNotDirectlyInConstraint()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL<T> where T : A, IList<$$"), @"System");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL<T> where T : A, IList<$$"), @"String");
+        var content = @"class CL<T> where T : A, IList<$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task TypeParameterConstraintClauseAnotherWhere()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<T> where T : A where$$"), @"System");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<T> where T : A where$$"), @"String");
+        var content = @"class CL<T> where T : A where$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
@@ -1826,29 +1838,45 @@ class CL<T> where T : A, $$", @"Test");
     [Fact]
     public async Task BaseList1()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL : $$"), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL : $$"), @"System");
+        var content = @"class CL : $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task BaseList2()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL : B, $$"), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL : B, $$"), @"System");
+        var content = @"class CL : B, $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task BaseListWhere()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<T> : B where$$"), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<T> : B where$$"), @"System");
+        var content = @"class CL<T> : B where$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task AliasedName()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", AddInsideMethod(@"global::$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"global::$$")), @"System");
+        var content = @"global::$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -1862,15 +1890,23 @@ class CL<T> where T : A, $$", @"Test");
     [Fact]
     public async Task ConstructorInitializer()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class C { C() : $$"), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class C { C() : $$"), @"System");
+        var content = @"class C { C() : $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task Typeof1()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"typeof($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"typeof($$")), @"System");
+        var content = @"typeof($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -1880,8 +1916,12 @@ class CL<T> where T : A, $$", @"Test");
     [Fact]
     public async Task Sizeof1()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"sizeof($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"sizeof($$")), @"System");
+        var content = @"sizeof($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -1891,8 +1931,12 @@ class CL<T> where T : A, $$", @"Test");
     [Fact]
     public async Task Default1()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"default($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"default($$")), @"System");
+        var content = @"default($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -2121,8 +2165,10 @@ class B : A
     }
 }
 ";
-        await VerifyItemIsAbsentAsync(markup, "Hidden");
-        await VerifyItemExistsAsync(markup, "Goo");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Hidden"),
+            CompletionTestExpectedResult.Exists("Goo")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539812")]
@@ -2142,8 +2188,10 @@ class B : A
     }
 }
 ";
-        await VerifyItemIsAbsentAsync(markup, "Hidden");
-        await VerifyItemExistsAsync(markup, "Goo");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Hidden"),
+            CompletionTestExpectedResult.Exists("Goo")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539812")]
@@ -2163,9 +2211,11 @@ class B : A
     }
 }
 ";
-        await VerifyItemIsAbsentAsync(markup, "Hidden");
-        await VerifyItemExistsAsync(markup, "Goo");
-        await VerifyItemIsAbsentAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Hidden"),
+            CompletionTestExpectedResult.Exists("Goo"),
+            CompletionTestExpectedResult.Absent("Bar"),
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539812")]
@@ -2185,8 +2235,10 @@ class B : A
     }
 }
 ";
-        await VerifyItemIsAbsentAsync(markup, "Hidden");
-        await VerifyItemExistsAsync(markup, "Goo");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Hidden"),
+            CompletionTestExpectedResult.Exists("Goo")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539812")]
@@ -2206,8 +2258,10 @@ class B : A
     }
 }
 ";
-        await VerifyItemIsAbsentAsync(markup, "Hidden");
-        await VerifyItemExistsAsync(markup, "Goo");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Hidden"),
+            CompletionTestExpectedResult.Exists("Goo")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539812")]
@@ -2227,8 +2281,10 @@ class B : A
     }
 }
 ";
-        await VerifyItemIsAbsentAsync(markup, "Hidden");
-        await VerifyItemExistsAsync(markup, "Goo");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Hidden"),
+            CompletionTestExpectedResult.Exists("Goo")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539812")]
@@ -2251,10 +2307,12 @@ class B : A
     }
 }
 ";
-        await VerifyItemIsAbsentAsync(markup, "HiddenStatic");
-        await VerifyItemExistsAsync(markup, "GooStatic");
-        await VerifyItemIsAbsentAsync(markup, "HiddenInstance");
-        await VerifyItemExistsAsync(markup, "GooInstance");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("HiddenStatic"),
+            CompletionTestExpectedResult.Exists("GooStatic"),
+            CompletionTestExpectedResult.Absent("HiddenInstance"),
+            CompletionTestExpectedResult.Exists("GooInstance")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540155")]
@@ -2422,8 +2480,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540212")]
@@ -2439,8 +2499,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/24326")]
@@ -2456,8 +2518,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact]
@@ -2473,8 +2537,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "field");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("field")
+        ]);
     }
 
     [Fact]
@@ -2490,8 +2556,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "field");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("field")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/24326")]
@@ -2507,8 +2575,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "field");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("field")
+        ]);
     }
 
     [Fact]
@@ -2524,8 +2594,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemExistsAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("parameter")
+        ]);
     }
 
     [Fact]
@@ -2541,8 +2613,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemExistsAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("parameter")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/24326")]
@@ -2558,8 +2632,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemExistsAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("parameter")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25569")]
@@ -2575,8 +2651,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemExistsAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("parameter")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25569")]
@@ -2592,8 +2670,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25569")]
@@ -2609,8 +2689,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact]
@@ -2626,8 +2708,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact]
@@ -2643,8 +2727,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact]
@@ -2660,8 +2746,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact]
@@ -2677,8 +2765,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "String");
-        await VerifyItemIsAbsentAsync(markup, "parameter");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Absent("parameter")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35178")]
@@ -3622,8 +3712,10 @@ namespace Namespace1
 }
 
 [Namespace1.$$]";
-        await VerifyItemIsAbsentAsync(markup, "Namespace2");
-        await VerifyItemExistsAsync(markup, "Namespace3");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Namespace2"),
+            CompletionTestExpectedResult.Exists("Namespace3"),
+        ]);
     }
 
     [Fact]
@@ -3670,10 +3762,12 @@ namespace Namespace1
 }
 
 [$$]";
-        await VerifyItemExistsAsync(markup, "Namespace1Alias");
-        await VerifyItemIsAbsentAsync(markup, "Namespace2Alias");
-        await VerifyItemExistsAsync(markup, "Namespace3Alias");
-        await VerifyItemExistsAsync(markup, "Namespace4Alias");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Namespace1Alias"),
+            CompletionTestExpectedResult.Absent("Namespace2Alias"),
+            CompletionTestExpectedResult.Exists("Namespace3Alias"),
+            CompletionTestExpectedResult.Exists("Namespace4Alias"),
+        ]);
     }
 
     [Fact]
@@ -4139,10 +4233,12 @@ class C
 }
 ";
 
-        await VerifyItemExistsAsync(markup, "a");
-        await VerifyItemExistsAsync(markup, "b");
-        await VerifyItemExistsAsync(markup, "c");
-        await VerifyItemIsAbsentAsync(markup, "Equals");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("a"),
+            CompletionTestExpectedResult.Exists("b"),
+            CompletionTestExpectedResult.Exists("c"),
+            CompletionTestExpectedResult.Absent("Equals"),
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543104")]
@@ -4160,10 +4256,12 @@ class C
 }
 ";
 
-        await VerifyItemIsAbsentAsync(markup, "a");
-        await VerifyItemIsAbsentAsync(markup, "b");
-        await VerifyItemIsAbsentAsync(markup, "c");
-        await VerifyItemExistsAsync(markup, "Equals");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("a"),
+            CompletionTestExpectedResult.Absent("b"),
+            CompletionTestExpectedResult.Absent("c"),
+            CompletionTestExpectedResult.Exists("Equals"),
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529138")]
@@ -7476,9 +7574,10 @@ class A
         A.$$
     }
 }";
-
-        await VerifyItemExistsAsync(markup, "Goo");
-        await VerifyItemExistsAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Goo"),
+            CompletionTestExpectedResult.Exists("Bar"),
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545647")]
@@ -7662,8 +7761,10 @@ class Program
     public async $$
 }";
 
-        await VerifyItemExistsAsync(markup, "Task");
-        await VerifyItemIsAbsentAsync(markup, "Console");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Task"),
+            CompletionTestExpectedResult.Absent("Console"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/60341")]
@@ -7678,8 +7779,10 @@ class Program
 
 class Test {}";
 
-        await VerifyItemExistsAsync(markup, "Task");
-        await VerifyItemIsAbsentAsync(markup, "Test");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Task"),
+            CompletionTestExpectedResult.Absent("Test"),
+        ]);
     }
 
     [Fact]
@@ -7818,8 +7921,10 @@ namespace N
     }
 }";
         // Nothing should be found: no awaiter for request.
-        await VerifyItemIsAbsentAsync(markup, "Result");
-        await VerifyItemIsAbsentAsync(markup, "ReadAsStreamAsync");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Result"),
+            CompletionTestExpectedResult.Absent("ReadAsStreamAsync"),
+        ]);
     }
 
     [Fact]
@@ -7846,8 +7951,10 @@ namespace N
     }
 }";
 
-        await VerifyItemIsAbsentAsync(markup, "Result");
-        await VerifyItemExistsAsync(markup, "ReadAsStreamAsync");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Result"),
+            CompletionTestExpectedResult.Exists("ReadAsStreamAsync"),
+        ]);
     }
 
     [Fact]
@@ -8663,8 +8770,10 @@ class A
         var q = a?.$$AB.BA.AB.BA;
     }
 }";
-        await VerifyItemExistsAsync(markup, "AA");
-        await VerifyItemExistsAsync(markup, "AB");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("AA"),
+            CompletionTestExpectedResult.Exists("AB"),
+        ]);
     }
 
     [Fact]
@@ -8686,8 +8795,10 @@ class A
         var q = a?.s?.$$;
     }
 }";
-        await VerifyItemExistsAsync(markup, "i");
-        await VerifyItemIsAbsentAsync(markup, "value");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("i"),
+            CompletionTestExpectedResult.Absent("Value"),
+        ]);
     }
 
     [Fact]
@@ -8708,8 +8819,10 @@ class A
         var q = s?.$$i?.ToString();
     }
 }";
-        await VerifyItemExistsAsync(markup, "i");
-        await VerifyItemIsAbsentAsync(markup, "value");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("i"),
+            CompletionTestExpectedResult.Absent("Value"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54361")]
@@ -8724,8 +8837,10 @@ class A
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "Day");
-        await VerifyItemIsAbsentAsync(markup, "Value");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Day"),
+            CompletionTestExpectedResult.Absent("Value"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54361")]
@@ -8740,8 +8855,10 @@ class A
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "Value");
-        await VerifyItemIsAbsentAsync(markup, "Day");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Value"),
+            CompletionTestExpectedResult.Absent("Day"),
+        ]);
     }
 
     [Fact]
@@ -9154,8 +9271,10 @@ class C
     }
 }
 ";
-        await VerifyItemExistsAsync(markup, "x");
-        await VerifyItemExistsAsync(markup, "y");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("x"),
+            CompletionTestExpectedResult.Exists("y"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1663")]
@@ -9385,9 +9504,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemIsAbsentAsync(markup, "A");
-        await VerifyItemIsAbsentAsync(markup, "B");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("A"),
+            CompletionTestExpectedResult.Absent("B"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact]
@@ -9407,9 +9528,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemIsAbsentAsync(markup, "C");
-        await VerifyItemIsAbsentAsync(markup, "D");
-        await VerifyItemExistsAsync(markup, "M");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("C"),
+            CompletionTestExpectedResult.Absent("D"),
+            CompletionTestExpectedResult.Exists("M"),
+        ]);
     }
 
     [Fact]
@@ -9429,9 +9552,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemExistsAsync(markup, "B");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact]
@@ -9451,9 +9576,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "C");
-        await VerifyItemExistsAsync(markup, "D");
-        await VerifyItemExistsAsync(markup, "M");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("D"),
+            CompletionTestExpectedResult.Exists("M"),
+        ]);
     }
 
     [Fact]
@@ -9473,9 +9600,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemExistsAsync(markup, "B");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact]
@@ -9495,9 +9624,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "C");
-        await VerifyItemExistsAsync(markup, "D");
-        await VerifyItemExistsAsync(markup, "M");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("D"),
+            CompletionTestExpectedResult.Exists("M"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67985")]
@@ -9517,9 +9648,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemExistsAsync(markup, "B");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact]
@@ -9539,9 +9672,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemIsAbsentAsync(markup, "B");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Absent("B"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact]
@@ -9561,9 +9696,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "C");
-        await VerifyItemIsAbsentAsync(markup, "D");
-        await VerifyItemExistsAsync(markup, "M");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Absent("D"),
+            CompletionTestExpectedResult.Exists("M"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67985")]
@@ -9583,9 +9720,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemIsAbsentAsync(markup, "B");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Absent("B"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact]
@@ -9606,9 +9745,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "C");
-        await VerifyItemExistsAsync(markup, "I");
-        await VerifyItemExistsAsync(markup, "M");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("C"),
+            CompletionTestExpectedResult.Exists("I"),
+            CompletionTestExpectedResult.Exists("M"),
+        ]);
     }
 
     [Fact]
@@ -9629,9 +9770,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemExistsAsync(markup, "I");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("I"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67985")]
@@ -9652,9 +9795,11 @@ namespace N
     namespace M { }
 }";
 
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemExistsAsync(markup, "I");
-        await VerifyItemExistsAsync(markup, "N");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("I"),
+            CompletionTestExpectedResult.Exists("N"),
+        ]);
     }
 
     [Fact]
@@ -9683,8 +9828,10 @@ class C
 }
 ";
 
-        await VerifyItemIsAbsentAsync(markup, "Goo");
-        await VerifyItemIsAbsentAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Goo"),
+            CompletionTestExpectedResult.Absent("Bar"),
+        ]);
     }
 
     [Fact]
@@ -9715,8 +9862,10 @@ class C
 }
 ";
 
-        await VerifyItemIsAbsentAsync(markup, "Goo");
-        await VerifyItemIsAbsentAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Goo"),
+            CompletionTestExpectedResult.Absent("Bar"),
+        ]);
     }
 
     [Fact]
@@ -9748,8 +9897,10 @@ class C
 }
 ";
 
-        await VerifyItemExistsAsync(markup, "Goo");
-        await VerifyItemExistsAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Goo"),
+            CompletionTestExpectedResult.Exists("Bar"),
+        ]);
     }
 
     [Fact]
@@ -9782,8 +9933,10 @@ class C
 }
 ";
 
-        await VerifyItemExistsAsync(markup, "Goo");
-        await VerifyItemExistsAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Goo"),
+            CompletionTestExpectedResult.Exists("Bar"),
+        ]);
     }
 
     [Fact]
@@ -9815,8 +9968,10 @@ class C
 }
 ";
 
-        await VerifyItemExistsAsync(markup, "Goo");
-        await VerifyItemIsAbsentAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Goo"),
+            CompletionTestExpectedResult.Absent("Bar"),
+        ]);
     }
 
     [Fact]
@@ -9848,8 +10003,10 @@ class C
 }
 ";
 
-        await VerifyItemIsAbsentAsync(markup, "Goo");
-        await VerifyItemExistsAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Goo"),
+            CompletionTestExpectedResult.Exists("Bar"),
+        ]);
     }
 
     [Fact]
@@ -9882,8 +10039,10 @@ class C
 }
 ";
 
-        await VerifyItemExistsAsync(markup, "Goo");
-        await VerifyItemExistsAsync(markup, "Bar");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("Goo"),
+            CompletionTestExpectedResult.Exists("Bar"),
+        ]);
     }
 
     [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/7932")]
@@ -10861,9 +11020,11 @@ namespace ClassLibrary1
     }
 }";
 
-        await VerifyItemIsAbsentAsync(markup, "Substring");
-        await VerifyItemExistsAsync(markup, "A");
-        await VerifyItemExistsAsync(markup, "B");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Substring"),
+            CompletionTestExpectedResult.Exists("A"),
+            CompletionTestExpectedResult.Exists("B"),
+        ]);
     }
 
     [Fact, WorkItem("https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1056325")]
@@ -10972,8 +11133,10 @@ class Program
 class Product1 { public void MyProperty1() { } }
 class Product2 { public void MyProperty2() { } }";
 
-        await VerifyItemExistsAsync(markup, "MyProperty1");
-        await VerifyItemExistsAsync(markup, "MyProperty2");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("MyProperty1"),
+            CompletionTestExpectedResult.Exists("MyProperty2"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42997")]
@@ -10999,9 +11162,11 @@ class Product1 { public void MyProperty1() { } }
 class Product2 { public void MyProperty2() { } }
 class Product3 { public void MyProperty3() { } }";
 
-        await VerifyItemExistsAsync(markup, "MyProperty1");
-        await VerifyItemExistsAsync(markup, "MyProperty2");
-        await VerifyItemExistsAsync(markup, "MyProperty3");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("MyProperty1"),
+            CompletionTestExpectedResult.Exists("MyProperty2"),
+            CompletionTestExpectedResult.Exists("MyProperty3")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42997")]
@@ -11288,9 +11453,11 @@ class AnotherBuilder
     public int AnotherSomething { get; set; }
 }";
 
-        await VerifyItemIsAbsentAsync(markup, "AnotherSomething");
-        await VerifyItemIsAbsentAsync(markup, "FirstOrDefault");
-        await VerifyItemExistsAsync(markup, "Something");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("AnotherSomething"),
+            CompletionTestExpectedResult.Absent("FirstOrDefault"),
+            CompletionTestExpectedResult.Exists("Something")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36029")]
@@ -11319,9 +11486,11 @@ class AnotherBuilder
     public int AnotherSomething { get; set; }
 }";
 
-        await VerifyItemIsAbsentAsync(markup, "Something");
-        await VerifyItemIsAbsentAsync(markup, "FirstOrDefault");
-        await VerifyItemExistsAsync(markup, "AnotherSomething");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Absent("Something"),
+            CompletionTestExpectedResult.Absent("FirstOrDefault"),
+            CompletionTestExpectedResult.Exists("AnotherSomething")
+        ]);
     }
 
     [Fact, Trait(Traits.Feature, Traits.Features.TargetTypedCompletion)]
@@ -11425,9 +11594,14 @@ public class C
     }
 }";
 
-        await VerifyItemExistsAsync(markup, "M");
-        await VerifyItemExistsAsync(markup, "Equals");
-        await VerifyItemIsAbsentAsync(markup, "DoSomething", displayTextSuffix: "<>");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("M"),
+            CompletionTestExpectedResult.Exists("Equals"),
+            CompletionTestExpectedResult.Absent("DoSomething") with
+            {
+                DisplayTextSuffix = "<>"
+            },
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38074")]
@@ -11704,9 +11878,11 @@ namespace Bar1
 	}
 }";
         // VerifyItemExistsAsync also tests with the item typed.
-        await VerifyItemExistsAsync(markup, "BillyJoel");
-        await VerifyItemExistsAsync(markup, "EveryoneElse");
-        await VerifyItemIsAbsentAsync(markup, "Equals");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("BillyJoel"),
+            CompletionTestExpectedResult.Exists("EveryoneElse"),
+            CompletionTestExpectedResult.Absent("Equals"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/49072")]
@@ -11732,9 +11908,11 @@ namespace Bar1
 	}
 }";
         // VerifyItemExistsAsync also tests with the item typed.
-        await VerifyItemExistsAsync(markup, "BillyJoel");
-        await VerifyItemExistsAsync(markup, "EveryoneElse");
-        await VerifyItemIsAbsentAsync(markup, "Equals");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("BillyJoel"),
+            CompletionTestExpectedResult.Exists("EveryoneElse"),
+            CompletionTestExpectedResult.Absent("Equals"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/49072")]
@@ -11760,9 +11938,11 @@ namespace Bar1
 	}
 }";
         // VerifyItemExistsAsync also tests with the item typed.
-        await VerifyItemExistsAsync(markup, "BillyJoel");
-        await VerifyItemExistsAsync(markup, "EveryoneElse");
-        await VerifyItemIsAbsentAsync(markup, "Equals");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("BillyJoel"),
+            CompletionTestExpectedResult.Exists("EveryoneElse"),
+            CompletionTestExpectedResult.Absent("Equals"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/49072")]
@@ -11807,9 +11987,11 @@ namespace Bar1
 	}
 }";
         // VerifyItemExistsAsync also tests with the item typed.
-        await VerifyItemExistsAsync(markup, "BillyJoel");
-        await VerifyItemExistsAsync(markup, "EveryoneElse");
-        await VerifyItemIsAbsentAsync(markup, "Equals");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("BillyJoel"),
+            CompletionTestExpectedResult.Exists("EveryoneElse"),
+            CompletionTestExpectedResult.Absent("Equals"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/49072")]
@@ -11835,9 +12017,11 @@ namespace Bar1
 	}
 }";
         // VerifyItemExistsAsync also tests with the item typed.
-        await VerifyItemExistsAsync(markup, "BillyJoel");
-        await VerifyItemExistsAsync(markup, "EveryoneElse");
-        await VerifyItemIsAbsentAsync(markup, "Equals");
+        await VerifyExpectedItemsAsync(markup, [
+            CompletionTestExpectedResult.Exists("BillyJoel"),
+            CompletionTestExpectedResult.Exists("EveryoneElse"),
+            CompletionTestExpectedResult.Absent("Equals"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/49609")]
@@ -13416,8 +13600,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13446,8 +13632,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13478,8 +13666,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "StatusEn");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("StatusEn"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13510,8 +13700,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13543,8 +13735,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13571,8 +13765,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13599,8 +13795,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13629,8 +13827,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "StatusEn");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("StatusEn"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13659,8 +13859,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75350")]
@@ -13690,8 +13892,10 @@ public static class Extension
                 Closed,
             }
             """;
-        await VerifyItemExistsAsync(source, "Undisclosed");
-        await VerifyItemIsAbsentAsync(source, "ToString");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("Undisclosed"),
+            CompletionTestExpectedResult.Absent("ToString"),
+        ]);
     }
 
     #region Collection expressions

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -346,8 +346,11 @@ class CL {}";
     [Fact]
     public async Task TypeParamAttribute()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL<[A$$]T> {}"), @"AttributeUsage");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"class CL<[A$$]T> {}"), @"System");
+        var code = AddUsingDirectives("using System;", @"class CL<[A$$]T> {}");
+        await VerifyExpectedItemsAsync(code, [
+            CompletionTestExpectedResult.Exists("AttributeUsage"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -357,8 +360,11 @@ class CL {}";
     [$$]
     void Method() {}
 }";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"AttributeUsage");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var code = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(code, [
+            CompletionTestExpectedResult.Exists("AttributeUsage"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -367,8 +373,11 @@ class CL {}";
         var content = @"class CL{
     void Method<[A$$]T> () {}
 }";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"AttributeUsage");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var code = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(code, [
+            CompletionTestExpectedResult.Exists("AttributeUsage"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -377,8 +386,11 @@ class CL {}";
         var content = @"class CL{
     void Method ([$$]int i) {}
 }";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"AttributeUsage");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var code = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(code, [
+            CompletionTestExpectedResult.Exists("AttributeUsage"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -408,8 +420,12 @@ namespace System
 
 namespace $$";
 
-        await VerifyItemExistsAsync(source, "System", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "String", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Exists("System"),
+                CompletionTestExpectedResult.Absent("String")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -419,8 +435,12 @@ namespace $$";
 
 namespace $$;";
 
-        await VerifyItemExistsAsync(source, "System", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "String", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Exists("System"),
+                CompletionTestExpectedResult.Absent("String")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -457,8 +477,12 @@ namespace A
     namespace $$
 }";
 
-        await VerifyItemIsAbsentAsync(source, "A", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemExistsAsync(source, "B", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Absent("A"),
+                CompletionTestExpectedResult.Exists("B")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -481,8 +505,12 @@ namespace A
     }
 }";
 
-        await VerifyItemIsAbsentAsync(source, "A", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "B", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Absent("A"),
+                CompletionTestExpectedResult.Absent("B")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -499,8 +527,12 @@ namespace A
     }
 }";
 
-        await VerifyItemIsAbsentAsync(source, "A", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemExistsAsync(source, "B", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Absent("A"),
+                CompletionTestExpectedResult.Exists("B")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -508,8 +540,12 @@ namespace A
     {
         var source = @"namespace Sys$$tem { }";
 
-        await VerifyItemExistsAsync(source, "System", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "Runtime", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Exists("System"),
+                CompletionTestExpectedResult.Absent("Runtime")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -591,9 +627,13 @@ namespace A
     namespace B.$$
 }";
 
-        await VerifyItemIsAbsentAsync(source, "A", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "B", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemExistsAsync(source, "C", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Absent("A"),
+                CompletionTestExpectedResult.Absent("B"),
+                CompletionTestExpectedResult.Exists("C")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -606,8 +646,12 @@ namespace A.$$
 }
 ";
 
-        await VerifyItemIsAbsentAsync(source, "A", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "B", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Absent("A"),
+                CompletionTestExpectedResult.Absent("B")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -622,8 +666,12 @@ namespace A.$$
 }
 ";
 
-        await VerifyItemIsAbsentAsync(source, "A", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemExistsAsync(source, "B", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Absent("A"),
+                CompletionTestExpectedResult.Exists("B")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -631,8 +679,12 @@ namespace A.$$
     {
         var source = @"namespace Sys$$tem.Runtime { }";
 
-        await VerifyItemExistsAsync(source, "System", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "Runtime", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Exists("System"),
+                CompletionTestExpectedResult.Absent("Runtime")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -652,8 +704,12 @@ namespace System
     name$$space Runtime { }
 }";
 
-        await VerifyItemIsAbsentAsync(source, "System", sourceCodeKind: SourceCodeKind.Regular);
-        await VerifyItemIsAbsentAsync(source, "Runtime", sourceCodeKind: SourceCodeKind.Regular);
+        await VerifyExpectedItemsAsync(source,
+            [
+                CompletionTestExpectedResult.Absent("System"),
+                CompletionTestExpectedResult.Absent("Runtime")
+            ],
+            sourceCodeKind: SourceCodeKind.Regular);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -698,19 +754,23 @@ namespace A.B.C.D3 { }";
     [Fact]
     public async Task UnderNamespace()
     {
-        await VerifyItemIsAbsentAsync(@"namespace NS { $$", @"String");
-        await VerifyItemIsAbsentAsync(@"namespace NS { $$", @"System");
+        var source = @"namespace NS { $$";
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task OutsideOfType1()
     {
-        await VerifyItemIsAbsentAsync(@"namespace NS {
+        var source = @"namespace NS {
 class CL {}
-$$", @"String");
-        await VerifyItemIsAbsentAsync(@"namespace NS {
-class CL {}
-$$", @"System");
+$$";
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
@@ -719,14 +779,17 @@ $$", @"System");
         var content = @"namespace NS {
 class CL {}
 $$";
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task CompletionInsideProperty()
     {
-        var content = @"class C
+        var source = @"class C
 {
     private string name;
     public string Name
@@ -734,22 +797,30 @@ $$";
         set
         {
             name = $$";
-        await VerifyItemExistsAsync(content, @"value");
-        await VerifyItemExistsAsync(content, @"C");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("value"),
+            CompletionTestExpectedResult.Exists("C")
+        ]);
     }
 
     [Fact]
     public async Task AfterDot()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"[assembly: A.$$"), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"[assembly: A.$$"), @"System");
+        var source = AddUsingDirectives("using System;", @"[assembly: A.$$");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task UsingAlias()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"using MyType = $$"), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", @"using MyType = $$"), @"System");
+        var source = AddUsingDirectives("using System;", @"using MyType = $$");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -758,8 +829,11 @@ $$";
         var content = @"class CL {
     $$
 ";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -768,106 +842,151 @@ $$";
         var content = @"class CL {
     public $$
 ";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task BadStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = $$)c")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = $$)c")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = $$)c"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task TypeTypeParameter()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<$$"), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<$$"), @"System");
+        var source = AddUsingDirectives("using System;", @"class CL<$$");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task TypeTypeParameterList()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<T, $$"), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"class CL<T, $$"), @"System");
+        var source = AddUsingDirectives("using System;", @"class CL<T, $$");
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task CastExpressionTypePart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = ($$)c")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = ($$)c")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = ($$)c"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ObjectCreationExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ArrayCreationExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$ [")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$ [")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$ ["));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task StackAllocArrayCreationExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = stackalloc $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = stackalloc $$")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = stackalloc $$"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task FromClauseTypeOptPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from $$ c")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from $$ c")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = from $$ c"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task JoinClause()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join $$ j")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join $$ j")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join $$ j"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task DeclarationStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$ i =")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$ i =")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"$$ i ="));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task VariableDeclaration()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"fixed($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"fixed($$")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"fixed($$"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ForEachStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"foreach($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"foreach($$")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"foreach($$"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ForEachStatementNoToken()
     {
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", AddInsideMethod(@"foreach $$")), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", AddInsideMethod(@"foreach $$")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"foreach $$"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
     public async Task CatchDeclaration()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"try {} catch($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"try {} catch($$")), @"System");
+        var source = AddUsingDirectives("using System;", AddInsideMethod(@"try {} catch($$"));
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -875,8 +994,11 @@ $$";
     {
         var content = @"class CL {
     $$ i";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -884,8 +1006,11 @@ $$";
     {
         var content = @"class CL {
     event $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -893,8 +1018,11 @@ $$";
     {
         var content = @"class CL {
     explicit operator $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -902,8 +1030,11 @@ $$";
     {
         var content = @"class CL {
     explicit $$";
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Absent("String"),
+            CompletionTestExpectedResult.Absent("System")
+        ]);
     }
 
     [Fact]
@@ -911,8 +1042,11 @@ $$";
     {
         var content = @"class CL {
     $$ Prop {";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -920,8 +1054,11 @@ $$";
     {
         var content = @"class CL {
     event $$ Event {";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -929,8 +1066,11 @@ $$";
     {
         var content = @"class CL {
     $$ this";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -938,8 +1078,11 @@ $$";
     {
         var content = @"class CL {
     void Method($$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -947,8 +1090,11 @@ $$";
     {
         var content = @"class CL {
     $$ [";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -956,8 +1102,11 @@ $$";
     {
         var content = @"class CL {
     $$ *";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -965,8 +1114,11 @@ $$";
     {
         var content = @"class CL {
     $$ ?";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -974,8 +1126,11 @@ $$";
     {
         var content = @"class CL {
     delegate $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -983,8 +1138,11 @@ $$";
     {
         var content = @"class CL {
     $$ M(";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
@@ -992,359 +1150,550 @@ $$";
     {
         var content = @"class CL {
     $$ operator";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ParenthesizedExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"($$")), @"System");
+        var content = @"($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task InvocationExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$(")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$(")), @"System");
+        var content = @"$$(";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ElementAccessExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$[")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$[")), @"System");
+        var content = @"$$[";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task Argument()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"i[$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"i[$$")), @"System");
+        var content = @"i[$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task CastExpressionExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"(c)$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"(c)$$")), @"System");
+        var content = @"(c)$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task FromClauseInPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in $$")), @"System");
+        var content = @"var t = from c in $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task LetClauseExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C let n = $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C let n = $$")), @"System");
+        var content = @"var t = from c in C let n = $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task OrderingExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C orderby $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C orderby $$")), @"System");
+        var content = @"var t = from c in C orderby $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task SelectClauseExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C select $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C select $$")), @"System");
+        var content = @"var t = from c in C select $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ExpressionStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$")), @"System");
+        var content = @"$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ReturnStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"return $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"return $$")), @"System");
+        var content = @"return $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ThrowStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"throw $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"throw $$")), @"System");
+        var content = @"throw $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/760097")]
     public async Task YieldReturnStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"yield return $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"yield return $$")), @"System");
+        var content = @"yield return $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ForEachStatementExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"foreach(T t in $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"foreach(T t in $$")), @"System");
+        var content = @"foreach(T t in $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task UsingStatementExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"using($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"using($$")), @"System");
+        var content = @"using($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task LockStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"lock($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"lock($$")), @"System");
+        var content = @"lock($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task EqualsValueClause()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var i = $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var i = $$")), @"System");
+        var content = @"var i = $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ForStatementInitializersPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"for($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"for($$")), @"System");
+        var content = @"for($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ForStatementConditionOptPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"for(i=0;$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"for(i=0;$$")), @"System");
+        var content = @"for(i=0;$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ForStatementIncrementorsPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"for(i=0;i>10;$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"for(i=0;i>10;$$")), @"System");
+        var content = @"for(i=0;i>10;$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task DoStatementConditionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"do {} while($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"do {} while($$")), @"System");
+        var content = @"do {} while($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task WhileStatementConditionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"while($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"while($$")), @"System");
+        var content = @"while($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ArrayRankSpecifierSizesPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"int [$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"int [$$")), @"System");
+        var content = @"int [$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task PrefixUnaryExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"+$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"+$$")), @"System");
+        var content = @"+$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task PostfixUnaryExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$++")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$++")), @"System");
+        var content = @"$$++";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task BinaryExpressionLeftPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$ + 1")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$ + 1")), @"System");
+        var content = @"$$ + 1";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task BinaryExpressionRightPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"1 + $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"1 + $$")), @"System");
+        var content = @"1 + $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task AssignmentExpressionLeftPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$ = 1")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$ = 1")), @"System");
+        var content = @"$$ = 1";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task AssignmentExpressionRightPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"1 = $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"1 = $$")), @"System");
+        var content = @"1 = $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ConditionalExpressionConditionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$? 1:")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"$$? 1:")), @"System");
+        var content = @"$$? 1:";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ConditionalExpressionWhenTruePart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"true? $$:")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"true? $$:")), @"System");
+        var content = @"true? $$:";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task ConditionalExpressionWhenFalsePart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"true? 1:$$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"true? 1:$$")), @"System");
+        var content = @"true? 1:$$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task JoinClauseInExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join p in $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join p in $$")), @"System");
+        var content = @"var t = from c in C join p in $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task JoinClauseLeftExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join p in P on $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join p in P on $$")), @"System");
+        var content = @"var t = from c in C join p in P on $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task JoinClauseRightExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join p in P on id equals $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join p in P on id equals $$")), @"System");
+        var content = @"var t = from c in C join p in P on id equals $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task WhereClauseConditionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C where $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C where $$")), @"System");
+        var content = @"var t = from c in C where $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task GroupClauseGroupExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C group $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C group $$")), @"System");
+        var content = @"var t = from c in C group $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task GroupClauseByExpressionPart()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C group g by $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C group g by $$")), @"System");
+        var content = @"var t = from c in C group g by $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task IfStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"if ($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"if ($$")), @"System");
+        var content = @"if ($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task SwitchStatement()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"switch($$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"switch($$")), @"System");
+        var content = @"switch($$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task SwitchLabelCase()
     {
         var content = @"switch(i) { case $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task SwitchPatternLabelCase()
     {
         var content = @"switch(i) { case $$ when";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/33915")]
     public async Task SwitchExpressionFirstBranch()
     {
         var content = @"i switch { $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/33915")]
     public async Task SwitchExpressionSecondBranch()
     {
         var content = @"i switch { 1 => true, $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/33915")]
     public async Task PositionalPatternFirstPosition()
     {
         var content = @"i is ($$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/33915")]
     public async Task PositionalPatternSecondPosition()
     {
         var content = @"i is (1, $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/33915")]
     public async Task PropertyPatternFirstPosition()
     {
         var content = @"i is { P: $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/33915")]
     public async Task PropertyPatternSecondPosition()
     {
         var content = @"i is { P1: 1, P2: $$";
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(content)), @"System");
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact]
     public async Task InitializerExpression()
     {
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = new [] { $$")), @"String");
-        await VerifyItemExistsAsync(AddUsingDirectives("using System;", AddInsideMethod(@"var t = new [] { $$")), @"System");
+        var content = @"var t = new [] { $$";
+        var source = AddUsingDirectives("using System;", content);
+        await VerifyExpectedItemsAsync(source, [
+            CompletionTestExpectedResult.Exists("String"),
+            CompletionTestExpectedResult.Exists("System")
+        ]);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30784")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -255,8 +255,8 @@ class C {
     {
         var code = AddUsingDirectives("using System;", AddInsideMethod("string s = \"$$"));
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -266,8 +266,8 @@ class C {
         var code = "#r \"$$";
         await VerifyExpectedItemsAsync(
             code, [
-                CompletionTestExpectedResult.Absent("String"),
-                CompletionTestExpectedResult.Absent("System")
+                ItemExpectation.Absent("String"),
+                ItemExpectation.Absent("System")
             ],
             sourceCodeKind: SourceCodeKind.Script);
     }
@@ -277,8 +277,8 @@ class C {
     {
         var code = AddUsingDirectives("using System;", AddInsideMethod("string s = \"$$\";"));
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -288,8 +288,8 @@ class C {
         var code = "#r \"$$\"";
         await VerifyExpectedItemsAsync(
             code, [
-                CompletionTestExpectedResult.Absent("String"),
-                CompletionTestExpectedResult.Absent("System")
+                ItemExpectation.Absent("String"),
+                ItemExpectation.Absent("System")
             ],
             sourceCodeKind: SourceCodeKind.Script);
     }
@@ -299,8 +299,8 @@ class C {
     {
         var code = AddUsingDirectives("using System;", AddInsideMethod("char c = '$$"));
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -309,8 +309,8 @@ class C {
     {
         var code = @"[assembly: $$]";
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -320,8 +320,8 @@ class C {
         var code = @"[assembly: $$]";
         var source = AddUsingDirectives("using System;", code);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("System"),
-            CompletionTestExpectedResult.Exists("AttributeUsage")
+            ItemExpectation.Exists("System"),
+            ItemExpectation.Exists("AttributeUsage")
         ]);
     }
 
@@ -349,8 +349,8 @@ class CL {}";
     {
         var code = AddUsingDirectives("using System;", @"class CL<[A$$]T> {}");
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Exists("AttributeUsage"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("AttributeUsage"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -363,8 +363,8 @@ class CL {}";
 }";
         var code = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Exists("AttributeUsage"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("AttributeUsage"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -376,8 +376,8 @@ class CL {}";
 }";
         var code = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Exists("AttributeUsage"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("AttributeUsage"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -389,8 +389,8 @@ class CL {}";
 }";
         var code = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(code, [
-            CompletionTestExpectedResult.Exists("AttributeUsage"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("AttributeUsage"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -423,8 +423,8 @@ namespace $$";
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Exists("System"),
-                CompletionTestExpectedResult.Absent("String")
+                ItemExpectation.Exists("System"),
+                ItemExpectation.Absent("String")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -438,8 +438,8 @@ namespace $$;";
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Exists("System"),
-                CompletionTestExpectedResult.Absent("String")
+                ItemExpectation.Exists("System"),
+                ItemExpectation.Absent("String")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -480,8 +480,8 @@ namespace A
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Exists("B")
+                ItemExpectation.Absent("A"),
+                ItemExpectation.Exists("B")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -508,8 +508,8 @@ namespace A
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Absent("B")
+                ItemExpectation.Absent("A"),
+                ItemExpectation.Absent("B")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -530,8 +530,8 @@ namespace A
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Exists("B")
+                ItemExpectation.Absent("A"),
+                ItemExpectation.Exists("B")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -543,8 +543,8 @@ namespace A
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Exists("System"),
-                CompletionTestExpectedResult.Absent("Runtime")
+                ItemExpectation.Exists("System"),
+                ItemExpectation.Absent("Runtime")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -575,14 +575,14 @@ namespace A.B.C3 { }";
                 //     C3 => A.A.B.C3
                 //
                 // ...none of which are found by the current algorithm.
-                CompletionTestExpectedResult.Absent("C1"),
-                CompletionTestExpectedResult.Absent("C2"),
-                CompletionTestExpectedResult.Absent("C3"),
-                CompletionTestExpectedResult.Absent("A"),
+                ItemExpectation.Absent("C1"),
+                ItemExpectation.Absent("C2"),
+                ItemExpectation.Absent("C3"),
+                ItemExpectation.Absent("A"),
 
                 // Because of the above, B does end up in the completion list
                 // since A.B.B appears to be a peer of the new declaration
-                CompletionTestExpectedResult.Exists("B")
+                ItemExpectation.Exists("B")
             ],
             SourceCodeKind.Regular);
     }
@@ -630,9 +630,9 @@ namespace A
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Absent("B"),
-                CompletionTestExpectedResult.Exists("C")
+                ItemExpectation.Absent("A"),
+                ItemExpectation.Absent("B"),
+                ItemExpectation.Exists("C")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -649,8 +649,8 @@ namespace A.$$
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Absent("B")
+                ItemExpectation.Absent("A"),
+                ItemExpectation.Absent("B")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -669,8 +669,8 @@ namespace A.$$
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Exists("B")
+                ItemExpectation.Absent("A"),
+                ItemExpectation.Exists("B")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -682,8 +682,8 @@ namespace A.$$
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Exists("System"),
-                CompletionTestExpectedResult.Absent("Runtime")
+                ItemExpectation.Exists("System"),
+                ItemExpectation.Absent("Runtime")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -707,8 +707,8 @@ namespace System
 
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Absent("System"),
-                CompletionTestExpectedResult.Absent("Runtime")
+                ItemExpectation.Absent("System"),
+                ItemExpectation.Absent("Runtime")
             ],
             sourceCodeKind: SourceCodeKind.Regular);
     }
@@ -733,9 +733,9 @@ namespace A.B.C.D3 { }";
 
         await VerifyExpectedItemsAsync(
             source, [
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Absent("B"),
-                CompletionTestExpectedResult.Absent("C"),
+                ItemExpectation.Absent("A"),
+                ItemExpectation.Absent("B"),
+                ItemExpectation.Absent("C"),
 
                 // Ideally, all the D* namespaces would be recommended but, because of how the parser
                 // recovers from the missing braces, they end up with the following qualified names...
@@ -745,9 +745,9 @@ namespace A.B.C.D3 { }";
                 //     D3 => A.A.B.C.D3
                 //
                 // ...none of which are found by the current algorithm.
-                CompletionTestExpectedResult.Absent("D1"),
-                CompletionTestExpectedResult.Absent("D2"),
-                CompletionTestExpectedResult.Absent("D3")
+                ItemExpectation.Absent("D1"),
+                ItemExpectation.Absent("D2"),
+                ItemExpectation.Absent("D3")
             ],
             SourceCodeKind.Regular);
     }
@@ -757,8 +757,8 @@ namespace A.B.C.D3 { }";
     {
         var source = @"namespace NS { $$";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -769,8 +769,8 @@ namespace A.B.C.D3 { }";
 class CL {}
 $$";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -782,8 +782,8 @@ class CL {}
 $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -799,8 +799,8 @@ $$";
         {
             name = $$";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("value"),
-            CompletionTestExpectedResult.Exists("C")
+            ItemExpectation.Exists("value"),
+            ItemExpectation.Exists("C")
         ]);
     }
 
@@ -809,8 +809,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", @"[assembly: A.$$");
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -819,8 +819,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", @"using MyType = $$");
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -832,8 +832,8 @@ $$";
 ";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -845,8 +845,8 @@ $$";
 ";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -855,8 +855,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = $$)c"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -865,8 +865,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", @"class CL<$$");
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -875,8 +875,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", @"class CL<T, $$");
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -885,8 +885,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = ($$)c"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -895,8 +895,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -905,8 +905,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = new $$ ["));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -915,8 +915,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = stackalloc $$"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -925,8 +925,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = from $$ c"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -935,8 +935,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"var t = from c in C join $$ j"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -945,8 +945,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"$$ i ="));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -955,8 +955,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"fixed($$"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -965,8 +965,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"foreach($$"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -975,8 +975,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"foreach $$"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -985,8 +985,8 @@ $$";
     {
         var source = AddUsingDirectives("using System;", AddInsideMethod(@"try {} catch($$"));
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -997,8 +997,8 @@ $$";
     $$ i";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1009,8 +1009,8 @@ $$";
     event $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1021,8 +1021,8 @@ $$";
     explicit operator $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1033,8 +1033,8 @@ $$";
     explicit $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -1045,8 +1045,8 @@ $$";
     $$ Prop {";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1057,8 +1057,8 @@ $$";
     event $$ Event {";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1069,8 +1069,8 @@ $$";
     $$ this";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1081,8 +1081,8 @@ $$";
     void Method($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1093,8 +1093,8 @@ $$";
     $$ [";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1105,8 +1105,8 @@ $$";
     $$ *";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1117,8 +1117,8 @@ $$";
     $$ ?";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1129,8 +1129,8 @@ $$";
     delegate $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1141,8 +1141,8 @@ $$";
     $$ M(";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1153,8 +1153,8 @@ $$";
     $$ operator";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1164,8 +1164,8 @@ $$";
         var content = @"($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1175,8 +1175,8 @@ $$";
         var content = @"$$(";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1186,8 +1186,8 @@ $$";
         var content = @"$$[";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1197,8 +1197,8 @@ $$";
         var content = @"i[$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1208,8 +1208,8 @@ $$";
         var content = @"(c)$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1219,8 +1219,8 @@ $$";
         var content = @"var t = from c in $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1230,8 +1230,8 @@ $$";
         var content = @"var t = from c in C let n = $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1241,8 +1241,8 @@ $$";
         var content = @"var t = from c in C orderby $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1252,8 +1252,8 @@ $$";
         var content = @"var t = from c in C select $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1263,8 +1263,8 @@ $$";
         var content = @"$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1274,8 +1274,8 @@ $$";
         var content = @"return $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1285,8 +1285,8 @@ $$";
         var content = @"throw $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1296,8 +1296,8 @@ $$";
         var content = @"yield return $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1307,8 +1307,8 @@ $$";
         var content = @"foreach(T t in $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1318,8 +1318,8 @@ $$";
         var content = @"using($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1329,8 +1329,8 @@ $$";
         var content = @"lock($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1340,8 +1340,8 @@ $$";
         var content = @"var i = $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1351,8 +1351,8 @@ $$";
         var content = @"for($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1362,8 +1362,8 @@ $$";
         var content = @"for(i=0;$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1373,8 +1373,8 @@ $$";
         var content = @"for(i=0;i>10;$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1384,8 +1384,8 @@ $$";
         var content = @"do {} while($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1395,8 +1395,8 @@ $$";
         var content = @"while($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1406,8 +1406,8 @@ $$";
         var content = @"int [$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1417,8 +1417,8 @@ $$";
         var content = @"+$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1428,8 +1428,8 @@ $$";
         var content = @"$$++";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1439,8 +1439,8 @@ $$";
         var content = @"$$ + 1";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1450,8 +1450,8 @@ $$";
         var content = @"1 + $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1461,8 +1461,8 @@ $$";
         var content = @"$$ = 1";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1472,8 +1472,8 @@ $$";
         var content = @"1 = $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1483,8 +1483,8 @@ $$";
         var content = @"$$? 1:";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1494,8 +1494,8 @@ $$";
         var content = @"true? $$:";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1505,8 +1505,8 @@ $$";
         var content = @"true? 1:$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1516,8 +1516,8 @@ $$";
         var content = @"var t = from c in C join p in $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1527,8 +1527,8 @@ $$";
         var content = @"var t = from c in C join p in P on $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1538,8 +1538,8 @@ $$";
         var content = @"var t = from c in C join p in P on id equals $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1549,8 +1549,8 @@ $$";
         var content = @"var t = from c in C where $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1560,8 +1560,8 @@ $$";
         var content = @"var t = from c in C group $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1571,8 +1571,8 @@ $$";
         var content = @"var t = from c in C group g by $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1582,8 +1582,8 @@ $$";
         var content = @"if ($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1593,8 +1593,8 @@ $$";
         var content = @"switch($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1604,8 +1604,8 @@ $$";
         var content = @"switch(i) { case $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1615,8 +1615,8 @@ $$";
         var content = @"switch(i) { case $$ when";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1626,8 +1626,8 @@ $$";
         var content = @"i switch { $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1637,8 +1637,8 @@ $$";
         var content = @"i switch { 1 => true, $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1648,8 +1648,8 @@ $$";
         var content = @"i is ($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1659,8 +1659,8 @@ $$";
         var content = @"i is (1, $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1670,8 +1670,8 @@ $$";
         var content = @"i is { P: $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1681,8 +1681,8 @@ $$";
         var content = @"i is { P1: 1, P2: $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1692,8 +1692,8 @@ $$";
         var content = @"var t = new [] { $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1745,8 +1745,8 @@ class CL<T> where T : $$", @"Test");
         var content = @"class CL<T> where T : IList<$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1798,8 +1798,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"class CL<T> where T : A, IList<$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1809,8 +1809,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"class CL<T> where T : A where$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -1842,8 +1842,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"class CL : $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1853,8 +1853,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"class CL : B, $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1864,8 +1864,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"class CL<T> : B where$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -1875,8 +1875,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"global::$$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1894,8 +1894,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"class C { C() : $$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("System")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("System")
         ]);
     }
 
@@ -1905,8 +1905,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"typeof($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1920,8 +1920,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"sizeof($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -1935,8 +1935,8 @@ class CL<T> where T : A, $$", @"Test");
         var content = @"default($$";
         var source = AddUsingDirectives("using System;", content);
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("System")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("System")
         ]);
     }
 
@@ -2167,8 +2167,8 @@ class B : A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Hidden"),
-            CompletionTestExpectedResult.Exists("Goo")
+            ItemExpectation.Absent("Hidden"),
+            ItemExpectation.Exists("Goo")
         ]);
     }
 
@@ -2190,8 +2190,8 @@ class B : A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Hidden"),
-            CompletionTestExpectedResult.Exists("Goo")
+            ItemExpectation.Absent("Hidden"),
+            ItemExpectation.Exists("Goo")
         ]);
     }
 
@@ -2213,9 +2213,9 @@ class B : A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Hidden"),
-            CompletionTestExpectedResult.Exists("Goo"),
-            CompletionTestExpectedResult.Absent("Bar"),
+            ItemExpectation.Absent("Hidden"),
+            ItemExpectation.Exists("Goo"),
+            ItemExpectation.Absent("Bar"),
         ]);
     }
 
@@ -2237,8 +2237,8 @@ class B : A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Hidden"),
-            CompletionTestExpectedResult.Exists("Goo")
+            ItemExpectation.Absent("Hidden"),
+            ItemExpectation.Exists("Goo")
         ]);
     }
 
@@ -2260,8 +2260,8 @@ class B : A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Hidden"),
-            CompletionTestExpectedResult.Exists("Goo")
+            ItemExpectation.Absent("Hidden"),
+            ItemExpectation.Exists("Goo")
         ]);
     }
 
@@ -2283,8 +2283,8 @@ class B : A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Hidden"),
-            CompletionTestExpectedResult.Exists("Goo")
+            ItemExpectation.Absent("Hidden"),
+            ItemExpectation.Exists("Goo")
         ]);
     }
 
@@ -2309,10 +2309,10 @@ class B : A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("HiddenStatic"),
-            CompletionTestExpectedResult.Exists("GooStatic"),
-            CompletionTestExpectedResult.Absent("HiddenInstance"),
-            CompletionTestExpectedResult.Exists("GooInstance")
+            ItemExpectation.Absent("HiddenStatic"),
+            ItemExpectation.Exists("GooStatic"),
+            ItemExpectation.Absent("HiddenInstance"),
+            ItemExpectation.Exists("GooInstance")
         ]);
     }
 
@@ -2482,8 +2482,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2501,8 +2501,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2520,8 +2520,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2539,8 +2539,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("field")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("field")
         ]);
     }
 
@@ -2558,8 +2558,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("field")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("field")
         ]);
     }
 
@@ -2577,8 +2577,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("field")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("field")
         ]);
     }
 
@@ -2596,8 +2596,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("parameter")
         ]);
     }
 
@@ -2615,8 +2615,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("parameter")
         ]);
     }
 
@@ -2634,8 +2634,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("parameter")
         ]);
     }
 
@@ -2653,8 +2653,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Exists("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Exists("parameter")
         ]);
     }
 
@@ -2672,8 +2672,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2691,8 +2691,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2710,8 +2710,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2729,8 +2729,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2748,8 +2748,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2767,8 +2767,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2807,10 +2807,10 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("ToString"),
-            CompletionTestExpectedResult.Absent("GetType"),
-            CompletionTestExpectedResult.Absent("Equals"),
-            CompletionTestExpectedResult.Absent("GetHashCode")
+            ItemExpectation.Exists("ToString"),
+            ItemExpectation.Absent("GetType"),
+            ItemExpectation.Absent("Equals"),
+            ItemExpectation.Absent("GetHashCode")
         ]);
     }
 
@@ -2829,10 +2829,10 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("ToString"),
-            CompletionTestExpectedResult.Exists("GetType"),
-            CompletionTestExpectedResult.Exists("Equals"),
-            CompletionTestExpectedResult.Exists("GetHashCode")
+            ItemExpectation.Exists("ToString"),
+            ItemExpectation.Exists("GetType"),
+            ItemExpectation.Exists("Equals"),
+            ItemExpectation.Exists("GetHashCode")
         ]);
     }
 
@@ -2850,8 +2850,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2878,8 +2878,8 @@ class C
 }}
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2904,8 +2904,8 @@ class C
 }}
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2923,8 +2923,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2949,8 +2949,8 @@ class C
 }}
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("String"),
-            CompletionTestExpectedResult.Absent("parameter")
+            ItemExpectation.Absent("String"),
+            ItemExpectation.Absent("parameter")
         ]);
     }
 
@@ -2966,8 +2966,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("field")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("field")
         ]);
     }
 
@@ -2983,8 +2983,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("String"),
-            CompletionTestExpectedResult.Absent("field")
+            ItemExpectation.Exists("String"),
+            ItemExpectation.Absent("field")
         ]);
     }
 
@@ -3002,8 +3002,8 @@ class Q
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Q"),
-            CompletionTestExpectedResult.Exists("R")
+            ItemExpectation.Exists("Q"),
+            ItemExpectation.Exists("R")
         ]);
     }
 
@@ -3020,8 +3020,8 @@ class Q
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Q"),
-            CompletionTestExpectedResult.Exists("R")
+            ItemExpectation.Exists("Q"),
+            ItemExpectation.Exists("R")
         ]);
     }
 
@@ -3038,8 +3038,8 @@ class Q
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Q"),
-            CompletionTestExpectedResult.Exists("R")
+            ItemExpectation.Exists("Q"),
+            ItemExpectation.Exists("R")
         ]);
     }
 
@@ -3091,8 +3091,8 @@ class Q
     }
     $$"; // At EOF
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Q"),
-            CompletionTestExpectedResult.Exists("R")
+            ItemExpectation.Exists("Q"),
+            ItemExpectation.Exists("R")
         ]);
     }
 
@@ -3106,8 +3106,8 @@ class Q
     {
         $$"; // At EOF
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Q"),
-            CompletionTestExpectedResult.Exists("R")
+            ItemExpectation.Exists("Q"),
+            ItemExpectation.Exists("R")
         ]);
     }
 
@@ -3239,8 +3239,8 @@ public class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("ToString"),
-            CompletionTestExpectedResult.Exists("Invoke")
+            ItemExpectation.Exists("ToString"),
+            ItemExpectation.Exists("Invoke")
         ]);
     }
 
@@ -3366,8 +3366,8 @@ using System;
 [$$";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("CLSCompliant"),
-            CompletionTestExpectedResult.Absent("CLSCompliantAttribute")
+            ItemExpectation.Exists("CLSCompliant"),
+            ItemExpectation.Absent("CLSCompliantAttribute")
         ]);
     }
 
@@ -3380,8 +3380,8 @@ using System;
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("CLSCompliant"),
-            CompletionTestExpectedResult.Absent("CLSCompliantAttribute")
+            ItemExpectation.Exists("CLSCompliant"),
+            ItemExpectation.Absent("CLSCompliantAttribute")
         ]);
     }
 
@@ -3393,8 +3393,8 @@ using System;
 [CLSCompliant, $$";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("CLSCompliant"),
-            CompletionTestExpectedResult.Absent("CLSCompliantAttribute")
+            ItemExpectation.Exists("CLSCompliant"),
+            ItemExpectation.Absent("CLSCompliantAttribute")
         ]);
     }
 
@@ -3407,8 +3407,8 @@ using System;
 class C { }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("CLSCompliant"),
-            CompletionTestExpectedResult.Absent("CLSCompliantAttribute")
+            ItemExpectation.Exists("CLSCompliant"),
+            ItemExpectation.Absent("CLSCompliantAttribute")
         ]);
     }
 
@@ -3421,8 +3421,8 @@ using System;
 class C { }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("CLSCompliant"),
-            CompletionTestExpectedResult.Absent("CLSCompliantAttribute")
+            ItemExpectation.Exists("CLSCompliant"),
+            ItemExpectation.Absent("CLSCompliantAttribute")
         ]);
     }
 
@@ -3435,8 +3435,8 @@ using System;
 class C { }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("CLSCompliantAttribute"),
-            CompletionTestExpectedResult.Absent("CLSCompliant")
+            ItemExpectation.Exists("CLSCompliantAttribute"),
+            ItemExpectation.Absent("CLSCompliant")
         ]);
     }
 
@@ -3448,8 +3448,8 @@ using System;
 class C { $$ }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("CLSCompliantAttribute"),
-            CompletionTestExpectedResult.Absent("CLSCompliant")
+            ItemExpectation.Exists("CLSCompliantAttribute"),
+            ItemExpectation.Absent("CLSCompliant")
         ]);
     }
 
@@ -3504,8 +3504,8 @@ namespace Test
     class Program { }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("My"),
-            CompletionTestExpectedResult.Absent("MyAttribute")
+            ItemExpectation.Exists("My"),
+            ItemExpectation.Absent("MyAttribute")
         ]);
     }
 
@@ -3523,8 +3523,8 @@ namespace Test
     }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("My"),
-            CompletionTestExpectedResult.Absent("MyAttribute")
+            ItemExpectation.Exists("My"),
+            ItemExpectation.Absent("MyAttribute")
         ]);
     }
 
@@ -3539,9 +3539,9 @@ namespace Test
     class Program { }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("namespaceAttribute"),
-            CompletionTestExpectedResult.Absent("namespace"),
-            CompletionTestExpectedResult.Absent("@namespace")
+            ItemExpectation.Exists("namespaceAttribute"),
+            ItemExpectation.Absent("namespace"),
+            ItemExpectation.Absent("@namespace")
         ]);
     }
 
@@ -3556,9 +3556,9 @@ namespace Test
     class Program { }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("namespaceAttribute"),
-            CompletionTestExpectedResult.Absent("namespace"),
-            CompletionTestExpectedResult.Absent("@namespace")
+            ItemExpectation.Exists("namespaceAttribute"),
+            ItemExpectation.Absent("namespace"),
+            ItemExpectation.Absent("@namespace")
         ]);
     }
 
@@ -3579,16 +3579,16 @@ class C
 
         await VerifyExpectedItemsAsync(markup, [
             // preprocessor keyword
-            CompletionTestExpectedResult.Exists("error"),
-            CompletionTestExpectedResult.Absent("@error"),
+            ItemExpectation.Exists("error"),
+            ItemExpectation.Absent("@error"),
 
             // contextual keyword
-            CompletionTestExpectedResult.Exists("method"),
-            CompletionTestExpectedResult.Absent("@method"),
+            ItemExpectation.Exists("method"),
+            ItemExpectation.Absent("@method"),
 
             // full keyword
-            CompletionTestExpectedResult.Exists("@int"),
-            CompletionTestExpectedResult.Absent("int")
+            ItemExpectation.Exists("@int"),
+            ItemExpectation.Absent("int")
         ]);
     }
 
@@ -3606,8 +3606,8 @@ class C
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("@from"),
-            CompletionTestExpectedResult.Absent("from")
+            ItemExpectation.Exists("@from"),
+            ItemExpectation.Absent("from")
         ]);
     }
 
@@ -3627,10 +3627,10 @@ class C
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("@from"),
-            CompletionTestExpectedResult.Absent("from"),
-            CompletionTestExpectedResult.Exists("@where"),
-            CompletionTestExpectedResult.Absent("where")
+            ItemExpectation.Exists("@from"),
+            ItemExpectation.Absent("from"),
+            ItemExpectation.Exists("@where"),
+            ItemExpectation.Absent("where")
         ]);
     }
 
@@ -3650,10 +3650,10 @@ class C
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("@from"),
-            CompletionTestExpectedResult.Absent("from"),
-            CompletionTestExpectedResult.Exists("@where"),
-            CompletionTestExpectedResult.Absent("where")
+            ItemExpectation.Exists("@from"),
+            ItemExpectation.Absent("from"),
+            ItemExpectation.Exists("@where"),
+            ItemExpectation.Absent("where")
         ]);
     }
 
@@ -3666,8 +3666,8 @@ class MyAttribute : System.Attribute { }
 class Program { }";
         await VerifyExpectedItemsAsync(
             markup, [
-                CompletionTestExpectedResult.Exists("My"),
-                CompletionTestExpectedResult.Absent("MyAttribute")
+                ItemExpectation.Exists("My"),
+                ItemExpectation.Absent("MyAttribute")
             ],
             SourceCodeKind.Regular);
     }
@@ -3681,9 +3681,9 @@ class namespaceAttribute : System.Attribute { }
 class Program { }";
         await VerifyExpectedItemsAsync(
             markup, [
-                CompletionTestExpectedResult.Exists("namespaceAttribute"),
-                CompletionTestExpectedResult.Absent("namespace"),
-                CompletionTestExpectedResult.Absent("@namespace")
+                ItemExpectation.Exists("namespaceAttribute"),
+                ItemExpectation.Absent("namespace"),
+                ItemExpectation.Absent("@namespace")
             ],
             SourceCodeKind.Regular);
     }
@@ -3714,8 +3714,8 @@ namespace Namespace1
 
 [Namespace1.$$]";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Namespace2"),
-            CompletionTestExpectedResult.Exists("Namespace3"),
+            ItemExpectation.Absent("Namespace2"),
+            ItemExpectation.Exists("Namespace3"),
         ]);
     }
 
@@ -3764,10 +3764,10 @@ namespace Namespace1
 
 [$$]";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Namespace1Alias"),
-            CompletionTestExpectedResult.Absent("Namespace2Alias"),
-            CompletionTestExpectedResult.Exists("Namespace3Alias"),
-            CompletionTestExpectedResult.Exists("Namespace4Alias"),
+            ItemExpectation.Exists("Namespace1Alias"),
+            ItemExpectation.Absent("Namespace2Alias"),
+            ItemExpectation.Exists("Namespace3Alias"),
+            ItemExpectation.Exists("Namespace4Alias"),
         ]);
     }
 
@@ -4235,10 +4235,10 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("a"),
-            CompletionTestExpectedResult.Exists("b"),
-            CompletionTestExpectedResult.Exists("c"),
-            CompletionTestExpectedResult.Absent("Equals"),
+            ItemExpectation.Exists("a"),
+            ItemExpectation.Exists("b"),
+            ItemExpectation.Exists("c"),
+            ItemExpectation.Absent("Equals"),
         ]);
     }
 
@@ -4258,10 +4258,10 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("a"),
-            CompletionTestExpectedResult.Absent("b"),
-            CompletionTestExpectedResult.Absent("c"),
-            CompletionTestExpectedResult.Exists("Equals"),
+            ItemExpectation.Absent("a"),
+            ItemExpectation.Absent("b"),
+            ItemExpectation.Absent("c"),
+            ItemExpectation.Exists("Equals"),
         ]);
     }
 
@@ -7576,8 +7576,8 @@ class A
     }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Goo"),
-            CompletionTestExpectedResult.Exists("Bar"),
+            ItemExpectation.Exists("Goo"),
+            ItemExpectation.Exists("Bar"),
         ]);
     }
 
@@ -7763,8 +7763,8 @@ class Program
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Task"),
-            CompletionTestExpectedResult.Absent("Console"),
+            ItemExpectation.Exists("Task"),
+            ItemExpectation.Absent("Console"),
         ]);
     }
 
@@ -7781,8 +7781,8 @@ class Program
 class Test {}";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Task"),
-            CompletionTestExpectedResult.Absent("Test"),
+            ItemExpectation.Exists("Task"),
+            ItemExpectation.Absent("Test"),
         ]);
     }
 
@@ -7923,8 +7923,8 @@ namespace N
 }";
         // Nothing should be found: no awaiter for request.
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Result"),
-            CompletionTestExpectedResult.Absent("ReadAsStreamAsync"),
+            ItemExpectation.Absent("Result"),
+            ItemExpectation.Absent("ReadAsStreamAsync"),
         ]);
     }
 
@@ -7953,8 +7953,8 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Result"),
-            CompletionTestExpectedResult.Exists("ReadAsStreamAsync"),
+            ItemExpectation.Absent("Result"),
+            ItemExpectation.Exists("ReadAsStreamAsync"),
         ]);
     }
 
@@ -8772,8 +8772,8 @@ class A
     }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("AA"),
-            CompletionTestExpectedResult.Exists("AB"),
+            ItemExpectation.Exists("AA"),
+            ItemExpectation.Exists("AB"),
         ]);
     }
 
@@ -8797,8 +8797,8 @@ class A
     }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("i"),
-            CompletionTestExpectedResult.Absent("Value"),
+            ItemExpectation.Exists("i"),
+            ItemExpectation.Absent("Value"),
         ]);
     }
 
@@ -8821,8 +8821,8 @@ class A
     }
 }";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("i"),
-            CompletionTestExpectedResult.Absent("Value"),
+            ItemExpectation.Exists("i"),
+            ItemExpectation.Absent("Value"),
         ]);
     }
 
@@ -8839,8 +8839,8 @@ class A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Day"),
-            CompletionTestExpectedResult.Absent("Value"),
+            ItemExpectation.Exists("Day"),
+            ItemExpectation.Absent("Value"),
         ]);
     }
 
@@ -8857,8 +8857,8 @@ class A
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Value"),
-            CompletionTestExpectedResult.Absent("Day"),
+            ItemExpectation.Exists("Value"),
+            ItemExpectation.Absent("Day"),
         ]);
     }
 
@@ -9273,8 +9273,8 @@ class C
 }
 ";
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("x"),
-            CompletionTestExpectedResult.Exists("y"),
+            ItemExpectation.Exists("x"),
+            ItemExpectation.Exists("y"),
         ]);
     }
 
@@ -9506,9 +9506,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("A"),
-            CompletionTestExpectedResult.Absent("B"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Absent("A"),
+            ItemExpectation.Absent("B"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9530,9 +9530,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("C"),
-            CompletionTestExpectedResult.Absent("D"),
-            CompletionTestExpectedResult.Exists("M"),
+            ItemExpectation.Absent("C"),
+            ItemExpectation.Absent("D"),
+            ItemExpectation.Exists("M"),
         ]);
     }
 
@@ -9554,9 +9554,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9578,9 +9578,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("D"),
-            CompletionTestExpectedResult.Exists("M"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("D"),
+            ItemExpectation.Exists("M"),
         ]);
     }
 
@@ -9602,9 +9602,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9626,9 +9626,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("D"),
-            CompletionTestExpectedResult.Exists("M"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("D"),
+            ItemExpectation.Exists("M"),
         ]);
     }
 
@@ -9650,9 +9650,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9674,9 +9674,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Absent("B"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Absent("B"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9698,9 +9698,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Absent("D"),
-            CompletionTestExpectedResult.Exists("M"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Absent("D"),
+            ItemExpectation.Exists("M"),
         ]);
     }
 
@@ -9722,9 +9722,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Absent("B"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Absent("B"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9747,9 +9747,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("I"),
-            CompletionTestExpectedResult.Exists("M"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("I"),
+            ItemExpectation.Exists("M"),
         ]);
     }
 
@@ -9772,9 +9772,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("I"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("I"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9797,9 +9797,9 @@ namespace N
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("I"),
-            CompletionTestExpectedResult.Exists("N"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("I"),
+            ItemExpectation.Exists("N"),
         ]);
     }
 
@@ -9830,8 +9830,8 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Goo"),
-            CompletionTestExpectedResult.Absent("Bar"),
+            ItemExpectation.Absent("Goo"),
+            ItemExpectation.Absent("Bar"),
         ]);
     }
 
@@ -9864,8 +9864,8 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Goo"),
-            CompletionTestExpectedResult.Absent("Bar"),
+            ItemExpectation.Absent("Goo"),
+            ItemExpectation.Absent("Bar"),
         ]);
     }
 
@@ -9899,8 +9899,8 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Goo"),
-            CompletionTestExpectedResult.Exists("Bar"),
+            ItemExpectation.Exists("Goo"),
+            ItemExpectation.Exists("Bar"),
         ]);
     }
 
@@ -9935,8 +9935,8 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Goo"),
-            CompletionTestExpectedResult.Exists("Bar"),
+            ItemExpectation.Exists("Goo"),
+            ItemExpectation.Exists("Bar"),
         ]);
     }
 
@@ -9970,8 +9970,8 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Goo"),
-            CompletionTestExpectedResult.Absent("Bar"),
+            ItemExpectation.Exists("Goo"),
+            ItemExpectation.Absent("Bar"),
         ]);
     }
 
@@ -10005,8 +10005,8 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Goo"),
-            CompletionTestExpectedResult.Exists("Bar"),
+            ItemExpectation.Absent("Goo"),
+            ItemExpectation.Exists("Bar"),
         ]);
     }
 
@@ -10041,8 +10041,8 @@ class C
 ";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Goo"),
-            CompletionTestExpectedResult.Exists("Bar"),
+            ItemExpectation.Exists("Goo"),
+            ItemExpectation.Exists("Bar"),
         ]);
     }
 
@@ -10439,25 +10439,25 @@ class C
 }" + TestResources.NetFX.ValueTuple.tuplelib_cs;
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Alice"),
-            CompletionTestExpectedResult.Exists("Bob"),
-            CompletionTestExpectedResult.Exists("CompareTo"),
-            CompletionTestExpectedResult.Exists("Equals"),
-            CompletionTestExpectedResult.Exists("GetHashCode"),
-            CompletionTestExpectedResult.Exists("GetType"),
-            CompletionTestExpectedResult.Exists("Item2"),
-            CompletionTestExpectedResult.Exists("ITEM3"),
-            CompletionTestExpectedResult.Exists("Item4"),
-            CompletionTestExpectedResult.Exists("Item5"),
-            CompletionTestExpectedResult.Exists("Item6"),
-            CompletionTestExpectedResult.Exists("Item7"),
-            CompletionTestExpectedResult.Exists("Item8"),
-            CompletionTestExpectedResult.Exists("ToString"),
+            ItemExpectation.Exists("Alice"),
+            ItemExpectation.Exists("Bob"),
+            ItemExpectation.Exists("CompareTo"),
+            ItemExpectation.Exists("Equals"),
+            ItemExpectation.Exists("GetHashCode"),
+            ItemExpectation.Exists("GetType"),
+            ItemExpectation.Exists("Item2"),
+            ItemExpectation.Exists("ITEM3"),
+            ItemExpectation.Exists("Item4"),
+            ItemExpectation.Exists("Item5"),
+            ItemExpectation.Exists("Item6"),
+            ItemExpectation.Exists("Item7"),
+            ItemExpectation.Exists("Item8"),
+            ItemExpectation.Exists("ToString"),
 
-            CompletionTestExpectedResult.Absent("Item1"),
-            CompletionTestExpectedResult.Absent("Item9"),
-            CompletionTestExpectedResult.Absent("Rest"),
-            CompletionTestExpectedResult.Absent("Item3")
+            ItemExpectation.Absent("Item1"),
+            ItemExpectation.Absent("Item9"),
+            ItemExpectation.Absent("Rest"),
+            ItemExpectation.Absent("Item3")
         ]);
     }
 
@@ -11022,9 +11022,9 @@ namespace ClassLibrary1
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Substring"),
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
+            ItemExpectation.Absent("Substring"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
         ]);
     }
 
@@ -11135,8 +11135,8 @@ class Product1 { public void MyProperty1() { } }
 class Product2 { public void MyProperty2() { } }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("MyProperty1"),
-            CompletionTestExpectedResult.Exists("MyProperty2"),
+            ItemExpectation.Exists("MyProperty1"),
+            ItemExpectation.Exists("MyProperty2"),
         ]);
     }
 
@@ -11164,9 +11164,9 @@ class Product2 { public void MyProperty2() { } }
 class Product3 { public void MyProperty3() { } }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("MyProperty1"),
-            CompletionTestExpectedResult.Exists("MyProperty2"),
-            CompletionTestExpectedResult.Exists("MyProperty3")
+            ItemExpectation.Exists("MyProperty1"),
+            ItemExpectation.Exists("MyProperty2"),
+            ItemExpectation.Exists("MyProperty3")
         ]);
     }
 
@@ -11344,11 +11344,11 @@ class Builder
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("Something"),
-            CompletionTestExpectedResult.Absent("BeginInvoke"),
-            CompletionTestExpectedResult.Absent("Clone"),
-            CompletionTestExpectedResult.Absent("Method"),
-            CompletionTestExpectedResult.Absent("Target")
+            ItemExpectation.Exists("Something"),
+            ItemExpectation.Absent("BeginInvoke"),
+            ItemExpectation.Absent("Clone"),
+            ItemExpectation.Absent("Method"),
+            ItemExpectation.Absent("Target")
         ]);
     }
 
@@ -11374,18 +11374,18 @@ class Program
 
         await VerifyExpectedItemsAsync(markup, [
             // Guid
-            CompletionTestExpectedResult.Exists("ToByteArray"),
+            ItemExpectation.Exists("ToByteArray"),
 
             // Uri
-            CompletionTestExpectedResult.Exists("AbsoluteUri"),
-            CompletionTestExpectedResult.Exists("Fragment"),
-            CompletionTestExpectedResult.Exists("Query"),
+            ItemExpectation.Exists("AbsoluteUri"),
+            ItemExpectation.Exists("Fragment"),
+            ItemExpectation.Exists("Query"),
 
             // Should not appear for Delegate
-            CompletionTestExpectedResult.Absent("BeginInvoke"),
-            CompletionTestExpectedResult.Absent("Clone"),
-            CompletionTestExpectedResult.Absent("Method"),
-            CompletionTestExpectedResult.Absent("Target")
+            ItemExpectation.Absent("BeginInvoke"),
+            ItemExpectation.Absent("Clone"),
+            ItemExpectation.Absent("Method"),
+            ItemExpectation.Absent("Target")
         ]);
     }
 
@@ -11410,18 +11410,18 @@ class Program
 }";
         await VerifyExpectedItemsAsync(markup, [
             // Guid
-            CompletionTestExpectedResult.Exists("ToByteArray"),
+            ItemExpectation.Exists("ToByteArray"),
 
             // Should not appear for Uri
-            CompletionTestExpectedResult.Absent("AbsoluteUri"),
-            CompletionTestExpectedResult.Absent("Fragment"),
-            CompletionTestExpectedResult.Absent("Query"),
+            ItemExpectation.Absent("AbsoluteUri"),
+            ItemExpectation.Absent("Fragment"),
+            ItemExpectation.Absent("Query"),
 
             // Should not appear for Delegate
-            CompletionTestExpectedResult.Absent("BeginInvoke"),
-            CompletionTestExpectedResult.Absent("Clone"),
-            CompletionTestExpectedResult.Absent("Method"),
-            CompletionTestExpectedResult.Absent("Target")
+            ItemExpectation.Absent("BeginInvoke"),
+            ItemExpectation.Absent("Clone"),
+            ItemExpectation.Absent("Method"),
+            ItemExpectation.Absent("Target")
         ]);
     }
 
@@ -11455,9 +11455,9 @@ class AnotherBuilder
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("AnotherSomething"),
-            CompletionTestExpectedResult.Absent("FirstOrDefault"),
-            CompletionTestExpectedResult.Exists("Something")
+            ItemExpectation.Absent("AnotherSomething"),
+            ItemExpectation.Absent("FirstOrDefault"),
+            ItemExpectation.Exists("Something")
         ]);
     }
 
@@ -11488,9 +11488,9 @@ class AnotherBuilder
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Absent("Something"),
-            CompletionTestExpectedResult.Absent("FirstOrDefault"),
-            CompletionTestExpectedResult.Exists("AnotherSomething")
+            ItemExpectation.Absent("Something"),
+            ItemExpectation.Absent("FirstOrDefault"),
+            ItemExpectation.Exists("AnotherSomething")
         ]);
     }
 
@@ -11596,9 +11596,9 @@ public class C
 }";
 
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("M"),
-            CompletionTestExpectedResult.Exists("Equals"),
-            CompletionTestExpectedResult.Absent("DoSomething") with
+            ItemExpectation.Exists("M"),
+            ItemExpectation.Exists("Equals"),
+            ItemExpectation.Absent("DoSomething") with
             {
                 DisplayTextSuffix = "<>"
             },
@@ -11880,9 +11880,9 @@ namespace Bar1
 }";
         // VerifyItemExistsAsync also tests with the item typed.
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("BillyJoel"),
-            CompletionTestExpectedResult.Exists("EveryoneElse"),
-            CompletionTestExpectedResult.Absent("Equals"),
+            ItemExpectation.Exists("BillyJoel"),
+            ItemExpectation.Exists("EveryoneElse"),
+            ItemExpectation.Absent("Equals"),
         ]);
     }
 
@@ -11910,9 +11910,9 @@ namespace Bar1
 }";
         // VerifyItemExistsAsync also tests with the item typed.
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("BillyJoel"),
-            CompletionTestExpectedResult.Exists("EveryoneElse"),
-            CompletionTestExpectedResult.Absent("Equals"),
+            ItemExpectation.Exists("BillyJoel"),
+            ItemExpectation.Exists("EveryoneElse"),
+            ItemExpectation.Absent("Equals"),
         ]);
     }
 
@@ -11940,9 +11940,9 @@ namespace Bar1
 }";
         // VerifyItemExistsAsync also tests with the item typed.
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("BillyJoel"),
-            CompletionTestExpectedResult.Exists("EveryoneElse"),
-            CompletionTestExpectedResult.Absent("Equals"),
+            ItemExpectation.Exists("BillyJoel"),
+            ItemExpectation.Exists("EveryoneElse"),
+            ItemExpectation.Absent("Equals"),
         ]);
     }
 
@@ -11989,9 +11989,9 @@ namespace Bar1
 }";
         // VerifyItemExistsAsync also tests with the item typed.
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("BillyJoel"),
-            CompletionTestExpectedResult.Exists("EveryoneElse"),
-            CompletionTestExpectedResult.Absent("Equals"),
+            ItemExpectation.Exists("BillyJoel"),
+            ItemExpectation.Exists("EveryoneElse"),
+            ItemExpectation.Absent("Equals"),
         ]);
     }
 
@@ -12019,9 +12019,9 @@ namespace Bar1
 }";
         // VerifyItemExistsAsync also tests with the item typed.
         await VerifyExpectedItemsAsync(markup, [
-            CompletionTestExpectedResult.Exists("BillyJoel"),
-            CompletionTestExpectedResult.Exists("EveryoneElse"),
-            CompletionTestExpectedResult.Absent("Equals"),
+            ItemExpectation.Exists("BillyJoel"),
+            ItemExpectation.Exists("EveryoneElse"),
+            ItemExpectation.Absent("Equals"),
         ]);
     }
 
@@ -12190,13 +12190,13 @@ class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("M0"),
+            ItemExpectation.Absent("M0"),
 
-            CompletionTestExpectedResult.Exists("M1"),
-            CompletionTestExpectedResult.Exists("M2"),
-            CompletionTestExpectedResult.Exists("M3"),
-            CompletionTestExpectedResult.Exists("P1"),
-            CompletionTestExpectedResult.Exists("E1")
+            ItemExpectation.Exists("M1"),
+            ItemExpectation.Exists("M2"),
+            ItemExpectation.Exists("M3"),
+            ItemExpectation.Exists("P1"),
+            ItemExpectation.Exists("E1")
         ]);
     }
 
@@ -12220,10 +12220,10 @@ unsafe class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("X"),
-            CompletionTestExpectedResult.Exists("Y"),
-            CompletionTestExpectedResult.Exists("Method"),
-            CompletionTestExpectedResult.Exists("ToString")
+            ItemExpectation.Exists("X"),
+            ItemExpectation.Exists("Y"),
+            ItemExpectation.Exists("Method"),
+            ItemExpectation.Exists("ToString")
         ]);
     }
 
@@ -12247,10 +12247,10 @@ unsafe class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("X"),
-            CompletionTestExpectedResult.Exists("Y"),
-            CompletionTestExpectedResult.Exists("Method"),
-            CompletionTestExpectedResult.Exists("ToString")
+            ItemExpectation.Exists("X"),
+            ItemExpectation.Exists("Y"),
+            ItemExpectation.Exists("Method"),
+            ItemExpectation.Exists("ToString")
         ]);
     }
 
@@ -12276,10 +12276,10 @@ unsafe class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("X"),
-            CompletionTestExpectedResult.Exists("Y"),
-            CompletionTestExpectedResult.Exists("Method"),
-            CompletionTestExpectedResult.Exists("ToString")
+            ItemExpectation.Exists("X"),
+            ItemExpectation.Exists("Y"),
+            ItemExpectation.Exists("Method"),
+            ItemExpectation.Exists("ToString")
         ]);
     }
 
@@ -12316,8 +12316,8 @@ unsafe class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("X"),
-            CompletionTestExpectedResult.Exists("Y")
+            ItemExpectation.Exists("X"),
+            ItemExpectation.Exists("Y")
         ]);
     }
 
@@ -12354,8 +12354,8 @@ unsafe class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("X"),
-            CompletionTestExpectedResult.Absent("Y")
+            ItemExpectation.Exists("X"),
+            ItemExpectation.Absent("Y")
         ]);
     }
 
@@ -12414,8 +12414,8 @@ unsafe class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("X"),
-            CompletionTestExpectedResult.Absent("Y")
+            ItemExpectation.Absent("X"),
+            ItemExpectation.Absent("Y")
         ]);
     }
 
@@ -12452,8 +12452,8 @@ unsafe class Test
 }
 ";
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("X"),
-            CompletionTestExpectedResult.Absent("Y")
+            ItemExpectation.Absent("X"),
+            ItemExpectation.Absent("Y")
         ]);
     }
 
@@ -12770,10 +12770,10 @@ public static class Extension
         var source = "enum E : $$";
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("System"),
+            ItemExpectation.Exists("System"),
 
             // Not accessible in the given context
-            CompletionTestExpectedResult.Absent(underlyingType),
+            ItemExpectation.Absent(underlyingType),
         ]);
     }
 
@@ -12805,14 +12805,14 @@ public static class Extension
             """;
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("System"),
+            ItemExpectation.Exists("System"),
 
-            CompletionTestExpectedResult.Exists(underlyingType),
+            ItemExpectation.Exists(underlyingType),
 
             // Verify that other things from `System` namespace are not present
-            CompletionTestExpectedResult.Absent("Console"),
-            CompletionTestExpectedResult.Absent("Action"),
-            CompletionTestExpectedResult.Absent("DateTime")
+            ItemExpectation.Absent("Console"),
+            ItemExpectation.Absent("Action"),
+            ItemExpectation.Absent("DateTime")
         ]);
     }
 
@@ -12828,13 +12828,13 @@ public static class Extension
             """;
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("E"),
+            ItemExpectation.Absent("E"),
 
-            CompletionTestExpectedResult.Exists("System"),
-            CompletionTestExpectedResult.Absent("MyNamespace"),
+            ItemExpectation.Exists("System"),
+            ItemExpectation.Absent("MyNamespace"),
 
             // Not accessible in the given context
-            CompletionTestExpectedResult.Absent(underlyingType)
+            ItemExpectation.Absent(underlyingType)
         ]);
     }
 
@@ -12844,14 +12844,14 @@ public static class Extension
         var source = "enum E : System.$$";
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("System"),
+            ItemExpectation.Absent("System"),
 
-            CompletionTestExpectedResult.Exists(underlyingType),
+            ItemExpectation.Exists(underlyingType),
 
             // Verify that other things from `System` namespace are not present
-            CompletionTestExpectedResult.Absent("Console"),
-            CompletionTestExpectedResult.Absent("Action"),
-            CompletionTestExpectedResult.Absent("DateTime")
+            ItemExpectation.Absent("Console"),
+            ItemExpectation.Absent("Action"),
+            ItemExpectation.Absent("DateTime")
         ]);
     }
 
@@ -12861,14 +12861,14 @@ public static class Extension
         var source = "enum E : global::System.$$";
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("System"),
+            ItemExpectation.Absent("System"),
 
-            CompletionTestExpectedResult.Exists(underlyingType),
+            ItemExpectation.Exists(underlyingType),
 
             // Verify that other things from `System` namespace are not present
-            CompletionTestExpectedResult.Absent("Console"),
-            CompletionTestExpectedResult.Absent("Action"),
-            CompletionTestExpectedResult.Absent("DateTime")
+            ItemExpectation.Absent("Console"),
+            ItemExpectation.Absent("Action"),
+            ItemExpectation.Absent("DateTime")
         ]);
     }
 
@@ -12937,15 +12937,15 @@ public static class Extension
             """;
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Absent("System"),
-            CompletionTestExpectedResult.Absent("MySystem"),
+            ItemExpectation.Absent("System"),
+            ItemExpectation.Absent("MySystem"),
 
-            CompletionTestExpectedResult.Exists(underlyingType),
+            ItemExpectation.Exists(underlyingType),
 
             // Verify that other things from `System` namespace are not present
-            CompletionTestExpectedResult.Absent("Console"),
-            CompletionTestExpectedResult.Absent("Action"),
-            CompletionTestExpectedResult.Absent("DateTime")
+            ItemExpectation.Absent("Console"),
+            ItemExpectation.Absent("Action"),
+            ItemExpectation.Absent("DateTime")
         ]);
     }
 
@@ -13028,9 +13028,9 @@ public static class Extension
             """;
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("endIndex"),
-            CompletionTestExpectedResult.Exists("Test"),
-            CompletionTestExpectedResult.Exists("C"),
+            ItemExpectation.Exists("endIndex"),
+            ItemExpectation.Exists("Test"),
+            ItemExpectation.Exists("C"),
         ]);
     }
 
@@ -13051,9 +13051,9 @@ public static class Extension
             """;
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("endIndex"),
-            CompletionTestExpectedResult.Exists("Test"),
-            CompletionTestExpectedResult.Exists("C"),
+            ItemExpectation.Exists("endIndex"),
+            ItemExpectation.Exists("Test"),
+            ItemExpectation.Exists("C"),
         ]);
     }
 
@@ -13078,10 +13078,10 @@ public static class Extension
             """;
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("foo"),
-            CompletionTestExpectedResult.Exists("M"),
-            CompletionTestExpectedResult.Exists("System"),
-            CompletionTestExpectedResult.Absent("Int32"),
+            ItemExpectation.Exists("foo"),
+            ItemExpectation.Exists("M"),
+            ItemExpectation.Exists("System"),
+            ItemExpectation.Absent("Int32"),
         ]);
     }
 
@@ -13104,9 +13104,9 @@ public static class Extension
             """;
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("System"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Absent("other"),
+            ItemExpectation.Exists("System"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Absent("other"),
         ]);
     }
 
@@ -13141,12 +13141,12 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Absent("D"),
-            CompletionTestExpectedResult.Absent("M"),
-            CompletionTestExpectedResult.Exists("R"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Absent("D"),
+            ItemExpectation.Absent("M"),
+            ItemExpectation.Exists("R"),
         ]);
     }
 
@@ -13158,12 +13158,12 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Absent("C"),
-            CompletionTestExpectedResult.Absent("D"),
-            CompletionTestExpectedResult.Absent("M"),
-            CompletionTestExpectedResult.Absent("R"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Absent("C"),
+            ItemExpectation.Absent("D"),
+            ItemExpectation.Absent("M"),
+            ItemExpectation.Absent("R"),
         ]);
     }
 
@@ -13175,9 +13175,9 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("Constants"),
-            CompletionTestExpectedResult.Exists("System"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("Constants"),
+            ItemExpectation.Exists("System"),
         ]);
     }
 
@@ -13191,8 +13191,8 @@ public static class Extension
         // In scripts, we also get a Script class containing our defined types
         await VerifyExpectedItemsAsync(source,
             [
-                CompletionTestExpectedResult.Exists("C"),
-                CompletionTestExpectedResult.Exists("Constants"),
+                ItemExpectation.Exists("C"),
+                ItemExpectation.Exists("Constants"),
             ],
             sourceCodeKind: SourceCodeKind.Regular);
         await VerifyItemExistsAsync(source, "System");
@@ -13205,10 +13205,10 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("input"),
-            CompletionTestExpectedResult.Exists("Constants"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("M"),
+            ItemExpectation.Exists("input"),
+            ItemExpectation.Exists("Constants"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("M"),
         ]);
     }
 
@@ -13220,12 +13220,12 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Absent("D"),
-            CompletionTestExpectedResult.Absent("M"),
-            CompletionTestExpectedResult.Exists("R"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Absent("D"),
+            ItemExpectation.Absent("M"),
+            ItemExpectation.Exists("R"),
         ]);
     }
 
@@ -13237,12 +13237,12 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("D"),
-            CompletionTestExpectedResult.Absent("M"),
-            CompletionTestExpectedResult.Absent("R"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("D"),
+            ItemExpectation.Absent("M"),
+            ItemExpectation.Absent("R"),
         ]);
     }
 
@@ -13254,14 +13254,14 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("D"),
-            CompletionTestExpectedResult.Exists("E"),
-            CompletionTestExpectedResult.Exists("M"),
-            CompletionTestExpectedResult.Exists("R"),
-            CompletionTestExpectedResult.Exists("ToString"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("D"),
+            ItemExpectation.Exists("E"),
+            ItemExpectation.Exists("M"),
+            ItemExpectation.Exists("R"),
+            ItemExpectation.Exists("ToString"),
         ]);
     }
 
@@ -13273,11 +13273,11 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("D"),
-            CompletionTestExpectedResult.Exists("E"),
-            CompletionTestExpectedResult.Exists("M"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("D"),
+            ItemExpectation.Exists("E"),
+            ItemExpectation.Exists("M"),
         ]);
     }
 
@@ -13289,13 +13289,13 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Exists("D"),
-            CompletionTestExpectedResult.Exists("E"),
-            CompletionTestExpectedResult.Exists("M"),
-            CompletionTestExpectedResult.Exists("R"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Exists("D"),
+            ItemExpectation.Exists("E"),
+            ItemExpectation.Exists("M"),
+            ItemExpectation.Exists("R"),
         ]);
     }
 
@@ -13307,12 +13307,12 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Absent("D"),
-            CompletionTestExpectedResult.Absent("M"),
-            CompletionTestExpectedResult.Exists("R"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Absent("D"),
+            ItemExpectation.Absent("M"),
+            ItemExpectation.Exists("R"),
         ]);
     }
 
@@ -13324,12 +13324,12 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("A"),
-            CompletionTestExpectedResult.Exists("B"),
-            CompletionTestExpectedResult.Exists("C"),
-            CompletionTestExpectedResult.Absent("D"),
-            CompletionTestExpectedResult.Absent("M"),
-            CompletionTestExpectedResult.Exists("R"),
+            ItemExpectation.Exists("A"),
+            ItemExpectation.Exists("B"),
+            ItemExpectation.Exists("C"),
+            ItemExpectation.Absent("D"),
+            ItemExpectation.Absent("M"),
+            ItemExpectation.Exists("R"),
         ]);
     }
 
@@ -13341,8 +13341,8 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Length"),
-            CompletionTestExpectedResult.Absent("Constants"),
+            ItemExpectation.Exists("Length"),
+            ItemExpectation.Absent("Constants"),
         ]);
     }
 
@@ -13354,9 +13354,9 @@ public static class Extension
         var source = WrapPatternMatchingSource(expression);
 
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Constants"),
-            CompletionTestExpectedResult.Absent("InstanceProperty"),
-            CompletionTestExpectedResult.Absent("P"),
+            ItemExpectation.Exists("Constants"),
+            ItemExpectation.Absent("InstanceProperty"),
+            ItemExpectation.Absent("P"),
         ]);
     }
 
@@ -13602,8 +13602,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13634,8 +13634,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13668,8 +13668,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("StatusEn"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("StatusEn"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13702,8 +13702,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13737,8 +13737,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13767,8 +13767,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13797,8 +13797,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13829,8 +13829,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("StatusEn"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("StatusEn"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13861,8 +13861,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 
@@ -13894,8 +13894,8 @@ public static class Extension
             }
             """;
         await VerifyExpectedItemsAsync(source, [
-            CompletionTestExpectedResult.Exists("Undisclosed"),
-            CompletionTestExpectedResult.Absent("ToString"),
+            ItemExpectation.Exists("Undisclosed"),
+            ItemExpectation.Absent("ToString"),
         ]);
     }
 

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 NonCompletionOptions?.SetGlobalOptions(workspace.GlobalOptions);
 
                 await VerifyWorkerAsync(
-                    code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionModeItem, 
+                    code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionModeItem,
                     sourceKind, results, matchingFilters, flags, options, skipSpeculation);
             }
         }

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected abstract Task BaseVerifyWorkerAsync(
             string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false);
 
         internal Task<CompletionList> GetCompletionListAsync(
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             CompletionItemFlags? flags,
             CompletionOptions options)
         {
-            var expectedResult = new CompletionTestExpectedResult(
+            var expectedResult = new ItemExpectation(
                 Name: expectedItemOrNull,
                 IsAbsent: checkForAbsence,
                 ExpectedDescription: expectedDescriptionOrNull,
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private protected async Task CheckResultsAsync(
             Document document, int position, bool usePreviousCharAsTrigger,
             char? deletedCharTrigger, bool? hasSuggestionModeItem,
-            CompletionTestExpectedResult[] expectedResults,
+            ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters,
             CompletionItemFlags? flags,
             CompletionOptions options)
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             }
         }
 
-        private protected record CompletionTestExpectedResult(
+        private protected record ItemExpectation(
             string Name,
             bool IsAbsent,
             string ExpectedDescription = null,
@@ -281,21 +281,21 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             bool? IsComplexTextEdit = null,
             SourceCodeKind? SourceCodeKind = null)
         {
-            public static CompletionTestExpectedResult[] None = CreateGeneralMatchingArray(true);
-            public static CompletionTestExpectedResult[] Any = CreateGeneralMatchingArray(false);
+            public static ItemExpectation[] None = CreateGeneralMatchingArray(true);
+            public static ItemExpectation[] Any = CreateGeneralMatchingArray(false);
 
-            private static CompletionTestExpectedResult[] CreateGeneralMatchingArray(bool absent)
+            private static ItemExpectation[] CreateGeneralMatchingArray(bool absent)
             {
-                return [new CompletionTestExpectedResult(Name: null, IsAbsent: absent)];
+                return [new ItemExpectation(Name: null, IsAbsent: absent)];
             }
 
-            public static CompletionTestExpectedResult Exists(string name)
+            public static ItemExpectation Exists(string name)
             {
-                return new CompletionTestExpectedResult(name, false);
+                return new ItemExpectation(name, false);
             }
-            public static CompletionTestExpectedResult Absent(string name)
+            public static ItemExpectation Absent(string name)
             {
-                return new CompletionTestExpectedResult(name, true);
+                return new ItemExpectation(name, true);
             }
         }
 
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private async Task VerifyAsync(
             string markup, SourceCodeKind? sourceCodeKind, char? deletedCharTrigger, bool usePreviousCharAsTrigger,
-            CompletionTestExpectedResult[] results, bool? hasSuggestionModeItem,
+            ItemExpectation[] results, bool? hasSuggestionModeItem,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
             SourceCodeKind[] evaluatedSourceCodeKinds = sourceCodeKind.HasValue ? [sourceCodeKind.Value] : [SourceCodeKind.Regular, SourceCodeKind.Script];
@@ -463,7 +463,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             bool? hasSuggestionModeItem = null, CompletionOptions options = null)
         {
             await VerifyExpectedItemsAsync(
-                markup, results: CompletionTestExpectedResult.Any, sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
+                markup, results: ItemExpectation.Any, sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
                 hasSuggestionModeItem: hasSuggestionModeItem, options: options);
         }
 
@@ -473,12 +473,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             CompletionOptions options = null)
         {
             await VerifyExpectedItemsAsync(
-                markup, results: CompletionTestExpectedResult.None, sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
+                markup, results: ItemExpectation.None, sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
                 hasSuggestionModeItem: hasSuggestionModeItem, options: options);
         }
 
         private protected async Task VerifyExpectedItemsAsync(
-            string markup, CompletionTestExpectedResult[] results,
+            string markup, ItemExpectation[] results,
             SourceCodeKind? sourceCodeKind = null,
             char? deletedCharTrigger = null,
             bool usePreviousCharAsTrigger = false,
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             CompletionOptions options,
             bool skipSpeculation = false)
         {
-            var expectedResult = new CompletionTestExpectedResult(
+            var expectedResult = new ItemExpectation(
                 Name: expectedItemOrNull,
                 IsAbsent: checkForAbsence,
                 ExpectedDescription: expectedDescriptionOrNull,
@@ -538,7 +538,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private protected async Task VerifyWorkerCoreAsync(
             string code, int position, bool usePreviousCharAsTrigger,
             char? deletedCharTrigger, bool? hasSuggestionModeItem, SourceCodeKind sourceCodeKind,
-            CompletionTestExpectedResult[] expectedResults,
+            ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters,
             CompletionItemFlags? flags,
             CompletionOptions options,
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private protected virtual Task VerifyWorkerAsync(
             string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
             bool? hasSuggestionModeItem, SourceCodeKind sourceCodeKind,
-            CompletionTestExpectedResult[] expectedResults,
+            ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters,
             CompletionItemFlags? flags,
             CompletionOptions options,
@@ -1060,7 +1060,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAtPositionAsync(
             string code, int position, string insertText, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem, SourceCodeKind sourceCodeKind,
-            CompletionTestExpectedResult[] expectedResults,
+            ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
             code = code[..position] + insertText + code[position..];
@@ -1073,7 +1073,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAtPositionAsync(
             string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
             await VerifyAtPositionAsync(code, position, string.Empty, usePreviousCharAsTrigger,
@@ -1083,7 +1083,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAtPosition_ItemPartiallyWrittenAsync(
             string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults, string partialItem,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults, string partialItem,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
             await VerifyAtPositionAsync(code, position, ItemPartiallyWritten(partialItem),
@@ -1143,7 +1143,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAtEndOfFileAsync(
             string code, int position, string insertText, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
             // only do this if the placeholder was at the end of the text.
@@ -1162,7 +1162,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAtEndOfFileAsync(
             string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
             await VerifyAtEndOfFileAsync(code, position, string.Empty,
@@ -1172,7 +1172,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAtEndOfFileAsync(
             string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options)
         {
             await VerifyAtEndOfFileAsync(code, position, string.Empty,
@@ -1222,7 +1222,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAtEndOfFile_ItemPartiallyWrittenAsync(
             string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, CompletionTestExpectedResult[] expectedResults, string partialItem,
+            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults, string partialItem,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options)
         {
             await VerifyAtEndOfFileAsync(

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -160,9 +160,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 InlineDescription: inlineDescription,
                 IsComplexTextEdit: isComplexTextEdit);
 
-            var expectedResultArray = new[] { expectedResult };
             await CheckResultsAsync(document, position, usePreviousCharAsTrigger, deletedCharTrigger,
-                hasSuggestionModeItem, expectedResultArray, matchingFilters, flags, options);
+                hasSuggestionModeItem, [expectedResult], matchingFilters, flags, options);
         }
 
         private protected async Task CheckResultsAsync(
@@ -198,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 Assert.Equal(hasSuggestionModeItem.Value, completionList.SuggestionModeItem != null);
             }
 
-            if (expectedResults.Length is 0)
+            if (expectedResults.Length == 0)
             {
                 Assert.Equal(items.Count, 0);
             }
@@ -316,7 +315,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             string displayTextPrefix, string inlineDescription, bool? isComplexTextEdit,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
-            IReadOnlyList<SourceCodeKind> evaluatedSourceCodeKinds = sourceCodeKind.HasValue ? [sourceCodeKind.Value] : [SourceCodeKind.Regular, SourceCodeKind.Script];
+            SourceCodeKind[] evaluatedSourceCodeKinds = sourceCodeKind.HasValue ? [sourceCodeKind.Value] : [SourceCodeKind.Regular, SourceCodeKind.Script];
             foreach (var sourceKind in evaluatedSourceCodeKinds)
             {
                 using var workspaceFixture = GetOrCreateWorkspaceFixture();
@@ -342,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             CompletionTestExpectedResult[] results, bool? hasSuggestionModeItem,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
-            IReadOnlyList<SourceCodeKind> evaluatedSourceCodeKinds = sourceCodeKind.HasValue ? [sourceCodeKind.Value] : [SourceCodeKind.Regular, SourceCodeKind.Script];
+            SourceCodeKind[] evaluatedSourceCodeKinds = sourceCodeKind.HasValue ? [sourceCodeKind.Value] : [SourceCodeKind.Regular, SourceCodeKind.Script];
             foreach (var sourceKind in evaluatedSourceCodeKinds)
             {
                 using var workspaceFixture = GetOrCreateWorkspaceFixture();
@@ -524,11 +523,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 InlineDescription: inlineDescription,
                 IsComplexTextEdit: isComplexTextEdit);
 
-            var expectedResultArray = new[] { expectedResult };
-
             await VerifyWorkerCoreAsync(
                 code, position, usePreviousCharAsTrigger, deletedCharTrigger,
-                hasSuggestionModeItem, sourceCodeKind, expectedResultArray,
+                hasSuggestionModeItem, sourceCodeKind, [expectedResult],
                 matchingFilters, flags, options, skipSpeculation);
         }
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
         Private Protected Overrides Function BaseVerifyWorkerAsync(
             code As String, position As Integer, usePreviousCharAsTrigger As Boolean, deletedCharTrigger As Char?,
-            hasSuggestionItem As Boolean?, sourceCodeKind As SourceCodeKind, expectedResults() As CompletionTestExpectedResult,
+            hasSuggestionItem As Boolean?, sourceCodeKind As SourceCodeKind, expectedResults() As ItemExpectation,
             matchingFilters As List(Of CompletionFilter), flags As CompletionItemFlags?, options As CompletionOptions, Optional skipSpeculation As Boolean = False) As Task
             Return MyBase.VerifyWorkerAsync(
                 code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionItem, sourceCodeKind,
@@ -87,7 +87,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
         Private Protected Overrides Async Function VerifyWorkerAsync(
             code As String, position As Integer, usePreviousCharAsTrigger As Boolean, deletedCharTrigger As Char?,
             hasSuggestionModeItem As Boolean?, sourceCodeKind As SourceCodeKind,
-            expectedResults() As CompletionTestExpectedResult, matchingFilters As List(Of CompletionFilter),
+            expectedResults() As ItemExpectation, matchingFilters As List(Of CompletionFilter),
             flags As CompletionItemFlags?, options As CompletionOptions, Optional skipSpeculation As Boolean = False) As Task
 
             ' Script/interactive support removed for now.

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -37,6 +37,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
                 isComplexTextEdit, matchingFilters, flags, options, skipSpeculation)
         End Function
 
+        Private Protected Overrides Function BaseVerifyWorkerAsync(
+            code As String, position As Integer, usePreviousCharAsTrigger As Boolean, deletedCharTrigger As Char?,
+            hasSuggestionItem As Boolean?, sourceCodeKind As SourceCodeKind, expectedResults() As CompletionTestExpectedResult,
+            matchingFilters As List(Of CompletionFilter), flags As CompletionItemFlags?, options As CompletionOptions, Optional skipSpeculation As Boolean = False) As Task
+            Return MyBase.VerifyWorkerAsync(
+                code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionItem, sourceCodeKind,
+                expectedResults, matchingFilters, flags, options, skipSpeculation)
+        End Function
+
         Private Protected Overrides Async Function VerifyWorkerAsync(
                 code As String, position As Integer,
                 expectedItemOrNull As String, expectedDescriptionOrNull As String,
@@ -75,6 +84,41 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
             End If
         End Function
 
+        Private Protected Overrides Async Function VerifyWorkerAsync(
+            code As String, position As Integer, usePreviousCharAsTrigger As Boolean, deletedCharTrigger As Char?,
+            hasSuggestionModeItem As Boolean?, sourceCodeKind As SourceCodeKind,
+            expectedResults() As CompletionTestExpectedResult, matchingFilters As List(Of CompletionFilter),
+            flags As CompletionItemFlags?, options As CompletionOptions, Optional skipSpeculation As Boolean = False) As Task
+
+            ' Script/interactive support removed for now.
+            ' TODO: Re-enable these when interactive is back in the product.
+            If sourceCodeKind <> SourceCodeKind.Regular Then
+                Return
+            End If
+
+            Await VerifyAtPositionAsync(
+                code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionModeItem, sourceCodeKind,
+                expectedResults, matchingFilters, flags, options, skipSpeculation)
+
+            Await VerifyAtEndOfFileAsync(
+                code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionModeItem, sourceCodeKind,
+                expectedResults, matchingFilters, flags, options)
+
+            ' Items cannot be partially written if we're checking for their absence,
+            ' or if we're verifying that the list will show up (without specifying an actual item)
+            For Each item In expectedResults
+                If Not item.IsAbsent AndAlso item.Name IsNot Nothing Then
+                    Await VerifyAtPosition_ItemPartiallyWrittenAsync(
+                        code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionModeItem, sourceCodeKind,
+                        expectedResults, item.Name, matchingFilters, flags:=Nothing, options, skipSpeculation)
+
+                    Await VerifyAtEndOfFile_ItemPartiallyWrittenAsync(
+                        code, position, usePreviousCharAsTrigger, deletedCharTrigger, hasSuggestionModeItem, sourceCodeKind,
+                        expectedResults, item.Name, matchingFilters, flags:=Nothing, options)
+                End If
+            Next
+
+        End Function
         Protected Overrides Async Function VerifyCustomCommitProviderWorkerAsync(codeBeforeCommit As String, position As Integer, itemToCommit As String, expectedCodeAfterCommit As String, sourceCodeKind As SourceCodeKind, Optional commitChar As Char? = Nothing) As Task
             ' Script/interactive support removed for now.
             ' TODO: Re-enable these when interactive is back in the product.


### PR DESCRIPTION
From #70307, redone in a fresh branch to avoid complex merge conflicts

----

With approval from @CyrusNajmabadi, many tests in `SymbolCompletionProviderTests` were adjusted with new methods that allow checking for multiple items in the suggestions with a single run, hence improving performance.

This PR contains those adjustments for many tests that were the biggest hits, with either many verifications in the same method on the same source, or in test theories that have many distinct combinations. The greatest hit was from pattern matching tests that were added in #70262, which test against a large parameter matrix and assert a lot of recommendations.

Additionally, the new API makes it very convenient to test the recommended items more extensively.

Tests for Visual Basic were not changed in this PR. However, the new APIs were overridden in the abstract recommender, to be used once those are also updated to use the new assertion APIs.

## Benchmarks

Running all the tests in `SymbolCompletionProviderTests.cs` (about 1110) in my machine, takes:
- Before: >4.5 min
- After: ~1.6 min

The performance aligns with the theory of each individual `await Verify...` doing unnecessary work to parse, etc. up until the completion is triggered, in order to test the presence/absence of the symbol.

## Notes

The new version removes seemingly unnecessary arguments and batches each individual argument about a specific item in a record. These may be freely updated depending on the requirements for each test.

Test methods that only verify exactly one item do not need to be updated. It will be required though if the same test is extended to test more than one recommendation items.