### PR TITLE
Ensure we only capture the BuildNumber when setting OriginalBuildNumber.

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -143,7 +143,7 @@ extends:
             ArtifactName: AssetManifests
 
         steps:
-        - powershell: Write-Host "##vso[task.setvariable variable=OriginalBuildNumber;isreadonly=true]$('$(Build.BuildNumber)')"
+        - powershell: Write-Host "##vso[task.setvariable variable=OriginalBuildNumber;isreadonly=true]$('$(Build.BuildNumber)'.Split(' - ')[0])"
           displayName: Setting OriginalBuildNumber variable
           condition: succeeded()
 

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -143,9 +143,14 @@ extends:
             ArtifactName: AssetManifests
 
         steps:
-        - powershell: Write-Host "##vso[task.setvariable variable=OriginalBuildNumber;isreadonly=true]$('$(Build.BuildNumber)'.Split(' - ')[0])"
+        - task: Powershell@2
           displayName: Setting OriginalBuildNumber variable
           condition: succeeded()
+          inputs:
+            targetType: inline
+            script: |
+              $originalBuildNumber = "$(Build.BuildNumber)".Split(' - ')[0]
+              Write-Host "##vso[task.setvariable variable=OriginalBuildNumber;isreadonly=true]$originalBuildNumber"
 
         - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName;isreadonly=true]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
           displayName: Setting SourceBranchName variable


### PR DESCRIPTION
The PR Val pipeline sets BuildNumber to provide additional details about the PR. This breaks upon rerun because the step which captures the OriginalBuildNumber isn't expecting the extra detail. This PR splits off the extra details when setting OriginalBuildNumber.

[Test PR Val Run ](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10445075&view=logs&j=1930c8f4-4651-5cf2-cfc2-17ae90d326d2&t=48e781f2-fde7-5788-5c4a-1c8141416ce9)