### PR TITLE
Bind lambda in `yield return` despite errors

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3167,7 +3167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             diagnostics.Add(syntax, useSiteInfo);
 
-            if (!argument.HasAnyErrors)
+            if (!argument.HasAnyErrors || argument.Kind == BoundKind.UnboundLambda)
             {
                 if (returnRefKind != RefKind.None)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -239,13 +239,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? BadExpression(node).MakeCompilerGenerated()
                 : BindValue(node.Expression, diagnostics, BindValueKind.RValue);
 
-            if (argument.HasErrors || ((object)argument.Type != null && argument.Type.IsErrorType()))
+            if (!argument.HasErrors && ((object)argument.Type == null || !argument.Type.IsErrorType()))
             {
-                argument = BindToTypeForErrorRecovery(argument);
+                argument = GenerateConversionForAssignment(elementType, argument, diagnostics);
             }
             else
             {
-                argument = GenerateConversionForAssignment(elementType, argument, diagnostics);
+                argument = BindToTypeForErrorRecovery(argument);
             }
 
             // NOTE: it's possible that more than one of these conditions is satisfied and that
@@ -273,7 +273,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             CheckRequiredLangVersionForIteratorMethods(node, diagnostics);
-
             return new BoundYieldReturnStatement(node, argument);
         }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PrimaryConstructorTests.cs
@@ -9540,7 +9540,10 @@ class C1 (int p1)
             comp1.VerifyEmitDiagnostics(
                 // (4,38): error CS1041: Identifier expected; 'delegate' is a keyword
                 //     public System.Func<int> M21() => delegate => p1;
-                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "delegate").WithArguments("", "delegate").WithLocation(4, 38)
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "delegate").WithArguments("", "delegate").WithLocation(4, 38),
+                // (4,47): error CS1593: Delegate 'Func<int>' does not take 1 arguments
+                //     public System.Func<int> M21() => delegate => p1;
+                Diagnostic(ErrorCode.ERR_BadDelArgCount, "=>").WithArguments("System.Func<int>", "1").WithLocation(4, 47)
                 );
 
             var source = @"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/68027

The problem was that `BindYieldReturnStatement` gave up too easily on trying to convert the lambda. Without conversion, the lambda state didn't account for the target delegate type, which provides the parameter types for the lambda. So the lookup result for identifier `s` (which finds a candidate for type in local declaration `s await`) lacked a type.

In fixing this, I noticed that the binding diagnostics for the `yield return` and the `return` scenarios were different. 
The `ERR_BadSKknown` and `ERR_IllegalStatement` binding errors were now reported in the `yield return` scenario, but not in the `return` scenario. 
In `BindYieldReturn`, we use `GenerateConversionForAssignment` which collects the conversion diagnostics from `GenerateImplicitConversionError` unless `expression.HasAnyErrors && expression.Kind != BoundKind.UnboundLambda`.
In `BindReturn`, we use `CreateReturnConversion`, which skipped reporting from `GenerateImplicitConversionError` if `argument.HasAnyErrors`.
So I made an adjustment to the `return` binding logic to also report the diagnostics from converting/binding the lambda (`BoundKind.UnboundLambda`).