### PR TITLE
Ensure discards are initially soft selected in VSCode

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -427,7 +427,7 @@ internal partial class ItemManager
                     return null;
                 }
 
-                var isHardSelection = CompletionService.IsHardSelection(bestOrFirstMatchResult.CompletionItem, bestOrFirstMatchResult.ShouldBeConsideredMatchingFilterText, _hasSuggestedItemOptions, _filterText);
+                var isHardSelection = IsHardSelection(bestOrFirstMatchResult.CompletionItem, bestOrFirstMatchResult.ShouldBeConsideredMatchingFilterText);
                 var updateSelectionHint = isHardSelection ? UpdateSelectionHint.Selected : UpdateSelectionHint.SoftSelected;
 
                 return new(selectedItemIndex, updateSelectionHint, uniqueItem);
@@ -752,6 +752,69 @@ internal partial class ItemManager
 
             initialTriggerLocation = default;
             return false;
+        }
+
+        private bool IsHardSelection(RoslynCompletionItem item, bool matchedFilterText)
+        {
+            if (_hasSuggestedItemOptions)
+            {
+                return false;
+            }
+
+            // We don't have a builder and we have a best match.  Normally this will be hard
+            // selected, except for a few cases.  Specifically, if no filter text has been
+            // provided, and this is not a preselect match then we will soft select it.  This
+            // happens when the completion list comes up implicitly and there is something in
+            // the MRU list.  In this case we do want to select it, but not with a hard
+            // selection.  Otherwise you can end up with the following problem:
+            //
+            //  dim i as integer =<space>
+            //
+            // Completion will comes up after = with 'integer' selected (Because of MRU).  We do
+            // not want 'space' to commit this.
+
+            // If all that has been typed is punctuation, then don't hard select anything.
+            // It's possible the user is just typing language punctuation and selecting
+            // anything in the list will interfere.  We only allow this if the filter text
+            // exactly matches something in the list already. 
+            if (_filterText.Length > 0 && CompletionService.IsAllPunctuation(_filterText) && _filterText != item.DisplayText)
+            {
+                return false;
+            }
+
+            // If the user hasn't actually typed anything, then don't hard select any item.
+            // The only exception to this is if the completion provider has requested the
+            // item be preselected.
+            if (_filterText.Length == 0)
+            {
+                // Item didn't want to be hard selected with no filter text.
+                // So definitely soft select it.
+                if (item.Rules.SelectionBehavior != CompletionItemSelectionBehavior.HardSelection)
+                {
+                    return false;
+                }
+
+                // Item did not ask to be preselected.  So definitely soft select it.
+                if (item.Rules.MatchPriority == MatchPriority.Default)
+                {
+                    return false;
+                }
+            }
+
+            // The user typed something, or the item asked to be preselected.  In 
+            // either case, don't soft select this.
+            Debug.Assert(_filterText.Length > 0 || item.Rules.MatchPriority != MatchPriority.Default);
+
+            // If the user moved the caret left after they started typing, the 'best' match may not match at all
+            // against the full text span that this item would be replacing.
+            if (!matchedFilterText)
+            {
+                return false;
+            }
+
+            // There was either filter text, or this was a preselect match.  In either case, we
+            // can hard select this.
+            return true;
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -363,69 +363,6 @@ public abstract partial class CompletionService : ILanguageService
         }
     }
 
-    internal static bool IsHardSelection(CompletionItem item, bool matchedFilterText, bool hasSuggestionModeItem, string filterText)
-    {
-        if (hasSuggestionModeItem)
-        {
-            return false;
-        }
-
-        // We don't have a builder and we have a best match.  Normally this will be hard
-        // selected, except for a few cases.  Specifically, if no filter text has been
-        // provided, and this is not a preselect match then we will soft select it.  This
-        // happens when the completion list comes up implicitly and there is something in
-        // the MRU list.  In this case we do want to select it, but not with a hard
-        // selection.  Otherwise you can end up with the following problem:
-        //
-        //  dim i as integer =<space>
-        //
-        // Completion will comes up after = with 'integer' selected (Because of MRU).  We do
-        // not want 'space' to commit this.
-
-        // If all that has been typed is punctuation, then don't hard select anything.
-        // It's possible the user is just typing language punctuation and selecting
-        // anything in the list will interfere.  We only allow this if the filter text
-        // exactly matches something in the list already. 
-        if (filterText.Length > 0 && IsAllPunctuation(filterText) && filterText != item.DisplayText)
-        {
-            return false;
-        }
-
-        // If the user hasn't actually typed anything, then don't hard select any item.
-        // The only exception to this is if the completion provider has requested the
-        // item be preselected.
-        if (filterText.Length == 0)
-        {
-            // Item didn't want to be hard selected with no filter text.
-            // So definitely soft select it.
-            if (item.Rules.SelectionBehavior != CompletionItemSelectionBehavior.HardSelection)
-            {
-                return false;
-            }
-
-            // Item did not ask to be preselected.  So definitely soft select it.
-            if (item.Rules.MatchPriority == MatchPriority.Default)
-            {
-                return false;
-            }
-        }
-
-        // The user typed something, or the item asked to be preselected.  In 
-        // either case, don't soft select this.
-        Debug.Assert(filterText.Length > 0 || item.Rules.MatchPriority != MatchPriority.Default);
-
-        // If the user moved the caret left after they started typing, the 'best' match may not match at all
-        // against the full text span that this item would be replacing.
-        if (!matchedFilterText)
-        {
-            return false;
-        }
-
-        // There was either filter text, or this was a preselect match.  In either case, we
-        // can hard select this.
-        return true;
-    }
-
     internal static bool IsAllPunctuation(string filterText)
     {
         foreach (var ch in filterText)

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -363,6 +363,82 @@ public abstract partial class CompletionService : ILanguageService
         }
     }
 
+    internal static bool IsHardSelection(CompletionItem item, bool matchedFilterText, bool hasSuggestionModeItem, string filterText)
+    {
+        if (hasSuggestionModeItem)
+        {
+            return false;
+        }
+
+        // We don't have a builder and we have a best match.  Normally this will be hard
+        // selected, except for a few cases.  Specifically, if no filter text has been
+        // provided, and this is not a preselect match then we will soft select it.  This
+        // happens when the completion list comes up implicitly and there is something in
+        // the MRU list.  In this case we do want to select it, but not with a hard
+        // selection.  Otherwise you can end up with the following problem:
+        //
+        //  dim i as integer =<space>
+        //
+        // Completion will comes up after = with 'integer' selected (Because of MRU).  We do
+        // not want 'space' to commit this.
+
+        // If all that has been typed is punctuation, then don't hard select anything.
+        // It's possible the user is just typing language punctuation and selecting
+        // anything in the list will interfere.  We only allow this if the filter text
+        // exactly matches something in the list already. 
+        if (filterText.Length > 0 && IsAllPunctuation(filterText) && filterText != item.DisplayText)
+        {
+            return false;
+        }
+
+        // If the user hasn't actually typed anything, then don't hard select any item.
+        // The only exception to this is if the completion provider has requested the
+        // item be preselected.
+        if (filterText.Length == 0)
+        {
+            // Item didn't want to be hard selected with no filter text.
+            // So definitely soft select it.
+            if (item.Rules.SelectionBehavior != CompletionItemSelectionBehavior.HardSelection)
+            {
+                return false;
+            }
+
+            // Item did not ask to be preselected.  So definitely soft select it.
+            if (item.Rules.MatchPriority == MatchPriority.Default)
+            {
+                return false;
+            }
+        }
+
+        // The user typed something, or the item asked to be preselected.  In 
+        // either case, don't soft select this.
+        Debug.Assert(filterText.Length > 0 || item.Rules.MatchPriority != MatchPriority.Default);
+
+        // If the user moved the caret left after they started typing, the 'best' match may not match at all
+        // against the full text span that this item would be replacing.
+        if (!matchedFilterText)
+        {
+            return false;
+        }
+
+        // There was either filter text, or this was a preselect match.  In either case, we
+        // can hard select this.
+        return true;
+    }
+
+    internal static bool IsAllPunctuation(string filterText)
+    {
+        foreach (var ch in filterText)
+        {
+            if (!char.IsPunctuation(ch))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /// <summary>
     /// Don't call. Used for pre-populating MEF providers only.
     /// </summary>

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -38,10 +38,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             CompletionCapabilityHelper capabilityHelper,
             CompletionList list,
             bool isIncomplete,
+            bool isHardSelection,
             long resultId,
             CancellationToken cancellationToken)
         {
-            var isSuggestionMode = list.SuggestionModeItem is not null;
+            var isSuggestionMode = !isHardSelection;
             if (list.ItemsList.Count == 0)
             {
                 return new LSP.VSInternalCompletionList
@@ -92,7 +93,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
                 //
                 // If we have a suggestion mode item, we just need to keep the list in suggestion mode.
                 // We don't need to return the fake suggestion mode item.
-                SuggestionMode = list.SuggestionModeItem != null,
+                SuggestionMode = isSuggestionMode,
                 Data = capabilityHelper.SupportVSInternalCompletionListData ? resolveData : null,
             };
 

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -809,6 +809,58 @@ public class C
             Assert.Null(item.CommitCharacters);
     }
 
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/7623")]
+    public async Task TestSoftSelectionForDiscardAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"
+public class A
+{
+    public void M()
+    {
+        var _someDiscard = 1;
+        _{|caret:|}
+    }
+}";
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, DefaultClientCapabilities);
+        var caretLocation = testLspServer.GetLocations("caret").Single();
+        await testLspServer.OpenDocumentAsync(caretLocation.Uri);
+
+        testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp, true);
+
+        var completionParams = CreateCompletionParams(
+            caretLocation,
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
+            triggerCharacter: "_",
+            triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+        var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+        var results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None).ConfigureAwait(false);
+        var actualItem = results.Items.First(i => i.Label == "_someDiscard");
+
+        Assert.True(results.IsIncomplete);
+        Assert.Empty(results.ItemDefaults.CommitCharacters);
+        Assert.Equal("_someDiscard", actualItem.Label);
+        Assert.Null(actualItem.CommitCharacters);
+
+        await testLspServer.InsertTextAsync(caretLocation.Uri, (caretLocation.Range.End.Line, caretLocation.Range.End.Character, "s"));
+
+        completionParams = CreateCompletionParams(
+            GetLocationPlusOne(caretLocation),
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
+            triggerCharacter: "s",
+            triggerKind: LSP.CompletionTriggerKind.TriggerForIncompleteCompletions);
+
+        results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None).ConfigureAwait(false);
+        actualItem = results.Items.First(i => i.Label == "_someDiscard");
+
+        Assert.False(results.IsIncomplete);
+        Assert.NotEmpty(results.ItemDefaults.CommitCharacters);
+        Assert.Equal("_someDiscard", actualItem.Label);
+        Assert.Null(actualItem.CommitCharacters);
+    }
+
     private sealed class CSharpLspThrowExceptionOnChangeCompletionService : CompletionService
     {
         private CSharpLspThrowExceptionOnChangeCompletionService(SolutionServices services, IAsynchronousOperationListenerProvider listenerProvider) : base(services, listenerProvider)


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/7623

Unfortunately LSP doesn't give servers much control over filtering.  Servers do not generally get callbacks as filter text is typed - meaning we generally are not able to modify hard vs soft selection after the initial list is presented.

However, we can force VSCode to call us back in some scenarios using the `isIncomplete` flag on the completion list.  For this case, when we see only punctuation typed (`_`), we set the `isIncomplete` flag and unset the commit characters to mimic soft selection.

As the user continues typing (e.g. `_o`) we get called again and we can update to hard selection if they are completing a variable.  

However - this does not cover every case of switching between hard/soft selection.  It could be covered by always setting `isIncomplete` but that would be expensive as we're re-computing and reserializing the entire list.