### PR TITLE
Reduce allocations in AbstractAsynchronousTaggerProvider.ComputeDifference

### DIFF
--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -118,6 +118,14 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
             tagSpans.Add(GetTranslatedTagSpan(tagSpan, textSnapshot));
     }
 
+    /// <inheritdoc cref="AddAllSpans(ITextSnapshot, HashSet{TagSpan{TTag}})"/>
+    /// <remarks>Spans will be added in sorted order</remarks>
+    public void AddAllSpans(ITextSnapshot textSnapshot, SegmentedList<(SnapshotSpan, TTag)> tagSpans)
+    {
+        foreach (var tagSpan in _tree)
+            tagSpans.Add((GetTranslatedSpan(tagSpan, textSnapshot, _spanTrackingMode), tagSpan.Tag));
+    }
+
     /// <summary>
     /// Removes from <paramref name="tagSpans"/> all the tags spans in <see langword="this"/> that intersect with any of
     /// the spans in <paramref name="snapshotSpansToRemove"/>.

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -629,8 +629,8 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             TagSpanIntervalTree<TTag> latestTree,
             TagSpanIntervalTree<TTag> previousTree)
         {
-            using var _1 = SegmentedListPool.GetPooledList<TagSpan<TTag>>(out var latestSpans);
-            using var _2 = SegmentedListPool.GetPooledList<TagSpan<TTag>>(out var previousSpans);
+            using var _1 = SegmentedListPool.GetPooledList<(SnapshotSpan, TTag)>(out var latestSpans);
+            using var _2 = SegmentedListPool.GetPooledList<(SnapshotSpan, TTag)>(out var previousSpans);
 
             using var _3 = ArrayBuilder<SnapshotSpan>.GetInstance(out var added);
             using var _4 = ArrayBuilder<SnapshotSpan>.GetInstance(out var removed);
@@ -646,8 +646,8 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
 
             while (latest != null && previous != null)
             {
-                var latestSpan = latest.Span;
-                var previousSpan = previous.Span;
+                var latestSpan = latest.Value.Span;
+                var previousSpan = previous.Value.Span;
 
                 if (latestSpan.Start < previousSpan.Start)
                 {
@@ -675,7 +675,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                     }
                     else
                     {
-                        if (!_dataSource.TagEquals(latest.Tag, previous.Tag))
+                        if (!_dataSource.TagEquals(latest.Value.Tag, previous.Value.Tag))
                             added.Add(latestSpan);
 
                         latest = NextOrNull(ref latestEnumerator);
@@ -686,19 +686,19 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
 
             while (latest != null)
             {
-                added.Add(latest.Span);
+                added.Add(latest.Value.Span);
                 latest = NextOrNull(ref latestEnumerator);
             }
 
             while (previous != null)
             {
-                removed.Add(previous.Span);
+                removed.Add(previous.Value.Span);
                 previous = NextOrNull(ref previousEnumerator);
             }
 
             return new DiffResult(new(added), new(removed));
 
-            static TagSpan<TTag>? NextOrNull(ref SegmentedList<TagSpan<TTag>>.Enumerator enumerator)
+            static (SnapshotSpan Span, TTag Tag)? NextOrNull(ref SegmentedList<(SnapshotSpan, TTag)>.Enumerator enumerator)
                 => enumerator.MoveNext() ? enumerator.Current : null;
         }
 


### PR DESCRIPTION
This method is showing up in a speedometer typing profile I'm looking at. This method computes the difference between two TagSpanIntervalTrees given an updated snapshot.

To do so, it currently creates a new heap allocated TagSpan for each item in both given interval trees. However, it need not do that, as that generated TagSpan isn't passed out of this method. Instead, TagSpanIntervalTree now has an AddAllSpans method that populates to a collection of value tuples, which ComputeDifference can now use.

This doesn't save a ton of allocations, but it's fairly simple and contained. The amount of allocations reduced by this change varies from 0.1% to 0.5% in a typing scenario I'm looking at depending on the profile.

*** allocations that are removed from the worse of the profiles of a typing scenarios in a speedometer test ***
![image](https://github.com/user-attachments/assets/4b1b42ab-9882-44e6-822b-dcbee5d79bdc)