### PR TITLE
Fix issue in PatternMatcher code where it was using a caseInsensitive index

### DIFF
--- a/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
+++ b/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
@@ -191,6 +191,9 @@ public class PatternMatcherTests
     [InlineData("[|_|]my_[|b|]utton", "_B", PatternMatchKind.CamelCaseNonContiguousPrefix, CaseInsensitive)]
     [InlineData("Com[|bin|]e", "bin", PatternMatchKind.LowercaseSubstring, CaseSensitive)]
     [InlineData("Combine[|Bin|]ary", "bin", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
+
+    [InlineData("_ABC_[|Abc|]_", "Abc", PatternMatchKind.StartOfWordSubstring, CaseSensitive)]
+
     [WorkItem("https://github.com/dotnet/roslyn/issues/51029")]
     internal void TestNonFuzzyMatch(
         string candidate, string pattern, PatternMatchKind matchKind, bool isCaseSensitive)

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -192,21 +192,15 @@ internal abstract partial class PatternMatcher : IDisposable
                 // user that they expect the same letters to be uppercase in the result.  As 
                 // such, only return this if we can find this pattern exactly in the candidate.
 
-                var caseSensitiveIndex = _compareInfo.IndexOf(candidate, patternChunk.Text, CompareOptions.None);
+                var caseSensitiveIndex = _compareInfo.IndexOf(candidate, patternChunk.Text, startIndex: caseInsensitiveIndex, CompareOptions.None);
                 if (caseSensitiveIndex > 0)
                 {
-                    if (char.IsUpper(candidate[caseInsensitiveIndex]))
-                    {
-                        return new PatternMatch(
-                            PatternMatchKind.StartOfWordSubstring, punctuationStripped, isCaseSensitive: true,
-                            matchedSpan: GetMatchedSpan(caseInsensitiveIndex, patternChunk.Text.Length));
-                    }
-                    else
-                    {
-                        return new PatternMatch(
-                            PatternMatchKind.NonLowercaseSubstring, punctuationStripped, isCaseSensitive: true,
-                            matchedSpan: GetMatchedSpan(caseSensitiveIndex, patternChunk.Text.Length));
-                    }
+                    var resultType = char.IsUpper(candidate[caseSensitiveIndex]) ? PatternMatchKind.StartOfWordSubstring : PatternMatchKind.NonLowercaseSubstring;
+                    return new PatternMatch(
+                        resultType,
+                        punctuationStripped,
+                        isCaseSensitive: true,
+                        matchedSpan: GetMatchedSpan(caseSensitiveIndex, patternChunk.Text.Length));
                 }
             }
             else
@@ -261,7 +255,7 @@ internal abstract partial class PatternMatcher : IDisposable
         // user has only barely started writing a word.
         if (patternIsLowercase && caseInsensitiveIndex > 0 && patternChunk.Text.Length >= 3)
         {
-            var caseSensitiveIndex = _compareInfo.IndexOf(candidate, patternChunk.Text, CompareOptions.None);
+            var caseSensitiveIndex = _compareInfo.IndexOf(candidate, patternChunk.Text, startIndex: caseInsensitiveIndex, CompareOptions.None);
             if (caseSensitiveIndex > 0)
             {
                 return new PatternMatch(


### PR DESCRIPTION
Noticed this while looking at a pooling issue in related code. The issue here is that the code found a case sensitive index, but was still returning a value based on the case insensitive index in one of the code paths.

Also, made a slight perf optimization to start the case sensitive search at the already located case insensitive search index.