### PR TITLE
Exclude two manually zipped servicehub symbol nupkgs from being signed

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,7 +15,11 @@
   <!--
     Non-default certificates.
   -->
-  <ItemGroup>
+  <ItemGroup>    
+    <!-- Exclude two manually zipped servicehub symbol nupkgs from being signed -->
+    <ItemsToSign Remove="@(ItemsToSign)" Condition="'%(FileName)%(Extension)' == 'Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.symbols.nupkg'" />
+    <ItemsToSign Remove="@(ItemsToSign)" Condition="'%(FileName)%(Extension)' == 'Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.x64.symbols.nupkg'" />
+
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tgz" />
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.zip" />
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -17,8 +17,8 @@
   -->
   <ItemGroup>    
     <!-- Exclude two manually zipped servicehub symbol nupkgs from being signed -->
-    <ItemsToSign Remove="@(ItemsToSign)" Condition="'%(FileName)%(Extension)' == 'Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.symbols.nupkg'" />
-    <ItemsToSign Remove="@(ItemsToSign)" Condition="'%(FileName)%(Extension)' == 'Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.x64.symbols.nupkg'" />
+    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.x64.symbols.nupkg"/>
+    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.symbols.nupkg"/>
 
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tgz" />
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.zip" />


### PR DESCRIPTION
Fixing signed build after theses two packages are being added in https://github.com/dotnet/roslyn/pull/75489