### PR TITLE
Fix symbol package name

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -17,8 +17,8 @@
   -->
   <ItemGroup>    
     <!-- Exclude two manually zipped servicehub symbol nupkgs from being signed -->
-    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.x64.symbols.nupkg"/>
-    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.symbols.nupkg"/>
+    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.x64.Symbols.nupkg"/>
+    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.Symbols.nupkg"/>
 
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tgz" />
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.zip" />

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -113,7 +113,7 @@
           Condition="'$(GenerateReadyToRun)' == 'true'">
     
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
-    <ZipDirectory SourceDirectory="$(PdbWorkDir)" DestinationFile="$(ArtifactsNonShippingPackagesDir)$(ProjectName).symbols.nupkg" />
+    <ZipDirectory SourceDirectory="$(PdbWorkDir)" DestinationFile="$(ArtifactsNonShippingPackagesDir)$(ProjectName).Symbols.nupkg" />
   </Target>
 
   <!--


### PR DESCRIPTION
It seems "Symbols" in the symbol package name has to be capitalized to be skipped for nuget publishing ([val build log](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10386730&view=logs&j=d8f66498-7756-5707-3b43-f2312930a35f&t=bbe08150-3f17-5cb4-1e71-ad095ec298fb))

https://github.com/dotnet/roslyn/blob/d408230503cc2ba987fae8e29df7dd73892413d6/eng/publish-assets.ps1#L73
