### PR TITLE
Don't allocate while walking a NormalizedSnapshotSpanCollection during classification tagging

### DIFF
--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -420,8 +420,8 @@ internal partial class SyntacticClassificationTaggerProvider
 
             using var _ = Classifier.GetPooledList(out var classifiedSpans);
 
-            foreach (var span in spans)
-                AddClassifications(span);
+            for (var i = 0; i < spans.Count; i++)
+                AddClassifications(spans[i]);
 
             var typeMap = _taggerProvider._typeMap;
             foreach (var classifiedSpan in classifiedSpans)


### PR DESCRIPTION
Saw this in a scrolling speedometer profile, only 0.3%, but it's trivial to remove. They don't publicly expose a struct based enumerator, but they do expose an indexer, so it's easy enough to use that to walk over the collection.

*** allocations from speedometer scrolling profile that should be removed by this change ***
![image](https://github.com/user-attachments/assets/46c077b9-d181-4845-82ab-26a669ced18d)
