### PR TITLE
Workaround for binding redirect generation issue

### DIFF
--- a/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
@@ -26,8 +26,11 @@
     <Content Include="..\App.config" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <Compile Include="..\InteractiveHostEntryPoint.cs" />
   </ItemGroup>
-  
-  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="PublishItemsOutputGroup" Returns="@(_VsixItem)">
+  <!--
+    BuildOnlySettings forces BuildingProject=true.
+    Workaround for https://github.com/dotnet/msbuild/issues/10901
+  -->  
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="BuildOnlySettings;PublishItemsOutputGroup" Returns="@(_VsixItem)">
     <!-- Workaround for https://github.com/dotnet/sdk/issues/42255 -->
     <PropertyGroup>
       <!-- IntermediateDepsFilePath is the location where the deps.json file is originally created -->


### PR DESCRIPTION
Fixes intermittent Roslyn.sln build failures: 

```
error MSB3030: Could not copy the file "... obj\InteractiveHost64\Debug\net472\win-x64\InteractiveHost64.exe.config" because it was not found.
```

Workaround for https://github.com/dotnet/msbuild/issues/10901