### PR TITLE
Change inline diagnostics tagger to be a viewport tagger

### DIFF
--- a/src/EditorFeatures/Core/InlineHints/InlineHintDataTag.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintDataTag.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
@@ -48,12 +49,12 @@ internal sealed class InlineHintDataTag(InlineHintsDataTaggerProvider provider, 
             return false;
 
         // Ensure both hints are talking about the same snapshot.
-        if (!_provider.SpanEquals(_snapshot, this.Hint.Span, other._snapshot, other.Hint.Span))
+        if (!_provider.SpanEquals(this.Hint.Span.ToSnapshotSpan(_snapshot), other.Hint.Span.ToSnapshotSpan(other._snapshot)))
             return false;
 
         if (this.Hint.ReplacementTextChange != null &&
             other.Hint.ReplacementTextChange != null &&
-            !_provider.SpanEquals(_snapshot, this.Hint.ReplacementTextChange.Value.Span, other._snapshot, other.Hint.ReplacementTextChange.Value.Span))
+            !_provider.SpanEquals(this.Hint.ReplacementTextChange.Value.Span.ToSnapshotSpan(_snapshot), other.Hint.ReplacementTextChange.Value.Span.ToSnapshotSpan(other._snapshot)))
         {
             return false;
         }

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
@@ -12,14 +12,12 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.InlineHints;
-using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
-using Roslyn.Utilities;
 using VSUtilities = Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.InlineHints;
@@ -33,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints;
 [VSUtilities.Name(nameof(InlineHintsDataTaggerProvider))]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 [method: ImportingConstructor]
-internal partial class InlineHintsDataTaggerProvider(
+internal sealed partial class InlineHintsDataTaggerProvider(
     TaggerHost taggerHost,
     [Import(AllowDefault = true)] IInlineHintKeyProcessor inlineHintKeyProcessor)
     : AsynchronousViewportTaggerProvider<InlineHintDataTag>(taggerHost, FeatureAttribute.InlineHints)


### PR DESCRIPTION
It was already replicating hte logic to tag parts of the file out of view.  This just sits us on the existing mechanism for doing that.