### PR TITLE
Don't offer 'convert anon type to tuple' when in an expression tree

### DIFF
--- a/src/Features/CSharp/Portable/ConvertAnonymousType/CSharpConvertAnonymousTypeToTupleCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAnonymousType/CSharpConvertAnonymousTypeToTupleCodeRefactoringProvider.cs
@@ -16,18 +16,14 @@ using static CSharpSyntaxTokens;
 using static SyntaxFactory;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertAnonymousTypeToTuple), Shared]
-internal class CSharpConvertAnonymousTypeToTupleCodeRefactoringProvider
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class CSharpConvertAnonymousTypeToTupleCodeRefactoringProvider()
     : AbstractConvertAnonymousTypeToTupleCodeRefactoringProvider<
         ExpressionSyntax,
         TupleExpressionSyntax,
         AnonymousObjectCreationExpressionSyntax>
 {
-    [ImportingConstructor]
-    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-    public CSharpConvertAnonymousTypeToTupleCodeRefactoringProvider()
-    {
-    }
-
     protected override int GetInitializerCount(AnonymousObjectCreationExpressionSyntax anonymousType)
         => anonymousType.Initializers.Count;
 

--- a/src/Features/CSharpTest/ConvertAnonymousType/ConvertAnonymousTypeToTupleTests.cs
+++ b/src/Features/CSharpTest/ConvertAnonymousType/ConvertAnonymousTypeToTupleTests.cs
@@ -9,12 +9,13 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.ConvertAnonymousType;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertAnonymousType;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsConvertAnonymousTypeToTuple)]
-public partial class ConvertAnonymousTypeToTupleTests : AbstractCSharpCodeActionTest_NoEditor
+public sealed class ConvertAnonymousTypeToTupleTests : AbstractCSharpCodeActionTest_NoEditor
 {
     protected override CodeRefactoringProvider CreateCodeRefactoringProvider(TestWorkspace workspace, TestParameters parameters)
         => new CSharpConvertAnonymousTypeToTupleCodeRefactoringProvider();
@@ -482,5 +483,22 @@ public partial class ConvertAnonymousTypeToTupleTests : AbstractCSharpCodeAction
             }
             """;
         await TestInRegularAndScriptAsync(text, expected);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/34749")]
+    public async Task NotInExpressionTree()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            using System.Linq.Expressions;
+
+            class C
+            {
+                static void Main(string[] args)
+                {
+                    Expression<Func<string, string, dynamic>> test =
+                        (par1, par2) => [||]new { Parameter1 = par1, Parameter2 = par2 };
+                }
+            }
+            """);
     }
 }

--- a/src/Features/Core/Portable/ConvertAnonymousType/AbstractConvertAnonymousTypeToTupleCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAnonymousType/AbstractConvertAnonymousTypeToTupleCodeRefactoringProvider.cs
@@ -42,6 +42,11 @@ internal abstract class AbstractConvertAnonymousTypeToTupleCodeRefactoringProvid
             return;
 
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var semanticFacts = document.GetRequiredLanguageService<ISemanticFactsService>();
+
+        if (semanticFacts.IsInExpressionTree(semanticModel, anonymousNode, semanticModel.Compilation.ExpressionOfTType(), cancellationToken))
+            return;
+
         var allAnonymousNodes = GetAllAnonymousTypesInContainer(document, semanticModel, anonymousNode, cancellationToken);
 
         // If we have multiple different anonymous types in this member, then offer two fixes, one to just fixup this


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/34749