### PR TITLE
Remove "untriaged" label on issue closure or milestone addition

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -273,5 +273,19 @@ configuration:
       then:
       - closeIssue
 
+    - description: Remove "untriaged" label from issues when closed or added to a milestone
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Issues
+      - or:
+        - isAction:
+            action: Closed
+        - isPartOfAnyMilestone
+      - hasLabel:
+          label: untriaged
+      then:
+      - removeLabel:
+          label: untriaged
+
 onFailure: 
 onSuccess:


### PR DESCRIPTION
#### Summary
This pull request updates the resourceManagement.yml file to enhance the issue management workflow by removing the "untriaged" label under specific conditions.

#### Changes

1. **Remove "untriaged" label on issue closure or milestone addition:**
   - When an issue is closed or added to any milestone, the "untriaged" label will be removed.

#### Purpose
These changes aim to streamline the issue triaging process by automatically removing the "untriaged" label when an issue is  closed or added to a milestone, ensuring that issues are properly categorized and managed.