### PR TITLE
Don't show C# on-the-fly-doc for namespace symbols

### DIFF
--- a/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
@@ -156,7 +156,8 @@ internal class CSharpSemanticQuickInfoProvider : CommonSemanticQuickInfoProvider
         var (symbol, _, _) = await symbolService.GetSymbolProjectAndBoundSpanAsync(
             document, position, cancellationToken).ConfigureAwait(false);
 
-        if (symbol is null)
+        // Don't show on-the-fly-docs for namespace symbols.
+        if (symbol is null || symbol.IsNamespace())
         {
             return null;
         }


### PR DESCRIPTION
The selected namespace symbol's [DeclaringSyntaxReferences](https://sourceroslyn.io/#Microsoft.CodeAnalysis/Symbols/ISymbol.cs,191) also include every child namespace declaration of it (e.g. both `MS.CA` and `MS.CA.Features` for `MS.CA`), this make it very different from say a type symbol and usually means a whole lot of namespaces declaration are being included, each of the reference range only contain the name themselves. This is very different from other types of symbols in C# and the result isn't very useful