### PR TITLE
Field-backed properties: recognize field in interpolated string

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         originalTextSpan[currentContentStart..interpolation.OpenBraceRange.Start]));
 
                     // Now parse the interpolation itself.
-                    var interpolationNode = ParseInterpolation(this.Options, originalText, interpolation, kind);
+                    var interpolationNode = ParseInterpolation(this.Options, originalText, interpolation, kind, IsInFieldKeywordContext);
 
                     // Make sure the interpolation starts at the right location.
                     var indentationError = getInterpolationIndentationError(indentationWhitespace, interpolation);
@@ -361,7 +361,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             CSharpParseOptions options,
             string text,
             Lexer.Interpolation interpolation,
-            Lexer.InterpolatedStringKind kind)
+            Lexer.InterpolatedStringKind kind,
+            bool isInFieldKeywordContext)
         {
             // Grab the text from after the { all the way to the start of the } (or the start of the : if present). This
             // will be used to parse out the expression of the interpolation.
@@ -377,6 +378,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // Now create a parser to actually handle the expression portion of the interpolation
             using var tempParser = new LanguageParser(tempLexer, oldTree: null, changes: null);
+            using var __ = new FieldKeywordContext(tempParser, isInFieldKeywordContext);
 
             var result = tempParser.ParseInterpolation(
                 text, interpolation, kind,

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // Now create a parser to actually handle the expression portion of the interpolation
             using var tempParser = new LanguageParser(tempLexer, oldTree: null, changes: null);
-            using var __ = new FieldKeywordContext(tempParser, isInFieldKeywordContext);
+            using var _ = new FieldKeywordContext(tempParser, isInFieldKeywordContext);
 
             var result = tempParser.ParseInterpolation(
                 text, interpolation, kind,

--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -10221,10 +10221,10 @@ class C<T>
             }
             else
             {
-                var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: """
+                var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("""
                     P1: True
                     2
-                    """);
+                    """));
                 verifier.VerifyIL("C.P1.get", """
                     {
                       // Code size       45 (0x2d)

--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -10225,6 +10225,7 @@ class C<T>
                     P1: True
                     2
                     """));
+                verifier.VerifyDiagnostics();
                 verifier.VerifyIL("C.P1.get", """
                     {
                       // Code size       45 (0x2d)
@@ -10308,6 +10309,7 @@ class C<T>
                     42
                     1
                     """));
+                verifier.VerifyDiagnostics();
                 verifier.VerifyIL("C.P1.get", """
                     {
                       // Code size       37 (0x25)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/FieldKeywordParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/FieldKeywordParsingTests.cs
@@ -1906,6 +1906,305 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             EOF();
         }
 
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedString_01(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$"""
+                class C
+                {
+                    object P => $"{field}";
+                }
+                """,
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.PropertyDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "P");
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.InterpolatedStringExpression);
+                            {
+                                N(SyntaxKind.InterpolatedStringStartToken);
+                                N(SyntaxKind.Interpolation);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    IdentifierNameOrFieldExpression(languageVersion, escapeIdentifier: false);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                                N(SyntaxKind.InterpolatedStringEndToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedString_02(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$"""
+                class C
+                {
+                    object P { get { return $"x{field}y"; } }
+                }
+                """,
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.PropertyDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "P");
+                        N(SyntaxKind.AccessorList);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.GetAccessorDeclaration);
+                            {
+                                N(SyntaxKind.GetKeyword);
+                                N(SyntaxKind.Block);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.ReturnStatement);
+                                    {
+                                        N(SyntaxKind.ReturnKeyword);
+                                        N(SyntaxKind.InterpolatedStringExpression);
+                                        {
+                                            N(SyntaxKind.InterpolatedStringStartToken);
+                                            N(SyntaxKind.InterpolatedStringText);
+                                            {
+                                                N(SyntaxKind.InterpolatedStringTextToken);
+                                            }
+                                            N(SyntaxKind.Interpolation);
+                                            {
+                                                N(SyntaxKind.OpenBraceToken);
+                                                IdentifierNameOrFieldExpression(languageVersion, escapeIdentifier: false);
+                                                N(SyntaxKind.CloseBraceToken);
+                                            }
+                                            N(SyntaxKind.InterpolatedStringText);
+                                            {
+                                                N(SyntaxKind.InterpolatedStringTextToken);
+                                            }
+                                            N(SyntaxKind.InterpolatedStringEndToken);
+                                        }
+                                        N(SyntaxKind.SemicolonToken);
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedString_03(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$$""""
+                class C
+                {
+                    object P => $"""{field}""";
+                }
+                """",
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.PropertyDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "P");
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.InterpolatedStringExpression);
+                            {
+                                N(SyntaxKind.InterpolatedSingleLineRawStringStartToken);
+                                N(SyntaxKind.Interpolation);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    IdentifierNameOrFieldExpression(languageVersion, escapeIdentifier: false);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                                N(SyntaxKind.InterpolatedRawStringEndToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedString_04(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$$""""
+                class C
+                {
+                    object P => $"""
+                        {field}
+                        """;
+                }
+                """",
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.PropertyDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "P");
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.InterpolatedStringExpression);
+                            {
+                                N(SyntaxKind.InterpolatedMultiLineRawStringStartToken);
+                                N(SyntaxKind.InterpolatedStringText);
+                                {
+                                    N(SyntaxKind.InterpolatedStringTextToken);
+                                }
+                                N(SyntaxKind.Interpolation);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    IdentifierNameOrFieldExpression(languageVersion, escapeIdentifier: false);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                                N(SyntaxKind.InterpolatedRawStringEndToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedString_05(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$"""
+                class C
+                {
+                    object this[int i] => $"{field}";
+                }
+                """,
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.IndexerDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.ThisKeyword);
+                        N(SyntaxKind.BracketedParameterList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.IdentifierToken, "i");
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.InterpolatedStringExpression);
+                            {
+                                N(SyntaxKind.InterpolatedStringStartToken);
+                                N(SyntaxKind.Interpolation);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "field");
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                                N(SyntaxKind.InterpolatedStringEndToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
         [Fact]
         public void Incremental_ChangeBetweenMethodAndProperty()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/FieldKeywordParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/FieldKeywordParsingTests.cs
@@ -1959,6 +1959,188 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Theory]
         [CombinatorialData]
+        public void InterpolatedString_01_Alignment(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$"""
+                class C
+                {
+                    object P => $"{x,field}";
+                }
+                """,
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.PropertyDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "P");
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.InterpolatedStringExpression);
+                            {
+                                N(SyntaxKind.InterpolatedStringStartToken);
+                                N(SyntaxKind.Interpolation);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "x");
+                                    }
+                                    N(SyntaxKind.InterpolationAlignmentClause);
+                                    {
+                                        N(SyntaxKind.CommaToken);
+                                        IdentifierNameOrFieldExpression(languageVersion, escapeIdentifier: false);
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                                N(SyntaxKind.InterpolatedStringEndToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedString_01_Format(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$"""
+                class C
+                {
+                    object P => $"{x:field}";
+                }
+                """,
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.PropertyDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "P");
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.InterpolatedStringExpression);
+                            {
+                                N(SyntaxKind.InterpolatedStringStartToken);
+                                N(SyntaxKind.Interpolation);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "x");
+                                    }
+                                    N(SyntaxKind.InterpolationFormatClause);
+                                    {
+                                        N(SyntaxKind.ColonToken);
+                                        N(SyntaxKind.InterpolatedStringTextToken);
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                                N(SyntaxKind.InterpolatedStringEndToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedString_01_AlignmentAndFormat(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingTree($$"""
+                class C
+                {
+                    object P => $"{x,field:field}";
+                }
+                """,
+                TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.PropertyDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "P");
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.InterpolatedStringExpression);
+                            {
+                                N(SyntaxKind.InterpolatedStringStartToken);
+                                N(SyntaxKind.Interpolation);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "x");
+                                    }
+                                    N(SyntaxKind.InterpolationAlignmentClause);
+                                    {
+                                        N(SyntaxKind.CommaToken);
+                                        IdentifierNameOrFieldExpression(languageVersion, escapeIdentifier: false);
+                                    }
+                                    N(SyntaxKind.InterpolationFormatClause);
+                                    {
+                                        N(SyntaxKind.ColonToken);
+                                        N(SyntaxKind.InterpolatedStringTextToken);
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                                N(SyntaxKind.InterpolatedStringEndToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Theory]
+        [CombinatorialData]
         public void InterpolatedString_02(
             [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersion.Preview)] LanguageVersion languageVersion)
         {


### PR DESCRIPTION
Parse `field` as a keyword when used in an interpolated string in an accessor.
 
See https://github.com/dotnet/csharplang/issues/140#issuecomment-2425018091