### PR TITLE
Detect struct cycles caused by erroneous field-like event declarations

### DIFF
--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowDiagnosticTests.cs
@@ -964,6 +964,11 @@ struct D<T>
 {
     static C<D<T>> x;
 }
+#pragma warning disable CS0067 // The event 'E<T>.x' is never used
+struct E<T>
+{
+    static event E<E<T>> x;
+}
 ";
             CreateCompilation(program)
                 .VerifyDiagnostics(
@@ -987,7 +992,13 @@ struct D<T>
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "x").WithArguments("D<T>.x").WithLocation(18, 20),
                 // (14,17): warning CS0169: The field 'C<T>.x' is never used
                 //     static D<T> x;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "x").WithArguments("C<T>.x").WithLocation(14, 17)
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "x").WithArguments("C<T>.x").WithLocation(14, 17),
+                // (23,26): error CS0523: Struct member 'E<T>.x' of type 'E<E<T>>' causes a cycle in the struct layout
+                //     static event E<E<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("E<T>.x", "E<E<T>>").WithLocation(23, 26),
+                // (23,26): error CS0066: 'E<T>.x': event must be of a delegate type
+                //     static event E<E<T>> x;
+                Diagnostic(ErrorCode.ERR_EventNotDelegate, "x").WithArguments("E<T>.x").WithLocation(23, 26)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -3773,7 +3773,7 @@ public struct YourStruct<T> where T : unmanaged
             Assert.False(compilation.GetMember<NamedTypeSymbol>("YourStruct").IsManagedTypeNoUseSiteDiagnostics);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/75620")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/75620")]
         public void UnmanagedExpandingTypeArgumentConstraintViolation_05()
         {
@@ -3794,6 +3794,9 @@ public struct YourStruct<T> where T : unmanaged
             var compilation = CreateCompilation(code, options: TestOptions.UnsafeReleaseDll);
 
             compilation.VerifyDiagnostics(
+                    // (6,52): error CS0523: Struct member 'MyStruct<T>.field' of type 'YourStruct<MyStruct<MyStruct<T>>>' causes a cycle in the struct layout
+                    //     public event YourStruct<MyStruct<MyStruct<T>>> field;
+                    Diagnostic(ErrorCode.ERR_StructLayoutCycle, "field").WithArguments("MyStruct<T>.field", "YourStruct<MyStruct<MyStruct<T>>>").WithLocation(6, 52),
                     // (6,52): error CS0066: 'MyStruct<T>.field': event must be of a delegate type
                     //     public event YourStruct<MyStruct<MyStruct<T>>> field;
                     Diagnostic(ErrorCode.ERR_EventNotDelegate, "field").WithArguments("MyStruct<T>.field").WithLocation(6, 52),
@@ -3806,7 +3809,7 @@ public struct YourStruct<T> where T : unmanaged
             Assert.False(compilation.GetMember<NamedTypeSymbol>("YourStruct").IsManagedTypeNoUseSiteDiagnostics);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/75620")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/75620")]
         public void UnmanagedExpandingTypeArgumentConstraintViolation_06()
         {
@@ -3826,15 +3829,16 @@ public struct YourStruct<T> where T : unmanaged
 ";
             var compilation = CreateCompilation(code, options: TestOptions.UnsafeReleaseDll);
             compilation.VerifyDiagnostics(
-                    // (4,52): error CS0066: 'MyStruct<T>.field': event must be of a delegate type
+                    // (7,52): error CS0523: Struct member 'MyStruct<T>.field' of type 'YourStruct<MyStruct<MyStruct<T>>>' causes a cycle in the struct layout
                     //     public event YourStruct<MyStruct<MyStruct<T>>> field;
-                    Diagnostic(ErrorCode.ERR_EventNotDelegate, "field").WithArguments("MyStruct<T>.field").WithLocation(4, 52),
-                    // (5,46): error CS0523: Struct member 'MyStruct<T>.field' of type 'YourStruct<MyStruct<MyStruct<T>>>' causes a cycle in the struct layout
-                    //     public YourStruct<MyStruct<MyStruct<T>>> field;
-                    Diagnostic(ErrorCode.ERR_StructLayoutCycle, "field").WithArguments("MyStruct<T>.field", "YourStruct<MyStruct<MyStruct<T>>>").WithLocation(5, 46),
-                    // (5,46): error CS8377: The type 'MyStruct<MyStruct<T>>' must be a non-nullable value type, along with all fields at any level of nesting, in order to use it as parameter 'T' in the generic type or method 'YourStruct<T>'
-                    //     public YourStruct<MyStruct<MyStruct<T>>> field;
-                    Diagnostic(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, "field").WithArguments("YourStruct<T>", "T", "MyStruct<MyStruct<T>>").WithLocation(5, 46));
+                    Diagnostic(ErrorCode.ERR_StructLayoutCycle, "field").WithArguments("MyStruct<T>.field", "YourStruct<MyStruct<MyStruct<T>>>").WithLocation(7, 52),
+                    // (7,52): error CS0066: 'MyStruct<T>.field': event must be of a delegate type
+                    //     public event YourStruct<MyStruct<MyStruct<T>>> field;
+                    Diagnostic(ErrorCode.ERR_EventNotDelegate, "field").WithArguments("MyStruct<T>.field").WithLocation(7, 52),
+                    // (7,52): error CS8377: The type 'MyStruct<MyStruct<T>>' must be a non-nullable value type, along with all fields at any level of nesting, in order to use it as parameter 'T' in the generic type or method 'YourStruct<T>'
+                    //     public event YourStruct<MyStruct<MyStruct<T>>> field;
+                    Diagnostic(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, "field").WithArguments("YourStruct<T>", "T", "MyStruct<MyStruct<T>>").WithLocation(7, 52)
+                    );
 
             Assert.True(compilation.GetMember<NamedTypeSymbol>("MyStruct").IsManagedTypeNoUseSiteDiagnostics);
             Assert.False(compilation.GetMember<NamedTypeSymbol>("YourStruct").IsManagedTypeNoUseSiteDiagnostics);


### PR DESCRIPTION
Fixes #75620.