### PR TITLE
Change from ArrayBuilder => SharedPools for pooling inside AddBracePairsAsync

### DIFF
--- a/src/Features/Core/Portable/BracePairs/IBracePairsService.cs
+++ b/src/Features/Core/Portable/BracePairs/IBracePairsService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.BracePairs;
@@ -46,9 +47,11 @@ internal abstract class AbstractBracePairsService : IBracePairsService
         Document document, TextSpan span, ArrayBuilder<BracePairData> bracePairs, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        using var _ = ArrayBuilder<SyntaxNodeOrToken>.GetInstance(out var stack);
 
-        stack.Add(root);
+        using var pooledStack = SharedPools.Default<Stack<SyntaxNodeOrToken>>().GetPooledObject();
+        var stack = pooledStack.Object;
+
+        stack.Push(root);
 
         while (stack.TryPop(out var current))
         {


### PR DESCRIPTION
It's pretty common for this array to exceed the size threshold supported by ArrayBuilder (128). For the files I'm testing on, the size supported by SharedPools (512) works much better.

Noticed this due to allocations in the editor's scrolling speedometer test, where it was showing up as 1.5% of allocations during scrolling.

*** allocations that should be alleviated by this change from the scrolling speedometer test ***
![image](https://github.com/user-attachments/assets/40d7e8d6-2cce-4b46-81db-05d3e40ddc00)