### PR TITLE
Add ETW events when ALCs are created or disposed

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis
         internal void DisposeAssemblyLoadContext(string directory) => WriteEvent(10, directory);
 
         [Event(11, Message = "ALC for directory '{0}' disposal failed with exception '{1}'", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.AnalyzerAssemblyLoader)]
-        internal void DisposeAssemblyLoadContextException(string directory, string errorMessage) => WriteEvent(10, directory, errorMessage);
+        internal void DisposeAssemblyLoadContextException(string directory, string errorMessage) => WriteEvent(11, directory, errorMessage);
 
         private static unsafe EventData GetEventDataForString(string value, char* ptr)
         {

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis
         [Event(10, Message = "ALC for directory '{0}' disposed", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.AnalyzerAssemblyLoader)]
         internal void DisposeAssemblyLoadContext(string directory) => WriteEvent(10, directory);
 
-        [Event(11, Message = "ALC for directory '{0}' disposal failed with exception '{1}'", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.AnalyzerAssemblyLoader)]
+        [Event(11, Message = "ALC for directory '{0}' disposal failed with exception '{1}'", Keywords = Keywords.Performance, Level = EventLevel.Error, Opcode = EventOpcode.Stop, Task = Tasks.AnalyzerAssemblyLoader)]
         internal void DisposeAssemblyLoadContextException(string directory, string errorMessage) => WriteEvent(11, directory, errorMessage);
 
         private static unsafe EventData GetEventDataForString(string value, char* ptr)

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -109,6 +109,9 @@ namespace Microsoft.CodeAnalysis
         [Event(10, Message = "ALC for directory '{0}' disposed", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.AnalyzerAssemblyLoader)]
         internal void DisposeAssemblyLoadContext(string directory) => WriteEvent(10, directory);
 
+        [Event(11, Message = "ALC for directory '{0}' disposal failed with exception '{1}'", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.AnalyzerAssemblyLoader)]
+        internal void DisposeAssemblyLoadContextException(string directory, string errorMessage) => WriteEvent(10, directory, errorMessage);
+
         private static unsafe EventData GetEventDataForString(string value, char* ptr)
         {
             fixed (char* ptr2 = value)

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis
             public const EventTask SingleGeneratorRunTime = (EventTask)2;
             public const EventTask BuildStateTable = (EventTask)3;
             public const EventTask Compilation = (EventTask)4;
+            public const EventTask AnalyzerAssemblyLoader = (EventTask)5;
         }
 
         private CodeAnalysisEventSource() { }
@@ -101,6 +102,12 @@ namespace Microsoft.CodeAnalysis
 
         [Event(8, Message = "Server compilation {0} completed", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.Compilation)]
         internal void StopServerCompilation(string name) => WriteEvent(8, name);
+
+        [Event(9, Message = "ALC for directory '{0}' created", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Task = Tasks.AnalyzerAssemblyLoader)]
+        internal void CreateAssemblyLoadContext(string directory) => WriteEvent(9, directory);
+
+        [Event(10, Message = "ALC for directory '{0}' disposed", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.AnalyzerAssemblyLoader)]
+        internal void DisposeAssemblyLoadContext(string directory) => WriteEvent(10, directory);
 
         private static unsafe EventData GetEventDataForString(string value, char* ptr)
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (!_loadContextByDirectory.TryGetValue(fullDirectoryPath, out loadContext))
                 {
+                    CodeAnalysisEventSource.Log.CreateAssemblyLoadContext(fullDirectoryPath);
                     loadContext = new DirectoryLoadContext(fullDirectoryPath, this);
                     _loadContextByDirectory[fullDirectoryPath] = loadContext;
                 }
@@ -110,6 +111,7 @@ namespace Microsoft.CodeAnalysis
             {
                 try
                 {
+                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContext(context.Directory);
                     context.Unload();
                 }
                 catch (Exception ex) when (FatalError.ReportAndCatch(ex, ErrorSeverity.Critical))

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -111,11 +111,12 @@ namespace Microsoft.CodeAnalysis
             {
                 try
                 {
-                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContext(context.Directory);
                     context.Unload();
+                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContext(context.Directory);
                 }
                 catch (Exception ex) when (FatalError.ReportAndCatch(ex, ErrorSeverity.Critical))
                 {
+                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContextException(context.Directory, ex.ToString());
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -40,6 +40,7 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\DefaultAnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\DefaultAnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\ShadowCopyAnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\ShadowCopyAnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\IAnalyzerAssemblyResolver.cs" Link="Diagnostics\CompilerShared\IAnalyzerAssemblyResolver.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\CodeAnalysisEventSource.cs" Link="Diagnostics\CompilerShared\CodeAnalysisEventSource.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\Text\SourceHashAlgorithms.cs" Link="Text\SourceHashAlgorithms.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\AssemblyUtilitiesCore.cs" Link="AssemblyUtilitiesCore.cs" />
   </ItemGroup>


### PR DESCRIPTION
Trying to get more data about increase in allocs from #75233.
@jaredpar @CyrusNajmabadi 

Appears to be working when compiling Microsoft.CodeAnalysis thru PerfView. I am assuming that merely compiling does not actually go thru the teardown process, so the lack of Stop events is not a surprise.
![image](https://github.com/user-attachments/assets/135a056e-4908-485f-b47f-4c0601f0b516)
