### PR TITLE
Do not crash server if we fail to determine language for non-mutating request

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -172,10 +173,11 @@ internal abstract class AbstractLanguageServer<TRequestContext>
         return _queue.Value;
     }
 
-    public virtual string GetLanguageForRequest(string methodName, object? serializedRequest)
+    public virtual bool TryGetLanguageForRequest(string methodName, object? serializedRequest, [NotNullWhen(true)] out string? language)
     {
         Logger.LogInformation($"Using default language handler for {methodName}");
-        return LanguageServerConstants.DefaultLanguageName;
+        language = LanguageServerConstants.DefaultLanguageName;
+        return true;
     }
 
     protected abstract DelegatingEntryPoint CreateDelegatingEntryPoint(string method);

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IQueueItem.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IQueueItem.cs
@@ -42,7 +42,7 @@ internal interface IQueueItem<TRequestContext>
     /// Handles when the queue needs to manually fail a request before the
     /// handler is invoked without shutting down the entire queue.
     /// </summary>
-    void FailRequest(Exception ex);
+    void FailRequest(string message);
 
     /// <summary>
     /// Provides access to LSP services.

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IQueueItem.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IQueueItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,6 +37,12 @@ internal interface IQueueItem<TRequestContext>
     /// If there was a recoverable failure in creating the request, this will return null and the caller should stop processing the request.
     /// </summary>
     Task<(TRequestContext, TRequest)?> CreateRequestContextAsync<TRequest>(IMethodHandler handler, RequestHandlerMetadata requestHandlerMetadata, AbstractLanguageServer<TRequestContext> languageServer, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Handles when the queue needs to manually fail a request before the
+    /// handler is invoked without shutting down the entire queue.
+    /// </summary>
+    void FailRequest(Exception ex);
 
     /// <summary>
     /// Provides access to LSP services.

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs
@@ -26,6 +26,11 @@ internal class QueueItem<TRequestContext> : IQueueItem<TRequestContext>
     private readonly ILspLogger _logger;
     private readonly AbstractRequestScope? _requestTelemetryScope;
 
+    /// <summary>
+    /// True if this queue item has actually started handling the request
+    /// by delegating to the handler.  False while the item is still being
+    /// processed by the queue.
+    /// </summary>
     private bool _requestHandlingStarted = false;
 
     /// <summary>

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs
@@ -245,12 +245,15 @@ internal class QueueItem<TRequestContext> : IQueueItem<TRequestContext>
         await _completionSource.Task.ConfigureAwait(false);
     }
 
-    public void FailRequest(Exception exception)
+    public void FailRequest(string message)
     {
+        // This is not valid to call after StartRequestAsync starts as they both access the same state.
+        // StartRequestAsync handles any failures internally once it runs.
         if (_requestHandlingStarted)
         {
             throw new InvalidOperationException("Cannot manually fail queue item after it has started");
         }
+        var exception = new Exception(message);
         _requestTelemetryScope?.RecordException(exception);
         _logger.LogException(exception);
 

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -245,10 +246,21 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
                     // notifications have been completed by the time we attempt to determine the language, so we have the up to date map of URI to language.
                     // Since didOpen notifications are marked as mutating, the queue will not advance to the next request until the server has finished processing
                     // the didOpen, ensuring that this line will only run once all prior didOpens have completed.
-                    var language = _languageServer.GetLanguageForRequest(work.MethodName, work.SerializedRequest);
+                    var language = TryGetLanguageForRequest(work, out var exception);
 
                     // Now that we know the actual language, we can deserialize the request and start creating the request context.
                     var (metadata, handler, methodInfo) = GetHandlerForRequest(work, language);
+
+                    // We had an exception determining the language.  Generally this is very rare and only occurs
+                    // if there is a mis-behaving client that sends us requests for files where we haven't saved the languageId.
+                    // We should only crash if this was a mutating method, otherwise we should just fail the single request. 
+                    if (exception != null)
+                    {
+                        if (handler.MutatesSolutionState)
+                            throw exception;
+                        else
+                            work.FailRequest(exception);
+                    }
 
                     // We now have the actual handler and language, so we can process the work item using the concrete types defined by the metadata.
                     await InvokeProcessCoreAsync(work, metadata, handler, methodInfo, concurrentlyExecutingTasks, currentWorkCts, cancellationToken).ConfigureAwait(false);
@@ -382,6 +394,21 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
         }
     }
 
+    private string TryGetLanguageForRequest(IQueueItem<TRequestContext> work,
+        out Exception? ex)
+    {
+        try
+        {
+            var language = _languageServer.GetLanguageForRequest(work.MethodName, work.SerializedRequest);
+            ex = null;
+            return language;
+        }
+        catch (Exception exception)
+        {
+            ex = exception;
+            return LanguageServerConstants.DefaultLanguageName;
+        }
+    }
     /// <summary>
     /// Allows an action to happen before the request runs, for example setting the current thread culture.
     /// </summary>

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -256,14 +256,14 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
                     // We should only crash if this was a mutating method, otherwise we should just fail the single request. 
                     if (!didGetLanguage)
                     {
-                        var exception = new InvalidOperationException($"Failed to get language for {work.MethodName}");
+                        var message = $"Failed to get language for {work.MethodName}";
                         if (handler.MutatesSolutionState)
                         {
-                            throw exception;
+                            throw new InvalidOperationException(message);
                         }
                         else
                         {
-                            work.FailRequest(exception);
+                            work.FailRequest(message);
                             return;
                         }
                     }

--- a/src/LanguageServer/Protocol/ILanguageInfoProvider.cs
+++ b/src/LanguageServer/Protocol/ILanguageInfoProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Features.Workspaces;
 
 namespace Microsoft.CodeAnalysis.LanguageServer
@@ -20,6 +21,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// In that case, we use the language Id that the LSP client gave us.
         /// </remarks>
         /// <exception cref="InvalidOperationException">Thrown when the language information cannot be determined.</exception>
-        LanguageInformation GetLanguageInformation(Uri documentUri, string? lspLanguageId);
+        bool TryGetLanguageInformation(Uri uri, string? lspLanguageId, [NotNullWhen(true)] out LanguageInformation? languageInformation);
     }
 }

--- a/src/LanguageServer/Protocol/ILanguageInfoProvider.cs
+++ b/src/LanguageServer/Protocol/ILanguageInfoProvider.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// It is totally possible to not find language based on the file path (e.g. a newly created file that hasn't been saved to disk).
         /// In that case, we use the language Id that the LSP client gave us.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">Thrown when the language information cannot be determined.</exception>
         bool TryGetLanguageInformation(Uri uri, string? lspLanguageId, [NotNullWhen(true)] out LanguageInformation? languageInformation);
     }
 }

--- a/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             }
 
             var languageInfoProvider = lspServices.GetRequiredService<ILanguageInfoProvider>();
-            var languageInformation = languageInfoProvider.GetLanguageInformation(uri, languageId);
-            if (languageInformation == null)
+            if (!languageInfoProvider.TryGetLanguageInformation(uri, languageId, out var languageInformation))
             {
                 // Only log here since throwing here could take down the LSP server.
                 logger.LogError($"Could not find language information for {uri} with absolute path {documentFilePath}");

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -532,7 +533,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// <summary>
     /// Returns a Roslyn language name for the given URI.
     /// </summary>
-    internal string GetLanguageForUri(Uri uri)
+    internal bool TryGetLanguageForUri(Uri uri, [NotNullWhen(true)] out string? language)
     {
         string? languageId = null;
         if (_trackedDocuments.TryGetValue(uri, out var trackedDocument))
@@ -540,7 +541,14 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
             languageId = trackedDocument.LanguageId;
         }
 
-        return _languageInfoProvider.GetLanguageInformation(uri, languageId).LanguageName;
+        if (_languageInfoProvider.TryGetLanguageInformation(uri, languageId, out var languageInfo))
+        {
+            language = languageInfo.LanguageName;
+            return true;
+        }
+
+        language = null;
+        return false;
     }
 
     /// <summary>

--- a/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 Uri = looseFileUri
             });
 
-            await Assert.ThrowsAnyAsync<Exception>(async() => await testLspServer.ExecuteRequestAsync<TestRequestTypeOne, string>(TestDocumentHandler.MethodName, request, CancellationToken.None)).ConfigureAwait(false);
+            await Assert.ThrowsAnyAsync<Exception>(async () => await testLspServer.ExecuteRequestAsync<TestRequestTypeOne, string>(TestDocumentHandler.MethodName, request, CancellationToken.None)).ConfigureAwait(false);
             await testLspServer.AssertServerShuttingDownAsync();
         }
 

--- a/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
@@ -17,6 +17,7 @@ using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.CodeAnalysis.LanguageServer.UnitTests.LocaleTests;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 {
@@ -293,6 +294,24 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 => await server.ExecuteRequestAsync<TestRequestWithDocument, TestConfigurableResponse>(TestConfigurableDocumentHandler.MethodName, request, CancellationToken.None));
 
             Assert.False(didReport);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestMutatingHandlerCrashesIfUnableToDetermineLanguage(bool mutatingLspWorkspace)
+        {
+            await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+            // Run a mutating request against a file which we have no saved languageId for
+            // and where the language cannot be determined from the URI.
+            // This should crash the server.
+            var looseFileUri = ProtocolConversions.CreateAbsoluteUri(@"untitled:untitledFile");
+            var request = new TestRequestTypeOne(new TextDocumentIdentifier
+            {
+                Uri = looseFileUri
+            });
+
+            await Assert.ThrowsAnyAsync<Exception>(async() => await testLspServer.ExecuteRequestAsync<TestRequestTypeOne, string>(TestDocumentHandler.MethodName, request, CancellationToken.None)).ConfigureAwait(false);
+            await testLspServer.AssertServerShuttingDownAsync();
         }
 
         internal record TestRequestTypeOne([property: JsonPropertyName("textDocument"), JsonRequired] TextDocumentIdentifier TextDocumentIdentifier);


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/7656

Sometimes VSCode will send a request or two with the old URI after it renames a temporary file.  When we close the file we lose the languageId that they told us about in didOpen (we drop the file info for it) and the server crashes.

Since this is a recoverable error, we should avoid crashing.  Instead, we just fail the request and allow the server to continue running, unless it is a mutating request.