### PR TITLE
Access services on Solution rather than workspace in Razor cohost (Roslyn OOP) scenarios

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -212,7 +212,7 @@ public abstract partial class CompletionService : ILanguageService
         if (provider is null)
             return CompletionDescription.Empty;
 
-        var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
+        var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
 
         // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
         (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
@@ -243,7 +243,7 @@ public abstract partial class CompletionService : ILanguageService
         var provider = GetProvider(item, document.Project);
         if (provider != null)
         {
-            var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
+            var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
 
             // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
             (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -151,7 +151,7 @@ public abstract partial class CompletionService
         static async Task<ImmutableArray<CompletionProvider>> GetAugmentingProvidersAsync(
             Document document, ImmutableArray<CompletionProvider> triggeredProviders, int caretPosition, CompletionTrigger trigger, CompletionOptions options, CancellationToken cancellationToken)
         {
-            var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
+            var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
             var additionalAugmentingProviders = ArrayBuilder<CompletionProvider>.GetInstance(triggeredProviders.Length);
             if (trigger.Kind == CompletionTriggerKind.Insertion)
             {
@@ -327,7 +327,7 @@ public abstract partial class CompletionService
         SharedSyntaxContextsWithSpeculativeModel? sharedContext,
         CancellationToken cancellationToken)
     {
-        var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
+        var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
 
         var context = new CompletionContext(provider, document, position, sharedContext, defaultSpan, triggerInfo, options, cancellationToken);
 


### PR DESCRIPTION
In Roslyn OOP, accessing Solution.Workspace is illegal. Since Razor cohosting code runs in Roslyn OOP, we need to avoid getting services or otherwise accessing Solution.Workspace.