### PR TITLE
Do not include source generated documents in related document results

### DIFF
--- a/src/Features/Core/Portable/RelatedDocuments/AbstractRelatedDocumentsService.cs
+++ b/src/Features/Core/Portable/RelatedDocuments/AbstractRelatedDocumentsService.cs
@@ -135,7 +135,7 @@ internal abstract class AbstractRelatedDocumentsService<
             foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
             {
                 var documentId = solution.GetDocument(syntaxReference.SyntaxTree)?.Id;
-                if (documentId != null && seenDocumentIds.Add(documentId))
+                if (documentId != null && !documentId.IsSourceGenerated && seenDocumentIds.Add(documentId))
                     callback(documentId);
             }
         }

--- a/src/LanguageServer/ProtocolUnitTests/RelatedDocuments/RelatedDocumentsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/RelatedDocuments/RelatedDocumentsTests.cs
@@ -180,15 +180,15 @@ public sealed class RelatedDocumentsTests(ITestOutputHelper testOutputHelper)
     public async Task DoesNotIncludeSourceGeneratedDocuments(bool mutatingLspWorkspace, bool useProgress)
     {
         var source =
-                """
-                namespace M
+            """
+            namespace M
+            {
+                class A
                 {
-                    class A
-                    {
-                        public {|caret:|}B b;
-                    }
+                    public {|caret:|}B b;
                 }
-                """;
+            }
+            """;
         var generated =
             """
             namespace M

--- a/src/LanguageServer/ProtocolUnitTests/RelatedDocuments/RelatedDocumentsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/RelatedDocuments/RelatedDocumentsTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
+using Roslyn.Test.Utilities.TestGenerators;
 using Roslyn.Utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -173,5 +174,40 @@ public sealed class RelatedDocumentsTests(ITestOutputHelper testOutputHelper)
             useProgress: useProgress);
 
         AssertJsonEquals(results2, expectedResult);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task DoesNotIncludeSourceGeneratedDocuments(bool mutatingLspWorkspace, bool useProgress)
+    {
+        var source =
+                """
+                namespace M
+                {
+                    class A
+                    {
+                        public {|caret:|}B b;
+                    }
+                }
+                """;
+        var generated =
+            """
+            namespace M
+            {
+                class B
+                {
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(source, mutatingLspWorkspace);
+        await AddGeneratorAsync(new SingleFileTestGenerator(generated), testLspServer.TestWorkspace);
+
+        var project = testLspServer.TestWorkspace.CurrentSolution.Projects.Single();
+        var results = await RunGetRelatedDocumentsAsync(
+            testLspServer,
+            project.Documents.First().GetURI(),
+            useProgress: useProgress);
+
+        Assert.Empty(results);
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2279755

Discussed with @genlu and decided that this approach was the best as sg documents are not editable and not necessarily addressable by a file path.