### PR TITLE
Ensure frozen snapshots don't return less data if solution already has compilation data (backport to 17.12)

### DIFF
--- a/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
+++ b/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
@@ -39,11 +39,11 @@ internal static class DataTipInfoGetter
 
             if (expression is LiteralExpressionSyntax)
             {
-                // If the user hovers over a literal, give them a DataTip for the type of the
-                // literal they're hovering over.
-                // Partial semantics should always be sufficient because the (unconverted) type
-                // of a literal can always easily be determined.
-                var (_, semanticModel) = await document.GetFullOrPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                // If the user hovers over a literal, give them a DataTip for the type of the literal they're hovering
+                // over. Partial semantics should always be sufficient because the (unconverted) type of a literal can
+                // always easily be determined.
+                document = document.WithFrozenPartialSemantics(cancellationToken);
+                var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 var type = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
                 return type == null
                     ? default

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -215,7 +215,8 @@ public abstract partial class CompletionService : ILanguageService
         var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
 
         // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
-        (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
+        document = GetDocumentWithFrozenPartialSemantics(document, cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
         var description = await extensionManager.PerformFunctionAsync(
             provider,
             cancellationToken => provider.GetDescriptionAsync(document, item, options, displayOptions, cancellationToken),
@@ -246,7 +247,8 @@ public abstract partial class CompletionService : ILanguageService
             var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
 
             // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
-            (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
+            document = GetDocumentWithFrozenPartialSemantics(document, cancellationToken);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var change = await extensionManager.PerformFunctionAsync(
                 provider,

--- a/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -128,9 +128,10 @@ internal abstract class AbstractSnippetCompletionProvider : CompletionProvider
         var textChange = new TextChange(span, string.Empty);
         originalText = originalText.WithChanges(textChange);
 
-        // The document might not be frozen, so make sure we freeze it here to avoid triggering source generator
-        // which is not needed for snippet completion and will cause perf issue.
-        var newDocument = document.WithText(originalText).WithFrozenPartialSemantics(cancellationToken);
+        // The document might not be frozen, so make sure we freeze it here to avoid triggering source generator which
+        // is not needed for snippet completion and will cause perf issue. Pass in 'forceFreeze: true' to ensure all
+        // further transformations we make do not run generators either.
+        var newDocument = document.WithText(originalText).WithFrozenPartialSemantics(forceFreeze: true, cancellationToken);
         return (newDocument, span.Start);
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
@@ -22,28 +21,6 @@ internal static partial class DocumentExtensions
 
     public static ValueTask<SyntaxTreeIndex?> GetSyntaxTreeIndexAsync(this Document document, bool loadOnly, CancellationToken cancellationToken)
         => SyntaxTreeIndex.GetIndexAsync(document, loadOnly, cancellationToken);
-
-    /// <summary>
-    /// Returns the semantic model for this document that may be produced from partial semantics. The semantic model
-    /// is only guaranteed to contain the syntax tree for <paramref name="document"/> and nothing else.
-    /// </summary>
-    public static async Task<(Document document, SemanticModel? semanticModel)> GetFullOrPartialSemanticModelAsync(this Document document, CancellationToken cancellationToken)
-    {
-        if (document.Project.TryGetCompilation(out var compilation))
-        {
-            // We already have a compilation, so at this point it's fastest to just get a SemanticModel
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-            // Make sure the compilation is kept alive so that GetSemanticModelAsync() doesn't become expensive
-            GC.KeepAlive(compilation);
-            return (document, semanticModel);
-        }
-        else
-        {
-            var frozenDocument = document.WithFrozenPartialSemantics(cancellationToken);
-            return (frozenDocument, await frozenDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false));
-        }
-    }
 
     internal static Document WithSolutionOptions(this Document document, OptionSet options)
         => document.Project.Solution.WithOptions(options).GetRequiredDocument(document.Id);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
@@ -26,7 +26,7 @@ public sealed class SourceGeneratedDocument : Document
 
     internal DateTime GenerationDateTime => State.GenerationDateTime;
 
-    internal override Document WithFrozenPartialSemantics(CancellationToken cancellationToken)
+    internal override Document WithFrozenPartialSemantics(bool forceFreeze, CancellationToken cancellationToken)
     {
         // For us to implement frozen partial semantics here with a source generated document,
         // we'd need to potentially deal with the combination where that happens on a snapshot that was already

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -318,7 +318,8 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
     }
 
     [Theory, CombinatorialData]
-    public async Task PartialCompilationsIncludeGeneratedFilesAfterFullGeneration(TestHost testHost)
+    public async Task PartialCompilationsIncludeGeneratedFilesAfterFullGeneration(
+        TestHost testHost, bool forceFreeze)
     {
         using var workspace = CreateWorkspaceWithPartialSemantics(testHost);
         var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
@@ -331,8 +332,15 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
 
         Assert.Equal(2, fullCompilation.SyntaxTrees.Count());
 
-        var partialProject = project.Documents.Single().WithFrozenPartialSemantics(CancellationToken.None).Project;
-        Assert.NotSame(partialProject, project);
+        var partialProject = project.Documents.Single().WithFrozenPartialSemantics(forceFreeze, CancellationToken.None).Project;
+
+        // If we're forcing the freeze, we must get a difference project instance.  If we're not, we'll get the same
+        // project since the compilation was already available.
+        if (forceFreeze)
+            Assert.NotSame(partialProject, project);
+        else
+            Assert.Same(partialProject, project);
+
         var partialCompilation = await partialProject.GetRequiredCompilationAsync(CancellationToken.None);
 
         Assert.Same(fullCompilation, partialCompilation);
@@ -721,7 +729,36 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
     }
 
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/56702")]
-    public async Task ForkAfterFreezeNoLongerRunsGenerators(TestHost testHost)
+    public async Task ForkAfterForceFreezeNoLongerRunsGenerators(TestHost testHost)
+    {
+        using var workspace = CreateWorkspaceWithPartialSemantics(testHost);
+        var generatorRan = false;
+        var analyzerReference = new TestGeneratorReference(new CallbackGenerator(_ => { }, onExecute: _ => { generatorRan = true; }, source: "// Hello World!"));
+        var project = AddEmptyProject(workspace.CurrentSolution)
+            .AddAnalyzerReference(analyzerReference)
+            .AddDocument("RegularDocument.cs", "// Source File", filePath: "RegularDocument.cs").Project;
+
+        // Ensure generators are ran
+        var objectReference = await project.GetCompilationAsync();
+
+        Assert.True(generatorRan);
+        generatorRan = false;
+
+        var document = project.Documents.Single().WithFrozenPartialSemantics(forceFreeze: true, CancellationToken.None);
+
+        // And fork with new contents; we'll ensure the contents of this tree are different, but the generator will not
+        // run since we explicitly force froze.
+        document = document.WithText(SourceText.From("// Something else"));
+
+        var compilation = await document.Project.GetRequiredCompilationAsync(CancellationToken.None);
+        Assert.Equal(2, compilation.SyntaxTrees.Count());
+        Assert.False(generatorRan);
+
+        Assert.Equal("// Something else", (await document.GetRequiredSyntaxRootAsync(CancellationToken.None)).ToFullString());
+    }
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/56702")]
+    public async Task ForkAfterFreezeOfCompletedDocumentStillRunsGenerators(TestHost testHost)
     {
         using var workspace = CreateWorkspaceWithPartialSemantics(testHost);
         var generatorRan = false;
@@ -738,12 +775,13 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
 
         var document = project.Documents.Single().WithFrozenPartialSemantics(CancellationToken.None);
 
-        // And fork with new contents; we'll ensure the contents of this tree are different, but the generator will still not be ran
+        // And fork with new contents; we'll ensure the contents of this tree are different, but the generator will run
+        // since we didn't force freeze, and we got the frozen document after its compilation was already computed.
         document = document.WithText(SourceText.From("// Something else"));
 
         var compilation = await document.Project.GetRequiredCompilationAsync(CancellationToken.None);
         Assert.Equal(2, compilation.SyntaxTrees.Count());
-        Assert.False(generatorRan);
+        Assert.True(generatorRan);
 
         Assert.Equal("// Something else", (await document.GetRequiredSyntaxRootAsync(CancellationToken.None)).ToFullString());
     }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -334,7 +334,7 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
 
         var partialProject = project.Documents.Single().WithFrozenPartialSemantics(forceFreeze, CancellationToken.None).Project;
 
-        // If we're forcing the freeze, we must get a difference project instance.  If we're not, we'll get the same
+        // If we're forcing the freeze, we must get a different project instance.  If we're not, we'll get the same
         // project since the compilation was already available.
         if (forceFreeze)
             Assert.NotSame(partialProject, project);


### PR DESCRIPTION
Backport of https://github.com/dotnet/roslyn/pull/75796 to 17.12.