### PR TITLE
Speculative changes to PrimaryConstructorBaseTypeSyntax

### DIFF
--- a/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -2251,6 +2251,34 @@ public partial class SimplifyTypeNamesTests : AbstractCSharpDiagnosticProviderBa
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75026")]
+    public async Task SimplifyUnmentionableTypeParameter3()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            public class C<T>;
+
+            public class D : C<[|D.E|]>
+            {
+                public class E;
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75026")]
+    public async Task SimplifyUnmentionableTypeParameter3_PrimaryCtor()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            public class C<T>;
+
+            public class D() : C<[|D.E|]>()
+            {
+                public class E;
+            }
+            """);
+    }
+
     [Fact]
     public async Task TestGlobalAlias()
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
@@ -72,10 +72,22 @@ internal class SpeculationAnalyzer : AbstractSpeculationAnalyzer<
     {
         Debug.Assert(expression != null);
 
-        var parentNodeToSpeculate = expression
-            .AncestorsAndSelf(ascendOutOfTrivia: false)
-            .Where(CanSpeculateOnNode)
-            .LastOrDefault();
+        SyntaxNode previousNode = null;
+        SyntaxNode parentNodeToSpeculate = null;
+        foreach (var node in expression.AncestorsAndSelf(ascendOutOfTrivia: false))
+        {
+            if (CanSpeculateOnNode(node))
+            {
+                // Only speculate on PrimaryConstructorBaseTypeSyntax if we are inside the argument list
+                if (node.Kind() is not SyntaxKind.PrimaryConstructorBaseType ||
+                    previousNode.Kind() is SyntaxKind.ArgumentList)
+                {
+                    parentNodeToSpeculate = node;
+                }
+            }
+
+            previousNode = node;
+        }
 
         return parentNodeToSpeculate ?? expression;
     }


### PR DESCRIPTION
As per the discussion in #75026 a `PrimaryConstructorBaseTypeSyntax` should only be used for speculation if we are making changes to it's `ArgumentList` and not the type definition part. This PR makes it so a `PrimaryConstructorBaseTypeSyntax` can be used as a `SemanticRootOfOriginalExpression` only if the original expression we are speculating on is inside the argument list.

Closes #75026