### PR TITLE
Modify Capacity growth rate to be linear instead of doubling on resize.

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/List/SegmentedList.Generic.Tests.Capacity.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/List/SegmentedList.Generic.Tests.Capacity.cs
@@ -80,13 +80,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 Assert.Same(resizedSegments[i], oldSegments[i]);
 
             for (var i = oldSegmentCount - 1; i < resizedSegmentCount - 1; i++)
-                Assert.Equal(resizedSegments[i].Length, SegmentedArray<T>.TestAccessor.SegmentSize);
+                Assert.Equal(resizedSegments[i]!.Length, SegmentedArray<T>.TestAccessor.SegmentSize);
 
             for (var i = resizedSegmentCount; i < resizedSegments.Length; i++)
                 Assert.Null(resizedSegments[i]);
 
             Assert.NotSame(resizedSegments[resizedSegmentCount - 1], oldSegments[oldSegmentCount - 1]);
-            Assert.Equal(resizedSegments[resizedSegmentCount - 1].Length, oldSegments[oldSegmentCount - 1].Length);
+            Assert.Equal(resizedSegments[resizedSegmentCount - 1]!.Length, oldSegments[oldSegmentCount - 1]!.Length);
         }
 
         [Theory]
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             Assert.Equal(1, oldSegments.Length);
             Assert.Equal(1, resizedSegments.Length);
             Assert.Same(resizedSegments[0], oldSegments[0]);
-            Assert.Equal(segmented.Capacity, resizedSegments[0].Length);
+            Assert.Equal(segmented.Capacity, resizedSegments[0]!.Length);
         }
 
         [Theory]

--- a/src/Dependencies/Collections/SegmentedArray.cs
+++ b/src/Dependencies/Collections/SegmentedArray.cs
@@ -450,16 +450,16 @@ namespace Microsoft.CodeAnalysis.Collections
 
         private struct AlignedSegmentEnumerator<T>
         {
-            private readonly T[][] _firstSegments;
+            private readonly T[]?[] _firstSegments;
             private readonly int _firstOffset;
-            private readonly T[][] _secondSegments;
+            private readonly T[]?[] _secondSegments;
             private readonly int _secondOffset;
             private readonly int _length;
 
             private int _completed;
             private (Memory<T> first, Memory<T> second) _current;
 
-            public AlignedSegmentEnumerator(T[][] firstSegments, int firstOffset, T[][] secondSegments, int secondOffset, int length)
+            public AlignedSegmentEnumerator(T[]?[] firstSegments, int firstOffset, T[]?[] secondSegments, int secondOffset, int length)
             {
                 _firstSegments = firstSegments;
                 _firstOffset = firstOffset;
@@ -488,8 +488,8 @@ namespace Microsoft.CodeAnalysis.Collections
                     var offset = _firstOffset & SegmentedArrayHelper.GetOffsetMask<T>();
                     Debug.Assert(offset == (_secondOffset & SegmentedArrayHelper.GetOffsetMask<T>()), "Aligned views must start at the same segment offset");
 
-                    var firstSegment = _firstSegments[initialFirstSegment];
-                    var secondSegment = _secondSegments[initialSecondSegment];
+                    var firstSegment = _firstSegments[initialFirstSegment]!;
+                    var secondSegment = _secondSegments[initialSecondSegment]!;
                     var remainingInSegment = firstSegment.Length - offset;
                     var currentSegmentLength = Math.Min(remainingInSegment, _length);
                     _current = (firstSegment.AsMemory().Slice(offset, currentSegmentLength), secondSegment.AsMemory().Slice(offset, currentSegmentLength));
@@ -555,16 +555,16 @@ namespace Microsoft.CodeAnalysis.Collections
 
         private struct UnalignedSegmentEnumerator<T>
         {
-            private readonly T[][] _firstSegments;
+            private readonly T[]?[] _firstSegments;
             private readonly int _firstOffset;
-            private readonly T[][] _secondSegments;
+            private readonly T[]?[] _secondSegments;
             private readonly int _secondOffset;
             private readonly int _length;
 
             private int _completed;
             private (Memory<T> first, Memory<T> second) _current;
 
-            public UnalignedSegmentEnumerator(T[][] firstSegments, int firstOffset, T[][] secondSegments, int secondOffset, int length)
+            public UnalignedSegmentEnumerator(T[]?[] firstSegments, int firstOffset, T[]?[] secondSegments, int secondOffset, int length)
             {
                 _firstSegments = firstSegments;
                 _firstOffset = firstOffset;
@@ -591,8 +591,8 @@ namespace Microsoft.CodeAnalysis.Collections
                 var firstOffset = (_completed + _firstOffset) & SegmentedArrayHelper.GetOffsetMask<T>();
                 var secondOffset = (_completed + _secondOffset) & SegmentedArrayHelper.GetOffsetMask<T>();
 
-                var firstSegment = _firstSegments[initialFirstSegment];
-                var secondSegment = _secondSegments[initialSecondSegment];
+                var firstSegment = _firstSegments[initialFirstSegment]!;
+                var secondSegment = _secondSegments[initialSecondSegment]!;
                 var remainingInFirstSegment = firstSegment.Length - firstOffset;
                 var remainingInSecondSegment = secondSegment.Length - secondOffset;
                 var currentSegmentLength = Math.Min(Math.Min(remainingInFirstSegment, remainingInSecondSegment), _length - _completed);
@@ -603,16 +603,16 @@ namespace Microsoft.CodeAnalysis.Collections
 
             public struct Reverse
             {
-                private readonly T[][] _firstSegments;
+                private readonly T[]?[] _firstSegments;
                 private readonly int _firstOffset;
-                private readonly T[][] _secondSegments;
+                private readonly T[]?[] _secondSegments;
                 private readonly int _secondOffset;
                 private readonly int _length;
 
                 private int _completed;
                 private (Memory<T> first, Memory<T> second) _current;
 
-                public Reverse(T[][] firstSegments, int firstOffset, T[][] secondSegments, int secondOffset, int length)
+                public Reverse(T[]?[] firstSegments, int firstOffset, T[]?[] secondSegments, int secondOffset, int length)
                 {
                     _firstSegments = firstSegments;
                     _firstOffset = firstOffset;
@@ -699,14 +699,14 @@ namespace Microsoft.CodeAnalysis.Collections
 
         private struct SegmentEnumerator<T>
         {
-            private readonly T[][] _segments;
+            private readonly T[]?[] _segments;
             private readonly int _offset;
             private readonly int _length;
 
             private int _completed;
             private Memory<T> _current;
 
-            public SegmentEnumerator(T[][] segments, int offset, int length)
+            public SegmentEnumerator(T[]?[] segments, int offset, int length)
             {
                 _segments = segments;
                 _offset = offset;
@@ -731,7 +731,7 @@ namespace Microsoft.CodeAnalysis.Collections
                     var firstSegment = _offset >> SegmentedArrayHelper.GetSegmentShift<T>();
                     var offset = _offset & SegmentedArrayHelper.GetOffsetMask<T>();
 
-                    var segment = _segments[firstSegment];
+                    var segment = _segments[firstSegment]!;
                     var remainingInSegment = segment.Length - offset;
                     _current = segment.AsMemory().Slice(offset, Math.Min(remainingInSegment, _length));
                     _completed = _current.Length;
@@ -748,14 +748,14 @@ namespace Microsoft.CodeAnalysis.Collections
 
             public struct Reverse
             {
-                private readonly T[][] _segments;
+                private readonly T[]?[] _segments;
                 private readonly int _offset;
                 private readonly int _length;
 
                 private int _completed;
                 private Memory<T> _current;
 
-                public Reverse(T[][] segments, int offset, int length)
+                public Reverse(T[]?[] segments, int offset, int length)
                 {
                     _segments = segments;
                     _offset = offset;
@@ -780,7 +780,7 @@ namespace Microsoft.CodeAnalysis.Collections
                         var firstSegment = _offset >> SegmentedArrayHelper.GetSegmentShift<T>();
                         var offset = _offset & SegmentedArrayHelper.GetOffsetMask<T>();
 
-                        var segment = _segments[firstSegment];
+                        var segment = _segments[firstSegment]!;
                         var remainingInSegment = segment.Length - offset;
                         _current = segment.AsMemory().Slice(offset, Math.Min(remainingInSegment, _length));
                         _completed = _current.Length;

--- a/src/Dependencies/Collections/SegmentedArray`1+PrivateMarshal.cs
+++ b/src/Dependencies/Collections/SegmentedArray`1+PrivateMarshal.cs
@@ -12,10 +12,10 @@ internal readonly partial struct SegmentedArray<T>
     internal static class PrivateMarshal
     {
         /// <inheritdoc cref="SegmentedCollectionsMarshal.AsSegments{T}(SegmentedArray{T})"/>
-        public static T[][] AsSegments(SegmentedArray<T> array)
+        public static T[]?[] AsSegments(SegmentedArray<T> array)
             => array._items;
 
-        public static SegmentedArray<T> AsSegmentedArray(int length, T[][] segments)
+        public static SegmentedArray<T> AsSegmentedArray(int length, T[]?[] segments)
             => new SegmentedArray<T>(length, segments);
     }
 }

--- a/src/Dependencies/Collections/SegmentedCollectionsMarshal.cs
+++ b/src/Dependencies/Collections/SegmentedCollectionsMarshal.cs
@@ -19,7 +19,7 @@ internal static class SegmentedCollectionsMarshal
     /// <param name="array">The segmented array.</param>
     /// <returns>The backing storage array for the segmented array. Note that replacing segments within the returned
     /// value will invalidate the <see cref="SegmentedArray{T}"/> data structure.</returns>
-    public static T[][] AsSegments<T>(SegmentedArray<T> array)
+    public static T[]?[] AsSegments<T>(SegmentedArray<T> array)
         => SegmentedArray<T>.PrivateMarshal.AsSegments(array);
 
     /// <summary>
@@ -38,7 +38,7 @@ internal static class SegmentedCollectionsMarshal
     /// </para>
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="segments"/> is <see langword="null"/></exception>
-    public static SegmentedArray<T> AsSegmentedArray<T>(int length, T[][] segments)
+    public static SegmentedArray<T> AsSegmentedArray<T>(int length, T[]?[] segments)
         => SegmentedArray<T>.PrivateMarshal.AsSegmentedArray(length, segments);
 
     /// <summary>

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -124,54 +124,57 @@ namespace Microsoft.CodeAnalysis.Collections
         public int Capacity
         {
             get => _items.Length;
-            set
+            set => SetCapacityInternal(value, isExactCapacity: true);
+        }
+
+        private void SetCapacityInternal(int value, bool isExactCapacity)
+        {
+            if (value < _size)
             {
-                if (value < _size)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.value, ExceptionResource.ArgumentOutOfRange_SmallCapacity);
+            }
+
+            if (value == _items.Length)
+                return;
+
+            if (value <= 0)
+            {
+                _items = s_emptyArray;
+                return;
+            }
+
+            if (_items.Length == 0)
+            {
+                // No data from existing array to reuse, just create a new one.
+                _items = new SegmentedArray<T>(value);
+            }
+            else
+            {
+                // Rather than creating a copy of _items, instead reuse as much of it's data as possible.
+                var segments = SegmentedCollectionsMarshal.AsSegments(_items);
+
+                var oldSegmentCount = segments.Length;
+                var newSegmentCount = (value + SegmentedArrayHelper.GetSegmentSize<T>() - 1) >> SegmentedArrayHelper.GetSegmentShift<T>();
+
+                if (newSegmentCount > segments.Length)
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.value, ExceptionResource.ArgumentOutOfRange_SmallCapacity);
+                    // Grow the array of segments, if necessary. If isExactCapacity is false, then this array may end up
+                    // having null entries at it's end when this method completes. Minimally doubling the outer array size
+                    // allows amortized linear cost growth properties.
+                    var newSegmentAllocCount = isExactCapacity ? newSegmentCount : Math.Max(newSegmentCount, segments.Length * 2);
+                    Array.Resize(ref segments, newSegmentAllocCount);
                 }
 
-                if (value == _items.Length)
-                    return;
+                // Resize all segments to full segment size from the last old segment to the next to last
+                // new segment.
+                for (var i = oldSegmentCount - 1; i < newSegmentCount - 1; i++)
+                    Array.Resize(ref segments[i], SegmentedArrayHelper.GetSegmentSize<T>());
 
-                if (value <= 0)
-                {
-                    _items = s_emptyArray;
-                    return;
-                }
+                // Resize the last segment
+                var lastSegmentSize = value - ((newSegmentCount - 1) << SegmentedArrayHelper.GetSegmentShift<T>());
+                Array.Resize(ref segments[newSegmentCount - 1], lastSegmentSize);
 
-                if (_items.Length == 0)
-                {
-                    // No data from existing array to reuse, just create a new one.
-                    _items = new SegmentedArray<T>(value);
-                }
-                else
-                {
-                    // Rather than creating a copy of _items, instead reuse as much of it's data as possible.
-                    var segments = SegmentedCollectionsMarshal.AsSegments(_items);
-
-                    var oldSegmentCount = segments.Length;
-                    var newSegmentCount = (value + SegmentedArrayHelper.GetSegmentSize<T>() - 1) >> SegmentedArrayHelper.GetSegmentShift<T>();
-
-                    if (newSegmentCount > segments.Length)
-                    {
-                        // Grow the array of segments, if necessary. Note that this array may end up having null entries
-                        // at it's end when this method completes. Minimally doubling the outer array size allows amortized
-                        // linear cost growth properties.
-                        Array.Resize(ref segments, Math.Max(newSegmentCount, segments.Length * 2));
-                    }
-
-                    // Resize all segments to full segment size from the last old segment to the next to last
-                    // new segment.
-                    for (var i = oldSegmentCount - 1; i < newSegmentCount - 1; i++)
-                        Array.Resize(ref segments[i], SegmentedArrayHelper.GetSegmentSize<T>());
-
-                    // Resize the last segment
-                    var lastSegmentSize = value - ((newSegmentCount - 1) << SegmentedArrayHelper.GetSegmentShift<T>());
-                    Array.Resize(ref segments[newSegmentCount - 1], lastSegmentSize);
-
-                    _items = SegmentedCollectionsMarshal.AsSegmentedArray(value, segments);
-                }
+                _items = SegmentedCollectionsMarshal.AsSegmentedArray(value, segments);
             }
         }
 
@@ -544,7 +547,7 @@ namespace Microsoft.CodeAnalysis.Collections
             if (newCapacity < capacity)
                 newCapacity = capacity;
 
-            Capacity = newCapacity;
+            SetCapacityInternal(newCapacity, isExactCapacity: false);
         }
 
         public bool Exists(Predicate<T> match)

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Collections
                     _items = new SegmentedArray<T>(count);
                     if (SegmentedCollectionsMarshal.AsSegments(_items) is { Length: 1 } segments)
                     {
-                        c.CopyTo(segments[0], 0);
+                        c.CopyTo(segments[0]!, 0);
                         _size = count;
                         return;
                     }

--- a/src/Tools/IdeCoreBenchmarks/SegmentedListBenchmarks_Add.cs
+++ b/src/Tools/IdeCoreBenchmarks/SegmentedListBenchmarks_Add.cs
@@ -38,28 +38,21 @@ namespace IdeCoreBenchmarks
                 array.Add(item);
         }
 
-        private struct LargeStruct
+        private struct MediumStruct
         {
             public int i1 { get; set; }
             public int i2 { get; set; }
             public int i3 { get; set; }
             public int i4 { get; set; }
             public int i5 { get; set; }
-            public int i6 { get; set; }
-            public int i7 { get; set; }
-            public int i8 { get; set; }
-            public int i9 { get; set; }
-            public int i10 { get; set; }
-            public int i11 { get; set; }
-            public int i12 { get; set; }
-            public int i13 { get; set; }
-            public int i14 { get; set; }
-            public int i15 { get; set; }
-            public int i16 { get; set; }
-            public int i17 { get; set; }
-            public int i18 { get; set; }
-            public int i19 { get; set; }
-            public int i20 { get; set; }
+        }
+
+        private struct LargeStruct
+        {
+            public MediumStruct s1 { get; set; }
+            public MediumStruct s2 { get; set; }
+            public MediumStruct s3 { get; set; }
+            public MediumStruct s4 { get; set; }
         }
 
         private struct EnormousStruct

--- a/src/Tools/IdeCoreBenchmarks/SegmentedListBenchmarks_Add_SegmentCounts.cs
+++ b/src/Tools/IdeCoreBenchmarks/SegmentedListBenchmarks_Add_SegmentCounts.cs
@@ -1,0 +1,67 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Collections.Internal;
+
+[MemoryDiagnoser]
+public class SegmentedListBenchmarks_Add_SegmentCounts
+{
+    [Params(16, 256, 4096, 65536)]
+    public int SegmentCount { get; set; }
+
+    [ParamsAllValues]
+    public bool AddExtraItem { get; set; }
+
+    [Benchmark]
+    public void AddObjectToList()
+        => AddToList(new object());
+
+    [Benchmark]
+    public void AddLargeStructToList()
+        => AddToList(new LargeStruct());
+
+    [Benchmark]
+    public void AddEnormousStructToList()
+        => AddToList(new EnormousStruct());
+
+    private void AddToList<T>(T item)
+    {
+        var count = SegmentCount * SegmentedArrayHelper.GetSegmentSize<T>();
+        if (AddExtraItem)
+            count++;
+
+        var array = new SegmentedList<T>();
+        for (var i = 0; i < count; i++)
+            array.Add(item);
+    }
+
+    private struct MediumStruct
+    {
+        public int i1 { get; set; }
+        public int i2 { get; set; }
+        public int i3 { get; set; }
+        public int i4 { get; set; }
+        public int i5 { get; set; }
+    }
+
+    private struct LargeStruct
+    {
+        public MediumStruct s1 { get; set; }
+        public MediumStruct s2 { get; set; }
+        public MediumStruct s3 { get; set; }
+        public MediumStruct s4 { get; set; }
+    }
+
+    private struct EnormousStruct
+    {
+        public LargeStruct s1 { get; set; }
+        public LargeStruct s2 { get; set; }
+        public LargeStruct s3 { get; set; }
+        public LargeStruct s4 { get; set; }
+        public LargeStruct s5 { get; set; }
+        public LargeStruct s6 { get; set; }
+        public LargeStruct s7 { get; set; }
+        public LargeStruct s8 { get; set; }
+        public LargeStruct s9 { get; set; }
+        public LargeStruct s10 { get; set; }
+    }
+}

--- a/src/Tools/IdeCoreBenchmarks/SegmentedListBenchmarks_Add_SegmentCounts.cs
+++ b/src/Tools/IdeCoreBenchmarks/SegmentedListBenchmarks_Add_SegmentCounts.cs
@@ -1,4 +1,8 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Collections.Internal;
 


### PR DESCRIPTION
Modify algorithm in SegmentedList.Grow to grow by a single segment at a time instead of doubling in size.  This is an extension from some work done in https://github.com/dotnet/roslyn/pull/75661.

Note that when allocating the outer array in the Capacity setter, we still utilize the double size allocation mechanism to avoid an n^2 allocation pattern for it. However, we *don't* allocate all the inner arrays, only what is needed. If a subsequent request comes in to Grow, we'll utilize those empty array entries.

*** Benchmark.NET data ***
Note: The AddExtraItem flag is used to demonstrate that the old algorithm had a large allocation occurrence at that count. The new algorithm doesn't have such a steep allocation cliff at those discrete points. Generally,

Allocation changes from PR1 => PR2 => this PR:
Purple went from n => n/2 => n/2
Blue went from n => n/2 => n/2 => n/4

CPU changes are a little harder to summarize, but generally went down anywhere from 20%-70%

Before https://github.com/dotnet/roslyn/pull/75661
![image](https://github.com/user-attachments/assets/829718ea-6e5f-4a6c-9f68-83044e4661c5)

Ater https://github.com/dotnet/roslyn/pull/75661, before this PR:
![image](https://github.com/user-attachments/assets/b104344a-c2b5-4a86-ae36-ec195d9575f6)

With both PRs:
![image](https://github.com/user-attachments/assets/df584ff8-9dbf-42a0-80a9-651039a49e18)