### PR TITLE
Make generate-compiler-code fail if CompilersIOperationGenerator encounters a problem

### DIFF
--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -1177,8 +1177,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IOperation? WhenFalse { get; }
         /// <summary>
-        /// Is result a managed reference
+        /// <see langword="true" /> if the result is by-reference.
         /// </summary>
+        /// <remarks>
+        /// This occurs in C# for ternaries whose branches use <see langword="ref" />.
+        /// </remarks>
         bool IsRef { get; }
     }
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -1137,7 +1137,7 @@
     </Property>
     <Property Name="IsRef" Type="bool">
       <Comments>
-        <value><see langword="true"/> if the result is by-reference.</value>
+        <summary><see langword="true"/> if the result is by-reference.</summary>
         <remarks>This occurs in C# for ternaries whose branches use <see langword="ref"/>.</remarks>
       </Comments>
     </Property>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -35,9 +35,10 @@ namespace IOperationGenerator
             _typeMap.Add("IOperation", null);
         }
 
-        public static void Write(Tree tree, string location)
+        /// <summary>Returns true for success</summary>
+        public static bool Write(Tree tree, string location)
         {
-            new IOperationClassWriter(tree, location).WriteFiles();
+            return new IOperationClassWriter(tree, location).WriteFiles();
         }
 
         #region Writing helpers
@@ -90,12 +91,13 @@ namespace IOperationGenerator
         }
         #endregion
 
-        private void WriteFiles()
+        /// <summary>Returns true for success</summary>
+        private bool WriteFiles()
         {
             if (ModelHasErrors(_tree))
             {
                 Console.WriteLine("Encountered xml errors, not generating");
-                return;
+                return false;
             }
 
             foreach (var grouping in _tree.Types.OfType<AbstractNode>().GroupBy(n => n.Namespace))
@@ -170,6 +172,8 @@ namespace IOperationGenerator
 
                 WriteEndNamespace();
             }
+
+            return true;
 
             void writeHeader()
             {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Model.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Model.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Xml;
 using System.Xml.Serialization;
 
@@ -24,6 +25,7 @@ namespace IOperationGenerator
         public List<TreeType> Types;
     }
 
+    [DebuggerDisplay("{Name, nq}")]
     public class TreeType
     {
         [XmlAttribute]

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Program.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Program.cs
@@ -33,6 +33,4 @@ if (tree is null)
     return 1;
 }
 
-IOperationClassWriter.Write(tree, outFilePath);
-
-return 0;
+return IOperationClassWriter.Write(tree, outFilePath) ? 0 : 1;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/75603

Validated that the correctness legs fail in CI prior to fixing the xml comment in IOperationInterfaces.xml:
```
========================== Starting Command Output ===========================
...
Running CompilersIOperationGenerator.csproj "D:\a\_work\1\s\src\Compilers\Core\Portable\Operations\OperationInterfaces.xml" "D:\a\_work\1\s\artifacts\log\Release\Generated\Core\Operations"
D:\a\_work\1\s\.dotnet\dotnet.exe run --project D:\a\_work\1\s\src\Tools\Source\CompilerGeneratorTools\Source\IOperationGenerator\CompilersIOperationGenerator.csproj --framework net9.0 "D:\a\_work\1\s\src\Compilers\Core\Portable\Operations\OperationInterfaces.xml" "D:\a\_work\1\s\artifacts\log\Release\Generated\Core\Operations"
]9;4;3;\]9;4;0;\IConditionalOperation.IsRef does not have correctly formatted comments, please ensure that there is a <summary> block for the property.
Encountered xml errors, not generating
Command failed to execute with exit code 1: D:\a\_work\1\s\.dotnet\dotnet.exe run --project D:\a\_work\1\s\src\Tools\Source\CompilerGeneratorTools\Source\IOperationGenerator\CompilersIOperationGenerator.csproj --framework net9.0 "D:\a\_work\1\s\src\Compilers\Core\Portable\Operations\OperationInterfaces.xml" "D:\a\_work\1\s\artifacts\log\Release\Generated\Core\Operations"
##[error]PowerShell exited with code '1'.
Finishing: Generate Syntax Files

```