### PR TITLE
Check for BackingField instead of IsAutoProperty in NullableWalker

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -917,6 +917,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: _, includeBaseRequiredMembers: false)
                                 => containingType.GetMembersUnordered(),
+
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: true)
                                 => getAllTypeAndRequiredMembers(containingType),
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -916,8 +916,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 => containingType.AllRequiredMembers.SelectManyAsArray(static kvp => getAllMembersToBeDefaulted(kvp.Value)),
 
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: _, includeBaseRequiredMembers: false)
-                                => containingType.GetMembersUnordered().SelectAsArray(getFieldSymbolToBeInitialized),
-
+                                => containingType.GetMembersUnordered(),
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: true)
                                 => getAllTypeAndRequiredMembers(containingType),
 
@@ -957,21 +956,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                             else
                             {
                                 var property = (PropertySymbol)requiredMember;
-                                yield return getFieldSymbolToBeInitialized(property);
+                                yield return property;
 
                                 // If the set method is null (ie missing), that's an error, but we'll recover as best we can
                                 foreach (var notNullMemberName in (property.SetMethod?.NotNullMembers ?? property.NotNullMembers))
                                 {
                                     foreach (var member in property.ContainingType.GetMembers(notNullMemberName))
                                     {
-                                        yield return getFieldSymbolToBeInitialized(member);
+                                        yield return member;
                                     }
                                 }
                             }
                         }
-
-                        static Symbol getFieldSymbolToBeInitialized(Symbol requiredMember)
-                            => requiredMember is SourcePropertySymbol { IsAutoProperty: true } prop ? prop.BackingField : requiredMember;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -4517,17 +4517,19 @@ class C
         );
     }
 
-    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
+    [Theory, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
     [WorkItem(6754, "https://github.com/dotnet/csharplang/issues/6754")]
-    public void RequiredMemberSuppressesNullabilityWarnings_MemberNotNull_ChainedConstructor_03()
+    [InlineData("public string Property2 { get; set; }")]
+    [InlineData("public string Property2 { get => field; set => field = value; }")]
+    public void RequiredMemberSuppressesNullabilityWarnings_MemberNotNull_ChainedConstructor_03(string property2Definition)
     {
-        var code = """
+        var code = $$"""
 using System.Diagnostics.CodeAnalysis;
 #nullable enable
 class C
 {
     public required string Property1 { get => Property2; [MemberNotNull(nameof(Property2))] set => Property2 = value; }
-    public string Property2 { get; set; }
+    {{property2Definition}}
 
     public C() { }
     public C(bool unused) : this()
@@ -4549,17 +4551,19 @@ class C
         );
     }
 
-    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
+    [Theory, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
     [WorkItem(6754, "https://github.com/dotnet/csharplang/issues/6754")]
-    public void RequiredMemberSuppressesNullabilityWarnings_MemberNotNull_ChainedConstructor_04()
+    [InlineData("public string Property2 { get; set; }")]
+    [InlineData("public string Property2 { get => field; set => field = value; }")]
+    public void RequiredMemberSuppressesNullabilityWarnings_MemberNotNull_ChainedConstructor_04(string property2Definition)
     {
-        var code = """
+        var code = $$"""
 using System.Diagnostics.CodeAnalysis;
 #nullable enable
 class C
 {
     public required string Property1 { get => Property2; [MemberNotNull(nameof(Property2))] set => Property2 = value; }
-    public string Property2 { get; set; }
+    {{property2Definition}}
 
     public C() { }
     [SetsRequiredMembers]


### PR DESCRIPTION
Closes #75245

It looks like this function is still needed for some complex cases involving required properties, MemberNotNull applied to setters, and constructor chaining. I adjusted the function to behave correctly with properties using the field keyword as well.

~~It looks like this function is no longer needed because we recently added a mechanism to share a slot between property and backing field under appropriate conditions. Specifically, changes to `NullableWalker.GetOrCreateSlot` in #75246.~~