### PR TITLE
Adjust `ContainingSymbol` for substituted local function

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7132,9 +7132,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return GetOrCreateSlot(thisParameter);
             }
 
-            // The ContainingSymbol on a substituted local function is incorrect (returns the containing type instead of the containing method)
-            // so we can't find the proper `this` receiver to apply the member post-conditions to.
-            // Tracked by https://github.com/dotnet/roslyn/issues/75543
             return -1;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ConstructedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstructedMethodSymbol.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly ImmutableArray<TypeWithAnnotations> _typeArgumentsWithAnnotations;
 
         internal ConstructedMethodSymbol(MethodSymbol constructedFrom, ImmutableArray<TypeWithAnnotations> typeArgumentsWithAnnotations)
-            : base(containingSymbol: constructedFrom.ContainingType,
+            : base(containingSymbol: constructedFrom.ContainingSymbol,
                    map: new TypeMap(constructedFrom.ContainingType, ((MethodSymbol)constructedFrom.OriginalDefinition).TypeParameters, typeArgumentsWithAnnotations),
                    originalDefinition: (MethodSymbol)constructedFrom.OriginalDefinition,
                    constructedFrom: constructedFrom)

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     // C<X>.M<Y> is a ConstructedMethodSymbol.
     internal class SubstitutedMethodSymbol : WrappedMethodSymbol
     {
-        private readonly NamedTypeSymbol _containingType;
+        private readonly Symbol _containingSymbol;
         private readonly MethodSymbol _underlyingMethod;
         private readonly TypeMap _inputMap;
         private readonly MethodSymbol _constructedFrom;
@@ -43,11 +43,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(TypeSymbol.Equals(originalDefinition.ContainingType, containingSymbol.OriginalDefinition, TypeCompareKind.ConsiderEverything2));
         }
 
-        protected SubstitutedMethodSymbol(NamedTypeSymbol containingSymbol, TypeMap map, MethodSymbol originalDefinition, MethodSymbol constructedFrom)
+        protected SubstitutedMethodSymbol(Symbol containingSymbol, TypeMap map, MethodSymbol originalDefinition, MethodSymbol constructedFrom)
         {
             Debug.Assert((object)originalDefinition != null);
             Debug.Assert(originalDefinition.IsDefinition);
-            _containingType = containingSymbol;
+            _containingSymbol = containingSymbol;
             _underlyingMethod = originalDefinition;
             _inputMap = map;
             if ((object)constructedFrom != null)
@@ -190,9 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return MethodKind is MethodKind.LocalFunction
-                    ? OriginalDefinition.ContainingSymbol
-                    : _containingType;
+                return _containingSymbol;
             }
         }
 
@@ -200,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _containingType;
+                return _containingSymbol is NamedTypeSymbol nt ? nt : _containingSymbol.ContainingType;
             }
         }
 
@@ -368,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // it's possible that we will compare equal to the original definition under certain conditions 
             // (e.g, ignoring nullability) and want to retain the same hashcode. As such, consider only
             // the original definition for the hashcode when we know equality is possible
-            containingHashCode = _containingType.GetHashCode();
+            containingHashCode = _containingSymbol.GetHashCode();
             if (containingHashCode == this.OriginalDefinition.ContainingType.GetHashCode() &&
                 wasConstructedForAnnotations(this))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -190,7 +190,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _containingType;
+                return MethodKind is MethodKind.LocalFunction
+                    ? OriginalDefinition.ContainingSymbol
+                    : _containingType;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/75543