### PR TITLE
Optimize single spread of IEnumerable to array

### DIFF
--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -9427,6 +9427,22 @@ static class Program
                       IL_0013:  ret
                     }
                     """,
+                ("IEnumerable<int>", "Span<int>") =>
+                    """
+                    {
+                      // Code size       25 (0x19)
+                      .maxstack  1
+                      .locals init (System.ReadOnlySpan<int> V_0)
+                      IL_0000:  ldarg.0
+                      IL_0001:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                      IL_0006:  newobj     "System.Span<int>..ctor(int[])"
+                      IL_000b:  call       "System.ReadOnlySpan<int> System.Span<int>.op_Implicit(System.Span<int>)"
+                      IL_0010:  stloc.0
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
+                      IL_0018:  ret
+                    }
+                    """,
                 ("int[]", "int[]") =>
                     """
                     {

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -34888,8 +34888,9 @@ partial class Program
             var source = """
                 using System;
 
-                C.M1(["a"]);
-                C.M2(["b"]);
+                string[] arr = ["a"];
+                C.M1(arr);
+                C.M2(arr);
 
                 class C
                 {
@@ -34906,7 +34907,7 @@ partial class Program
                 }
                 """;
 
-            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: IncludeExpectedOutput("[a], [b], "), targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
+            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: IncludeExpectedOutput("[a], [a], "), targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
             var expectedIL = """
                 {
                   // Code size       25 (0x19)
@@ -34932,8 +34933,9 @@ partial class Program
             var source = """
                 using System;
 
-                C.M1(["a"]);
-                C.M2(["b"]);
+                string[] arr = ["a"];
+                C.M1(arr);
+                C.M2(arr);
 
                 class C
                 {
@@ -34950,7 +34952,7 @@ partial class Program
                 }
                 """;
 
-            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: IncludeExpectedOutput("[a], [b], "), targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
+            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: IncludeExpectedOutput("[a], [a], "), targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
             var expectedIL = """
                 {
                   // Code size       21 (0x15)

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -34906,7 +34906,7 @@ partial class Program
                 }
                 """;
 
-            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: "[a], [b], ", targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
+            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: IncludeExpectedOutput("[a], [b], "), targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
             var expectedIL = """
                 {
                   // Code size       25 (0x19)
@@ -34950,7 +34950,7 @@ partial class Program
                 }
                 """;
 
-            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: "[a], [b], ", targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
+            var verifier = CompileAndVerify([source, s_collectionExtensionsWithSpan], expectedOutput: IncludeExpectedOutput("[a], [b], "), targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
             var expectedIL = """
                 {
                   // Code size       21 (0x15)

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -4639,50 +4639,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 expectedOutput: IncludeExpectedOutput("[a, b, c, d], "));
             verifier.VerifyIL("Program.GetChars", """
                 {
-                  // Code size       64 (0x40)
-                  .maxstack  3
-                  .locals init (int V_0,
-                                char[] V_1,
-                                System.CharEnumerator V_2,
-                                char V_3)
+                  // Code size       11 (0xb)
+                  .maxstack  1
                   IL_0000:  ldstr      "abcd"
-                  IL_0005:  ldc.i4.0
-                  IL_0006:  stloc.0
-                  IL_0007:  dup
-                  IL_0008:  callvirt   "int string.Length.get"
-                  IL_000d:  newarr     "char"
-                  IL_0012:  stloc.1
-                  IL_0013:  callvirt   "System.CharEnumerator string.GetEnumerator()"
-                  IL_0018:  stloc.2
-                  .try
-                  {
-                    IL_0019:  br.s       IL_002a
-                    IL_001b:  ldloc.2
-                    IL_001c:  callvirt   "char System.CharEnumerator.Current.get"
-                    IL_0021:  stloc.3
-                    IL_0022:  ldloc.1
-                    IL_0023:  ldloc.0
-                    IL_0024:  ldloc.3
-                    IL_0025:  stelem.i2
-                    IL_0026:  ldloc.0
-                    IL_0027:  ldc.i4.1
-                    IL_0028:  add
-                    IL_0029:  stloc.0
-                    IL_002a:  ldloc.2
-                    IL_002b:  callvirt   "bool System.CharEnumerator.MoveNext()"
-                    IL_0030:  brtrue.s   IL_001b
-                    IL_0032:  leave.s    IL_003e
-                  }
-                  finally
-                  {
-                    IL_0034:  ldloc.2
-                    IL_0035:  brfalse.s  IL_003d
-                    IL_0037:  ldloc.2
-                    IL_0038:  callvirt   "void System.IDisposable.Dispose()"
-                    IL_003d:  endfinally
-                  }
-                  IL_003e:  ldloc.1
-                  IL_003f:  ret
+                  IL_0005:  call       "char[] System.Linq.Enumerable.ToArray<char>(System.Collections.Generic.IEnumerable<char>)"
+                  IL_000a:  ret
                 }
                 """);
         }
@@ -9454,37 +9415,31 @@ static class Program
                 ("IEnumerable<int>", "int[]") =>
                     """
                     {
-                      // Code size       31 (0x1f)
-                      .maxstack  3
+                      // Code size       20 (0x14)
+                      .maxstack  1
                       .locals init (System.ReadOnlySpan<int> V_0)
-                      IL_0000:  newobj     "System.Collections.Generic.List<int>..ctor()"
-                      IL_0005:  dup
-                      IL_0006:  ldarg.0
-                      IL_0007:  callvirt   "void System.Collections.Generic.List<int>.AddRange(System.Collections.Generic.IEnumerable<int>)"
-                      IL_000c:  callvirt   "int[] System.Collections.Generic.List<int>.ToArray()"
-                      IL_0011:  call       "System.ReadOnlySpan<int> System.ReadOnlySpan<int>.op_Implicit(int[])"
-                      IL_0016:  stloc.0
-                      IL_0017:  ldloca.s   V_0
-                      IL_0019:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
-                      IL_001e:  ret
+                      IL_0000:  ldarg.0
+                      IL_0001:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                      IL_0006:  call       "System.ReadOnlySpan<int> System.ReadOnlySpan<int>.op_Implicit(int[])"
+                      IL_000b:  stloc.0
+                      IL_000c:  ldloca.s   V_0
+                      IL_000e:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
+                      IL_0013:  ret
                     }
                     """,
                 ("int[]", "int[]") =>
                     """
                     {
-                      // Code size       28 (0x1c)
+                      // Code size       20 (0x14)
                       .maxstack  1
                       .locals init (System.ReadOnlySpan<int> V_0)
                       IL_0000:  ldarg.0
-                      IL_0001:  newobj     "System.ReadOnlySpan<int>..ctor(int[])"
-                      IL_0006:  stloc.0
-                      IL_0007:  ldloca.s   V_0
-                      IL_0009:  call       "int[] System.ReadOnlySpan<int>.ToArray()"
-                      IL_000e:  call       "System.ReadOnlySpan<int> System.ReadOnlySpan<int>.op_Implicit(int[])"
-                      IL_0013:  stloc.0
-                      IL_0014:  ldloca.s   V_0
-                      IL_0016:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
-                      IL_001b:  ret
+                      IL_0001:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                      IL_0006:  call       "System.ReadOnlySpan<int> System.ReadOnlySpan<int>.op_Implicit(int[])"
+                      IL_000b:  stloc.0
+                      IL_000c:  ldloca.s   V_0
+                      IL_000e:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
+                      IL_0013:  ret
                     }
                     """,
                 ("ReadOnlySpan<int>", "ReadOnlySpan<int>") =>
@@ -23887,18 +23842,14 @@ partial class Program
 
                 verifier.VerifyIL("R<T>..ctor(int, T[])", """
                     {
-                      // Code size       26 (0x1a)
+                      // Code size       18 (0x12)
                       .maxstack  2
-                      .locals init (System.ReadOnlySpan<T> V_0)
                       IL_0000:  ldarg.0
                       IL_0001:  ldarg.2
-                      IL_0002:  newobj     "System.ReadOnlySpan<T>..ctor(T[])"
-                      IL_0007:  stloc.0
-                      IL_0008:  ldloca.s   V_0
-                      IL_000a:  call       "T[] System.ReadOnlySpan<T>.ToArray()"
-                      IL_000f:  newobj     "System.Span<T>..ctor(T[])"
-                      IL_0014:  call       "R<T>..ctor(scoped System.Span<T>)"
-                      IL_0019:  ret
+                      IL_0002:  call       "T[] System.Linq.Enumerable.ToArray<T>(System.Collections.Generic.IEnumerable<T>)"
+                      IL_0007:  newobj     "System.Span<T>..ctor(T[])"
+                      IL_000c:  call       "R<T>..ctor(scoped System.Span<T>)"
+                      IL_0011:  ret
                     }
                     """);
             }
@@ -24677,27 +24628,24 @@ partial class Program
                 expectedOutput: IncludeExpectedOutput("[1, null, 3], "));
             verifier.VerifyIL("Program.M<T>", """
                 {
-                  // Code size       47 (0x2f)
+                  // Code size       39 (0x27)
                   .maxstack  2
                   .locals init (System.Span<T> V_0, //s
                                 System.ReadOnlySpan<T> V_1)
                   IL_0000:  ldloca.s   V_0
                   IL_0002:  initobj    "System.Span<T>"
                   IL_0008:  ldarg.0
-                  IL_0009:  brfalse.s  IL_0020
+                  IL_0009:  brfalse.s  IL_0018
                   IL_000b:  ldloca.s   V_0
                   IL_000d:  ldarg.1
-                  IL_000e:  newobj     "System.ReadOnlySpan<T>..ctor(T[])"
-                  IL_0013:  stloc.1
-                  IL_0014:  ldloca.s   V_1
-                  IL_0016:  call       "T[] System.ReadOnlySpan<T>.ToArray()"
-                  IL_001b:  call       "System.Span<T>..ctor(T[])"
-                  IL_0020:  ldloc.0
-                  IL_0021:  call       "System.ReadOnlySpan<T> System.Span<T>.op_Implicit(System.Span<T>)"
-                  IL_0026:  stloc.1
-                  IL_0027:  ldloca.s   V_1
-                  IL_0029:  call       "void CollectionExtensions.Report<T>(in System.ReadOnlySpan<T>)"
-                  IL_002e:  ret
+                  IL_000e:  call       "T[] System.Linq.Enumerable.ToArray<T>(System.Collections.Generic.IEnumerable<T>)"
+                  IL_0013:  call       "System.Span<T>..ctor(T[])"
+                  IL_0018:  ldloc.0
+                  IL_0019:  call       "System.ReadOnlySpan<T> System.Span<T>.op_Implicit(System.Span<T>)"
+                  IL_001e:  stloc.1
+                  IL_001f:  ldloca.s   V_1
+                  IL_0021:  call       "void CollectionExtensions.Report<T>(in System.ReadOnlySpan<T>)"
+                  IL_0026:  ret
                 }
                 """);
         }
@@ -30396,23 +30344,19 @@ partial class Program
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("Program.Main", """
                 {
-                  // Code size       47 (0x2f)
+                  // Code size       39 (0x27)
                   .maxstack  3
-                  .locals init (System.ReadOnlySpan<int> V_0)
                   IL_0000:  ldc.i4.3
                   IL_0001:  newarr     "int"
                   IL_0006:  dup
                   IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D"
                   IL_000c:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
-                  IL_0011:  newobj     "System.ReadOnlySpan<int>..ctor(int[])"
-                  IL_0016:  stloc.0
-                  IL_0017:  ldloca.s   V_0
-                  IL_0019:  call       "int[] System.ReadOnlySpan<int>.ToArray()"
-                  IL_001e:  call       "System.Collections.Immutable.ImmutableArray<int> System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsImmutableArray<int>(int[])"
-                  IL_0023:  box        "System.Collections.Immutable.ImmutableArray<int>"
-                  IL_0028:  ldc.i4.0
-                  IL_0029:  call       "void CollectionExtensions.Report(object, bool)"
-                  IL_002e:  ret
+                  IL_0011:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                  IL_0016:  call       "System.Collections.Immutable.ImmutableArray<int> System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsImmutableArray<int>(int[])"
+                  IL_001b:  box        "System.Collections.Immutable.ImmutableArray<int>"
+                  IL_0020:  ldc.i4.0
+                  IL_0021:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_0026:  ret
                 }
                 """);
         }
@@ -30439,26 +30383,20 @@ partial class Program
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("Program.Main", """
                 {
-                  // Code size       57 (0x39)
+                  // Code size       44 (0x2c)
                   .maxstack  3
-                  .locals init (System.Collections.Generic.IEnumerable<int> V_0) //arr
                   IL_0000:  ldc.i4.3
                   IL_0001:  newarr     "int"
                   IL_0006:  dup
                   IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D"
                   IL_000c:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
                   IL_0011:  newobj     "<>z__ReadOnlyArray<int>..ctor(int[])"
-                  IL_0016:  stloc.0
-                  IL_0017:  newobj     "System.Collections.Generic.List<int>..ctor()"
-                  IL_001c:  dup
-                  IL_001d:  ldloc.0
-                  IL_001e:  callvirt   "void System.Collections.Generic.List<int>.AddRange(System.Collections.Generic.IEnumerable<int>)"
-                  IL_0023:  callvirt   "int[] System.Collections.Generic.List<int>.ToArray()"
-                  IL_0028:  call       "System.Collections.Immutable.ImmutableArray<int> System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsImmutableArray<int>(int[])"
-                  IL_002d:  box        "System.Collections.Immutable.ImmutableArray<int>"
-                  IL_0032:  ldc.i4.0
-                  IL_0033:  call       "void CollectionExtensions.Report(object, bool)"
-                  IL_0038:  ret
+                  IL_0016:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                  IL_001b:  call       "System.Collections.Immutable.ImmutableArray<int> System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsImmutableArray<int>(int[])"
+                  IL_0020:  box        "System.Collections.Immutable.ImmutableArray<int>"
+                  IL_0025:  ldc.i4.0
+                  IL_0026:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_002b:  ret
                 }
                 """);
         }
@@ -34205,8 +34143,9 @@ partial class Program
                 """);
         }
 
-        [Fact]
-        public void ArrayToArray_Covariant_SingleSpread()
+        [Theory]
+        [CombinatorialData]
+        public void ArrayToArray_Covariant_SingleSpread(bool missingReadOnlySpanCtor)
         {
             var source = """
                 class Base { }
@@ -34225,11 +34164,16 @@ partial class Program
                 }
                 """;
 
-            var verifier = CompileAndVerify(new[] { source, s_collectionExtensionsWithSpan }, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput("[Derived], [Derived], "), targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(new[] { source, s_collectionExtensionsWithSpan }, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+
+            if (missingReadOnlySpanCtor)
+                comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ctor_Array);
+
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput("[Derived], [Derived], "));
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.Main", """
                 {
-                  // Code size       57 (0x39)
+                  // Code size       49 (0x31)
                   .maxstack  4
                   .locals init (Base[] V_0,
                                 System.ReadOnlySpan<Base> V_1)
@@ -34246,107 +34190,12 @@ partial class Program
                   IL_0016:  stloc.1
                   IL_0017:  ldloca.s   V_1
                   IL_0019:  call       "void CollectionExtensions.Report<Base>(in System.ReadOnlySpan<Base>)"
-                  IL_001e:  newobj     "System.ReadOnlySpan<Base>..ctor(Base[])"
-                  IL_0023:  stloc.1
-                  IL_0024:  ldloca.s   V_1
-                  IL_0026:  call       "Base[] System.ReadOnlySpan<Base>.ToArray()"
-                  IL_002b:  call       "System.ReadOnlySpan<Base> System.ReadOnlySpan<Base>.op_Implicit(Base[])"
-                  IL_0030:  stloc.1
-                  IL_0031:  ldloca.s   V_1
-                  IL_0033:  call       "void CollectionExtensions.Report<Base>(in System.ReadOnlySpan<Base>)"
-                  IL_0038:  ret
-                }
-                """);
-        }
-
-        [Fact]
-        public void ArrayToArray_Covariant_SingleSpread_ReadOnlySpanCtorMissing()
-        {
-            var source = """
-                class Base { }
-                class Derived : Base { }
-
-                class C
-                {
-                    static void Main()
-                    {
-                        Base[] array = new Derived[] { new Derived() };
-                        array.Report();
-
-                        Base[] copy = [..array];
-                        copy.Report();
-                    }
-                }
-                """;
-
-            // In the event that the ReadOnlySpan ctor is missing, we do not fall back to converting the array spread value to Span.
-            // Instead, we lower the spread without optimizing it.
-            var comp = CreateCompilation(new[] { source, s_collectionExtensionsWithSpan }, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
-            comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ctor_Array);
-
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput("[Derived], [Derived], "));
-            verifier.VerifyDiagnostics();
-            verifier.VerifyIL("C.Main", """
-                {
-                  // Code size       90 (0x5a)
-                  .maxstack  4
-                  .locals init (Base[] V_0,
-                                System.ReadOnlySpan<Base> V_1,
-                                int V_2,
-                                Base[] V_3,
-                                int V_4,
-                                Base V_5)
-                  IL_0000:  ldc.i4.1
-                  IL_0001:  newarr     "Derived"
-                  IL_0006:  dup
-                  IL_0007:  ldc.i4.0
-                  IL_0008:  newobj     "Derived..ctor()"
-                  IL_000d:  stelem.ref
-                  IL_000e:  stloc.0
-                  IL_000f:  ldloc.0
-                  IL_0010:  dup
-                  IL_0011:  call       "System.ReadOnlySpan<Base> System.ReadOnlySpan<Base>.op_Implicit(Base[])"
-                  IL_0016:  stloc.1
-                  IL_0017:  ldloca.s   V_1
-                  IL_0019:  call       "void CollectionExtensions.Report<Base>(in System.ReadOnlySpan<Base>)"
-                  IL_001e:  ldc.i4.0
-                  IL_001f:  stloc.2
-                  IL_0020:  dup
-                  IL_0021:  ldlen
-                  IL_0022:  conv.i4
-                  IL_0023:  newarr     "Base"
-                  IL_0028:  stloc.0
-                  IL_0029:  stloc.3
-                  IL_002a:  ldc.i4.0
-                  IL_002b:  stloc.s    V_4
-                  IL_002d:  br.s       IL_0044
-                  IL_002f:  ldloc.3
-                  IL_0030:  ldloc.s    V_4
-                  IL_0032:  ldelem.ref
-                  IL_0033:  stloc.s    V_5
-                  IL_0035:  ldloc.0
-                  IL_0036:  ldloc.2
-                  IL_0037:  ldloc.s    V_5
-                  IL_0039:  stelem.ref
-                  IL_003a:  ldloc.2
-                  IL_003b:  ldc.i4.1
-                  IL_003c:  add
-                  IL_003d:  stloc.2
-                  IL_003e:  ldloc.s    V_4
-                  IL_0040:  ldc.i4.1
-                  IL_0041:  add
-                  IL_0042:  stloc.s    V_4
-                  IL_0044:  ldloc.s    V_4
-                  IL_0046:  ldloc.3
-                  IL_0047:  ldlen
-                  IL_0048:  conv.i4
-                  IL_0049:  blt.s      IL_002f
-                  IL_004b:  ldloc.0
-                  IL_004c:  call       "System.ReadOnlySpan<Base> System.ReadOnlySpan<Base>.op_Implicit(Base[])"
-                  IL_0051:  stloc.1
-                  IL_0052:  ldloca.s   V_1
-                  IL_0054:  call       "void CollectionExtensions.Report<Base>(in System.ReadOnlySpan<Base>)"
-                  IL_0059:  ret
+                  IL_001e:  call       "Base[] System.Linq.Enumerable.ToArray<Base>(System.Collections.Generic.IEnumerable<Base>)"
+                  IL_0023:  call       "System.ReadOnlySpan<Base> System.ReadOnlySpan<Base>.op_Implicit(Base[])"
+                  IL_0028:  stloc.1
+                  IL_0029:  ldloca.s   V_1
+                  IL_002b:  call       "void CollectionExtensions.Report<Base>(in System.ReadOnlySpan<Base>)"
+                  IL_0030:  ret
                 }
                 """);
         }
@@ -34857,8 +34706,9 @@ partial class Program
                 """);
         }
 
-        [Fact]
-        public void SingleSpread_WellKnownMemberMissing()
+        [Theory]
+        [CombinatorialData]
+        public void SingleSpread_WellKnownMemberMissing(bool readOnlySpanMembersMissing)
         {
             var source = """
                 class C
@@ -34874,14 +34724,18 @@ partial class Program
                 """;
 
             var comp = CreateCompilation([source, s_collectionExtensions], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+            if (readOnlySpanMembersMissing)
+            {
+                comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ctor_Array);
+                comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ToArray);
+            }
 
             var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("[1, 2, 3], [1, 2, 3],"));
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.Main", """
                 {
-                  // Code size       44 (0x2c)
+                  // Code size       36 (0x24)
                   .maxstack  3
-                  .locals init (System.ReadOnlySpan<int> V_0)
                   IL_0000:  ldc.i4.3
                   IL_0001:  newarr     "int"
                   IL_0006:  dup
@@ -34890,131 +34744,10 @@ partial class Program
                   IL_0011:  dup
                   IL_0012:  ldc.i4.0
                   IL_0013:  call       "void CollectionExtensions.Report(object, bool)"
-                  IL_0018:  newobj     "System.ReadOnlySpan<int>..ctor(int[])"
-                  IL_001d:  stloc.0
-                  IL_001e:  ldloca.s   V_0
-                  IL_0020:  call       "int[] System.ReadOnlySpan<int>.ToArray()"
-                  IL_0025:  ldc.i4.0
-                  IL_0026:  call       "void CollectionExtensions.Report(object, bool)"
-                  IL_002b:  ret
-                }
-                """);
-
-            // No ReadOnlySpan(T[]) constructor. Spread optimizations can't be performed.
-            comp = CreateCompilation([source, s_collectionExtensions], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
-            comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ctor_Array);
-
-            verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("[1, 2, 3], [1, 2, 3],"));
-            verifier.VerifyDiagnostics();
-            verifier.VerifyIL("C.Main", """
-                {
-                // Code size       72 (0x48)
-                .maxstack  3
-                .locals init (int V_0,
-                                int[] V_1,
-                                int[] V_2,
-                                int V_3,
-                                int V_4)
-                IL_0000:  ldc.i4.3
-                IL_0001:  newarr     "int"
-                IL_0006:  dup
-                IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D"
-                IL_000c:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
-                IL_0011:  dup
-                IL_0012:  ldc.i4.0
-                IL_0013:  call       "void CollectionExtensions.Report(object, bool)"
-                IL_0018:  ldc.i4.0
-                IL_0019:  stloc.0
-                IL_001a:  dup
-                IL_001b:  ldlen
-                IL_001c:  conv.i4
-                IL_001d:  newarr     "int"
-                IL_0022:  stloc.1
-                IL_0023:  stloc.2
-                IL_0024:  ldc.i4.0
-                IL_0025:  stloc.3
-                IL_0026:  br.s       IL_003a
-                IL_0028:  ldloc.2
-                IL_0029:  ldloc.3
-                IL_002a:  ldelem.i4
-                IL_002b:  stloc.s    V_4
-                IL_002d:  ldloc.1
-                IL_002e:  ldloc.0
-                IL_002f:  ldloc.s    V_4
-                IL_0031:  stelem.i4
-                IL_0032:  ldloc.0
-                IL_0033:  ldc.i4.1
-                IL_0034:  add
-                IL_0035:  stloc.0
-                IL_0036:  ldloc.3
-                IL_0037:  ldc.i4.1
-                IL_0038:  add
-                IL_0039:  stloc.3
-                IL_003a:  ldloc.3
-                IL_003b:  ldloc.2
-                IL_003c:  ldlen
-                IL_003d:  conv.i4
-                IL_003e:  blt.s      IL_0028
-                IL_0040:  ldloc.1
-                IL_0041:  ldc.i4.0
-                IL_0042:  call       "void CollectionExtensions.Report(object, bool)"
-                IL_0047:  ret
-                }
-                """);
-
-            // No ReadOnlySpan.ToArray method. ToArray optimization for single spreads cannot be performed, but CopyTo optimization still can.
-            comp = CreateCompilation([source, s_collectionExtensions], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
-            comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ToArray);
-
-            verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("[1, 2, 3], [1, 2, 3],"));
-            verifier.VerifyDiagnostics();
-            verifier.VerifyIL("C.Main", """
-                {
-                  // Code size       92 (0x5c)
-                  .maxstack  4
-                  .locals init (int[] V_0,
-                                int V_1,
-                                int[] V_2,
-                                System.ReadOnlySpan<int> V_3,
-                                System.Span<int> V_4)
-                  IL_0000:  ldc.i4.3
-                  IL_0001:  newarr     "int"
-                  IL_0006:  dup
-                  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D"
-                  IL_000c:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
-                  IL_0011:  dup
-                  IL_0012:  ldc.i4.0
-                  IL_0013:  call       "void CollectionExtensions.Report(object, bool)"
-                  IL_0018:  stloc.0
-                  IL_0019:  ldc.i4.0
-                  IL_001a:  stloc.1
-                  IL_001b:  ldloc.0
-                  IL_001c:  ldlen
-                  IL_001d:  conv.i4
-                  IL_001e:  newarr     "int"
-                  IL_0023:  stloc.2
-                  IL_0024:  ldloca.s   V_3
-                  IL_0026:  ldloc.0
-                  IL_0027:  call       "System.ReadOnlySpan<int>..ctor(int[])"
-                  IL_002c:  ldloca.s   V_3
-                  IL_002e:  ldloc.2
-                  IL_002f:  newobj     "System.Span<int>..ctor(int[])"
-                  IL_0034:  stloc.s    V_4
-                  IL_0036:  ldloca.s   V_4
-                  IL_0038:  ldloc.1
-                  IL_0039:  ldloca.s   V_3
-                  IL_003b:  call       "int System.ReadOnlySpan<int>.Length.get"
-                  IL_0040:  call       "System.Span<int> System.Span<int>.Slice(int, int)"
-                  IL_0045:  call       "void System.ReadOnlySpan<int>.CopyTo(System.Span<int>)"
-                  IL_004a:  ldloc.1
-                  IL_004b:  ldloca.s   V_3
-                  IL_004d:  call       "int System.ReadOnlySpan<int>.Length.get"
-                  IL_0052:  add
-                  IL_0053:  stloc.1
-                  IL_0054:  ldloc.2
-                  IL_0055:  ldc.i4.0
-                  IL_0056:  call       "void CollectionExtensions.Report(object, bool)"
-                  IL_005b:  ret
+                  IL_0018:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                  IL_001d:  ldc.i4.0
+                  IL_001e:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_0023:  ret
                 }
                 """);
         }
@@ -35547,7 +35280,7 @@ partial class Program
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.Main", """
                 {
-                  // Code size       65 (0x41)
+                  // Code size       57 (0x39)
                   .maxstack  3
                   .locals init (int[] V_0, //arr
                                 System.ReadOnlySpan<int> V_1)
@@ -35563,16 +35296,13 @@ partial class Program
                   IL_0019:  ldloca.s   V_1
                   IL_001b:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
                   IL_0020:  ldloc.0
-                  IL_0021:  newobj     "System.ReadOnlySpan<int>..ctor(int[])"
-                  IL_0026:  stloc.1
-                  IL_0027:  ldloca.s   V_1
-                  IL_0029:  call       "int[] System.ReadOnlySpan<int>.ToArray()"
-                  IL_002e:  newobj     "System.Span<int>..ctor(int[])"
-                  IL_0033:  call       "System.ReadOnlySpan<int> System.Span<int>.op_Implicit(System.Span<int>)"
-                  IL_0038:  stloc.1
-                  IL_0039:  ldloca.s   V_1
-                  IL_003b:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
-                  IL_0040:  ret
+                  IL_0021:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                  IL_0026:  newobj     "System.Span<int>..ctor(int[])"
+                  IL_002b:  call       "System.ReadOnlySpan<int> System.Span<int>.op_Implicit(System.Span<int>)"
+                  IL_0030:  stloc.1
+                  IL_0031:  ldloca.s   V_1
+                  IL_0033:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
+                  IL_0038:  ret
                 }
                 """);
         }
@@ -35598,7 +35328,7 @@ partial class Program
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.Main", """
                 {
-                  // Code size       56 (0x38)
+                  // Code size       48 (0x30)
                   .maxstack  3
                   .locals init (System.ReadOnlySpan<int> V_0)
                   IL_0000:  ldc.i4.3
@@ -35611,14 +35341,11 @@ partial class Program
                   IL_0017:  stloc.0
                   IL_0018:  ldloca.s   V_0
                   IL_001a:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
-                  IL_001f:  newobj     "System.ReadOnlySpan<int>..ctor(int[])"
-                  IL_0024:  stloc.0
-                  IL_0025:  ldloca.s   V_0
-                  IL_0027:  call       "int[] System.ReadOnlySpan<int>.ToArray()"
-                  IL_002c:  newobj     "<>z__ReadOnlyArray<int>..ctor(int[])"
-                  IL_0031:  ldc.i4.0
-                  IL_0032:  call       "void CollectionExtensions.Report(object, bool)"
-                  IL_0037:  ret
+                  IL_001f:  call       "int[] System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)"
+                  IL_0024:  newobj     "<>z__ReadOnlyArray<int>..ctor(int[])"
+                  IL_0029:  ldc.i4.0
+                  IL_002a:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_002f:  ret
                 }
                 """);
         }
@@ -36609,6 +36336,183 @@ partial class Program
                   }
                   IL_0037:  ldloc.0
                   IL_0038:  ret
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74615")]
+        public void Array_SingleSpread_CustomCollection_NotICollectionAndStructEnumerator()
+        {
+            var source = """
+                using System.Collections;
+                using System.Collections.Generic;
+
+                class MyCollection(List<int> list) : IEnumerable<int>
+                {
+                    public Enumerator GetEnumerator() => new(list.GetEnumerator());
+
+                    IEnumerator<int> IEnumerable<int>.GetEnumerator() => GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+                    public int Count => list.Count;
+
+                    public struct Enumerator(List<int>.Enumerator enumerator) : IEnumerator<int>
+                    {
+                        public int Current => enumerator.Current;
+
+                        object IEnumerator.Current => Current;
+
+                        public bool MoveNext() => enumerator.MoveNext();
+
+                        public void Dispose() => enumerator.Dispose();
+
+                        public void Reset() { }
+                    }
+                }
+
+                class C
+                {
+                    static void Main()
+                    {
+                        M(new([1, 2, 3])).Report();
+                    }
+
+                    static int[] M(MyCollection c) => [..c];
+                }
+                """;
+
+            var verifier = CompileAndVerify([source, s_collectionExtensions], expectedOutput: "[1, 2, 3],", verify: Verification.Skipped);
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("C.M", """
+                {
+                  // Code size       66 (0x42)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                int[] V_1,
+                                MyCollection.Enumerator V_2,
+                                int V_3)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  stloc.0
+                  IL_0003:  dup
+                  IL_0004:  callvirt   "int MyCollection.Count.get"
+                  IL_0009:  newarr     "int"
+                  IL_000e:  stloc.1
+                  IL_000f:  callvirt   "MyCollection.Enumerator MyCollection.GetEnumerator()"
+                  IL_0014:  stloc.2
+                  .try
+                  {
+                    IL_0015:  br.s       IL_0027
+                    IL_0017:  ldloca.s   V_2
+                    IL_0019:  call       "int MyCollection.Enumerator.Current.get"
+                    IL_001e:  stloc.3
+                    IL_001f:  ldloc.1
+                    IL_0020:  ldloc.0
+                    IL_0021:  ldloc.3
+                    IL_0022:  stelem.i4
+                    IL_0023:  ldloc.0
+                    IL_0024:  ldc.i4.1
+                    IL_0025:  add
+                    IL_0026:  stloc.0
+                    IL_0027:  ldloca.s   V_2
+                    IL_0029:  call       "bool MyCollection.Enumerator.MoveNext()"
+                    IL_002e:  brtrue.s   IL_0017
+                    IL_0030:  leave.s    IL_0040
+                  }
+                  finally
+                  {
+                    IL_0032:  ldloca.s   V_2
+                    IL_0034:  constrained. "MyCollection.Enumerator"
+                    IL_003a:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_003f:  endfinally
+                  }
+                  IL_0040:  ldloc.1
+                  IL_0041:  ret
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74615")]
+        public void Array_SingleSpread_CustomCollection_NotICollectionAndStructEnumerator_NoCountProperty()
+        {
+            var source = """
+                using System.Collections;
+                using System.Collections.Generic;
+
+                class MyCollection(List<int> list) : IEnumerable<int>
+                {
+                    public Enumerator GetEnumerator() => new(list.GetEnumerator());
+
+                    IEnumerator<int> IEnumerable<int>.GetEnumerator() => GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+                    public struct Enumerator(List<int>.Enumerator enumerator) : IEnumerator<int>
+                    {
+                        public int Current => enumerator.Current;
+
+                        object IEnumerator.Current => Current;
+
+                        public bool MoveNext() => enumerator.MoveNext();
+
+                        public void Dispose() => enumerator.Dispose();
+
+                        public void Reset() { }
+                    }
+                }
+
+                class C
+                {
+                    static void Main()
+                    {
+                        M(new([1, 2, 3])).Report();
+                    }
+
+                    static int[] M(MyCollection c) => [..c];
+                }
+                """;
+
+            var verifier = CompileAndVerify([source, s_collectionExtensions], expectedOutput: "[1, 2, 3],", verify: Verification.Skipped);
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("C.M", """
+                {
+                  // Code size       62 (0x3e)
+                  .maxstack  2
+                  .locals init (System.Collections.Generic.List<int> V_0,
+                                MyCollection.Enumerator V_1,
+                                int V_2)
+                  IL_0000:  newobj     "System.Collections.Generic.List<int>..ctor()"
+                  IL_0005:  stloc.0
+                  IL_0006:  ldarg.0
+                  IL_0007:  callvirt   "MyCollection.Enumerator MyCollection.GetEnumerator()"
+                  IL_000c:  stloc.1
+                  .try
+                  {
+                    IL_000d:  br.s       IL_001e
+                    IL_000f:  ldloca.s   V_1
+                    IL_0011:  call       "int MyCollection.Enumerator.Current.get"
+                    IL_0016:  stloc.2
+                    IL_0017:  ldloc.0
+                    IL_0018:  ldloc.2
+                    IL_0019:  callvirt   "void System.Collections.Generic.List<int>.Add(int)"
+                    IL_001e:  ldloca.s   V_1
+                    IL_0020:  call       "bool MyCollection.Enumerator.MoveNext()"
+                    IL_0025:  brtrue.s   IL_000f
+                    IL_0027:  leave.s    IL_0037
+                  }
+                  finally
+                  {
+                    IL_0029:  ldloca.s   V_1
+                    IL_002b:  constrained. "MyCollection.Enumerator"
+                    IL_0031:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_0036:  endfinally
+                  }
+                  IL_0037:  ldloc.0
+                  IL_0038:  callvirt   "int[] System.Collections.Generic.List<int>.ToArray()"
+                  IL_003d:  ret
                 }
                 """);
         }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -36948,7 +36948,7 @@ partial class Program
                 }
                 """;
 
-            var verifier = CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("1234"), targetFramework: TargetFramework.Net80);
+            var verifier = CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("1234"), targetFramework: TargetFramework.Net80, verify: Verification.Skipped);
             verifier.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -34904,11 +34904,116 @@ partial class Program
             var verifier = CompileAndVerify(source, expectedOutput: "a");
             verifier.VerifyIL("C.M", """
                 {
-                  // Code size        7 (0x7)
-                  .maxstack  1
+                  // Code size       66 (0x42)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                object[] V_1,
+                                System.Collections.Generic.List<string>.Enumerator V_2,
+                                string V_3)
                   IL_0000:  ldarg.0
-                  IL_0001:  call       "object[] System.Linq.Enumerable.ToArray<object>(System.Collections.Generic.IEnumerable<object>)"
-                  IL_0006:  ret
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  stloc.0
+                  IL_0003:  dup
+                  IL_0004:  callvirt   "int System.Collections.Generic.List<string>.Count.get"
+                  IL_0009:  newarr     "object"
+                  IL_000e:  stloc.1
+                  IL_000f:  callvirt   "System.Collections.Generic.List<string>.Enumerator System.Collections.Generic.List<string>.GetEnumerator()"
+                  IL_0014:  stloc.2
+                  .try
+                  {
+                    IL_0015:  br.s       IL_0027
+                    IL_0017:  ldloca.s   V_2
+                    IL_0019:  call       "string System.Collections.Generic.List<string>.Enumerator.Current.get"
+                    IL_001e:  stloc.3
+                    IL_001f:  ldloc.1
+                    IL_0020:  ldloc.0
+                    IL_0021:  ldloc.3
+                    IL_0022:  stelem.ref
+                    IL_0023:  ldloc.0
+                    IL_0024:  ldc.i4.1
+                    IL_0025:  add
+                    IL_0026:  stloc.0
+                    IL_0027:  ldloca.s   V_2
+                    IL_0029:  call       "bool System.Collections.Generic.List<string>.Enumerator.MoveNext()"
+                    IL_002e:  brtrue.s   IL_0017
+                    IL_0030:  leave.s    IL_0040
+                  }
+                  finally
+                  {
+                    IL_0032:  ldloca.s   V_2
+                    IL_0034:  constrained. "System.Collections.Generic.List<string>.Enumerator"
+                    IL_003a:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_003f:  endfinally
+                  }
+                  IL_0040:  ldloc.1
+                  IL_0041:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void SingleSpread_ListToIEnumerable_Covariant()
+        {
+            var source = """
+                using System;
+                using System.Collections.Generic;
+
+                foreach (var item in C.M(["a"]))
+                    Console.Write(item);
+
+                class C
+                {
+                    public static IEnumerable<object> M(List<string> list) => [..list];
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: "a");
+            verifier.VerifyIL("C.M", """
+                {
+                  // Code size       71 (0x47)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                object[] V_1,
+                                System.Collections.Generic.List<string>.Enumerator V_2,
+                                string V_3)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  stloc.0
+                  IL_0003:  dup
+                  IL_0004:  callvirt   "int System.Collections.Generic.List<string>.Count.get"
+                  IL_0009:  newarr     "object"
+                  IL_000e:  stloc.1
+                  IL_000f:  callvirt   "System.Collections.Generic.List<string>.Enumerator System.Collections.Generic.List<string>.GetEnumerator()"
+                  IL_0014:  stloc.2
+                  .try
+                  {
+                    IL_0015:  br.s       IL_0027
+                    IL_0017:  ldloca.s   V_2
+                    IL_0019:  call       "string System.Collections.Generic.List<string>.Enumerator.Current.get"
+                    IL_001e:  stloc.3
+                    IL_001f:  ldloc.1
+                    IL_0020:  ldloc.0
+                    IL_0021:  ldloc.3
+                    IL_0022:  stelem.ref
+                    IL_0023:  ldloc.0
+                    IL_0024:  ldc.i4.1
+                    IL_0025:  add
+                    IL_0026:  stloc.0
+                    IL_0027:  ldloca.s   V_2
+                    IL_0029:  call       "bool System.Collections.Generic.List<string>.Enumerator.MoveNext()"
+                    IL_002e:  brtrue.s   IL_0017
+                    IL_0030:  leave.s    IL_0040
+                  }
+                  finally
+                  {
+                    IL_0032:  ldloca.s   V_2
+                    IL_0034:  constrained. "System.Collections.Generic.List<string>.Enumerator"
+                    IL_003a:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_003f:  endfinally
+                  }
+                  IL_0040:  ldloc.1
+                  IL_0041:  newobj     "<>z__ReadOnlyArray<object>..ctor(object[])"
+                  IL_0046:  ret
                 }
                 """);
         }
@@ -34973,6 +35078,68 @@ partial class Program
                   IL_002c:  blt.s      IL_0011
                   IL_002e:  ldloc.1
                   IL_002f:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void SingleSpread_ArrayToIEnumerable_Covariant()
+        {
+            var source = """
+                using System;
+                using System.Collections.Generic;
+
+                foreach (var item in C.M(["a"]))
+                    Console.Write(item);
+
+                class C
+                {
+                    public static IEnumerable<object> M(string[] arr) => [..arr];
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: "a");
+            verifier.VerifyIL("C.M", """
+                {
+                  // Code size       12 (0xc)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "object[] System.Linq.Enumerable.ToArray<object>(System.Collections.Generic.IEnumerable<object>)"
+                  IL_0006:  newobj     "<>z__ReadOnlyArray<object>..ctor(object[])"
+                  IL_000b:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void SingleSpread_IEnumerableToIEnumerable_Covariant()
+        {
+            var source = """
+                using System;
+                using System.Collections.Generic;
+
+                foreach (var item in C.M(["a"]))
+                    Console.Write(item);
+
+                class C
+                {
+                    public static IEnumerable<object> M(IEnumerable<string> enumerable) => [..enumerable];
+                }
+                """;
+
+            // Note: We could use the Linq ToArray method here and save an allocation compared to making a List.
+            // However, it's not that significant, since the current codegen doesn't redundantly copy the elements themselves.
+            var verifier = CompileAndVerify(source, expectedOutput: "a");
+            verifier.VerifyIL("C.M", """
+                {
+                  // Code size       18 (0x12)
+                  .maxstack  3
+                  IL_0000:  newobj     "System.Collections.Generic.List<object>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  callvirt   "void System.Collections.Generic.List<object>.AddRange(System.Collections.Generic.IEnumerable<object>)"
+                  IL_000c:  newobj     "<>z__ReadOnlyList<object>..ctor(System.Collections.Generic.List<object>)"
+                  IL_0011:  ret
                 }
                 """);
         }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -34724,7 +34724,7 @@ partial class Program
 
         [Theory]
         [CombinatorialData]
-        public void SingleSpread_WellKnownMemberMissing(bool readOnlySpanMembersMissing)
+        public void SingleSpread_ArrayToArray_WellKnownMemberMissing_01(bool readOnlySpanMembersMissing)
         {
             var source = """
                 class C
@@ -34766,6 +34766,195 @@ partial class Program
                   IL_0023:  ret
                 }
                 """);
+        }
+
+        [Fact]
+        public void SingleSpread_ArrayToArray_WellKnownMemberMissing_02()
+        {
+            var source = """
+                class C
+                {
+                    static void Main()
+                    {
+                        int[] arr = [1, 2, 3];
+                        arr.Report();
+                        int[] arr1 = [..arr];
+                        arr1.Report();
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation([source, s_collectionExtensions], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+            comp.MakeMemberMissing(WellKnownMember.System_Linq_Enumerable__ToArray);
+
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("[1, 2, 3], [1, 2, 3],"));
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("C.Main", """
+                {
+                  // Code size       44 (0x2c)
+                  .maxstack  3
+                  .locals init (System.ReadOnlySpan<int> V_0)
+                  IL_0000:  ldc.i4.3
+                  IL_0001:  newarr     "int"
+                  IL_0006:  dup
+                  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D"
+                  IL_000c:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+                  IL_0011:  dup
+                  IL_0012:  ldc.i4.0
+                  IL_0013:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_0018:  newobj     "System.ReadOnlySpan<int>..ctor(int[])"
+                  IL_001d:  stloc.0
+                  IL_001e:  ldloca.s   V_0
+                  IL_0020:  call       "int[] System.ReadOnlySpan<int>.ToArray()"
+                  IL_0025:  ldc.i4.0
+                  IL_0026:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_002b:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void SingleSpread_ArrayToArray_WellKnownMemberMissing_03()
+        {
+            var source = """
+                class C
+                {
+                    static void Main()
+                    {
+                        int[] arr = [1, 2, 3];
+                        arr.Report();
+                        int[] arr1 = [..arr];
+                        arr1.Report();
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation([source, s_collectionExtensions], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+            comp.MakeMemberMissing(WellKnownMember.System_Linq_Enumerable__ToArray);
+            comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ctor_Array);
+            comp.MakeMemberMissing(WellKnownMember.System_ReadOnlySpan_T__ToArray);
+
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("[1, 2, 3], [1, 2, 3],"));
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("C.Main", """
+                {
+                  // Code size       72 (0x48)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                int[] V_1,
+                                int[] V_2,
+                                int V_3,
+                                int V_4)
+                  IL_0000:  ldc.i4.3
+                  IL_0001:  newarr     "int"
+                  IL_0006:  dup
+                  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D"
+                  IL_000c:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+                  IL_0011:  dup
+                  IL_0012:  ldc.i4.0
+                  IL_0013:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_0018:  ldc.i4.0
+                  IL_0019:  stloc.0
+                  IL_001a:  dup
+                  IL_001b:  ldlen
+                  IL_001c:  conv.i4
+                  IL_001d:  newarr     "int"
+                  IL_0022:  stloc.1
+                  IL_0023:  stloc.2
+                  IL_0024:  ldc.i4.0
+                  IL_0025:  stloc.3
+                  IL_0026:  br.s       IL_003a
+                  IL_0028:  ldloc.2
+                  IL_0029:  ldloc.3
+                  IL_002a:  ldelem.i4
+                  IL_002b:  stloc.s    V_4
+                  IL_002d:  ldloc.1
+                  IL_002e:  ldloc.0
+                  IL_002f:  ldloc.s    V_4
+                  IL_0031:  stelem.i4
+                  IL_0032:  ldloc.0
+                  IL_0033:  ldc.i4.1
+                  IL_0034:  add
+                  IL_0035:  stloc.0
+                  IL_0036:  ldloc.3
+                  IL_0037:  ldc.i4.1
+                  IL_0038:  add
+                  IL_0039:  stloc.3
+                  IL_003a:  ldloc.3
+                  IL_003b:  ldloc.2
+                  IL_003c:  ldlen
+                  IL_003d:  conv.i4
+                  IL_003e:  blt.s      IL_0028
+                  IL_0040:  ldloc.1
+                  IL_0041:  ldc.i4.0
+                  IL_0042:  call       "void CollectionExtensions.Report(object, bool)"
+                  IL_0047:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void SingleSpread_ArrayToArray_Covariant()
+        {
+            var source = """
+                using System;
+
+                Console.Write(C.M(["a"])[0]);
+
+                class C
+                {
+                    public static object[] M(string[] arr) => [..arr];
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: "a");
+            verifier.VerifyIL("C.M", """
+                {
+                  // Code size       43 (0x2b)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                object[] V_1,
+                                string[] V_2,
+                                int V_3,
+                                string V_4)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  stloc.0
+                  IL_0003:  dup
+                  IL_0004:  ldlen
+                  IL_0005:  conv.i4
+                  IL_0006:  newarr     "object"
+                  IL_000b:  stloc.1
+                  IL_000c:  stloc.2
+                  IL_000d:  ldc.i4.0
+                  IL_000e:  stloc.3
+                  IL_000f:  br.s       IL_0023
+                  IL_0011:  ldloc.2
+                  IL_0012:  ldloc.3
+                  IL_0013:  ldelem.ref
+                  IL_0014:  stloc.s    V_4
+                  IL_0016:  ldloc.1
+                  IL_0017:  ldloc.0
+                  IL_0018:  ldloc.s    V_4
+                  IL_001a:  stelem.ref
+                  IL_001b:  ldloc.0
+                  IL_001c:  ldc.i4.1
+                  IL_001d:  add
+                  IL_001e:  stloc.0
+                  IL_001f:  ldloc.3
+                  IL_0020:  ldc.i4.1
+                  IL_0021:  add
+                  IL_0022:  stloc.3
+                  IL_0023:  ldloc.3
+                  IL_0024:  ldloc.2
+                  IL_0025:  ldlen
+                  IL_0026:  conv.i4
+                  IL_0027:  blt.s      IL_0011
+                  IL_0029:  ldloc.1
+                  IL_002a:  ret
+                }
+                """);
+
         }
 
         [Fact]
@@ -36531,6 +36720,49 @@ partial class Program
                   IL_003d:  ret
                 }
                 """);
+        }
+
+        [Fact]
+        public void SingleSpread_ToArray_MustLowerSpreadOperand()
+        {
+            var source = """
+                using System;
+                using System.Collections.Generic;
+
+                class C
+                {
+                    static Action[] M1()
+                    {
+                        return [..new[] { () => Console.Write(1) }];
+                    }
+
+                    static Action[] M2()
+                    {
+                        return [..new List<Action> { () => Console.Write(2) }];
+                    }
+
+                    static Action[] M3()
+                    {
+                        return [..new Span<Action>(new[] { () => Console.Write(3) })];
+                    }
+
+                    static Action[] M4()
+                    {
+                        return [..new ReadOnlySpan<Action>(new[] { () => Console.Write(4) })];
+                    }
+
+                    static void Main()
+                    {
+                        M1()[0]();
+                        M2()[0]();
+                        M3()[0]();
+                        M4()[0]();
+                    }
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("1234"), targetFramework: TargetFramework.Net80);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74615")]

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -625,6 +625,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_ParamCollectionAttribute__ctor,
 
         System_Linq_Enumerable__ToList,
+        System_Linq_Enumerable__ToArray,
 
         System_Linq_Expressions_Expression__ArrayIndex_Expression_Expression,
         System_Linq_Expressions_Expression__ArrayIndex_Expression_Expressions,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -4352,6 +4352,17 @@ namespace Microsoft.CodeAnalysis
                         1,
                         (byte)SignatureTypeCode.GenericMethodParameter, 0,
 
+                // System_Linq_Enumerable__ToArray
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.System_Linq_Enumerable,                                                                 // DeclaringTypeId
+                1,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return Type
+                    (byte)SignatureTypeCode.GenericTypeInstance,
+                        (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Collections_Generic_IEnumerable_T,
+                        1,
+                        (byte)SignatureTypeCode.GenericMethodParameter, 0,
+
                 // System_Linq_Expressions_Expression__ArrayIndex_Expression_Expression,
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.System_Linq_Expressions_Expression,                                                     // DeclaringTypeId
@@ -5706,6 +5717,7 @@ namespace Microsoft.CodeAnalysis
                 "AddRange",                                 // System_Collections_Generic_List_T__AddRange
                 ".ctor",                                    // System_Runtime_CompilerServices_ParamCollectionAttribute__ctor
                 "ToList",                                   // System_Linq_Enumerable__ToList
+                "ToArray",                                  // System_Linq_Enumerable__ToArray
                 "ArrayIndex",                               // System_Linq_Expressions_Expression__ArrayIndex_Expression_Expression
                 "ArrayIndex",                               // System_Linq_Expressions_Expression__ArrayIndex_Expression_Expressions
                 "Constant",                                 // System_Linq_Expressions_Expression__Constant


### PR DESCRIPTION
Closes #71296
Closes #71755

Some of these issues also discuss optimization in cases when multiple spreads of unknown length are present in the collection-expr, such as `[..e1, e2, ..e3]` and so on. I am thinking we should just handle the single spread case `[..e]` for now as this is the source of majority of complaints. This is now handled by simply calling `System.Linq.Enumerable.ToArray<T>(IEnumerable<T>)` in most cases when the spread value is convertible to IEnumerable.
