### PR TITLE
Add wrapper service broker to allow for easy MEF consumption

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/WrappedServiceBroker.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/WrappedServiceBroker.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
 /// This wrapper will wait for the service broker to be available before invoking the requested method.
 /// </summary>
 [Export(typeof(SVsFullAccessServiceBroker)), Shared]
-[Export(typeof(IServiceBroker))]
 [Export(typeof(WrappedServiceBroker))]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/WrappedServiceBroker.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/WrappedServiceBroker.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
 /// This wrapper will wait for the service broker to be available before invoking the requested method.
 /// </summary>
 [Export(typeof(SVsFullAccessServiceBroker)), Shared]
+[Export(typeof(IServiceBroker))]
 [Export(typeof(WrappedServiceBroker))]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/WrappedServiceBroker.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/WrappedServiceBroker.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Composition;
+using System.IO.Pipelines;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
+#pragma warning restore RS0030 // Do not used banned APIs
+
+/// <summary>
+/// Implements a wrapper around <see cref="IServiceBroker"/> that allows clients to MEF import the service broker.
+/// This wrapper will wait for the service broker to be available before invoking the requested method.
+/// </summary>
+[Export(typeof(SVsFullAccessServiceBroker)), Shared]
+[Export(typeof(WrappedServiceBroker))]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class WrappedServiceBroker() : IServiceBroker
+{
+    private readonly TaskCompletionSource<IServiceBroker> _serviceBrokerTask = new();
+
+    internal void SetServiceBroker(IServiceBroker serviceBroker)
+    {
+        serviceBroker.AvailabilityChanged += (s, e) => AvailabilityChanged?.Invoke(s, e);
+        _serviceBrokerTask.SetResult(serviceBroker);
+    }
+
+    public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged;
+
+    public async ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+    {
+        var serviceBroker = await _serviceBrokerTask.Task;
+        return await serviceBroker.GetPipeAsync(serviceMoniker, options, cancellationToken);
+    }
+
+    public async ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default) where T : class
+    {
+        var serviceBroker = await _serviceBrokerTask.Task;
+#pragma warning disable ISB001 // Dispose of proxies - caller is responsible for disposing the proxy.
+        return await serviceBroker.GetProxyAsync<T>(serviceDescriptor, options, cancellationToken);
+#pragma warning restore ISB001 // Dispose of proxies
+    }
+}


### PR DESCRIPTION
We want to allow partners that run in our process to have easy access to the `IServiceBroker` so they can access services from devkit.  Previously we provided access via an IVT `OnServiceBrokerInitialized` method.  However there are a number of other assemblies that would also like access to the service broker instance, and we'd have to add IVTs for each one.

Unfortunately it is not straightforward to just mef export our IServiceBroker instance as it is only created *after* the mef composition is created.

To make this easier we create our own wrapper of `IServiceBroker` that we export via mef.  The wrapper implementation waits for the brokered service to be available before delegating to the real instance.

@etvorun tested with xaml to confirm it can be consumed.
