### PR TITLE
Reduce allocations in TextDocumentStates.AddRange

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -138,9 +138,18 @@ internal sealed class TextDocumentStates<TState>
     }
 
     public TextDocumentStates<TState> AddRange(ImmutableArray<TState> states)
-        => new(_ids.AddRange(states.Select(state => state.Id)),
-               States.AddRange(states.Select(state => KeyValuePairUtil.Create(state.Id, state))),
-               filePathToDocumentIds: null);
+    {
+        using var pooledIds = SharedPools.Default<List<DocumentId>>().GetPooledObject();
+        var ids = pooledIds.Object;
+
+        foreach (var state in states)
+            ids.Add(state.Id);
+
+        return new(
+            _ids.AddRange(ids),
+            States.AddRange(states.Select(state => KeyValuePairUtil.Create(state.Id, state))),
+            filePathToDocumentIds: null);
+    }
 
     public TextDocumentStates<TState> RemoveRange(ImmutableArray<DocumentId> ids)
     {


### PR DESCRIPTION
This method was calling ImmutableList.AddRange giving it the result of a Select linq expression. The underlying ImmutableList code doesn't end up special casing that collection type, and thus creates a FallbackWrapper around the enumeration. The FallbackWrapper.Count method uses Enumerable.ToArray to cache a collection object, which ends up

1) doing the double resize allocation dance pass until done 
2) resizing that final array

This essentially means we've allocated around 3x the amount of memory needed to hold our documentids. Instead, if we use a pooled list, we can generally avoid the allocations completely (the ImmutableList code instead creates a ListOfTWrapper around our List which doesn't need to allocate)

This method is showing up as around 0.8% of allocations in the typing section of the csharp editing speedometer test.

*** allocations that should be removed by this change ***
![image](https://github.com/user-attachments/assets/996ef13c-5732-416e-b5e8-d54c2a5b2013)