### PR TITLE
Also compare other properties when remove block spans

### DIFF
--- a/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
+++ b/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
@@ -363,14 +363,14 @@ End Module";
     public async Task LambdaShouldBeCollapsed()
     {
         var code = """
-public class MyClass
-{
-    public void MyMethod() => System.Linq.Enumerable.Range(10, 100).Any(x =>
-    {
-        return x == 10;
-    });
-}
-""";
+            public class MyClass
+            {
+                public void MyMethod() => System.Linq.Enumerable.Range(10, 100).Any(x =>
+                {
+                    return x == 10;
+                });
+            }
+            """;
 
         using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
         var tags = await GetTagsFromWorkspaceAsync(workspace);

--- a/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
+++ b/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
@@ -359,18 +359,18 @@ End Module";
         });
     }
 
-    [WpfFact]
-    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2112145")]
+    [WpfFact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2112145")]
     public async Task LambdaShouldBeCollapsed()
     {
-        var code = @"
+        var code = """
 public class MyClass
 {
     public void MyMethod() => System.Linq.Enumerable.Range(10, 100).Any(x =>
     {
         return x == 10;
     });
-}";
+}
+""";
 
         using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
         var tags = await GetTagsFromWorkspaceAsync(workspace);

--- a/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
+++ b/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
@@ -359,6 +359,39 @@ End Module";
         });
     }
 
+    [WpfFact]
+    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2112145")]
+    public async Task LambdaShouldBeCollapsed()
+    {
+        var code = @"
+public class MyClass
+{
+    public void MyMethod() => System.Linq.Enumerable.Range(10, 100).Any(x =>
+    {
+        return x == 10;
+    });
+}";
+
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        var tags = await GetTagsFromWorkspaceAsync(workspace);
+
+        Assert.Collection(tags, programTag =>
+        {
+            Assert.Equal("public class MyClass", GetHeaderText(programTag));
+            Assert.Equal(7, GetCollapsedHintLineCount(programTag));
+        },
+        mainTag =>
+        {
+            Assert.Equal("public void MyMethod()", GetHeaderText(mainTag));
+            Assert.Equal(4, GetCollapsedHintLineCount(mainTag));
+        },
+        IfTag =>
+        {
+            Assert.Equal("x =>", GetHeaderText(IfTag));
+            Assert.Equal(4, GetCollapsedHintLineCount(IfTag));
+        });
+    }
+
 #pragma warning disable CS0618 // Type or member is obsolete
     private static async Task<List<IContainerStructureTag>> GetTagsFromWorkspaceAsync(EditorTestWorkspace workspace)
     {

--- a/src/Features/Core/Portable/Structure/BlockSpan.cs
+++ b/src/Features/Core/Portable/Structure/BlockSpan.cs
@@ -114,4 +114,28 @@ internal readonly struct BlockSpan(
         return new BlockSpan(
             newType, newIsCollapsible, newTextSpan, newHintSpan, newPrimarySpans, newBannerText, newAutoCollapse, newIsDefaultCollapsed);
     }
+
+    internal bool IsOverlappingBlockSpan(TextLineCollection lines, BlockSpan? other)
+    {
+        // Compare collapse region related properties to decide should two block span be consider as one.
+        // We only want one block span (inner block) for case like:
+        // M1(M2(
+        // ))
+        if (other is null)
+            return false;
+
+        var startLine = lines.GetLinePosition(this.TextSpan.Start).Line;
+        var otherStartLine = lines.GetLinePosition(other.Value.TextSpan.Start).Line;
+        if (startLine != otherStartLine)
+            return false;
+
+        var endLine = lines.GetLinePosition(this.TextSpan.End).Line;
+        var otherEndLine = lines.GetLinePosition(other.Value.TextSpan.End).Line;
+        if (endLine != otherEndLine)
+            return false;
+
+        return this.AutoCollapse == other.Value.AutoCollapse
+            && this.IsCollapsible == other.Value.IsCollapsible
+            && this.IsDefaultCollapsed == other.Value.IsDefaultCollapsed;
+    }
 }

--- a/src/Features/Core/Portable/Structure/BlockSpan.cs
+++ b/src/Features/Core/Portable/Structure/BlockSpan.cs
@@ -124,6 +124,13 @@ internal readonly struct BlockSpan(
         if (other is null)
             return false;
 
+        if (this.AutoCollapse != other.Value.AutoCollapse
+            || this.IsCollapsible != other.Value.IsCollapsible
+            || this.IsDefaultCollapsed != other.Value.IsDefaultCollapsed)
+        {
+            return false;
+        }
+
         var startLine = lines.GetLinePosition(this.TextSpan.Start).Line;
         var otherStartLine = lines.GetLinePosition(other.Value.TextSpan.Start).Line;
         if (startLine != otherStartLine)
@@ -131,11 +138,6 @@ internal readonly struct BlockSpan(
 
         var endLine = lines.GetLinePosition(this.TextSpan.End).Line;
         var otherEndLine = lines.GetLinePosition(other.Value.TextSpan.End).Line;
-        if (endLine != otherEndLine)
-            return false;
-
-        return this.AutoCollapse == other.Value.AutoCollapse
-            && this.IsCollapsible == other.Value.IsCollapsible
-            && this.IsDefaultCollapsed == other.Value.IsDefaultCollapsed;
+        return endLine == otherEndLine;
     }
 }

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
@@ -49,24 +49,19 @@ internal abstract class AbstractBlockStructureProvider : BlockStructureProvider
             //
             // We only collapse the "inner" span which has larger start.
             context.Spans.Sort(initialContextCount, s_blockSpanComparer);
-
-            var lastAddedLineStart = -1;
-            var lastAddedLineEnd = -1;
             var text = context.SyntaxTree.GetText(context.CancellationToken);
+            BlockSpan? lastSpan = null;
+
             context.Spans.RemoveWhere((span, index, _) =>
                 {
                     // do not remove items before the first item that we added
                     if (index < initialContextCount)
                         return false;
 
-                    var lineStart = text.Lines.GetLinePosition(span.TextSpan.Start).Line;
-                    var lineEnd = text.Lines.GetLinePosition(span.TextSpan.End).Line;
-                    if (lineStart == lastAddedLineStart && lastAddedLineEnd == lineEnd)
+                    if (span.IsOverlappingBlockSpan(text.Lines, lastSpan))
                         return true;
 
-                    lastAddedLineStart = lineStart;
-                    lastAddedLineEnd = lineEnd;
-
+                    lastSpan = span;
                     return false;
                 },
                 arg: default(VoidResult));


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2112145

Right now you can't call `collapse to definition` in this case:
![collapseToDefinition](https://github.com/user-attachments/assets/389320c3-5333-4aca-8ce0-3f3f75bad904)

It is regressed back in https://github.com/dotnet/roslyn/pull/71064
In that PR we want to support a scenario:
```
M1(M2(
))
```
only M2 will be collapsed.
The implementation is to compare the start line of the block span (later it changes to compare both start & end line in https://github.com/dotnet/roslyn/pull/74413)

However, the problem is in the lamda case:
```
public class YY
{
    public void YX() => System.Linq.Enumerable.Range(10, 100).Any(x =>
    {
        return x == 10;
    });
}
```
Method `YX` and lambda 
```
x => {
 return x == 10;
}
```
generate two block spans with same line start and line end. But `AutoCollapse` proprety is different,
https://github.com/dotnet/roslyn/blob/0068ee9ac48a9c3d19410cdea20474f5cdf2e7f1/src/Features/CSharp/Portable/Structure/Providers/ArrowExpressionClauseStructureProvider.cs#L30
https://github.com/dotnet/roslyn/blob/0068ee9ac48a9c3d19410cdea20474f5cdf2e7f1/src/Features/CSharp/Portable/Structure/Providers/SimpleLambdaExpressionStructureProvider.cs#L45

Fix is to also compare other properties in Block span when remove them from the context.


