### PR TITLE
Disable retaining PR val builds

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -321,6 +321,7 @@ extends:
             publishDataURI: "https://raw.githubusercontent.com/dotnet/roslyn/main/eng/config/PublishData.json"
             queueSpeedometerValidation: true
             dropPath: '$(Pipeline.Workspace)\VSSetup'
+            retainInsertedBuild: false
         # Arcade is done so we can set BuildNumber back
         - powershell: Write-Host "##vso[build.updatebuildnumber]$(FancyBuildNumber)"
           displayName: Reset BuildNumber

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -14,6 +14,9 @@ parameters:
   - name: queueSpeedometerValidation
     type: string
     default: 'true'
+  - name: retainInsertedBuild
+    type: string
+    default: 'true'
 
   - name: buildUserName
     type: string
@@ -207,7 +210,8 @@ steps:
         -updateCoreXTLibraries "(default)" `
         -visualStudioBranchName "$(Template.VSBranchName)" `
         -writePullRequest "prid.txt" `
-        -queueSpeedometerValidation "${{ parameters.queueSpeedometerValidation }}"
+        -queueSpeedometerValidation "${{ parameters.queueSpeedometerValidation }}" `
+        -retaininsertedbuild "${{ parameters.retainInsertedBuild }}" 
     displayName: 'Run OneOffInsertion.ps1'
 
   - script: 'echo. && echo. && type "prid.txt" && echo. && echo.'


### PR DESCRIPTION
There is no need to retain PR val builds indefinitely. This change will have val builds retained for the default period specified by the pipeline.