### PR TITLE
Make MaxSupportedLangVersion calculation dynamic

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1727,7 +1727,7 @@ class C
             // When a new version is added, this test will break. This list must be checked:
             // - update the "UpgradeProject" codefixer
             // - update all the tests that call this canary
-            // - update MaxSupportedLangVersion (a relevant test should break when new version is introduced)
+            // - update _MaxAvailableLangVersion (a relevant test should break when new version is introduced)
             // - email release management to add to the release notes (see old example: https://github.com/dotnet/core/pull/1454)
             AssertEx.SetEqual(new[] { "default", "1", "2", "3", "4", "5", "6", "7.0", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "latest", "latestmajor", "preview" },
                 Enum.GetValues(typeof(LanguageVersion)).Cast<LanguageVersion>().Select(v => v.ToDisplayString()));

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -7,31 +7,20 @@
     <!-- .NETCoreApp < 3.0, .NETStandard < 2.1, or any other target framework -->
     <_MaxSupportedLangVersion Condition="('$(TargetFrameworkIdentifier)' != '.NETCoreApp' OR '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0') AND
                                          ('$(TargetFrameworkIdentifier)' != '.NETStandard' OR '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1')">7.3</_MaxSupportedLangVersion>
-    
+
     <!-- .NETCoreApp < 5.0, .NETStandard == 2.1 -->
     <_MaxSupportedLangVersion Condition="(('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '5.0') OR
                                           ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(_TargetFrameworkVersionWithoutV)' == '2.1')) AND
                                           '$(_MaxSupportedLangVersion)' == ''">8.0</_MaxSupportedLangVersion>
 
-    <!-- .NETCoreApp == 5.0 -->
-    <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' == '5.0' AND
-                                         '$(_MaxSupportedLangVersion)' == ''">9.0</_MaxSupportedLangVersion>
-
-    <!-- .NETCoreApp == 6.0 -->
-    <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' == '6.0' AND
-                                         '$(_MaxSupportedLangVersion)' == ''">10.0</_MaxSupportedLangVersion>
-
-    <!-- .NETCoreApp == 7.0 -->
-    <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' == '7.0' AND
-                                         '$(_MaxSupportedLangVersion)' == ''">11.0</_MaxSupportedLangVersion>
-
-    <!-- .NETCoreApp == 8.0 -->
-    <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' == '8.0' AND
-                                         '$(_MaxSupportedLangVersion)' == ''">12.0</_MaxSupportedLangVersion>
-
-    <!-- .NETCoreApp == 9.0 -->
-    <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' == '9.0' AND
-                                         '$(_MaxSupportedLangVersion)' == ''">13.0</_MaxSupportedLangVersion>
+    <!-- 
+      Automatically calculate the maximum supported C# language version based on the .NET Target Framework.
+      - Pattern: .NET 5.0 uses C# 9.0, .NET 6.0 uses C# 10.0, and so on.
+      - Starting from C# 9.0 for .NET 5.0, we add the difference between the major .NET version and 5 
+        to determine the correct language version.
+    -->
+    <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
+                                         '$(_MaxSupportedLangVersion)' == ''">$([MSBuild]::Add(9, $([MSBuild]::Subtract($(_TargetFrameworkVersionWithoutV), 5)))).0</_MaxSupportedLangVersion>
 
     <MaxSupportedLangVersion>$(_MaxSupportedLangVersion)</MaxSupportedLangVersion>
     <LangVersion Condition="'$(LangVersion)' == '' AND '$(_MaxSupportedLangVersion)' != ''">$(_MaxSupportedLangVersion)</LangVersion>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -22,6 +22,11 @@
     <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
                                          '$(_MaxSupportedLangVersion)' == ''">$([MSBuild]::Add(9, $([MSBuild]::Subtract($(_TargetFrameworkVersionWithoutV), 5)))).0</_MaxSupportedLangVersion>
 
+    <!-- Cap _MaxSupportedLangVersion if it exceeds _MaxAvailableLangVersion -->
+    <_MaxAvailableLangVersion>13.0</_MaxAvailableLangVersion>
+    <_MaxSupportedLangVersion Condition="Condition="'$(_MaxSupportedLangVersion)' != '' AND
+                                                    '$(_MaxSupportedLangVersion)' &gt; '$(_MaxAvailableLangVersion)'">$(_MaxAvailableLangVersion)</_MaxSupportedLangVersion>
+
     <MaxSupportedLangVersion>$(_MaxSupportedLangVersion)</MaxSupportedLangVersion>
     <LangVersion Condition="'$(LangVersion)' == '' AND '$(_MaxSupportedLangVersion)' != ''">$(_MaxSupportedLangVersion)</LangVersion>
   </PropertyGroup>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -24,8 +24,8 @@
 
     <!-- Cap _MaxSupportedLangVersion if it exceeds _MaxAvailableLangVersion -->
     <_MaxAvailableLangVersion>13.0</_MaxAvailableLangVersion>
-    <_MaxSupportedLangVersion Condition="Condition="'$(_MaxSupportedLangVersion)' != '' AND
-                                                    '$(_MaxSupportedLangVersion)' &gt; '$(_MaxAvailableLangVersion)'">$(_MaxAvailableLangVersion)</_MaxSupportedLangVersion>
+    <_MaxSupportedLangVersion Condition="'$(_MaxSupportedLangVersion)' != '' AND
+                                         '$(_MaxSupportedLangVersion)' &gt; '$(_MaxAvailableLangVersion)'">$(_MaxAvailableLangVersion)</_MaxSupportedLangVersion>
 
     <MaxSupportedLangVersion>$(_MaxSupportedLangVersion)</MaxSupportedLangVersion>
     <LangVersion Condition="'$(LangVersion)' == '' AND '$(_MaxSupportedLangVersion)' != ''">$(_MaxSupportedLangVersion)</LangVersion>

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         [InlineData(".NETCoreApp", "7.0", "11.0")]
         [InlineData(".NETCoreApp", "8.0", "12.0")]
         [InlineData(".NETCoreApp", "9.0", "13.0")]
-        [InlineData(".NETCoreApp", "10.0", "")]
+        [InlineData(".NETCoreApp", "10.0", "14.0")]
 
         [InlineData(".NETStandard", "1.0", "7.3")]
         [InlineData(".NETStandard", "1.5", "7.3")]

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         [InlineData(".NETCoreApp", "7.0", "11.0")]
         [InlineData(".NETCoreApp", "8.0", "12.0")]
         [InlineData(".NETCoreApp", "9.0", "13.0")]
-        [InlineData(".NETCoreApp", "10.0", "14.0")]
+        [InlineData(".NETCoreApp", "10.0", "13.0")] // update when 14.0 is released
 
         [InlineData(".NETStandard", "1.0", "7.3")]
         [InlineData(".NETStandard", "1.5", "7.3")]


### PR DESCRIPTION
Uses historical trend to calculate language version based on the .NET version, removing hardcoded mappings. Ensures future .NET versions automatically align with expected C# version.