### PR TITLE
When replacing CodeStyle analyzers do not provide Features analyzers fallback options

### DIFF
--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using Roslyn.Utilities;
 
@@ -78,12 +77,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
             }
 
-            private static readonly ImmutableHashSet<string> FeaturesAnalyzerFileNames = [
-                "Microsoft.CodeAnalysis.Features.dll",
-                "Microsoft.CodeAnalysis.CSharp.Features.dll",
-                "Microsoft.CodeAnalysis.VisualBasic.Features.dll",
-            ];
-
             private static ImmutableHashSet<object> GetReferenceIdsToRedirectAsProjectAnalyzers(Project project)
             {
                 if (project.State.HasSdkCodeStyleAnalyzers)
@@ -102,11 +95,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     foreach (var analyzerReference in hostAnalyzers.HostAnalyzerReferences)
                     {
-                        var fileName = Path.GetFileName(analyzerReference.FullPath)!;
-                        if (FeaturesAnalyzerFileNames.Contains(fileName))
-                        {
+                        if (analyzerReference.IsFeaturesAnalyzer())
                             builder.Add(analyzerReference.Id);
-                        }
                     }
 
                     return builder.ToImmutable();

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -187,23 +187,28 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private readonly struct HostAnalyzerStateSetKey : IEquatable<HostAnalyzerStateSetKey>
             {
-                public HostAnalyzerStateSetKey(string language, IReadOnlyList<AnalyzerReference> analyzerReferences)
+                public HostAnalyzerStateSetKey(string language, bool hasSdkCodeStyleAnalyzers, IReadOnlyList<AnalyzerReference> analyzerReferences)
                 {
                     Language = language;
+                    HasSdkCodeStyleAnalyzers = hasSdkCodeStyleAnalyzers;
                     AnalyzerReferences = analyzerReferences;
                 }
 
                 public string Language { get; }
+                public bool HasSdkCodeStyleAnalyzers { get; }
                 public IReadOnlyList<AnalyzerReference> AnalyzerReferences { get; }
 
                 public bool Equals(HostAnalyzerStateSetKey other)
-                    => Language == other.Language && AnalyzerReferences == other.AnalyzerReferences;
+                    => Language == other.Language &&
+                       HasSdkCodeStyleAnalyzers == other.HasSdkCodeStyleAnalyzers &&
+                       AnalyzerReferences == other.AnalyzerReferences;
 
                 public override bool Equals(object? obj)
                     => obj is HostAnalyzerStateSetKey key && Equals(key);
 
                 public override int GetHashCode()
-                    => Hash.Combine(Language.GetHashCode(), AnalyzerReferences.GetHashCode());
+                    => Hash.Combine(Language.GetHashCode(),
+                       Hash.Combine(HasSdkCodeStyleAnalyzers.GetHashCode(), AnalyzerReferences.GetHashCode()));
             }
         }
     }

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -866,7 +866,7 @@ public class C
         }
     }
 
-    [Theory, CombinatorialData]
+    [Theory(Skip = "https://github.com/dotnet/roslyn/issues/75611"), CombinatorialData]
     public async Task TestHandleExceptionFromGetCompletionChange(bool mutatingLspWorkspace)
     {
         var markup = "Item {|caret:|}";

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -211,11 +211,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
                     "Project", LanguageNames.CSharp, CancellationToken.None)
 
+                ' Ensure HasSdkCodeStyleAnalyzers is proper.
+                Assert.False(project.HasSdkCodeStyleAnalyzers)
+
                 ' These are the in-box C# codestyle analyzers that ship with the SDK
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CodeStyle.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CodeStyle.Fixes.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CSharp.CodeStyle.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll"))
+
+                ' Ensure HasSdkCodeStyleAnalyzers is being properly updated.
+                Assert.True(project.HasSdkCodeStyleAnalyzers)
 
                 ' Ensure they are not returned when getting AnalyzerReferences
                 Assert.Empty(environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences)
@@ -228,6 +234,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 {
                     Path.Combine(TempRoot.Root, "Dir", "File.dll")
                 }, environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Select(Function(r) r.FullPath))
+
+                ' Remove codestyle analyzers
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CodeStyle.dll"))
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CodeStyle.Fixes.dll"))
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CSharp.CodeStyle.dll"))
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll"))
+
+                ' Ensure HasSdkCodeStyleAnalyzers is being properly updated.
+                Assert.False(project.HasSdkCodeStyleAnalyzers)
             End Using
         End Function
 
@@ -237,11 +252,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
                     "Project", LanguageNames.VisualBasic, CancellationToken.None)
 
+                ' Ensure HasSdkCodeStyleAnalyzers is proper.
+                Assert.False(project.HasSdkCodeStyleAnalyzers)
+
                 ' These are the in-box VB codestyle analyzers that ship with the SDK
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.CodeStyle.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.CodeStyle.Fixes.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.VisualBasic.CodeStyle.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.dll"))
+
+                ' Ensure HasSdkCodeStyleAnalyzers is being properly updated.
+                Assert.True(project.HasSdkCodeStyleAnalyzers)
 
                 ' Ensure they are not returned when getting AnalyzerReferences
                 Assert.Empty(environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences)
@@ -254,6 +275,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 {
                     Path.Combine(TempRoot.Root, "Dir", "File.dll")
                 }, environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Select(Function(r) r.FullPath))
+
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.CodeStyle.dll"))
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.CodeStyle.Fixes.dll"))
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.VisualBasic.CodeStyle.dll"))
+                project.RemoveAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk", "codestyle", "vb", "Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.dll"))
+
+                ' Ensure HasSdkCodeStyleAnalyzers is being properly updated.
+                Assert.False(project.HasSdkCodeStyleAnalyzers)
             End Using
         End Function
     End Class

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpRedirectFeaturesAnalyzers.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpRedirectFeaturesAnalyzers.cs
@@ -1,0 +1,167 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.VisualStudio.NewIntegrationTests.InProcess;
+using Xunit;
+
+namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp;
+
+public class CSharpRedirectFeaturesAnalyzers : AbstractEditorTest
+{
+    protected override string LanguageName => LanguageNames.CSharp;
+
+    private const int GlobalIndentationSize = 6;
+    private const int DefaultIndentationSize = 4;
+
+    [IdeFact]
+    public async Task DoesNotUseHostOptions_WhenEnforceCodeStyleInBuildIsTrue()
+    {
+        await SetupSolutionAsync(
+            enforceCodeStyleInBuild: true,
+            GlobalIndentationSize,
+            HangMitigatingCancellationToken);
+
+        var code = GenerateTestCode(GlobalIndentationSize);
+
+        await TestServices.SolutionExplorer.AddFileAsync(ProjectName, "C.cs", code, open: true, cancellationToken: HangMitigatingCancellationToken);
+
+        var errors = await GetErrorsFromErrorListAsync(HangMitigatingCancellationToken);
+        AssertEx.Equal(
+            [
+                "C.cs(3, 5): error IDE0055: Fix formatting",
+                "C.cs(4, 5): error IDE0055: Fix formatting",
+                "C.cs(6, 5): error IDE0055: Fix formatting",
+            ],
+            errors);
+    }
+
+    [IdeFact]
+    public async Task UsesHostOptions_WhenEnforceCodeStyleInBuildIsFalse()
+    {
+        await SetupSolutionAsync(
+            enforceCodeStyleInBuild: false,
+            GlobalIndentationSize,
+            HangMitigatingCancellationToken);
+
+        var code = GenerateTestCode(DefaultIndentationSize);
+
+        await TestServices.SolutionExplorer.AddFileAsync(ProjectName, "C.cs", code, open: true, cancellationToken: HangMitigatingCancellationToken);
+
+        var errors = await GetErrorsFromErrorListAsync(HangMitigatingCancellationToken);
+        AssertEx.Equal(
+            [
+                "C.cs(3, 5): error IDE0055: Fix formatting",
+                "C.cs(4, 5): error IDE0055: Fix formatting",
+                "C.cs(6, 5): error IDE0055: Fix formatting",
+            ],
+            errors);
+    }
+
+    private async Task SetupSolutionAsync(bool enforceCodeStyleInBuild, int globalIndentationSize, CancellationToken cancellationToken)
+    {
+        await TestServices.SolutionExplorer.CreateSolutionAsync(SolutionName, cancellationToken);
+
+        await TestServices.SolutionExplorer.AddCustomProjectAsync(
+            ProjectName,
+            ".csproj",
+            $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <EnforceCodeStyleInBuild>{enforceCodeStyleInBuild}</EnforceCodeStyleInBuild>
+              </PropertyGroup>
+
+            </Project>
+            """,
+            cancellationToken);
+        await TestServices.SolutionExplorer.RestoreNuGetPackagesAsync(ProjectName, cancellationToken);
+
+        // Configure the global indentation size which would be part of the Host fallback options.
+        var globalOptions = await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(cancellationToken);
+        globalOptions.SetGlobalOption(FormattingOptions2.UseTabs, LanguageNames.CSharp, false);
+        globalOptions.SetGlobalOption(FormattingOptions2.IndentationSize, LanguageNames.CSharp, globalIndentationSize);
+
+        // Add .editorconfig to configure so that formatting diagnostics are errors
+        await TestServices.SolutionExplorer.AddFileAsync(ProjectName,
+            ".editorconfig",
+            """
+            root = true
+
+            [*.cs]
+            dotnet_diagnostic.IDE0055.severity = error
+            """,
+            open: false,
+            cancellationToken);
+
+        await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+            [
+                FeatureAttribute.Workspace,
+                FeatureAttribute.SolutionCrawlerLegacy,
+                FeatureAttribute.DiagnosticService,
+                FeatureAttribute.ErrorSquiggles
+            ],
+            cancellationToken);
+    }
+
+    private static string GenerateTestCode(int indentationSize)
+    {
+        var indentation = new string(' ', indentationSize);
+        return $$"""
+            class C
+            {
+            {{indentation}}void M()
+            {{indentation}}{
+
+            {{indentation}}}
+            }
+            """;
+    }
+
+    private async Task<ImmutableArray<string>> GetErrorsFromErrorListAsync(CancellationToken cancellationToken)
+    {
+        await WaitForCodeActionListToPopulateAsync(cancellationToken);
+
+        await TestServices.ErrorList.ShowErrorListAsync(cancellationToken);
+        await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+            [
+                FeatureAttribute.Workspace,
+                FeatureAttribute.SolutionCrawlerLegacy,
+                FeatureAttribute.DiagnosticService,
+                FeatureAttribute.ErrorSquiggles,
+                FeatureAttribute.ErrorList
+             ],
+             cancellationToken);
+        return await TestServices.ErrorList.GetErrorsAsync(cancellationToken);
+    }
+
+    private async Task WaitForCodeActionListToPopulateAsync(CancellationToken cancellationToken)
+    {
+        await TestServices.Editor.ActivateAsync(cancellationToken);
+        await TestServices.Editor.PlaceCaretAsync("void M()", charsOffset: -1, cancellationToken);
+
+        await TestServices.Editor.InvokeCodeActionListAsync(cancellationToken);
+
+        await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+            [
+                FeatureAttribute.Workspace,
+                FeatureAttribute.SolutionCrawlerLegacy,
+                FeatureAttribute.DiagnosticService,
+                FeatureAttribute.ErrorSquiggles
+            ],
+            cancellationToken);
+
+        await TestServices.Editor.DismissLightBulbSessionAsync(cancellationToken);
+    }
+}

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,12 +82,31 @@ internal static partial class Extensions
 
     private static string GetAssemblyQualifiedName(Type type)
     {
-        // AnalyzerFileReference now includes things like versions, public key as part of its identity. 
+        // AnalyzerFileReference now includes things like versions, public key as part of its identity.
         // so we need to consider them.
         return RoslynImmutableInterlocked.GetOrAdd(
             ref s_typeToAssemblyQualifiedName,
             type,
             static type => type.AssemblyQualifiedName ?? throw ExceptionUtilities.UnexpectedValue(type));
+    }
+
+    private static readonly ImmutableHashSet<string> s_featuresAnalyzerFileNames = new[] {
+        "Microsoft.CodeAnalysis.Features.dll",
+        "Microsoft.CodeAnalysis.CSharp.Features.dll",
+        "Microsoft.CodeAnalysis.VisualBasic.Features.dll",
+    }.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static ImmutableSegmentedDictionary<string, bool> s_analyzerFullPathToIsFeatureAnalyzer = ImmutableSegmentedDictionary<string, bool>.Empty;
+
+    public static bool IsFeaturesAnalyzer(this AnalyzerReference reference)
+    {
+        if (reference.FullPath is null)
+            return false;
+
+        return RoslynImmutableInterlocked.GetOrAdd(
+            ref s_analyzerFullPathToIsFeatureAnalyzer,
+            reference.FullPath,
+            static fullPath => s_featuresAnalyzerFileNames.Contains(Path.GetFileName(fullPath)));
     }
 
     public static async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResultBuilder>> ToResultBuilderMapAsync(

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -59,6 +59,11 @@ internal sealed partial class ProjectSystemProject
     private readonly HashSet<string> _projectAnalyzerPaths = [];
 
     /// <summary>
+    /// The set of unmapped analyzer reference paths that the project knows about.
+    /// </summary>
+    private readonly HashSet<string> _unmappedProjectAnalyzerPaths = [];
+
+    /// <summary>
     /// Paths to analyzers we want to add when the current batch completes.
     /// </summary>
     private readonly List<string> _analyzersAddedInBatch = [];
@@ -81,6 +86,7 @@ internal sealed partial class ProjectSystemProject
     private string? _outputFilePath;
     private string? _outputRefFilePath;
     private string? _defaultNamespace;
+    private bool _hasSdkCodeStyleAnalyzers;
 
     /// <summary>
     /// If this project is the 'primary' project the project system cares about for a group of Roslyn projects that
@@ -446,14 +452,20 @@ internal sealed partial class ProjectSystemProject
         ChangeProjectProperty(ref _runAnalyzers, runAnalyzers, s => s.WithRunAnalyzers(Id, runAnalyzers));
     }
 
+    internal bool HasSdkCodeStyleAnalyzers
+    {
+        get => _hasSdkCodeStyleAnalyzers;
+        set => ChangeProjectProperty(ref _hasSdkCodeStyleAnalyzers, value, s => s.WithHasSdkCodeStyleAnalyzers(Id, value));
+    }
+
     /// <summary>
     /// The default namespace of the project.
     /// </summary>
     /// <remarks>
-    /// In C#, this is defined as the value of "rootnamespace" msbuild property. Right now VB doesn't 
+    /// In C#, this is defined as the value of "rootnamespace" msbuild property. Right now VB doesn't
     /// have the concept of "default namespace", but we conjure one in workspace by assigning the value
     /// of the project's root namespace to it. So various features can choose to use it for their own purpose.
-    /// 
+    ///
     /// In the future, we might consider officially exposing "default namespace" for VB project
     /// (e.g.through a "defaultnamespace" msbuild property)
     /// </remarks>
@@ -464,8 +476,8 @@ internal sealed partial class ProjectSystemProject
     }
 
     /// <summary>
-    /// The max language version supported for this project, if applicable. Useful to help indicate what 
-    /// language version features should be suggested to a user, as well as if they can be upgraded. 
+    /// The max language version supported for this project, if applicable. Useful to help indicate what
+    /// language version features should be suggested to a user, as well as if they can be upgraded.
     /// </summary>
     internal string? MaxLangVersion
     {
@@ -857,7 +869,7 @@ internal sealed partial class ProjectSystemProject
                 // Don't get confused by _filePath and filePath.
                 // VisualStudioProject._filePath points to csproj/vbproj of the project
                 // and the parameter filePath points to dynamic file such as ASP.NET .g.cs files.
-                // 
+                //
                 // Also, provider is free-threaded. so fine to call Wait rather than JTF.
                 fileInfo = provider.Value.GetDynamicFileInfoAsync(
                     projectId: Id, projectFilePath: _filePath, filePath: dynamicFilePath, CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
@@ -948,7 +960,7 @@ internal sealed partial class ProjectSystemProject
         {
             if (!_dynamicFilePathMaps.TryGetValue(dynamicFilePath, out fileInfoPath))
             {
-                // given file doesn't belong to this project. 
+                // given file doesn't belong to this project.
                 // this happen since the event this is handling is shared between all projects
                 return;
             }
@@ -970,10 +982,18 @@ internal sealed partial class ProjectSystemProject
 
         var mappedPaths = GetMappedAnalyzerPaths(fullPath);
 
+        bool containsSdkCodeStyleAnalyzers;
+
         using var _ = CreateBatchScope();
 
         using (_gate.DisposableWait())
         {
+            // Track the unmapped analyzer paths
+            _unmappedProjectAnalyzerPaths.Add(fullPath);
+
+            // Determine if we started using SDK CodeStyle analyzers while access to _unmappedProjectAnalyzerPaths is gated.
+            containsSdkCodeStyleAnalyzers = _unmappedProjectAnalyzerPaths.Any(IsSdkCodeStyleAnalyzer);
+
             // check all mapped paths first, so that all analyzers are either added or not
             foreach (var mappedFullPath in mappedPaths)
             {
@@ -998,6 +1018,8 @@ internal sealed partial class ProjectSystemProject
                 }
             }
         }
+
+        HasSdkCodeStyleAnalyzers = containsSdkCodeStyleAnalyzers;
     }
 
     public void RemoveAnalyzerReference(string fullPath)
@@ -1007,10 +1029,18 @@ internal sealed partial class ProjectSystemProject
 
         var mappedPaths = GetMappedAnalyzerPaths(fullPath);
 
+        bool containsSdkCodeStyleAnalyzers;
+
         using var _ = CreateBatchScope();
 
         using (_gate.DisposableWait())
         {
+            // Track the unmapped analyzer paths
+            _unmappedProjectAnalyzerPaths.Remove(fullPath);
+
+            // Determine if we are still using SDK CodeStyle analyzers while access to _unmappedProjectAnalyzerPaths is gated.
+            containsSdkCodeStyleAnalyzers = _unmappedProjectAnalyzerPaths.Any(IsSdkCodeStyleAnalyzer);
+
             // check all mapped paths first, so that all analyzers are either removed or not
             foreach (var mappedFullPath in mappedPaths)
             {
@@ -1028,6 +1058,8 @@ internal sealed partial class ProjectSystemProject
                     _analyzersRemovedInBatch.Add(mappedFullPath);
             }
         }
+
+        HasSdkCodeStyleAnalyzers = containsSdkCodeStyleAnalyzers;
     }
 
     private OneOrMany<string> GetMappedAnalyzerPaths(string fullPath)
@@ -1060,6 +1092,14 @@ internal sealed partial class ProjectSystemProject
         LanguageNames.VisualBasic => DirectoryNameEndsWith(fullPath, s_visualBasicCodeStyleAnalyzerSdkDirectory),
         _ => false,
     };
+
+    private void UpdateHasSdkCodeStyleAnalyzers()
+    {
+        var containsSdkCodeStyleAnalyzers = _unmappedProjectAnalyzerPaths.Any(IsSdkCodeStyleAnalyzer);
+        if (containsSdkCodeStyleAnalyzers == HasSdkCodeStyleAnalyzers)
+            return;
+        HasSdkCodeStyleAnalyzers = containsSdkCodeStyleAnalyzers;
+    }
 
     internal const string RazorVsixExtensionId = "Microsoft.VisualStudio.RazorExtension";
     private static readonly string s_razorSourceGeneratorSdkDirectory = CreateDirectoryPathFragment("Sdks", "Microsoft.NET.Sdk.Razor", "source-generators");

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -128,7 +128,8 @@ internal sealed partial class ProjectSystemProjectFactory
                 compilationOutputInfo: new(creationInfo.CompilationOutputAssemblyFilePath),
                 SourceHashAlgorithms.Default, // will be updated when command line is set
                 filePath: creationInfo.FilePath,
-                telemetryId: creationInfo.TelemetryId),
+                telemetryId: creationInfo.TelemetryId,
+                hasSdkCodeStyleAnalyzers: project.HasSdkCodeStyleAnalyzers),
             compilationOptions: creationInfo.CompilationOptions,
             parseOptions: creationInfo.ParseOptions);
 
@@ -260,7 +261,7 @@ internal sealed partial class ProjectSystemProjectFactory
     /// <summary>
     /// Applies a solution transformation to the workspace and triggers workspace changed event for specified <paramref name="projectId"/>.
     /// The transformation shall only update the project of the solution with the specified <paramref name="projectId"/>.
-    /// 
+    ///
     /// The <paramref name="solutionTransformation"/> function must be safe to be attempted multiple times (and not update local state).
     /// </summary>
     public void ApplyChangeToWorkspace(ProjectId projectId, Func<CodeAnalysis.Solution, CodeAnalysis.Solution> solutionTransformation)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -104,6 +104,11 @@ public sealed class ProjectInfo
     internal bool RunAnalyzers => Attributes.RunAnalyzers;
 
     /// <summary>
+    /// True if the project contains references to the SDK CodeStyle analyzers.
+    /// </summary>
+    internal bool HasSdkCodeStyleAnalyzers => Attributes.HasSdkCodeStyleAnalyzers;
+
+    /// <summary>
     /// The initial compilation options for the project, or null if the default options should be used.
     /// </summary>
     public CompilationOptions? CompilationOptions { get; }
@@ -391,6 +396,11 @@ public sealed class ProjectInfo
         return With(attributes: Attributes.With(telemetryId: telemetryId));
     }
 
+    internal ProjectInfo WithHasSdkCodeStyleAnalyzers(bool hasSdkCodeStyleAnalyzers)
+    {
+        return With(attributes: Attributes.With(hasSdkCodeStyleAnalyzers: hasSdkCodeStyleAnalyzers));
+    }
+
     internal string GetDebuggerDisplay()
         => nameof(ProjectInfo) + " " + Name + (!string.IsNullOrWhiteSpace(FilePath) ? " " + FilePath : "");
 
@@ -413,7 +423,8 @@ public sealed class ProjectInfo
         Guid telemetryId = default,
         bool isSubmission = false,
         bool hasAllInformation = true,
-        bool runAnalyzers = true)
+        bool runAnalyzers = true,
+        bool hasSdkCodeStyleAnalyzers = false)
     {
         /// <summary>
         /// Matches names like: Microsoft.CodeAnalysis.Features (netcoreapp3.1)
@@ -497,6 +508,11 @@ public sealed class ProjectInfo
         /// </summary>
         public Guid TelemetryId { get; } = telemetryId;
 
+        /// <summary>
+        /// True if the project contains references to the SDK CodeStyle analyzers.
+        /// </summary>
+        public bool HasSdkCodeStyleAnalyzers { get; } = hasSdkCodeStyleAnalyzers;
+
         private SingleInitNullable<(string? name, string? flavor)> _lazyNameAndFlavor;
         private SingleInitNullable<Checksum> _lazyChecksum;
 
@@ -527,7 +543,8 @@ public sealed class ProjectInfo
             Optional<bool> isSubmission = default,
             Optional<bool> hasAllInformation = default,
             Optional<bool> runAnalyzers = default,
-            Optional<Guid> telemetryId = default)
+            Optional<Guid> telemetryId = default,
+            Optional<bool> hasSdkCodeStyleAnalyzers = default)
         {
             var newId = id ?? Id;
             var newVersion = version ?? Version;
@@ -543,6 +560,7 @@ public sealed class ProjectInfo
             var newHasAllInformation = hasAllInformation.HasValue ? hasAllInformation.Value : HasAllInformation;
             var newRunAnalyzers = runAnalyzers.HasValue ? runAnalyzers.Value : RunAnalyzers;
             var newTelemetryId = telemetryId.HasValue ? telemetryId.Value : TelemetryId;
+            var newHasSdkCodeStyleAnalyzers = hasSdkCodeStyleAnalyzers.HasValue ? hasSdkCodeStyleAnalyzers.Value : HasSdkCodeStyleAnalyzers;
 
             if (newId == Id &&
                 newVersion == Version &&
@@ -557,7 +575,8 @@ public sealed class ProjectInfo
                 newIsSubmission == IsSubmission &&
                 newHasAllInformation == HasAllInformation &&
                 newRunAnalyzers == RunAnalyzers &&
-                newTelemetryId == TelemetryId)
+                newTelemetryId == TelemetryId &&
+                newHasSdkCodeStyleAnalyzers == HasSdkCodeStyleAnalyzers)
             {
                 return this;
             }
@@ -577,7 +596,8 @@ public sealed class ProjectInfo
                 newTelemetryId,
                 newIsSubmission,
                 newHasAllInformation,
-                newRunAnalyzers);
+                newRunAnalyzers,
+                newHasSdkCodeStyleAnalyzers);
         }
 
         public void WriteTo(ObjectWriter writer)
@@ -600,6 +620,7 @@ public sealed class ProjectInfo
             writer.WriteBoolean(HasAllInformation);
             writer.WriteBoolean(RunAnalyzers);
             writer.WriteGuid(TelemetryId);
+            writer.WriteBoolean(HasSdkCodeStyleAnalyzers);
 
             // TODO: once CompilationOptions, ParseOptions, ProjectReference, MetadataReference, AnalyzerReference supports
             //       serialization, we should include those here as well.
@@ -623,6 +644,7 @@ public sealed class ProjectInfo
             var hasAllInformation = reader.ReadBoolean();
             var runAnalyzers = reader.ReadBoolean();
             var telemetryId = reader.ReadGuid();
+            var hasSdkCodeStyleAnalyzers = reader.ReadBoolean();
 
             return new ProjectAttributes(
                 projectId,
@@ -639,7 +661,8 @@ public sealed class ProjectInfo
                 telemetryId,
                 isSubmission: isSubmission,
                 hasAllInformation: hasAllInformation,
-                runAnalyzers: runAnalyzers);
+                runAnalyzers: runAnalyzers,
+                hasSdkCodeStyleAnalyzers: hasSdkCodeStyleAnalyzers);
         }
 
         public Checksum Checksum

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -597,9 +597,9 @@ internal partial class ProjectState
     {
         var docVersion = await _lazyLatestDocumentTopLevelChangeVersion.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
-        // This is unfortunate, however the impact of this is that *any* change to our project-state version will 
+        // This is unfortunate, however the impact of this is that *any* change to our project-state version will
         // cause us to think the semantic version of the project has changed.  Thus, any change to a project property
-        // that does *not* flow into the compiler still makes us think the semantic version has changed.  This is 
+        // that does *not* flow into the compiler still makes us think the semantic version has changed.  This is
         // likely to not be too much of an issue as these changes should be rare, and it's better to be conservative
         // and assume there was a change than to wrongly presume there was not.
         return docVersion.GetNewerVersion(this.Version);
@@ -675,6 +675,9 @@ internal partial class ProjectState
     [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
     public bool RunAnalyzers => this.ProjectInfo.RunAnalyzers;
 
+    [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+    internal bool HasSdkCodeStyleAnalyzers => this.ProjectInfo.HasSdkCodeStyleAnalyzers;
+
     private ProjectState With(
         ProjectInfo? projectInfo = null,
         TextDocumentStates<DocumentState>? documentStates = null,
@@ -735,6 +738,9 @@ internal partial class ProjectState
 
     public ProjectState WithRunAnalyzers(bool runAnalyzers)
         => (runAnalyzers == RunAnalyzers) ? this : WithNewerAttributes(Attributes.With(runAnalyzers: runAnalyzers, version: Version.GetNewerVersion()));
+
+    internal ProjectState WithHasSdkCodeStyleAnalyzers(bool hasSdkCodeStyleAnalyzers)
+    => (hasSdkCodeStyleAnalyzers == HasSdkCodeStyleAnalyzers) ? this : WithNewerAttributes(Attributes.With(hasSdkCodeStyleAnalyzers: hasSdkCodeStyleAnalyzers, version: Version.GetNewerVersion()));
 
     public ProjectState WithChecksumAlgorithm(SourceHashAlgorithm checksumAlgorithm)
     {
@@ -962,7 +968,7 @@ internal partial class ProjectState
 
         var newDocumentStates = DocumentStates.SetStates(newDocuments);
 
-        // When computing the latest dependent version, we just need to know how 
+        // When computing the latest dependent version, we just need to know how
         GetLatestDependentVersions(
             newDocumentStates,
             AdditionalDocumentStates,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -533,6 +533,17 @@ public partial class Solution
     }
 
     /// <summary>
+    /// Create a new solution instance with the project specified updated to have
+    /// the specified hasSdkCodeStyleAnalyzers.
+    /// </summary>
+    internal Solution WithHasSdkCodeStyleAnalyzers(ProjectId projectId, bool hasSdkCodeStyleAnalyzers)
+    {
+        CheckContainsProject(projectId);
+
+        return WithCompilationState(CompilationState.WithHasSdkCodeStyleAnalyzers(projectId, hasSdkCodeStyleAnalyzers));
+    }
+
+    /// <summary>
     /// Creates a new solution instance with the project documents in the order by the specified document ids.
     /// The specified document ids must be the same as what is already in the project; no adding or removing is allowed.
     /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -538,6 +538,16 @@ internal sealed partial class SolutionCompilationState
             forkTracker: true);
     }
 
+    /// <inheritdoc cref="SolutionState.WithHasSdkCodeStyleAnalyzers"/>
+    internal SolutionCompilationState WithHasSdkCodeStyleAnalyzers(
+        ProjectId projectId, bool hasSdkCodeStyleAnalyzers)
+    {
+        return ForkProject(
+            this.SolutionState.WithHasSdkCodeStyleAnalyzers(projectId, hasSdkCodeStyleAnalyzers),
+            translate: null,
+            forkTracker: true);
+    }
+
     /// <inheritdoc cref="SolutionState.WithProjectDocumentsOrder"/>
     public SolutionCompilationState WithProjectDocumentsOrder(
         ProjectId projectId, ImmutableList<DocumentId> documentIds)
@@ -574,7 +584,8 @@ internal sealed partial class SolutionCompilationState
             .WithProjectDefaultNamespace(projectId, attributes.DefaultNamespace)
             .WithHasAllInformation(projectId, attributes.HasAllInformation)
             .WithRunAnalyzers(projectId, attributes.RunAnalyzers)
-            .WithProjectChecksumAlgorithm(projectId, attributes.ChecksumAlgorithm);
+            .WithProjectChecksumAlgorithm(projectId, attributes.ChecksumAlgorithm)
+            .WithHasSdkCodeStyleAnalyzers(projectId, attributes.HasSdkCodeStyleAnalyzers);
     }
 
     public SolutionCompilationState WithProjectInfo(ProjectInfo info)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -702,6 +702,24 @@ internal sealed partial class SolutionState
     }
 
     /// <summary>
+    /// Create a new solution instance with the project specified updated to have
+    /// the specified hasSdkCodeStyleAnalyzers.
+    /// </summary>
+    internal StateChange WithHasSdkCodeStyleAnalyzers(ProjectId projectId, bool hasSdkCodeStyleAnalyzers)
+    {
+        var oldProject = GetRequiredProjectState(projectId);
+        var newProject = oldProject.WithHasSdkCodeStyleAnalyzers(hasSdkCodeStyleAnalyzers);
+
+        if (oldProject == newProject)
+        {
+            return new(this, oldProject, newProject);
+        }
+
+        // fork without any change on compilation.
+        return ForkProject(oldProject, newProject);
+    }
+
+    /// <summary>
     /// Create a new solution instance with the project specified updated to include
     /// the specified project references.
     /// </summary>


### PR DESCRIPTION
This PR adds a ProjectAttribute to track whether the Project uses the SDK CodeStyle analyzers. This attribute is populated by the ProjectSystemProject which has access to the unmapped set of AnalyzerReferences. This attribute is then used when creating the HostAnalyzerStateSets to determine whether the Features analyzers should be treated as Project analyzers or not. It is also used by the DiagnosticComputer when building the Host and Project CompilationWithAnalyzers to ensure they mirror the statesets.

Suggest to review a commit at a time.