### PR TITLE
Change nodes to reduce compute logic

### DIFF
--- a/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
@@ -40,6 +40,37 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74839")]
+    public async Task InsertNestedForSnippetInMethodTest()
+    {
+        await VerifySnippetAsync("""
+            class Program
+            {
+                public void Method()
+                {
+                    for (int i = 0; i < 5; i++)
+                    {
+                        $$
+                    }
+                }
+            }
+            """, """
+            class Program
+            {
+                public void Method()
+                {
+                    for (int i = 0; i < 5; i++)
+                    {
+                        for (int {|0:j|} = 0; {|0:j|} < {|1:length|}; {|0:j|}++)
+                        {
+                            $$
+                        }
+                    }
+                }
+            }
+            """);
+    }
+
     [Fact]
     public async Task InsertForSnippetInMethodUsedIncrementorTest()
     {
@@ -135,7 +166,6 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
     [Fact]
     public async Task InsertForSnippetInLocalFunctionTest()
     {
-        // TODO: fix this test when bug with simplifier failing to find correct node is fixed
         await VerifySnippetAsync("""
             class Program
             {
@@ -154,7 +184,7 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
                 {
                     void LocalFunction()
                     {
-                        for (global::System.Int32 {|0:i|} = 0; {|0:i|} < {|1:length|}; {|0:i|}++)
+                        for (int {|0:i|} = 0; {|0:i|} < {|1:length|}; {|0:i|}++)
                         {
                             $$
                         }
@@ -167,7 +197,6 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
     [Fact]
     public async Task InsertForSnippetInAnonymousFunctionTest()
     {
-        // TODO: fix this test when bug with simplifier failing to find correct node is fixed
         await VerifySnippetAsync("""
             class Program
             {
@@ -186,7 +215,7 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
                 {
                     var action = delegate()
                     {
-                        for (global::System.Int32 {|0:i|} = 0; {|0:i|} < {|1:length|}; {|0:i|}++)
+                        for (int {|0:i|} = 0; {|0:i|} < {|1:length|}; {|0:i|}++)
                         {
                             $$
                         }
@@ -199,7 +228,6 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
     [Fact]
     public async Task InsertForSnippetInParenthesizedLambdaExpressionTest()
     {
-        // TODO: fix this test when bug with simplifier failing to find correct node is fixed
         await VerifySnippetAsync("""
             class Program
             {
@@ -218,7 +246,7 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
                 {
                     var action = () =>
                     {
-                        for (global::System.Int32 {|0:i|} = 0; {|0:i|} < {|1:length|}; {|0:i|}++)
+                        for (int {|0:i|} = 0; {|0:i|} < {|1:length|}; {|0:i|}++)
                         {
                             $$
                         }

--- a/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
@@ -40,6 +40,37 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74839")]
+    public async Task InsertNestedReversedForSnippetInMethodTest()
+    {
+        await VerifySnippetAsync("""
+            class Program
+            {
+                public void Method()
+                {
+                    for (int i = 5; i >= 0; i--)
+                    {
+                        $$
+                    }
+                }
+            }
+            """, """
+            class Program
+            {
+                public void Method()
+                {
+                    for (int i = 5; i >= 0; i--)
+                    {
+                        for (int {|0:j|} = {|1:length|} - 1; {|0:j|} >= 0; {|0:j|}--)
+                        {
+                            $$
+                        }
+                    }
+                }
+            }
+            """);
+    }
+
     [Fact]
     public async Task InsertReversedForSnippetInMethodUsedIncrementorTest()
     {
@@ -135,7 +166,6 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
     [Fact]
     public async Task InsertReversedForSnippetInLocalFunctionTest()
     {
-        // TODO: fix this test when bug with simplifier failing to find correct node is fixed
         await VerifySnippetAsync("""
             class Program
             {
@@ -154,7 +184,7 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
                 {
                     void LocalFunction()
                     {
-                        for (global::System.Int32 {|0:i|} = {|1:(length)|} - (1); {|0:i|} >= 0; {|0:i|}--)
+                        for (int {|0:i|} = {|1:length|} - 1; {|0:i|} >= 0; {|0:i|}--)
                         {
                             $$
                         }
@@ -167,7 +197,6 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
     [Fact]
     public async Task InsertReversedForSnippetInAnonymousFunctionTest()
     {
-        // TODO: fix this test when bug with simplifier failing to find correct node is fixed
         await VerifySnippetAsync("""
             class Program
             {
@@ -186,7 +215,7 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
                 {
                     var action = delegate()
                     {
-                        for (global::System.Int32 {|0:i|} = {|1:(length)|} - (1); {|0:i|} >= 0; {|0:i|}--)
+                        for (int {|0:i|} = {|1:length|} - 1; {|0:i|} >= 0; {|0:i|}--)
                         {
                             $$
                         }
@@ -199,7 +228,6 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
     [Fact]
     public async Task InsertReversedForSnippetInParenthesizedLambdaExpressionTest()
     {
-        // TODO: fix this test when bug with simplifier failing to find correct node is fixed
         await VerifySnippetAsync("""
             class Program
             {
@@ -218,7 +246,7 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
                 {
                     var action = () =>
                     {
-                        for (global::System.Int32 {|0:i|} = {|1:(length)|} - (1); {|0:i|} >= 0; {|0:i|}--)
+                        for (int {|0:i|} = {|1:length|} - 1; {|0:i|} >= 0; {|0:i|}--)
                         {
                             $$
                         }


### PR DESCRIPTION
This PR fixes a bug in `CSharpSimplificationService.NodesAndTokensToReduceComputer`. Assuming the example:

```C#
for (int i = 0; i < 5; i++)
{
    for (global::System.Int32 j = 0; j = (length) - (1); j++) // This node has the simplifier annotation
    {
    }
}
```

Currently we pick the first node that can be speculated on for reducing (the outer for loop above), which does not make any simplifications at the actual annotated node.

The proposed change would make it so that we start by picking the first speculate-able node (as before) and then if we visit a different one further down in the tree switch to it if it would mean that we do not miss on any simplifier annotations. In other words the node needs to have an equal amount of simplifier annotations in it's subtree as the node we are currently considering as candidate for reducing.

There is a VisualBasic equivalent of this code that is (almost) exactly the same. Assuming this change is correct for the C# side I would like to add it also there, however there are no snippet tests (or snippets for that matter) for me to easily check if it works. Is it safe to assume that it's gonna work?

Closes #74839