### PR TITLE
Struct layout check – break an infinite generic expansion cycle that doesn’t include the target struct (a cycle at the end of the path)

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
@@ -65,30 +65,50 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert((object)on != null);
             Debug.Assert(on.IsDefinition);
 
-            var hs = PooledHashSet<Symbol>.GetInstance();
-            StructDependsClosure(depends, hs, on);
+            var hs = PooledHashSet<NamedTypeSymbol>.GetInstance();
+            var typesWithCycle = PooledHashSet<NamedTypeSymbol>.GetInstance();
+            StructDependsClosure(depends, hs, typesWithCycle, ConsList<NamedTypeSymbol>.Empty.Prepend(on));
 
-            var result = hs.Contains(on);
+            var result = typesWithCycle.Contains(on);
+            typesWithCycle.Free();
             hs.Free();
 
             return result;
         }
 
-        private static void StructDependsClosure(NamedTypeSymbol type, HashSet<Symbol> partialClosure, NamedTypeSymbol on)
+        private static void StructDependsClosure(NamedTypeSymbol type, HashSet<NamedTypeSymbol> partialClosure, HashSet<NamedTypeSymbol> typesWithCycle, ConsList<NamedTypeSymbol> on)
         {
             Debug.Assert((object)type != null);
 
-            if ((object)type.OriginalDefinition == on)
+            if (typesWithCycle.Contains(type.OriginalDefinition))
+            {
+                return;
+            }
+
+            if (on.ContainsReference(type.OriginalDefinition))
             {
                 // found a possibly expanding cycle, for example
                 //     struct X<T> { public T t; }
                 //     struct W<T> { X<W<W<T>>> x; }
                 // while not explicitly forbidden by the spec, it should be.
-                partialClosure.Add(on);
+                typesWithCycle.Add(type.OriginalDefinition);
                 return;
             }
 
             if (partialClosure.Add(type))
+            {
+                if (!type.IsDefinition)
+                {
+                    // First, visit type as a definition in order to detect the fact that it itself has a cycle.
+                    // This prevents us from going into an infinite generic expansion while visiting constructed form
+                    // of the type below.
+                    visitFields(type.OriginalDefinition, partialClosure, typesWithCycle, on.Prepend(type.OriginalDefinition));
+                }
+
+                visitFields(type, partialClosure, typesWithCycle, on);
+            }
+
+            static void visitFields(NamedTypeSymbol type, HashSet<NamedTypeSymbol> partialClosure, HashSet<NamedTypeSymbol> typesWithCycle, ConsList<NamedTypeSymbol> on)
             {
                 foreach (var member in type.GetMembersUnordered())
                 {
@@ -99,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         continue;
                     }
 
-                    StructDependsClosure((NamedTypeSymbol)fieldType, partialClosure, on);
+                    StructDependsClosure((NamedTypeSymbol)fieldType, partialClosure, typesWithCycle, on);
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/StructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/StructTests.cs
@@ -219,6 +219,196 @@ class GraphicsContext
                 Diagnostic(ErrorCode.ERR_StructLayoutCycle, "P").WithArguments("S<T>.P", "S<T[]>?").WithLocation(3, 13));
         }
 
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void InstanceMemberExplosion_01()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct A<T>
+{
+    A<A<T>> x;
+}
+
+struct B<T>
+{
+    A<B<T>> x;
+}
+
+struct C<T>
+{
+    D<T> x;
+}
+struct D<T>
+{
+    C<D<T>> x;
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (4,13): error CS0523: Struct member 'A<T>.x' of type 'A<A<T>>' causes a cycle in the struct layout
+                //     A<A<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("A<T>.x", "A<A<T>>").WithLocation(4, 13),
+                // (14,10): error CS0523: Struct member 'C<T>.x' of type 'D<T>' causes a cycle in the struct layout
+                //     D<T> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("C<T>.x", "D<T>").WithLocation(14, 10),
+                // (18,13): error CS0523: Struct member 'D<T>.x' of type 'C<D<T>>' causes a cycle in the struct layout
+                //     C<D<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("D<T>.x", "C<D<T>>").WithLocation(18, 13)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void InstanceMemberExplosion_02()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct A<T>
+{
+    A<A<T>> x;
+}
+
+struct B<T>
+{
+    A<C<B<T>>> x;
+}
+
+struct C<T>
+{
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (4,13): error CS0523: Struct member 'A<T>.x' of type 'A<A<T>>' causes a cycle in the struct layout
+                //     A<A<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("A<T>.x", "A<A<T>>").WithLocation(4, 13)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void InstanceMemberExplosion_03()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct E
+{}
+
+struct X<T>
+{
+    T _t;
+}
+
+struct Y
+{
+    X<Z> xz;
+}
+
+struct Z
+{
+    X<E> xe;
+    X<Y> xy;
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (12,10): error CS0523: Struct member 'Y.xz' of type 'X<Z>' causes a cycle in the struct layout
+                //     X<Z> xz;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "xz").WithArguments("Y.xz", "X<Z>").WithLocation(12, 10),
+                // (18,10): error CS0523: Struct member 'Z.xy' of type 'X<Y>' causes a cycle in the struct layout
+                //     X<Y> xy;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "xy").WithArguments("Z.xy", "X<Y>").WithLocation(18, 10)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void StaticMemberExplosion_01()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct A<T>
+{
+    static A<A<T>> x;
+}
+
+struct B<T>
+{
+    static A<B<T>> x;
+}
+
+struct C<T>
+{
+    static D<T> x;
+}
+struct D<T>
+{
+    static C<D<T>> x;
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (4,20): error CS0523: Struct member 'A<T>.x' of type 'A<A<T>>' causes a cycle in the struct layout
+                //     static A<A<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("A<T>.x", "A<A<T>>").WithLocation(4, 20),
+                // (14,17): error CS0523: Struct member 'C<T>.x' of type 'D<T>' causes a cycle in the struct layout
+                //     static D<T> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("C<T>.x", "D<T>").WithLocation(14, 17),
+                // (18,20): error CS0523: Struct member 'D<T>.x' of type 'C<D<T>>' causes a cycle in the struct layout
+                //     static C<D<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("D<T>.x", "C<D<T>>").WithLocation(18, 20)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void StaticMemberExplosion_02()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct A<T>
+{
+    static A<A<T>> x;
+}
+
+struct B<T>
+{
+    static A<C<B<T>>> x;
+}
+
+struct C<T>
+{
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (4,20): error CS0523: Struct member 'A<T>.x' of type 'A<A<T>>' causes a cycle in the struct layout
+                //     static A<A<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("A<T>.x", "A<A<T>>").WithLocation(4, 20)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/75701")]
+        public void StaticMemberExplosion_03()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct E
+{}
+
+struct X<T>
+{
+    static T _t;
+}
+
+struct Y
+{
+    static X<Z> xz;
+}
+
+struct Z
+{
+    static X<E> xe;
+    static X<Y> xy;
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // Errors are expected here, see https://github.com/dotnet/roslyn/issues/75701.
+                );
+        }
+
         [Fact, WorkItem(1017887, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1017887")]
         public void EmptyStructsFromMetadata()
         {

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/StructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/StructTests.cs
@@ -318,6 +318,126 @@ struct Z
 
         [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void InstanceMemberExplosion_04()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct A<T>
+{
+    A<A<T>> x;
+}
+
+struct C<T>
+{
+    C<C<T>> x;
+}
+
+struct B<T>
+{
+    A<B<T>> x;
+    C<B<T>> y;
+    B<T> z;
+}
+
+struct D
+{
+    B<int> x;
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (4,13): error CS0523: Struct member 'A<T>.x' of type 'A<A<T>>' causes a cycle in the struct layout
+                //     A<A<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("A<T>.x", "A<A<T>>").WithLocation(4, 13),
+                // (9,13): error CS0523: Struct member 'C<T>.x' of type 'C<C<T>>' causes a cycle in the struct layout
+                //     C<C<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("C<T>.x", "C<C<T>>").WithLocation(9, 13),
+                // (16,10): error CS0523: Struct member 'B<T>.z' of type 'B<T>' causes a cycle in the struct layout
+                //     B<T> z;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "z").WithArguments("B<T>.z", "B<T>").WithLocation(16, 10)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void InstanceMemberExplosion_05()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct A<T>
+{
+    A<A<T>> x;
+}
+
+struct C<T>
+{
+    C<C<T>> x;
+}
+
+struct B<T>
+{
+    B<T> z;
+    A<B<T>> x;
+    C<B<T>> y;
+}
+
+struct D
+{
+    B<int> x;
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (4,13): error CS0523: Struct member 'A<T>.x' of type 'A<A<T>>' causes a cycle in the struct layout
+                //     A<A<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("A<T>.x", "A<A<T>>").WithLocation(4, 13),
+                // (9,13): error CS0523: Struct member 'C<T>.x' of type 'C<C<T>>' causes a cycle in the struct layout
+                //     C<C<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("C<T>.x", "C<C<T>>").WithLocation(9, 13),
+                // (14,10): error CS0523: Struct member 'B<T>.z' of type 'B<T>' causes a cycle in the struct layout
+                //     B<T> z;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "z").WithArguments("B<T>.z", "B<T>").WithLocation(14, 10)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
+        public void InstanceMemberExplosion_06()
+        {
+            string program = @"#pragma warning disable CS0169 // The field is never used
+struct A<T>
+{
+    A<A<T>> x;
+}
+
+struct C<T>
+{
+    C<C<T>> x;
+}
+
+struct B<T>
+{
+    A<B<T>> x;
+    B<T> z;
+    C<B<T>> y;
+}
+
+struct D
+{
+    B<int> x;
+}
+";
+            CreateCompilation(program).VerifyDiagnostics(
+                // (4,13): error CS0523: Struct member 'A<T>.x' of type 'A<A<T>>' causes a cycle in the struct layout
+                //     A<A<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("A<T>.x", "A<A<T>>").WithLocation(4, 13),
+                // (9,13): error CS0523: Struct member 'C<T>.x' of type 'C<C<T>>' causes a cycle in the struct layout
+                //     C<C<T>> x;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "x").WithArguments("C<T>.x", "C<C<T>>").WithLocation(9, 13),
+                // (15,10): error CS0523: Struct member 'B<T>.z' of type 'B<T>' causes a cycle in the struct layout
+                //     B<T> z;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "z").WithArguments("B<T>.z", "B<T>").WithLocation(15, 10)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66844")]
         public void StaticMemberExplosion_01()
         {
             string program = @"#pragma warning disable CS0169 // The field is never used

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -2022,16 +2022,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ''' <summary> Set of processed structure types </summary>
             Public ReadOnly ProcessedTypes As HashSet(Of NamedTypeSymbol)
 
+            Public ReadOnly TypesWithCycle As HashSet(Of NamedTypeSymbol)
+
             ''' <summary> Queue element structure </summary>
             Public Structure QueueElement
                 Public ReadOnly Type As NamedTypeSymbol
-                Public ReadOnly Path As ConsList(Of FieldSymbol)
+                Public ReadOnly FieldPath As ConsList(Of FieldSymbol)
+                Public ReadOnly ContainingDefinitionsPath As ConsList(Of NamedTypeSymbol)
+                Public ReadOnly Report As Boolean
 
-                Public Sub New(type As NamedTypeSymbol, path As ConsList(Of FieldSymbol))
+                Public Sub New(type As NamedTypeSymbol, fieldPath As ConsList(Of FieldSymbol), containingDefinitionsPath As ConsList(Of NamedTypeSymbol), report As Boolean)
                     Debug.Assert(type IsNot Nothing)
-                    Debug.Assert(path IsNot Nothing)
+                    Debug.Assert(fieldPath IsNot Nothing)
+                    Debug.Assert(containingDefinitionsPath IsNot Nothing)
                     Me.Type = type
-                    Me.Path = path
+                    Me.FieldPath = fieldPath
+                    Me.ContainingDefinitionsPath = containingDefinitionsPath
+                    Me.Report = report
                 End Sub
             End Structure
 
@@ -2040,6 +2047,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Private Sub New()
                 ProcessedTypes = New HashSet(Of NamedTypeSymbol)()
+                TypesWithCycle = New HashSet(Of NamedTypeSymbol)()
                 Queue = New Queue(Of QueueElement)
             End Sub
 
@@ -2050,6 +2058,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Public Sub Free()
                 Me.Queue.Clear()
                 Me.ProcessedTypes.Clear()
+                Me.TypesWithCycle.Clear()
                 s_pool.Free(Me)
             End Sub
 
@@ -2091,7 +2100,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             '  Allocate data set
             Dim data = StructureCircularityDetectionDataSet.GetInstance()
-            data.Queue.Enqueue(New StructureCircularityDetectionDataSet.QueueElement(Me, ConsList(Of FieldSymbol).Empty))
+            data.Queue.Enqueue(New StructureCircularityDetectionDataSet.QueueElement(Me, ConsList(Of FieldSymbol).Empty, ConsList(Of NamedTypeSymbol).Empty.Prepend(Me), report:=True))
 
             Dim hasCycle = False
 
@@ -2101,6 +2110,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Dim current = data.Queue.Dequeue()
                     If Not data.ProcessedTypes.Add(current.Type) Then
                         ' In some cases the queue may contain two same types which are not processed yet
+                        Continue While
+                    End If
+
+                    If data.TypesWithCycle.Contains(current.Type.OriginalDefinition) Then
                         Continue While
                     End If
 
@@ -2121,13 +2134,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     Continue For
                                 End If
 
-                                If fieldType.OriginalDefinition.Equals(Me) Then
+                                If current.ContainingDefinitionsPath.ContainsReference(fieldType.OriginalDefinition) Then
                                     '  a cycle detected
 
-                                    If Not cycleReportedForCurrentType Then
+                                    data.TypesWithCycle.Add(fieldType.OriginalDefinition)
+
+                                    If current.Report AndAlso Not cycleReportedForCurrentType AndAlso fieldType.OriginalDefinition.Equals(Me) Then
 
                                         '  the cycle includes 'current.Path' and ends with 'field'; the order is reversed in the list
-                                        Dim cycleFields = New ConsList(Of FieldSymbol)(field, current.Path)
+                                        Dim cycleFields = New ConsList(Of FieldSymbol)(field, current.FieldPath)
 
                                         '  generate a message info
                                         Dim diagnosticInfos = ArrayBuilder(Of DiagnosticInfo).GetInstance()
@@ -2158,18 +2173,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                         hasCycle = True
                                     End If
 
-                                ElseIf Not data.ProcessedTypes.Contains(fieldType) Then
+                                ElseIf Not data.ProcessedTypes.Contains(fieldType) AndAlso Not data.TypesWithCycle.Contains(fieldType.OriginalDefinition) Then
                                     ' Add to the queue if we don't know yet if it was processed
-
-                                    If Not fieldType.IsDefinition Then
-                                        ' Types constructed from generic types are considered to be a separate types. We never report 
-                                        ' errors on such types. We also process only fields actually changed compared to original generic type.
-                                        data.Queue.Enqueue(New StructureCircularityDetectionDataSet.QueueElement(
-                                                fieldType, New ConsList(Of FieldSymbol)(field, current.Path)))
-
-                                        ' The original Generic type is added using regular rules (see next note).
-                                        fieldType = fieldType.OriginalDefinition
-                                    End If
 
                                     ' NOTE: we want to make sure we report the same error for the same types 
                                     '       consistently and don't depend on the call order; this solution uses
@@ -2180,14 +2185,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     '           (b) thus, this analysis only considers the cycles consisting of the 
                                     '               types which are 'bigger' than 'structBeingAnalyzed' because we will not 
                                     '               report the error regarding this cycle for this type anyway
-                                    Dim stepIntoType As Boolean = DetectTypeCircularity_ShouldStepIntoType(fieldType)
-                                    If stepIntoType Then
+                                    Dim stepIntoType As Boolean = DetectTypeCircularity_ShouldStepIntoType(fieldType.OriginalDefinition)
+
+                                    If stepIntoType OrElse Not fieldType.IsDefinition Then
                                         '  enqueue to be processed
+                                        ' First, visit type as a definition in order to detect the fact that it itself has a cycle.
+                                        ' This prevents us from going into an infinite generic expansion while visiting constructed form
+                                        ' of the type below.
                                         data.Queue.Enqueue(New StructureCircularityDetectionDataSet.QueueElement(
-                                                fieldType, New ConsList(Of FieldSymbol)(field, current.Path)))
+                                                fieldType.OriginalDefinition, New ConsList(Of FieldSymbol)(field, current.FieldPath),
+                                                current.ContainingDefinitionsPath.Prepend(fieldType.OriginalDefinition),
+                                                report:=stepIntoType))
                                     Else
                                         '  should not process 
                                         data.ProcessedTypes.Add(fieldType)
+                                    End If
+
+                                    If Not fieldType.IsDefinition Then
+                                        ' Types constructed from generic types are considered to be a separate types. We never report 
+                                        ' errors on such types. We also process only fields actually changed compared to original generic type.
+                                        data.Queue.Enqueue(New StructureCircularityDetectionDataSet.QueueElement(
+                                                fieldType, New ConsList(Of FieldSymbol)(field, current.FieldPath),
+                                                current.ContainingDefinitionsPath,
+                                                report:=True))
                                     End If
                                 End If
                             End If

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -1610,6 +1610,126 @@ BC30294: Structure 'A' cannot contain an instance of itself:
 
         <Fact>
         <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
+        Public Sub InstanceMemberExplosion_04()
+            Dim compilation = CompilationUtils.CreateCompilation("
+Structure A(Of T)
+    Dim x As A(Of A(Of T))
+End Structure
+
+Structure C(Of T)
+    Dim x As C(Of C(Of T))
+End Structure
+
+Structure B(Of T)
+    Dim x As A(Of B(Of T))
+    Dim y As C(Of C(Of T))
+    Dim z As B(Of T)
+End Structure
+    
+Structure D
+    Dim x As B(Of Integer)
+End Structure
+")
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<errors>
+BC30294: Structure 'A' cannot contain an instance of itself: 
+    'A(Of T)' contains 'A(Of A(Of T))' (variable 'x').
+    Dim x As A(Of A(Of T))
+        ~
+BC30294: Structure 'C' cannot contain an instance of itself: 
+    'C(Of T)' contains 'C(Of C(Of T))' (variable 'x').
+    Dim x As C(Of C(Of T))
+        ~
+BC30294: Structure 'B' cannot contain an instance of itself: 
+    'B(Of T)' contains 'B(Of T)' (variable 'z').
+    Dim z As B(Of T)
+        ~
+</errors>)
+        End Sub
+
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
+        Public Sub InstanceMemberExplosion_05()
+            Dim compilation = CompilationUtils.CreateCompilation("
+Structure A(Of T)
+    Dim x As A(Of A(Of T))
+End Structure
+
+Structure C(Of T)
+    Dim x As C(Of C(Of T))
+End Structure
+
+Structure B(Of T)
+    Dim z As B(Of T)
+    Dim x As A(Of B(Of T))
+    Dim y As C(Of C(Of T))
+End Structure
+    
+Structure D
+    Dim x As B(Of Integer)
+End Structure
+")
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<errors>
+BC30294: Structure 'A' cannot contain an instance of itself: 
+    'A(Of T)' contains 'A(Of A(Of T))' (variable 'x').
+    Dim x As A(Of A(Of T))
+        ~
+BC30294: Structure 'C' cannot contain an instance of itself: 
+    'C(Of T)' contains 'C(Of C(Of T))' (variable 'x').
+    Dim x As C(Of C(Of T))
+        ~
+BC30294: Structure 'B' cannot contain an instance of itself: 
+    'B(Of T)' contains 'B(Of T)' (variable 'z').
+    Dim z As B(Of T)
+        ~
+</errors>)
+        End Sub
+
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
+        Public Sub InstanceMemberExplosion_06()
+            Dim compilation = CompilationUtils.CreateCompilation("
+Structure A(Of T)
+    Dim x As A(Of A(Of T))
+End Structure
+
+Structure C(Of T)
+    Dim x As C(Of C(Of T))
+End Structure
+
+Structure B(Of T)
+    Dim x As A(Of B(Of T))
+    Dim z As B(Of T)
+    Dim y As C(Of C(Of T))
+End Structure
+    
+Structure D
+    Dim x As B(Of Integer)
+End Structure
+")
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<errors>
+BC30294: Structure 'A' cannot contain an instance of itself: 
+    'A(Of T)' contains 'A(Of A(Of T))' (variable 'x').
+    Dim x As A(Of A(Of T))
+        ~
+BC30294: Structure 'C' cannot contain an instance of itself: 
+    'C(Of T)' contains 'C(Of C(Of T))' (variable 'x').
+    Dim x As C(Of C(Of T))
+        ~
+BC30294: Structure 'B' cannot contain an instance of itself: 
+    'B(Of T)' contains 'B(Of T)' (variable 'z').
+    Dim z As B(Of T)
+        ~
+</errors>)
+        End Sub
+
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
         Public Sub StaticMemberExplosion_01()
             Dim compilation = CompilationUtils.CreateCompilation("
 Structure A(Of T)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -1539,6 +1539,119 @@ BC30294: Structure 'SI_1' cannot contain an instance of itself:
         End Sub
 
         <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
+        Public Sub InstanceMemberExplosion_01()
+            Dim compilation = CompilationUtils.CreateCompilation("
+Structure A(Of T)
+    Dim x As A(Of A(Of T))
+End Structure
+
+Structure B(Of T)
+    Dim x As A(Of B(Of T))
+End Structure
+
+Structure C(Of T)
+    Dim x As D(Of T)
+End Structure
+    
+Structure D(Of T)
+    Dim x As C(Of D(Of T))
+End Structure
+")
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<errors>
+BC30294: Structure 'A' cannot contain an instance of itself: 
+    'A(Of T)' contains 'A(Of A(Of T))' (variable 'x').
+    Dim x As A(Of A(Of T))
+        ~
+BC30294: Structure 'C' cannot contain an instance of itself: 
+    'C(Of T)' contains 'D(Of T)' (variable 'x').
+    'D(Of T)' contains 'C(Of D(Of T))' (variable 'x').
+    Dim x As D(Of T)
+        ~
+BC30294: Structure 'C' cannot contain an instance of itself: 
+    'C(Of T)' contains 'D(Of T)' (variable 'x').
+    'D(Of T)' contains 'C(Of D(Of T))' (variable 'x').
+    Dim x As D(Of T)
+        ~
+BC30294: Structure 'D' cannot contain an instance of itself: 
+    'D(Of T)' contains 'C(Of D(Of T))' (variable 'x').
+    'C(Of D(Of T))' contains 'D(Of D(Of T))' (variable 'x').
+    Dim x As C(Of D(Of T))
+        ~
+</errors>)
+        End Sub
+
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
+        Public Sub InstanceMemberExplosion_02()
+            Dim compilation = CompilationUtils.CreateCompilation("
+Structure A(Of T)
+    Dim x As A(Of A(Of T))
+End Structure
+
+Structure B(Of T)
+    Dim x As A(Of C(Of B(Of T)))
+End Structure
+
+Structure C(Of T)
+End Structure
+")
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<errors>
+BC30294: Structure 'A' cannot contain an instance of itself: 
+    'A(Of T)' contains 'A(Of A(Of T))' (variable 'x').
+    Dim x As A(Of A(Of T))
+        ~
+</errors>)
+        End Sub
+
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
+        Public Sub StaticMemberExplosion_01()
+            Dim compilation = CompilationUtils.CreateCompilation("
+Structure A(Of T)
+    Shared x As A(Of A(Of T))
+End Structure
+
+Structure B(Of T)
+    Shared x As A(Of B(Of T))
+End Structure
+
+Structure C(Of T)
+    Shared x As D(Of T)
+End Structure
+    
+Structure D(Of T)
+    Shared x As C(Of D(Of T))
+End Structure
+")
+
+            CompileAndVerify(compilation, verify:=Verification.Skipped).VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/66844")>
+        Public Sub StaticMemberExplosion_02()
+            Dim compilation = CompilationUtils.CreateCompilation("
+Structure A(Of T)
+    Shared x As A(Of A(Of T))
+End Structure
+
+Structure B(Of T)
+    Shared x As A(Of C(Of B(Of T)))
+End Structure
+
+Structure C(Of T)
+End Structure
+")
+
+            CompileAndVerify(compilation, verify:=Verification.Skipped).VerifyDiagnostics()
+        End Sub
+
+        <Fact>
         Public Sub SynthesizedConstructorLocation()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40(
                <compilation name="C">


### PR DESCRIPTION
Fixes #66844