### PR TITLE
Change tagging to free a SegmentedList back to a pool

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/SegmentedListPool.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SegmentedListPool.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Utilities;
@@ -32,37 +30,4 @@ internal static class SegmentedListPool
         classifiedSpans = pooledObject.Object;
         return pooledObject;
     }
-
-    /// <summary>
-    /// Computes a list of results based on a provided <paramref name="addItems"/> callback.  The callback is passed
-    /// a <see cref="SegmentedList{T}"/> to add results to, and additional args to assist the process.  If no items
-    /// are added to the list, then the <see cref="Array.Empty{T}"/> singleton will be returned.  Otherwise the 
-    /// <see cref="SegmentedList{T}"/> instance will be returned.
-    /// </summary>
-    public static IReadOnlyList<T> ComputeList<T, TArgs>(
-        Action<TArgs, SegmentedList<T>> addItems,
-        TArgs args,
-        // Only used to allow type inference to work at callsite
-        T? _)
-    {
-        var pooledObject = GetPooledList<T>(out var list);
-
-        addItems(args, list);
-
-        // If the result was empty, return it to the pool, and just pass back the empty array singleton.
-        if (pooledObject.Object.Count == 0)
-        {
-            pooledObject.Dispose();
-            return [];
-        }
-
-        // Otherwise, do not dispose.  Caller needs this value to stay alive.
-        return list;
-    }
-}
-
-internal static class SegmentedListPool<T>
-{
-    public static IReadOnlyList<T> ComputeList<TArgs>(Action<TArgs, SegmentedList<T>> addItems, TArgs args)
-        => SegmentedListPool.ComputeList(addItems, args, _: default);
 }


### PR DESCRIPTION
The GetTags calls into our taggers require passing back an IEnumerable. Previously, we created a SegmentedList to hold all the data and then passed that back. However, that suffers from not being able to add back the returned list into a pool. Instead, switch to using yield return over the populated segmented list as that will allow the list to be freed back to the pool upon completion.

Utilizing the yield state machinery does incur an allocation, but this should be a much smaller allocation than the potentially very large arrays that our taggers were returning.