### PR TITLE
Ensure more callers of analyzer config options use correct case comparer

### DIFF
--- a/src/Features/ExternalAccess/OmniSharp/Formatting/OmniSharpSyntaxFormattingOptionsWrapper.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Formatting/OmniSharpSyntaxFormattingOptionsWrapper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Formatting
             var configOptions = await document.GetHostAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             var optionsWithFallback = StructuredAnalyzerConfigOptions.Create(configOptions,
-                StructuredAnalyzerConfigOptions.Create(new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty
+                StructuredAnalyzerConfigOptions.Create(new DictionaryAnalyzerConfigOptions(DictionaryAnalyzerConfigOptions.EmptyDictionary
                     .Add(FormattingOptions2.TabSize.Definition.ConfigName, FormattingOptions2.TabSize.Definition.Serializer.Serialize(fallbackLineFormattingOptions.TabSize))
                     .Add(FormattingOptions2.IndentationSize.Definition.ConfigName, FormattingOptions2.IndentationSize.Definition.Serializer.Serialize(fallbackLineFormattingOptions.IndentationSize))
                     .Add(FormattingOptions2.UseTabs.Definition.ConfigName, FormattingOptions2.UseTabs.Definition.Serializer.Serialize(fallbackLineFormattingOptions.UseTabs))

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -206,7 +206,7 @@ internal partial class SerializerService(SolutionServices workspaceServices) : I
         Contract.ThrowIfFalse(count <= 2);
 
         var optionsByLanguage = ImmutableDictionary.CreateBuilder<string, StructuredAnalyzerConfigOptions>();
-        var options = ImmutableDictionary.CreateBuilder<string, string>();
+        var options = ImmutableDictionary.CreateBuilder<string, string>(AnalyzerConfigOptions.KeyComparer);
 
         for (var i = 0; i < count; i++)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/StructuredAnalyzerConfigOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/StructuredAnalyzerConfigOptions.cs
@@ -45,7 +45,7 @@ internal abstract class StructuredAnalyzerConfigOptions : AnalyzerConfigOptions,
             => _lazyNamingStylePreferences.Value is { IsEmpty: false } nonEmpty ? nonEmpty : _fallback?.GetNamingStylePreferences() ?? NamingStylePreferences.Empty;
     }
 
-    public static readonly StructuredAnalyzerConfigOptions Empty = Create(new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty));
+    public static readonly StructuredAnalyzerConfigOptions Empty = Create(DictionaryAnalyzerConfigOptions.Empty);
 
     public abstract NamingStylePreferences GetNamingStylePreferences();
 


### PR DESCRIPTION
trying to track down a nfw - 
```
System.ArgumentException: An element with the same key but a different value already exists. Key: 'tab_width'
```

```
["System.Collections.Immutable.ImmutableDictionary`2.HashBucket.Add(TKey,TValue,IEqualityComparer`1,IEqualityComparer`1,KeyCollisionBehavior,OperationResult&)",
"System.Collections.Immutable.ImmutableDictionary`2.Add(TKey,TValue,KeyCollisionBehavior,MutationInput)",
"System.Collections.Immutable.ImmutableDictionary`2.Builder.Add(TKey,TValue)",
"Microsoft.CodeAnalysis.Options.SolutionAnalyzerConfigOptionsUpdater.<>c__DisplayClass4_0.<GlobalOptionsChanged>g__UpdateOptions|1(Solution)",
"Microsoft.CodeAnalysis.Workspace.<>c.<SetCurrentSolutionAsync>b__27_3(Solution,ValueTuple`5)",
"Microsoft.CodeAnalysis.Workspace.<SetCurrentSolutionAsync>d__30`1.MoveNext()"]
```

looking at the blamed code, it is iterating the old snapshot options and adding them to a new dictionary.  it appears to be throwing as the old snapshot options have a duplicate key.  

Only way I could see hitting this issue is if the old snapshot options are created with the wrong comparer and have both `tab_width` and `Tab_Width` keys