### PR TITLE
Bump Razor to 9.0.0-preview.24555.12

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -144,7 +144,7 @@
     <PackageVersion Include="NuGet.ProjectModel" Version="6.8.0-rc.112" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(_MicrosoftTestPlatformVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(_MicrosoftTestPlatformVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="9.0.0-preview.24528.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="9.0.0-preview.24555.12" />
 
     <!--
       Analyzers


### PR DESCRIPTION
The previous bump was because of a serialization change from v6 to v7. Sadly RPS meant that change got reverted, so this takes us back to v6.

I suspect we'll be back at v7 soon, but preparing this so Razor insertions are not otherwise blocked.