### PR TITLE
Expose code actions to Razor cohosting

### DIFF
--- a/src/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileHandler.cs
+++ b/src/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileHandler.cs
@@ -59,6 +59,12 @@ internal sealed class FormatNewFileHandler : ILspServiceRequestHandler<FormatNew
 
         var document = solution.GetRequiredDocument(documentId);
 
+        return await GetFormattedNewFileContentAsync(document, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<string> GetFormattedNewFileContentAsync(Document document, CancellationToken cancellationToken)
+    {
+        var project = document.Project;
         // Run the new document formatting service, to make sure the right namespace type is used, among other things
         var formattingService = document.GetLanguageService<INewDocumentFormattingService>();
         if (formattingService is not null)
@@ -79,7 +85,7 @@ internal sealed class FormatNewFileHandler : ILspServiceRequestHandler<FormatNew
         // Now format the document so indentation etc. is correct
         var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
         var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-        root = Formatter.Format(root, solution.Services, syntaxFormattingOptions, cancellationToken);
+        root = Formatter.Format(root, project.Solution.Services, syntaxFormattingOptions, cancellationToken);
 
         return root.ToFullString();
     }

--- a/src/LanguageServer/Protocol/ExternalAccess/Razor/SimplifyMethodHandler.cs
+++ b/src/LanguageServer/Protocol/ExternalAccess/Razor/SimplifyMethodHandler.cs
@@ -43,9 +43,16 @@ internal class SimplifyMethodHandler : ILspServiceDocumentRequestHandler<Simplif
         if (originalDocument is null)
             return null;
 
+        var textEdit = request.TextEdit;
+
+        return await GetSimplifiedEditsAsync(originalDocument, textEdit, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<TextEdit[]> GetSimplifiedEditsAsync(Document originalDocument, TextEdit textEdit, CancellationToken cancellationToken)
+    {
         // Create a temporary syntax tree that includes the text edit.
         var originalSourceText = await originalDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var pendingChange = ProtocolConversions.TextEditToTextChange(request.TextEdit, originalSourceText);
+        var pendingChange = ProtocolConversions.TextEditToTextChange(textEdit, originalSourceText);
         var newSourceText = originalSourceText.WithChanges(pendingChange);
         var originalTree = await originalDocument.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
         var newTree = originalTree.WithChangedText(newSourceText);

--- a/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -7,7 +7,6 @@ using System.Composition;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -97,7 +96,7 @@ internal class CodeActionResolveHandler : ILspServiceDocumentRequestHandler<LSP.
         return codeAction;
     }
 
-    private static CodeActionResolveData GetCodeActionResolveData(LSP.CodeAction request)
+    internal static CodeActionResolveData GetCodeActionResolveData(LSP.CodeAction request)
     {
         var resolveData = JsonSerializer.Deserialize<CodeActionResolveData>((JsonElement)request.Data!, ProtocolConversions.LspJsonSerializerOptions);
         Contract.ThrowIfNull(resolveData, "Missing data for code action resolve request");

--- a/src/Tools/ExternalAccess/Razor/Cohost/Handlers/CodeActions.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Handlers/CodeActions.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions;
+using Roslyn.LanguageServer.Protocol;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
+
+internal static class CodeActions
+{
+    public static Task<CodeAction[]> GetCodeActionsAsync(
+        Document document,
+        CodeActionParams request,
+        bool supportsVSExtensions,
+        CancellationToken cancellationToken)
+    {
+        var solution = document.Project.Solution;
+
+        var codeFixService = solution.Services.ExportProvider.GetService<ICodeFixService>();
+        var codeRefactoringService = solution.Services.ExportProvider.GetService<ICodeRefactoringService>();
+
+        return CodeActionHelpers.GetVSCodeActionsAsync(request, document, codeFixService, codeRefactoringService, supportsVSExtensions, cancellationToken);
+    }
+
+    public static async Task<CodeAction> ResolveCodeActionAsync(Document document, CodeAction codeAction, ResourceOperationKind[] resourceOperations, CancellationToken cancellationToken)
+    {
+        Contract.ThrowIfNull(codeAction.Data);
+        var data = CodeActionResolveHandler.GetCodeActionResolveData(codeAction);
+        Assumes.Present(data);
+
+        // We don't need to resolve a top level code action that has nested actions - it requires further action
+        // on the client to pick which of the nested actions to actually apply.
+        if (data.NestedCodeActions.HasValue && data.NestedCodeActions.Value.Length > 0)
+        {
+            return codeAction;
+        }
+
+        var solution = document.Project.Solution;
+
+        var codeFixService = solution.Services.ExportProvider.GetService<ICodeFixService>();
+        var codeRefactoringService = solution.Services.ExportProvider.GetService<ICodeRefactoringService>();
+
+        var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
+            document,
+            data.Range,
+            codeFixService,
+            codeRefactoringService,
+            fixAllScope: null,
+            cancellationToken).ConfigureAwait(false);
+
+        Contract.ThrowIfNull(data.CodeActionPath);
+        var codeActionToResolve = CodeActionHelpers.GetCodeActionToResolve(data.CodeActionPath, codeActions, isFixAllAction: false);
+
+        var operations = await codeActionToResolve.GetOperationsAsync(solution, CodeAnalysisProgress.None, cancellationToken).ConfigureAwait(false);
+
+        var edit = await CodeActionResolveHelper.GetCodeActionResolveEditsAsync(
+            solution,
+            data,
+            operations,
+            resourceOperations,
+            logFunction: static s => { },
+            cancellationToken).ConfigureAwait(false);
+
+        codeAction.Edit = edit;
+        return codeAction;
+    }
+
+    public static Task<string> GetFormattedNewFileContentAsync(Document document, CancellationToken cancellationToken)
+        => FormatNewFileHandler.GetFormattedNewFileContentAsync(document, cancellationToken);
+
+    public static Task<TextEdit[]> GetSimplifiedEditsAsync(Document document, TextEdit textEdit, CancellationToken cancellationToken)
+        => SimplifyMethodHandler.GetSimplifiedEditsAsync(document, textEdit, cancellationToken);
+}


### PR DESCRIPTION
Roslyn side of https://github.com/dotnet/razor/issues/10742

Exposes code actions functionality to the Razor EA, as well as our 3 custom LSP endpoints.