### PR TITLE
Allow renaming with overload resolution when there is only one overload

### DIFF
--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -857,8 +857,10 @@ End Enum";
         Assert.Same(thrownException, caughtException);
     }
 
-    [WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063943")]
-    public async Task RenameTrackingNotFromReferenceWithWrongNumberOfArguments()
+    [WpfFact]
+    [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063943")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/10914")]
+    public async Task RenameTrackingOnReferenceWithWrongNumberOfArguments()
     {
         var code = @"
 class C
@@ -866,6 +868,29 @@ class C
     void M(int x)
     {
         M$$();
+    }
+}";
+
+        using var state = RenameTrackingTestState.Create(code, LanguageNames.CSharp);
+        state.EditorOperations.InsertText("eow");
+        await state.AssertTag("M", "Meow");
+    }
+
+    [WpfFact]
+    [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063943")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/10914")]
+    public async Task RenameTrackingOnReferenceWithWrongNumberOfArguments_Overloads()
+    {
+        var code = @"
+class C
+{
+    void M(int x)
+    {
+        M$$();
+    }
+
+    void M(bool x)
+    {
     }
 }";
 

--- a/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
@@ -6,7 +6,6 @@ Imports Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 Imports Microsoft.CodeAnalysis.Editor.InlineRename
 Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Commanding

--- a/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
@@ -75,8 +75,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         Public Sub CannotRenameSpecialNames(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -97,8 +96,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         Public Sub CannotRenameTrivia(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -114,9 +112,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             End Using
         End Sub
 
-        <WpfTheory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/883263")>
-        <CombinatorialData>
-        Public Sub CannotRenameCandidateSymbol(host As RenameTestHost)
+        <WpfTheory, CombinatorialData>
+        <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/883263")>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/10914")>
+        Public Sub CanRenameCandidateSymbol(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
@@ -132,12 +131,11 @@ class Program
                         </Project>
                     </Workspace>, host)
 
-                AssertTokenNotRenamable(workspace)
+                AssertTokenRenamable(workspace)
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         Public Sub CannotRenameSyntheticDefinition(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -158,8 +156,7 @@ class Program
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         Public Sub CannotRenameXmlLiteralProperty(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -176,8 +173,7 @@ class Program
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         Public Sub CannotRenameSymbolDefinedInMetaData(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -198,8 +194,7 @@ class Program
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         Public Sub CannotRenameSymbolInReadOnlyBuffer(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -227,8 +222,7 @@ class Program
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         Public Sub CannotRenameSymbolThatBindsToErrorType(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -249,8 +243,7 @@ class Program
             End Using
         End Sub
 
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543018")>
         Public Sub CannotRenameSynthesizedParameters(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
@@ -635,8 +628,7 @@ namespace System
         End Sub
 
         <WorkItem(10567, "https://github.com/dotnet/roslyn/issues/14600")>
-        <WpfTheory>
-        <CombinatorialData>
+        <WpfTheory, CombinatorialData>
         <CompilerTrait(CompilerFeature.Tuples)>
         Public Sub RenameTupleFiledInLiteralRegress14600(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -171,6 +171,12 @@ internal static class RenameUtilities
             return TokenRenameInfo.CreateMemberGroupTokenInfo(symbolInfo.CandidateSymbols);
         }
 
+        // If we have overload resolution issues at the callsite, we generally don't want to rename (as it's unclear
+        // which overload the user is actually calling).  However, if there is just a single overload, there's no real
+        // issue since it's clear which one the user wants to rename in that case.
+        if (symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure && symbolInfo.CandidateSymbols.Length == 1)
+            return TokenRenameInfo.CreateMemberGroupTokenInfo(symbolInfo.CandidateSymbols);
+
         if (RenameLocation.ShouldRename(symbolInfo.CandidateReason) &&
             symbolInfo.CandidateSymbols.Length == 1)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/10914