### PR TITLE
Use distinct EventSource names for compiler and workspace layer events

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.Common.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.Common.cs
@@ -7,11 +7,8 @@ using System.Diagnostics.Tracing;
 
 namespace Microsoft.CodeAnalysis
 {
-    [EventSource(Name = "Microsoft-CodeAnalysis-General")]
-    internal sealed class CodeAnalysisEventSource : EventSource
+    internal sealed partial class CodeAnalysisEventSource : EventSource
     {
-        public static readonly CodeAnalysisEventSource Log = new CodeAnalysisEventSource();
-
         public static class Keywords
         {
             public const EventKeywords Performance = (EventKeywords)1;

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.Compiler.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.Compiler.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.CodeAnalysis
+{
+    [EventSource(Name = "Microsoft-CodeAnalysis-General")]
+    internal sealed partial class CodeAnalysisEventSource
+    {
+        public static readonly CodeAnalysisEventSource Log = new CodeAnalysisEventSource();
+    }
+}

--- a/src/Workspaces/Core/Portable/Diagnostics/CodeAnalysisEventSource.Workspaces.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/CodeAnalysisEventSource.Workspaces.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.CodeAnalysis
+{
+    [EventSource(Name = "Microsoft-CodeAnalysis-Workspaces")]
+    internal sealed partial class CodeAnalysisEventSource
+    {
+        public static readonly CodeAnalysisEventSource Log = new CodeAnalysisEventSource();
+    }
+}

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -40,7 +40,7 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\DefaultAnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\DefaultAnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\ShadowCopyAnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\ShadowCopyAnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\IAnalyzerAssemblyResolver.cs" Link="Diagnostics\CompilerShared\IAnalyzerAssemblyResolver.cs" />
-    <Compile Include="..\..\..\Compilers\Core\Portable\CodeAnalysisEventSource.cs" Link="Diagnostics\CompilerShared\CodeAnalysisEventSource.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\CodeAnalysisEventSource.Common.cs" Link="Diagnostics\CompilerShared\CodeAnalysisEventSource.Common.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\Text\SourceHashAlgorithms.cs" Link="Text\SourceHashAlgorithms.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\AssemblyUtilitiesCore.cs" Link="AssemblyUtilitiesCore.cs" />
   </ItemGroup>


### PR DESCRIPTION
Related VS regression bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2289777

We think this issue may be causing CodeAnalysis events to fail to appear in IDE traces.

VS PR to enable new event source in RPS/Speedometer: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/587560

Alternatively, we could expose the CodeAnalysisEventSource as a public experimental API.