### PR TITLE
Revert "Update BuildHost STJ to 8.0.4"

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="17.3.4" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="17.3.4" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" VersionOverride="8.0.4" PrivateAssets="All" Condition="'$(DotNetBuildSourceOnly)' != 'true'"/>
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
This reverts commit 6f65bfca9ce7afc4b3a081b8f7406d046301d27e.

System.Text.Json.dll was eliminated from BuildHost by https://github.com/dotnet/roslyn/pull/73393 but then re-added back by flow from internal branch.