### PR TITLE
Reduce IVsFreeThreadedFileChangeEvents2.DirectoryChangedEx2 notifications from VS shell

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Text.Json;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -62,7 +61,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
         var tempDirectory = tempRoot.CreateDirectory();
 
         // Try creating a context and ensure we created the registration
-        var context = lspFileChangeWatcher.CreateContext([new ProjectSystem.WatchedDirectory(tempDirectory.Path, extensionFilters: ImmutableArray<string>.Empty)]);
+        var context = lspFileChangeWatcher.CreateContext([new ProjectSystem.WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
         await WaitForFileWatcherAsync(testLspServer);
 
         var watcher = GetSingleFileWatcher(dynamicCapabilitiesRpcTarget);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Text.Json;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -61,7 +62,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
         var tempDirectory = tempRoot.CreateDirectory();
 
         // Try creating a context and ensure we created the registration
-        var context = lspFileChangeWatcher.CreateContext([new ProjectSystem.WatchedDirectory(tempDirectory.Path, extensionFilter: null)]);
+        var context = lspFileChangeWatcher.CreateContext([new ProjectSystem.WatchedDirectory(tempDirectory.Path, extensionFilters: ImmutableArray<string>.Empty)]);
         await WaitForFileWatcherAsync(testLspServer);
 
         var watcher = GetSingleFileWatcher(dynamicCapabilitiesRpcTarget);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
@@ -75,13 +75,23 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
             // If we have any watched directories, then watch those directories directly
             if (watchedDirectories.Any())
             {
-                var directoryWatches = watchedDirectories.Select(d => new FileSystemWatcher
+                var directoryWatches = watchedDirectories.Select(d =>
                 {
-                    GlobPattern = new RelativePattern
+                    var pattern = "**/*" + d.ExtensionFilters.Length switch
                     {
-                        BaseUri = ProtocolConversions.CreateRelativePatternBaseUri(d.Path),
-                        Pattern = d.ExtensionFilter is not null ? "**/*" + d.ExtensionFilter : "**/*"
-                    }
+                        0 => string.Empty,
+                        1 => d.ExtensionFilters[0],
+                        _ => "{" + string.Join(',', d.ExtensionFilters) + "}"
+                    };
+
+                    return new FileSystemWatcher
+                    {
+                        GlobPattern = new RelativePattern
+                        {
+                            BaseUri = ProtocolConversions.CreateRelativePatternBaseUri(d.Path),
+                            Pattern = pattern
+                        }
+                    };
                 }).ToArray();
 
                 _directoryWatchRegistration = new LspFileWatchRegistration(lspFileChangeWatcher, directoryWatches);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/SimpleFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/SimpleFileChangeWatcher.cs
@@ -46,8 +46,8 @@ internal sealed class SimpleFileChangeWatcher : IFileChangeWatcher
                     var watcher = new FileSystemWatcher(watchedDirectory.Path);
                     watcher.IncludeSubdirectories = true;
 
-                    if (watchedDirectory.ExtensionFilter != null)
-                        watcher.Filter = '*' + watchedDirectory.ExtensionFilter;
+                    foreach (var filter in watchedDirectory.ExtensionFilters)
+                        watcher.Filters.Add('*' + filter);
 
                     watcher.Changed += RaiseEvent;
                     watcher.Created += RaiseEvent;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -53,11 +53,7 @@ internal sealed class LoadedProject : IDisposable
         // TODO: we only should listen for add/removals here, but we can't specify such a filter now
         _projectDirectory = Path.GetDirectoryName(_projectFilePath)!;
 
-        _fileChangeContext = fileWatcher.CreateContext([
-            new(_projectDirectory, ".cs"),
-            new(_projectDirectory, ".cshtml"),
-            new(_projectDirectory, ".razor")
-        ]);
+        _fileChangeContext = fileWatcher.CreateContext([new(_projectDirectory, [".cs", ".cshtml", ".razor"])]);
         _fileChangeContext.FileChanged += FileChangedContext_FileChanged;
 
         // Start watching for file changes for the project file as well

--- a/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
@@ -45,7 +45,7 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
         _fileChangeService = fileChangeService;
 
         // 📝 Empirical testing during high activity (e.g. solution open/close) showed strong batching performance
-        // with batching delay of 500 ms.
+        // with delay of 500 ms, batching over 95% of the calls.
         _taskQueue = new AsyncBatchingWorkQueue<WatcherOperation>(
             TimeSpan.FromMilliseconds(500),
             ProcessBatchAsync,
@@ -291,6 +291,7 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
             if (_kind == Kind.WatchDirectory)
                 return false;
 
+            // Don't allow combining if either the kind or sink differ
             return _kind == other._kind && _sink == other._sink;
         }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.ProjectSystem;
@@ -145,7 +146,7 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
             _kind = kind;
 
             _paths = new OneOrMany<string>(directory);
-            _filters = filters;
+            _filters = filters.NullToEmpty();
             _sink = sink;
             _cookies = cookies;
 
@@ -305,7 +306,7 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
                     var cookie = await service.AdviseDirChangeAsync(_paths[0], watchSubdirectories: true, _sink, cancellationToken).ConfigureAwait(false);
                     _cookies.Add(cookie);
 
-                    if (_filters != null)
+                    if (_filters.Length > 0)
                         await service.FilterDirectoryChangesAsync(cookie, _filters.ToArray(), cancellationToken).ConfigureAwait(false);
 
                     return;

--- a/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
@@ -44,10 +44,10 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
     {
         _fileChangeService = fileChangeService;
 
-        // 📝 Empirical testing during high activity (e.g. solution close) showed strong batching performance even
-        // though the batching delay is 0.
+        // 📝 Empirical testing during high activity (e.g. solution open/close) showed strong batching performance
+        // with batching delay of 500 ms.
         _taskQueue = new AsyncBatchingWorkQueue<WatcherOperation>(
-            TimeSpan.Zero,
+            TimeSpan.FromMilliseconds(500),
             ProcessBatchAsync,
             listenerProvider.GetListener(FeatureAttribute.Workspace),
             CancellationToken.None);

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/FileChangeWatcherTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/FileChangeWatcherTests.vb
@@ -1,0 +1,57 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.IO
+Imports Microsoft.CodeAnalysis.ProjectSystem
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Roslyn.Test.Utilities
+Imports IVsAsyncFileChangeEx2 = Microsoft.VisualStudio.Shell.IVsAsyncFileChangeEx2
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
+    <UseExportProvider>
+    Public Class FileChangeWatcherTests
+        Implements IDisposable
+
+        Private ReadOnly _tempPath As String
+
+        Public Sub New()
+            _tempPath = Path.Combine(TempRoot.Root, Path.GetRandomFileName())
+            Directory.CreateDirectory(_tempPath)
+        End Sub
+
+        Private Sub Dispose() Implements IDisposable.Dispose
+            Directory.Delete(_tempPath, recursive:=True)
+        End Sub
+
+        <WpfFact>
+        Public Async Function WatchingMultipleContexts() As Task
+            Using workspace = New EditorTestWorkspace()
+                Dim fileChangeService = New MockVsFileChangeEx
+                Dim fileChangeWatcher = New FileChangeWatcher(workspace.GetService(Of IAsynchronousOperationListenerProvider)(), Task.FromResult(Of IVsAsyncFileChangeEx2)(fileChangeService))
+
+                Dim context1 = fileChangeWatcher.CreateContext(ImmutableArray.Create(New WatchedDirectory(_tempPath, ImmutableArray(Of String).Empty)))
+                Dim context2 = fileChangeWatcher.CreateContext(ImmutableArray.Create(New WatchedDirectory(_tempPath, ImmutableArray(Of String).Empty)))
+
+                Dim handler1Called As Boolean = False
+                Dim handler2Called As Boolean = False
+
+                AddHandler context1.FileChanged, Sub(sender, args) handler1Called = True
+                AddHandler context2.FileChanged, Sub(sender, args) handler2Called = True
+
+                Dim watchedFile1 = context1.EnqueueWatchingFile("file1.txt")
+                Dim watchedFile2 = context2.EnqueueWatchingFile("file2.txt")
+
+                Await workspace.GetService(Of AsynchronousOperationListenerProvider)().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync()
+
+                fileChangeService.FireUpdate("file2.txt")
+
+                Assert.False(handler1Called)
+                Assert.True(handler2Called)
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/FileChangeWatcherTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/FileChangeWatcherTests.vb
@@ -13,7 +13,7 @@ Imports IVsAsyncFileChangeEx2 = Microsoft.VisualStudio.Shell.IVsAsyncFileChangeE
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     <UseExportProvider>
-    Public Class FileChangeWatcherTests
+    Public NotInheritable Class FileChangeWatcherTests
         Implements IDisposable
 
         Private ReadOnly _tempPath As String

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -109,7 +109,7 @@ internal sealed class FileWatchedReferenceFactory<TReference>
                 referenceDirectories.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages"));
             }
 
-            return referenceDirectories.SelectAsArray(static d => new WatchedDirectory(d, ".dll"));
+            return referenceDirectories.SelectAsArray(static d => new WatchedDirectory(d, [".dll"]));
         }
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -222,8 +222,8 @@ internal sealed partial class ProjectSystemProject
 
             return language switch
             {
-                LanguageNames.VisualBasic => [new(rootPath, ".vb")],
-                LanguageNames.CSharp => [new(rootPath, ".cs"), new(rootPath, ".razor"), new(rootPath, ".cshtml")],
+                LanguageNames.VisualBasic => [new(rootPath, [".vb"])],
+                LanguageNames.CSharp => [new(rootPath, [".cs", ".razor", ".cshtml"])],
                 _ => []
             };
         }


### PR DESCRIPTION
While looking into another FileWatcher issue, I noticed that we were getting more notifications from shell on directory changes than I would have expected. It turns out this is because we don't currently combine WatchDirectory operations as we do WatchFile/UnwatchFile/UnwatchDirectories.

This is generally the desired behavior as vs shell doesn't support multiple directories being supported by a single notification. However, they do support multiple filters on the same directory, and this is exactly the case that we usualy experience when processing a batch of WatcherOperations. This PR simply allows combining of directory watch notifications for the same directory (and sink), keeping track of the combined set of filters that all requests had.

Note that this PR also changed the mergability of WatchFiles by only allowing merging if the sinks are the same. I don't have context to be completely confident the prior behavior is a bug, but it sure seems wrong.