### PR TITLE
Prefer Cancel() rather than Commit() when rename is async.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
@@ -33,8 +34,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
     internal partial class RenameCommandHandler(
         IThreadingContext threadingContext,
         InlineRenameService renameService,
+        IGlobalOptionService globalOptionService,
         IAsynchronousOperationListenerProvider asynchronousOperationListenerProvider)
-        : AbstractRenameCommandHandler(threadingContext, renameService, asynchronousOperationListenerProvider.GetListener(FeatureAttribute.Rename))
+        : AbstractRenameCommandHandler(threadingContext, renameService, globalOptionService, asynchronousOperationListenerProvider.GetListener(FeatureAttribute.Rename))
     {
         protected override bool AdornmentShouldReceiveKeyboardNavigation(ITextView textView)
             => GetAdornment(textView) switch

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -111,7 +111,7 @@ internal abstract partial class AbstractRenameCommandHandler(
 
     private void CommitOrCancel(EditorCommandArgs args, IUIThreadOperationContext operationContext)
     {
-        // When the command is invalid, in sync commit mode, we always prefer to 'Commit()' to keep our legacy behavior.
+        // When the command is invalid, in sync commit mode, we always prefer 'Commit()' to keep our legacy behavior.
         // If the commit is async, we always prefer 'Cancel()' to session.
         if (globalOptionService.ShouldCommitAsynchronously())
             renameService.ActiveSession?.Cancel();

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -93,7 +93,7 @@ internal abstract partial class AbstractRenameCommandHandler(
     }
 
     private void HandleTypingOutsideEditableSpan(EditorCommandArgs args, IUIThreadOperationContext operationContext)
-        => CommitOrCancel(args, operationContext);
+        => CommitIfSynchronousOrCancelIfAsynchronous(args, operationContext);
 
     private void CommitIfActive(EditorCommandArgs args, IUIThreadOperationContext operationContext, bool placeCaretAtTheEndOfIdentifier = true)
     {
@@ -110,10 +110,12 @@ internal abstract partial class AbstractRenameCommandHandler(
         }
     }
 
-    private void CommitOrCancel(EditorCommandArgs args, IUIThreadOperationContext operationContext, bool placeCaretAtTheEndOfIdentifier = true)
+    /// <summary>
+    /// Commit() will be called if rename commit is sync. Editor command would be executed after the rename operation complete and it is our legacy behavior.
+    /// Cancel() will be called if rename is async. It also matches the other editor's behavior (like VS LSP and VSCode).
+    /// </summary>
+    private void CommitIfSynchronousOrCancelIfAsynchronous(EditorCommandArgs args, IUIThreadOperationContext operationContext, bool placeCaretAtTheEndOfIdentifier = true)
     {
-        // When the command is invalid, in sync commit mode, we always prefer 'Commit()' to keep our legacy behavior.
-        // If the commit is async, we always prefer 'Cancel()' to session.
         if (globalOptionService.ShouldCommitAsynchronously())
             renameService.ActiveSession?.Cancel();
         else

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -100,9 +100,7 @@ internal abstract partial class AbstractRenameCommandHandler(
         if (renameService.ActiveSession != null)
         {
             var selection = args.TextView.Selection.VirtualSelectedSpans.First();
-
             Commit(operationContext);
-
             var translatedSelection = selection.TranslateTo(args.TextView.TextBuffer.CurrentSnapshot);
             args.TextView.Selection.Select(translatedSelection.Start, translatedSelection.End);
             args.TextView.Caret.MoveTo(translatedSelection.End);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -111,14 +111,12 @@ internal abstract partial class AbstractRenameCommandHandler(
 
     private void CommitOrCancel(EditorCommandArgs args, IUIThreadOperationContext operationContext)
     {
+        // When the command is invalid, in sync commit mode, we always prefer to 'Commit()' to keep our legacy behavior.
+        // If the commit is async, we always prefer 'Cancel()' to session.
         if (globalOptionService.ShouldCommitAsynchronously())
-        {
             renameService.ActiveSession?.Cancel();
-        }
         else
-        {
             CommitIfActive(args, operationContext);
-        }
     }
 
     private void Commit(IUIThreadOperationContext operationContext)

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -93,18 +93,7 @@ internal abstract partial class AbstractRenameCommandHandler(
     }
 
     private void HandleTypingOutsideEditableSpan(EditorCommandArgs args, IUIThreadOperationContext operationContext)
-    {
-        if (globalOptionService.ShouldCommitAsynchronously())
-        {
-            renameService.ActiveSession?.Cancel();
-        }
-        else
-        {
-            // It's in a read-only area that is open, so let's commit the rename 
-            // and then let the character go through
-            CommitIfActive(args, operationContext);
-        }
-    }
+        => CommitOrCancel(args, operationContext);
 
     private void CommitIfActive(EditorCommandArgs args, IUIThreadOperationContext operationContext)
     {
@@ -117,6 +106,18 @@ internal abstract partial class AbstractRenameCommandHandler(
             var translatedSelection = selection.TranslateTo(args.TextView.TextBuffer.CurrentSnapshot);
             args.TextView.Selection.Select(translatedSelection.Start, translatedSelection.End);
             args.TextView.Caret.MoveTo(translatedSelection.End);
+        }
+    }
+
+    private void CommitOrCancel(EditorCommandArgs args, IUIThreadOperationContext operationContext)
+    {
+        if (globalOptionService.ShouldCommitAsynchronously())
+        {
+            renameService.ActiveSession?.Cancel();
+        }
+        else
+        {
+            CommitIfActive(args, operationContext);
         }
     }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -93,7 +93,7 @@ internal abstract partial class AbstractRenameCommandHandler(
     }
 
     private void HandleTypingOutsideEditableSpan(EditorCommandArgs args, IUIThreadOperationContext operationContext)
-        => CommitIfSynchronousOrCancelIfAsynchronous(args, operationContext);
+        => CommitIfSynchronousOrCancelIfAsynchronous(args, operationContext, placeCaretAtTheEndOfIdentifier: true);
 
     private void CommitIfActive(EditorCommandArgs args, IUIThreadOperationContext operationContext, bool placeCaretAtTheEndOfIdentifier = true)
     {
@@ -114,7 +114,7 @@ internal abstract partial class AbstractRenameCommandHandler(
     /// Commit() will be called if rename commit is sync. Editor command would be executed after the rename operation complete and it is our legacy behavior.
     /// Cancel() will be called if rename is async. It also matches the other editor's behavior (like VS LSP and VSCode).
     /// </summary>
-    private void CommitIfSynchronousOrCancelIfAsynchronous(EditorCommandArgs args, IUIThreadOperationContext operationContext, bool placeCaretAtTheEndOfIdentifier = true)
+    private void CommitIfSynchronousOrCancelIfAsynchronous(EditorCommandArgs args, IUIThreadOperationContext operationContext, bool placeCaretAtTheEndOfIdentifier)
     {
         if (globalOptionService.ShouldCommitAsynchronously())
             renameService.ActiveSession?.Cancel();

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -57,6 +57,7 @@ internal abstract partial class AbstractRenameCommandHandler(
 
         if (renameService.ActiveSession.IsCommitInProgress)
         {
+            // When rename commit is in progress, swallow the command so it won't change the workspace
             return;
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_LineStartEndHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_LineStartEndHandler.cs
@@ -46,39 +46,42 @@ internal abstract partial class AbstractRenameCommandHandler :
         }
 
         var caretPoint = view.GetCaretPoint(subjectBuffer);
-        if (caretPoint.HasValue && renameService.ActiveSession.TryGetContainingEditableSpan(caretPoint.Value, out var span))
+        if (caretPoint.HasValue)
         {
-            var newPoint = lineStart ? span.Start : span.End;
-            if (newPoint == caretPoint.Value && (view.Selection.IsEmpty || extendSelection))
+            if (renameService.ActiveSession.TryGetContainingEditableSpan(caretPoint.Value, out var span))
             {
-                // We're already at a boundary, let the editor handle the command
-                return false;
-            }
+                var newPoint = lineStart ? span.Start : span.End;
+                if (newPoint == caretPoint.Value && (view.Selection.IsEmpty || extendSelection))
+                {
+                    // We're already at a boundary, let the editor handle the command
+                    return false;
+                }
 
-            // The PointTrackingMode should not matter because we are not tracking between
-            // versions, and the PositionAffinity is set towards the identifier.
-            var newPointInView = view.BufferGraph.MapUpToBuffer(
-                newPoint,
-                PointTrackingMode.Negative,
-                lineStart ? PositionAffinity.Successor : PositionAffinity.Predecessor,
-                view.TextBuffer);
+                // The PointTrackingMode should not matter because we are not tracking between
+                // versions, and the PositionAffinity is set towards the identifier.
+                var newPointInView = view.BufferGraph.MapUpToBuffer(
+                    newPoint,
+                    PointTrackingMode.Negative,
+                    lineStart ? PositionAffinity.Successor : PositionAffinity.Predecessor,
+                    view.TextBuffer);
 
-            if (!newPointInView.HasValue)
-            {
-                return false;
-            }
+                if (!newPointInView.HasValue)
+                {
+                    return false;
+                }
 
-            if (extendSelection)
-            {
-                view.Selection.Select(view.Selection.AnchorPoint, new VirtualSnapshotPoint(newPointInView.Value));
-            }
-            else
-            {
-                view.Selection.Clear();
-            }
+                if (extendSelection)
+                {
+                    view.Selection.Select(view.Selection.AnchorPoint, new VirtualSnapshotPoint(newPointInView.Value));
+                }
+                else
+                {
+                    view.Selection.Clear();
+                }
 
-            view.Caret.MoveTo(newPointInView.Value);
-            return true;
+                view.Caret.MoveTo(newPointInView.Value);
+                return true;
+            }
         }
 
         return false;

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using Microsoft.CodeAnalysis.InlineRename;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -29,7 +29,7 @@ internal abstract partial class AbstractRenameCommandHandler :
         if (IsRenameCommitInProgress())
             return true;
 
-        CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext);
+        CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext, placeCaretAtTheEndOfIdentifier: true);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -31,11 +31,7 @@ internal abstract partial class AbstractRenameCommandHandler :
         if (IsRenameCommitInProgress())
             return true;
 
-        if (globalOptionService.ShouldCommitAsynchronously())
-            renameService.ActiveSession?.Cancel();
-        else
-            CommitIfActive(args, context.OperationContext);
-
+        CommitOrCancel(args, context.OperationContext);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -29,7 +29,7 @@ internal abstract partial class AbstractRenameCommandHandler :
         if (IsRenameCommitInProgress())
             return true;
 
-        CommitOrCancel(args, context.OperationContext);
+        CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -16,6 +16,7 @@ internal abstract partial class AbstractRenameCommandHandler :
     public bool ExecuteCommand(MoveSelectedLinesUpCommandArgs args, CommandExecutionContext context)
     {
         if (IsRenameCommitInProgress())
+            // When rename commit is in progress, swallow the command so it won't change the workspace
             return true;
 
         CommitIfActive(args, context.OperationContext);
@@ -28,6 +29,7 @@ internal abstract partial class AbstractRenameCommandHandler :
     public bool ExecuteCommand(MoveSelectedLinesDownCommandArgs args, CommandExecutionContext context)
     {
         if (IsRenameCommitInProgress())
+            // When rename commit is in progress, swallow the command so it won't change the workspace
             return true;
 
         CommitIfActive(args, context.OperationContext);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
@@ -17,7 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            CommitOrCancel(args, operationContext);
+            CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
@@ -17,6 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
+            // Caret would be move to the new line when editor command is handled, so we don't need to move it.
             CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
@@ -18,7 +18,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
             // Caret would be moved to the new line when editor command is handled, so we don't need to move it.
-            CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
+            CommitIfSynchronousOrCancelIfAsynchronous(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
@@ -17,7 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            // Caret would be move to the new line when editor command is handled, so we don't need to move it.
+            // Caret would be moved to the new line when editor command is handled, so we don't need to move it.
             CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
@@ -17,7 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            Commit(operationContext);
+            CommitOrCancel(args, operationContext);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
@@ -17,7 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            CommitOrCancel(args, operationContext);
+            CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
@@ -17,6 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
+            // Caret would be move to the new line when editor command is handled, so we don't need to move it.
             CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
@@ -18,7 +18,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
             // Caret would be moved to the new line when editor command is handled, so we don't need to move it.
-            CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
+            CommitIfSynchronousOrCancelIfAsynchronous(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
@@ -17,7 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            // Caret would be move to the new line when editor command is handled, so we don't need to move it.
+            // Caret would be moved to the new line when editor command is handled, so we don't need to move it.
             CommitOrCancel(args, operationContext, placeCaretAtTheEndOfIdentifier: false);
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
@@ -17,7 +17,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
     {
         HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            Commit(operationContext);
+            CommitOrCancel(args, operationContext);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -44,7 +44,7 @@ internal abstract partial class AbstractRenameCommandHandler :
         if (IsRenameCommitInProgress())
             return true;
 
-        CommitOrCancel(args, context.OperationContext);
+        CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -51,11 +51,7 @@ internal abstract partial class AbstractRenameCommandHandler :
         if (IsRenameCommitInProgress())
             return true;
 
-        if (globalOptionService.ShouldCommitAsynchronously())
-            renameService.ActiveSession?.Cancel();
-        else
-            CommitIfActive(args, context.OperationContext);
-
+        CommitOrCancel(args, context.OperationContext);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -19,6 +19,7 @@ internal abstract partial class AbstractRenameCommandHandler :
     public bool ExecuteCommand(ReorderParametersCommandArgs args, CommandExecutionContext context)
     {
         if (IsRenameCommitInProgress())
+            // When rename commit is in progress, swallow the command so it won't change the workspace
             return true;
 
         CommitIfActive(args, context.OperationContext);
@@ -31,6 +32,7 @@ internal abstract partial class AbstractRenameCommandHandler :
     public bool ExecuteCommand(RemoveParametersCommandArgs args, CommandExecutionContext context)
     {
         if (IsRenameCommitInProgress())
+            // When rename commit is in progress, swallow the command so it won't change the workspace
             return true;
 
         CommitIfActive(args, context.OperationContext);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.InlineRename;
 using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
@@ -30,36 +32,30 @@ internal abstract partial class AbstractRenameCommandHandler :
         => CommandState.Unspecified;
 
     public bool ExecuteCommand(RemoveParametersCommandArgs args, CommandExecutionContext context)
-    {
-        if (IsRenameCommitInProgress())
-            // When rename commit is in progress, swallow the command so it won't change the workspace
-            return true;
-
-        CommitIfActive(args, context.OperationContext);
-        return false;
-    }
+        => HandleRefactoringCommands(args, context);
 
     public CommandState GetCommandState(ExtractInterfaceCommandArgs args)
         => CommandState.Unspecified;
 
     public bool ExecuteCommand(ExtractInterfaceCommandArgs args, CommandExecutionContext context)
-    {
-        if (IsRenameCommitInProgress())
-            return true;
-
-        CommitIfActive(args, context.OperationContext);
-        return false;
-    }
+        => HandleRefactoringCommands(args, context);
 
     public CommandState GetCommandState(EncapsulateFieldCommandArgs args)
         => CommandState.Unspecified;
 
     public bool ExecuteCommand(EncapsulateFieldCommandArgs args, CommandExecutionContext context)
+        => HandleRefactoringCommands(args, context);
+
+    private bool HandleRefactoringCommands(EditorCommandArgs args, CommandExecutionContext context)
     {
         if (IsRenameCommitInProgress())
             return true;
 
-        CommitIfActive(args, context.OperationContext);
+        if (globalOptionService.ShouldCommitAsynchronously())
+            renameService.ActiveSession?.Cancel();
+        else
+            CommitIfActive(args, context.OperationContext);
+
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -19,14 +19,7 @@ internal abstract partial class AbstractRenameCommandHandler :
         => CommandState.Unspecified;
 
     public bool ExecuteCommand(ReorderParametersCommandArgs args, CommandExecutionContext context)
-    {
-        if (IsRenameCommitInProgress())
-            // When rename commit is in progress, swallow the command so it won't change the workspace
-            return true;
-
-        CommitIfActive(args, context.OperationContext);
-        return false;
-    }
+        => HandleRefactoringCommands(args, context);
 
     public CommandState GetCommandState(RemoveParametersCommandArgs args)
         => CommandState.Unspecified;

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -44,7 +44,7 @@ internal abstract partial class AbstractRenameCommandHandler :
         if (IsRenameCommitInProgress())
             return true;
 
-        CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext);
+        CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext, placeCaretAtTheEndOfIdentifier: true);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
@@ -83,7 +83,8 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
             else
             {
                 // Otherwise, commit or cancel the existing session and start a new one.
-                CommitOrCancel(args, editorOperationContext);
+                // Set placeCaretAtTheEndOfIdentifier to false because a new rename session will be created based on caret's location.
+                CommitOrCancel(args, editorOperationContext, placeCaretAtTheEndOfIdentifier: false);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
@@ -84,7 +84,7 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
             {
                 // Otherwise, commit or cancel the existing session and start a new one.
                 // Set placeCaretAtTheEndOfIdentifier to false because a new rename session will be created based on caret's location.
-                CommitOrCancel(args, editorOperationContext, placeCaretAtTheEndOfIdentifier: false);
+                CommitIfSynchronousOrCancelIfAsynchronous(args, editorOperationContext, placeCaretAtTheEndOfIdentifier: false);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.BackgroundWorkIndicator;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.InlineRename;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -82,7 +83,10 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
             else
             {
                 // Otherwise, commit the existing session and start a new one.
-                Commit(editorOperationContext);
+                if (globalOptionService.ShouldCommitAsynchronously())
+                    renameService.ActiveSession?.Cancel();
+                else
+                    Commit(editorOperationContext);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
@@ -82,11 +82,8 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
             }
             else
             {
-                // Otherwise, commit the existing session and start a new one.
-                if (globalOptionService.ShouldCommitAsynchronously())
-                    renameService.ActiveSession?.Cancel();
-                else
-                    Commit(editorOperationContext);
+                // Otherwise, commit or cancel the existing session and start a new one.
+                CommitOrCancel(args, editorOperationContext);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.InlineRename;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
@@ -14,7 +15,7 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<S
 
     public bool ExecuteCommand(SaveCommandArgs args, CommandExecutionContext context)
     {
-        if (renameService.ActiveSession != null)
+        if (renameService.ActiveSession != null && !globalOptionService.ShouldCommitAsynchronously())
         {
             Commit(context.OperationContext);
             SetFocusToTextView(args.TextView);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
@@ -16,7 +16,7 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<S
     public bool ExecuteCommand(SaveCommandArgs args, CommandExecutionContext context)
     {
         // If commit is async, just let editor save the document.
-        // because we can't make sure async commit could finish after the save command.
+        // If call async commit here, it could finish after the save command so the workspace would still be dirty.
         if (renameService.ActiveSession != null && !globalOptionService.ShouldCommitAsynchronously())
         {
             Commit(context.OperationContext);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
@@ -15,6 +15,8 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<S
 
     public bool ExecuteCommand(SaveCommandArgs args, CommandExecutionContext context)
     {
+        // If commit is async, just let editor save the document.
+        // because we can't make sure async commit could finish after the save command.
         if (renameService.ActiveSession != null && !globalOptionService.ShouldCommitAsynchronously())
         {
             Commit(context.OperationContext);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SelectAllHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SelectAllHandler.cs
@@ -27,16 +27,13 @@ internal abstract partial class AbstractRenameCommandHandler :
         }
 
         var caretPoint = view.GetCaretPoint(subjectBuffer);
-        if (caretPoint.HasValue)
+        if (caretPoint.HasValue && renameService.ActiveSession.TryGetContainingEditableSpan(caretPoint.Value, out var span))
         {
-            if (renameService.ActiveSession.TryGetContainingEditableSpan(caretPoint.Value, out var span))
+            if (view.Selection.Start.Position != span.Start.Position ||
+                view.Selection.End.Position != span.End.Position)
             {
-                if (view.Selection.Start.Position != span.Start.Position ||
-                    view.Selection.End.Position != span.End.Position)
-                {
-                    view.SetSelection(span);
-                    return true;
-                }
+                view.SetSelection(span);
+                return true;
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
@@ -73,7 +73,7 @@ internal abstract partial class AbstractRenameCommandHandler :
             }
             else
             {
-                CommitOrCancel(args, context.OperationContext);
+                CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.InlineRename;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
@@ -23,13 +24,14 @@ internal abstract partial class AbstractRenameCommandHandler :
         => GetCommandState();
 
     public bool ExecuteCommand(WordDeleteToStartCommandArgs args, CommandExecutionContext context)
-        => HandleWordDeleteCommand(args.SubjectBuffer, context, args.TextView, deleteToStart: true);
+        => HandleWordDeleteCommand(args, context, args.TextView, deleteToStart: true);
 
     public bool ExecuteCommand(WordDeleteToEndCommandArgs args, CommandExecutionContext context)
-        => HandleWordDeleteCommand(args.SubjectBuffer, context, args.TextView, deleteToStart: false);
+        => HandleWordDeleteCommand(args, context, args.TextView, deleteToStart: false);
 
-    private bool HandleWordDeleteCommand(ITextBuffer subjectBuffer, CommandExecutionContext context, ITextView view, bool deleteToStart)
+    private bool HandleWordDeleteCommand(EditorCommandArgs args, CommandExecutionContext context, ITextView view, bool deleteToStart)
     {
+        var subjectBuffer = args.SubjectBuffer;
         if (renameService.ActiveSession == null)
         {
             return false;
@@ -72,10 +74,7 @@ internal abstract partial class AbstractRenameCommandHandler :
             }
             else
             {
-                if (globalOptionService.ShouldCommitAsynchronously())
-                    renameService.ActiveSession?.Cancel();
-                else
-                    Commit(context.OperationContext);
+                CommitOrCancel(args, context.OperationContext);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
@@ -4,7 +4,6 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.InlineRename;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.InlineRename;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -22,12 +23,12 @@ internal abstract partial class AbstractRenameCommandHandler :
         => GetCommandState();
 
     public bool ExecuteCommand(WordDeleteToStartCommandArgs args, CommandExecutionContext context)
-        => HandleWordDeleteCommand(args.SubjectBuffer, args.TextView, deleteToStart: true);
+        => HandleWordDeleteCommand(args.SubjectBuffer, context, args.TextView, deleteToStart: true);
 
     public bool ExecuteCommand(WordDeleteToEndCommandArgs args, CommandExecutionContext context)
-        => HandleWordDeleteCommand(args.SubjectBuffer, args.TextView, deleteToStart: false);
+        => HandleWordDeleteCommand(args.SubjectBuffer, context, args.TextView, deleteToStart: false);
 
-    private bool HandleWordDeleteCommand(ITextBuffer subjectBuffer, ITextView view, bool deleteToStart)
+    private bool HandleWordDeleteCommand(ITextBuffer subjectBuffer, CommandExecutionContext context, ITextView view, bool deleteToStart)
     {
         if (renameService.ActiveSession == null)
         {
@@ -68,6 +69,13 @@ internal abstract partial class AbstractRenameCommandHandler :
                     : Span.FromBounds(start, span.End));
 
                 return true;
+            }
+            else
+            {
+                if (globalOptionService.ShouldCommitAsynchronously())
+                    renameService.ActiveSession?.Cancel();
+                else
+                    Commit(context.OperationContext);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_WordDeleteHandler.cs
@@ -73,7 +73,7 @@ internal abstract partial class AbstractRenameCommandHandler :
             }
             else
             {
-                CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext);
+                CommitIfSynchronousOrCancelIfAsynchronous(args, context.OperationContext, placeCaretAtTheEndOfIdentifier: true);
             }
         }
 


### PR DESCRIPTION
Following part of https://github.com/dotnet/roslyn/pull/75335

There are many command handlers handling Rename Session.
If the command is considered as invalid, like:
1. Modify the workspace (making change outside the active renaming spans).
2. Trigger code refactoring.
3. Trigger rename again.

In all these cases, cancel the active rename session if `globalOptionService.ShouldCommitAsynchronously()` is true.