### PR TITLE
Adjust semantic model for method group conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4294,17 +4294,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // we want to get the symbol that overload resolution chose for M, not the whole method group M.
                         var conversion = (BoundConversion)boundNodeForSyntacticParent;
 
-                        if (conversion.ConversionKind is not ConversionKind.MethodGroup && conversion.Operand is BoundConversion nestedConversion)
+                        MethodSymbol method = null;
+                        if (conversion.ConversionKind == ConversionKind.MethodGroup)
                         {
-                            Debug.Assert(conversion.ConversionKind is ConversionKind.NoConversion || conversion.ExplicitCastInCode);
-                            conversion = nestedConversion;
+                            method = conversion.SymbolOpt;
+                        }
+                        else if (conversion.Operand is BoundConversion { ConversionKind: ConversionKind.MethodGroup } nestedMethodGroupConversion)
+                        {
+                            method = nestedMethodGroupConversion.SymbolOpt;
                         }
 
-                        var method = conversion.SymbolOpt;
                         if ((object)method != null)
                         {
-                            Debug.Assert(conversion.ConversionKind == ConversionKind.MethodGroup);
-
                             if (conversion.IsExtensionMethod)
                             {
                                 method = ReducedExtensionMethodSymbol.Create(method);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4294,6 +4294,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // we want to get the symbol that overload resolution chose for M, not the whole method group M.
                         var conversion = (BoundConversion)boundNodeForSyntacticParent;
 
+                        if (conversion.ConversionKind is not ConversionKind.MethodGroup && conversion.Operand is BoundConversion nestedConversion)
+                        {
+                            Debug.Assert(conversion.ConversionKind is ConversionKind.NoConversion || conversion.ExplicitCastInCode);
+                            conversion = nestedConversion;
+                        }
+
                         var method = conversion.SymbolOpt;
                         if ((object)method != null)
                         {

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -5154,5 +5154,33 @@ True
             CompileAndVerify(compilation, expectedOutput:=expectedOutput).VerifyDiagnostics()
         End Sub
 
+        <Fact(), WorkItem("https://github.com/dotnet/roslyn/issues/36377")>
+        Public Sub GetSymbolInfo_ExplicitCastOnMethodGroup()
+            Dim compilation = CreateCompilation(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Public Class C
+    Public Shared Sub M()
+        Dim x As C = DirectCast(AddressOf C.Test, C)
+    End Sub
+
+    Public Shared Function Test() As Integer
+        Return 1
+    End Function
+
+    Public Shared Widening Operator CType(ByVal intDelegate As System.Func(Of Integer)) As C
+        Return New C()
+    End Operator
+End Class
+    ]]></file>
+    </compilation>)
+
+            compilation.AssertTheseEmitDiagnostics(<expected>
+BC30581: 'AddressOf' expression cannot be converted to 'C' because 'C' is not a delegate type.
+        Dim x As C = DirectCast(AddressOf C.Test, C)
+                                ~~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -5180,6 +5180,12 @@ BC30581: 'AddressOf' expression cannot be converted to 'C' because 'C' is not a 
         Dim x As C = DirectCast(AddressOf C.Test, C)
                                 ~~~~~~~~~~~~~~~~
 </expected>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim model = compilation.GetSemanticModel(tree)
+            Dim syntax = tree.GetRoot().DescendantNodes().OfType(Of UnaryExpressionSyntax)().Single()
+            Assert.Null(model.GetSymbolInfo(syntax).Symbol)
+            Assert.Null(model.GetSymbolInfo(syntax.Operand).Symbol)
         End Sub
 
     End Class


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36377

In the scenario, we have a user-defined conversion for cast, stacked with a method group conversion.