### PR TITLE
[EnC] Implement support for restarting subset of projects affected by rude edits

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -122,7 +122,7 @@
     <!--
       VS Debugger
     -->
-    <PackageVersion Include="Microsoft.VisualStudio.Debugger.Contracts" Version="17.12.0-beta.24403.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Debugger.Contracts" Version="17.13.0-beta.24561.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Debugger.Engine-implementation" Version="17.13.1100701-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Debugger.Metadata-implementation" Version="17.13.1100701-preview" />
 

--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -182,15 +182,15 @@ namespace Roslyn.Test.Utilities
         public static void Equal<T>(IEnumerable<T> expected, ImmutableArray<T> actual)
             => Equal(expected, actual, comparer: null, message: null, itemInspector: null);
 
-        public static void Equal<T>(IEnumerable<T> expected, ImmutableArray<T> actual, IEqualityComparer<T> comparer = null, string message = null, string itemSeparator = null)
+        public static void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T> comparer = null, string message = null, string itemSeparator = null)
         {
-            if (expected == null || actual.IsDefault)
+            if (expected == null || actual == null)
             {
-                Assert.True((expected == null) == actual.IsDefault, message);
+                Assert.True(expected is null == actual is null, message);
             }
             else
             {
-                Equal(expected, (IEnumerable<T>)actual, comparer, message, itemSeparator);
+                Equal(expected, actual, comparer, message, itemSeparator);
             }
         }
 

--- a/src/Compilers/Test/Core/InstrumentationChecker.cs
+++ b/src/Compilers/Test/Core/InstrumentationChecker.cs
@@ -335,7 +335,7 @@ End Namespace
                 var actualSnippets = GetActualSnippets(method, reader, sourceLines);
                 var expectedSnippets = _spanExpectations[method].SnippetExpectations;
 
-                AssertEx.Equal(expectedSnippets, actualSnippets, new SnippetComparer(), $"Validation of method {method} failed.");
+                AssertEx.SequenceEqual(expectedSnippets, actualSnippets, new SnippetComparer(), $"Validation of method {method} failed.");
             }
         }
 

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.BrokeredServices;
@@ -13,6 +14,8 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 using Roslyn.Utilities;
@@ -21,6 +24,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 [Shared]
 [Export(typeof(IManagedHotReloadLanguageService))]
+[Export(typeof(IManagedHotReloadLanguageService2))]
 [Export(typeof(IEditAndContinueSolutionProvider))]
 [Export(typeof(EditAndContinueLanguageService))]
 [ExportMetadata("UIContext", EditAndContinueUIContext.EncCapableProjectExistsInWorkspaceUIContextString)]
@@ -33,7 +37,7 @@ internal sealed class EditAndContinueLanguageService(
     Lazy<IManagedHotReloadService> debuggerService,
     PdbMatchingSourceTextProvider sourceTextProvider,
     IDiagnosticsRefresher diagnosticRefresher,
-    IAsynchronousOperationListenerProvider listenerProvider) : IManagedHotReloadLanguageService, IEditAndContinueSolutionProvider
+    IAsynchronousOperationListenerProvider listenerProvider) : IManagedHotReloadLanguageService2, IEditAndContinueSolutionProvider
 {
     private sealed class NoSessionException : InvalidOperationException
     {
@@ -242,6 +246,46 @@ internal sealed class EditAndContinueLanguageService(
         }
     }
 
+    public async ValueTask UpdateBaselinesAsync(ImmutableArray<string> projectPaths, CancellationToken cancellationToken)
+    {
+        if (_disabled)
+        {
+            return;
+        }
+
+        var currentDesignTimeSolution = GetCurrentDesignTimeSolution();
+        var currentCompileTimeSolution = GetCurrentCompileTimeSolution(currentDesignTimeSolution);
+
+        try
+        {
+            SolutionCommitted?.Invoke(currentDesignTimeSolution);
+        }
+        catch (Exception e) when (FatalError.ReportAndCatch(e))
+        {
+        }
+
+        _committedDesignTimeSolution = currentDesignTimeSolution;
+
+        // TODO: log projects that are not found
+        var projectIds = from path in projectPaths
+                         let projectId = currentCompileTimeSolution.Projects.FirstOrDefault(project => project.FilePath == path)?.Id
+                         where projectId != null
+                         select projectId;
+        try
+        {
+
+            await GetDebuggingSession().UpdateBaselinesAsync(currentCompileTimeSolution, projectIds.ToImmutableArray(), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
+        {
+        }
+
+        foreach (var projectId in projectIds)
+        {
+            workspaceProvider.Value.Workspace.EnqueueUpdateSourceGeneratorVersion(projectId, forceRegeneration: false);
+        }
+    }
+
     public async ValueTask EndSessionAsync(CancellationToken cancellationToken)
     {
         sessionState.IsSessionActive = false;
@@ -309,7 +353,11 @@ internal sealed class EditAndContinueLanguageService(
         }
     }
 
-    public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(CancellationToken cancellationToken)
+    [Obsolete]
+    public ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(CancellationToken cancellationToken)
+        => GetUpdatesAsync(runningProjects: [], cancellationToken);
+
+    public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(ImmutableArray<string> runningProjects, CancellationToken cancellationToken)
     {
         if (_disabled)
         {
@@ -319,7 +367,12 @@ internal sealed class EditAndContinueLanguageService(
         var designTimeSolution = GetCurrentDesignTimeSolution();
         var solution = GetCurrentCompileTimeSolution(designTimeSolution);
         var activeStatementSpanProvider = GetActiveStatementSpanProvider(solution);
-        var result = await GetDebuggingSession().EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+
+        using var _ = PooledHashSet<string>.GetInstance(out var runningProjectPaths);
+        runningProjectPaths.AddAll(runningProjects);
+
+        var runningProjectIds = solution.Projects.Where(p => p.FilePath != null && runningProjectPaths.Contains(p.FilePath)).Select(static p => p.Id).ToImmutableHashSet();
+        var result = await GetDebuggingSession().EmitSolutionUpdateAsync(solution, runningProjectIds, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 
         // Only store the solution if we have any changes to apply, otherwise CommitUpdatesAsync/DiscardUpdatesAsync won't be called.
         if (result.ModuleUpdates.Status == ModuleUpdateStatus.Ready)

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageServiceBridge.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageServiceBridge.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
@@ -13,7 +15,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 /// TODO (https://github.com/dotnet/roslyn/issues/72713):
 /// Once debugger is updated to use the brokered service, this class should be removed and <see cref="EditAndContinueLanguageService"/> should be exported directly.
 /// </summary>
-internal sealed partial class ManagedEditAndContinueLanguageServiceBridge(EditAndContinueLanguageService service) : IManagedHotReloadLanguageService
+internal sealed partial class ManagedEditAndContinueLanguageServiceBridge(EditAndContinueLanguageService service) : IManagedHotReloadLanguageService2
 {
     public ValueTask StartSessionAsync(CancellationToken cancellationToken)
         => service.StartSessionAsync(cancellationToken);
@@ -30,11 +32,18 @@ internal sealed partial class ManagedEditAndContinueLanguageServiceBridge(EditAn
     public ValueTask OnCapabilitiesChangedAsync(CancellationToken cancellationToken)
         => service.OnCapabilitiesChangedAsync(cancellationToken);
 
-    public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(CancellationToken cancellationToken)
-        => (await service.GetUpdatesAsync(cancellationToken).ConfigureAwait(false));
+    [Obsolete]
+    public ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(CancellationToken cancellationToken)
+        => service.GetUpdatesAsync(cancellationToken);
+
+    public ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(ImmutableArray<string> runningProjects, CancellationToken cancellationToken)
+        => service.GetUpdatesAsync(runningProjects, cancellationToken);
 
     public ValueTask CommitUpdatesAsync(CancellationToken cancellationToken)
         => service.CommitUpdatesAsync(cancellationToken);
+
+    public ValueTask UpdateBaselinesAsync(ImmutableArray<string> projectPaths, CancellationToken cancellationToken)
+        => service.UpdateBaselinesAsync(projectPaths, cancellationToken);
 
     public ValueTask DiscardUpdatesAsync(CancellationToken cancellationToken)
         => service.DiscardUpdatesAsync(cancellationToken);

--- a/src/EditorFeatures/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
+++ b/src/EditorFeatures/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Debugger
 
         public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(Solution solution, CancellationToken cancellationToken)
         {
-            var results = (await _encService.EmitSolutionUpdateAsync(GetSessionId(), solution, s_noActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false)).Dehydrate();
+            var results = (await _encService.EmitSolutionUpdateAsync(GetSessionId(), solution, runningProjects: [], s_noActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false)).Dehydrate();
             return new ManagedHotReloadUpdates(results.ModuleUpdates.Updates.FromContract(), results.GetAllDiagnostics().FromContract());
         }
     }

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -156,7 +156,7 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
 
         var diagnosticDescriptor1 = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.ErrorReadingFile);
 
-        mockEncService.EmitSolutionUpdateImpl = (solution, _) =>
+        mockEncService.EmitSolutionUpdateImpl = (solution, runningProjects, _) =>
         {
             var syntaxTree = solution.GetRequiredDocument(documentId).GetSyntaxTreeSynchronously(CancellationToken.None)!;
 
@@ -171,11 +171,13 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
                 ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.Ready, []),
                 Diagnostics = [new ProjectDiagnostics(project.Id, [documentDiagnostic, projectDiagnostic])],
                 RudeEdits = [new ProjectDiagnostics(project.Id, [rudeEditDiagnostic])],
-                SyntaxError = syntaxError
+                SyntaxError = syntaxError,
+                ProjectsToRebuild = [project.Id],
+                ProjectsToRestart = [project.Id]
             };
         };
 
-        var updates = await localService.GetUpdatesAsync(CancellationToken.None);
+        var updates = await localService.GetUpdatesAsync(runningProjects: [project.FilePath], CancellationToken.None);
 
         Assert.Equal(++observedDiagnosticVersion, diagnosticRefresher.GlobalStateVersion);
 

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
@@ -271,7 +271,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                     Dim expectedDiagnostics = GetExpectedDiagnostics(workspace, diagnostics)
 
                     If ordered Then
-                        AssertEx.Equal(expectedDiagnostics, actualDiagnostics, New Comparer())
+                        AssertEx.SequenceEqual(expectedDiagnostics, actualDiagnostics, New Comparer())
                     Else
                         AssertEx.SetEqual(expectedDiagnostics, actualDiagnostics, New Comparer())
                     End If

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/IManagedHotReloadLanguageService.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/IManagedHotReloadLanguageService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,4 +19,10 @@ internal interface IManagedHotReloadLanguageService
     ValueTask<bool> HasChangesAsync(string? sourceFilePath, CancellationToken cancellationToken);
     ValueTask OnCapabilitiesChangedAsync(CancellationToken cancellationToken);
     ValueTask StartSessionAsync(CancellationToken cancellationToken);
+}
+
+internal interface IManagedHotReloadLanguageService2 : IManagedHotReloadLanguageService
+{
+    ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(ImmutableArray<string> runningProjects, CancellationToken cancellationToken);
+    ValueTask UpdateBaselinesAsync(ImmutableArray<string> projectPaths, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -21,7 +21,6 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using System.ComponentModel;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
@@ -638,8 +637,10 @@ internal sealed class DebuggingSession : IDisposable
             }
         }
 
-        // TODO:
-        // _editSessionTelemetry.LogUpdateBaselines();
+        foreach (var projectId in rebuiltProjects)
+        {
+            _editSessionTelemetry.LogUpdatedBaseline(solution.GetRequiredProject(projectId).State.ProjectInfo.Attributes.TelemetryId);
+        }
 
         // Restart edit session reusing previous non-remappable regions and break state:
         RestartEditSession(nonRemappableRegions: null, inBreakState: null);

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -21,6 +21,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using System.ComponentModel;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
@@ -53,7 +54,7 @@ internal sealed class DebuggingSession : IDisposable
     /// even when it's replaced in <see cref="_projectBaselines"/> by a newer baseline.
     /// </remarks>
     private readonly Dictionary<ProjectId, ProjectBaseline> _projectBaselines = [];
-    private readonly List<IDisposable> _initialBaselineModuleReaders = [];
+    private readonly Dictionary<ProjectId, (IDisposable metadata, IDisposable pdb)> _initialBaselineModuleReaders = [];
     private readonly object _projectEmitBaselinesGuard = new();
 
     /// <summary>
@@ -143,9 +144,13 @@ internal sealed class DebuggingSession : IDisposable
         // Wait for all operations on baseline to finish before we dispose the readers.
         _baselineAccessLock.EnterWriteLock();
 
-        foreach (var reader in GetBaselineModuleReaders())
+        lock (_projectEmitBaselinesGuard)
         {
-            reader.Dispose();
+            foreach (var (_, readers) in _initialBaselineModuleReaders)
+            {
+                readers.metadata.Dispose();
+                readers.pdb.Dispose();
+            }
         }
 
         _baselineAccessLock.ExitWriteLock();
@@ -221,14 +226,6 @@ internal sealed class DebuggingSession : IDisposable
             EditSession.Telemetry,
             (inBreakState == null) ? EditSession.BaseActiveStatements : null,
             inBreakState ?? EditSession.InBreakState);
-    }
-
-    private ImmutableArray<IDisposable> GetBaselineModuleReaders()
-    {
-        lock (_projectEmitBaselinesGuard)
-        {
-            return _initialBaselineModuleReaders.ToImmutableArrayOrEmpty();
-        }
     }
 
     internal CompilationOutputs GetCompilationOutputs(Project project)
@@ -353,8 +350,7 @@ internal sealed class DebuggingSession : IDisposable
             baseline = new ProjectBaseline(baselineProject.Id, initialBaseline, generation: 0);
 
             _projectBaselines.Add(baselineProject.Id, baseline);
-            _initialBaselineModuleReaders.Add(metadataReaderProvider);
-            _initialBaselineModuleReaders.Add(debugInfoReaderProvider);
+            _initialBaselineModuleReaders.Add(baselineProject.Id, (metadataReaderProvider, debugInfoReaderProvider));
         }
 
         return true;
@@ -517,6 +513,7 @@ internal sealed class DebuggingSession : IDisposable
 
     public async ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(
         Solution solution,
+        IImmutableSet<ProjectId> runningProjects,
         ActiveStatementSpanProvider activeStatementSpanProvider,
         CancellationToken cancellationToken)
     {
@@ -552,6 +549,14 @@ internal sealed class DebuggingSession : IDisposable
             }
         }
 
+        EmitSolutionUpdateResults.GetProjectsToRebuildAndRestart(
+            solution,
+            solutionUpdate.ModuleUpdates,
+            rudeEditDiagnostics,
+            runningProjects,
+            out var projectsToRestart,
+            out var projectsToRebuild);
+
         // Note that we may return empty deltas if all updates have been deferred.
         // The debugger will still call commit or discard on the update batch.
         return new EmitSolutionUpdateResults()
@@ -561,6 +566,8 @@ internal sealed class DebuggingSession : IDisposable
             Diagnostics = solutionUpdate.Diagnostics,
             RudeEdits = rudeEditDiagnostics.ToImmutable(),
             SyntaxError = solutionUpdate.SyntaxError,
+            ProjectsToRestart = projectsToRestart,
+            ProjectsToRebuild = projectsToRebuild
         };
     }
 
@@ -606,6 +613,36 @@ internal sealed class DebuggingSession : IDisposable
     {
         ThrowIfDisposed();
         _ = RetrievePendingUpdate();
+    }
+
+    public void UpdateBaselines(Solution solution, ImmutableArray<ProjectId> rebuiltProjects)
+    {
+        ThrowIfDisposed();
+
+        // Make sure the solution snapshot has all source-generated documents up-to-date.
+        solution = solution.WithUpToDateSourceGeneratorDocuments(solution.ProjectIds);
+
+        LastCommittedSolution.CommitSolution(solution);
+
+        lock (_projectEmitBaselinesGuard)
+        {
+            foreach (var projectId in rebuiltProjects)
+            {
+                _projectBaselines.Remove(projectId);
+
+                var (metadata, pdb) = _initialBaselineModuleReaders[projectId];
+                metadata.Dispose();
+                pdb.Dispose();
+
+                _initialBaselineModuleReaders.Remove(projectId);
+            }
+        }
+
+        // TODO:
+        // _editSessionTelemetry.LogUpdateBaselines();
+
+        // Restart edit session reusing previous non-remappable regions and break state:
+        RestartEditSession(nonRemappableRegions: null, inBreakState: null);
     }
 
     /// <summary>
@@ -851,31 +888,42 @@ internal sealed class DebuggingSession : IDisposable
 
     internal readonly struct TestAccessor(DebuggingSession instance)
     {
-        private readonly DebuggingSession _instance = instance;
-
         public ImmutableHashSet<Guid> GetModulesPreparedForUpdate()
         {
-            lock (_instance._modulesPreparedForUpdateGuard)
+            lock (instance._modulesPreparedForUpdateGuard)
             {
-                return [.. _instance._modulesPreparedForUpdate];
+                return [.. instance._modulesPreparedForUpdate];
             }
         }
 
         public EmitBaseline GetProjectEmitBaseline(ProjectId id)
         {
-            lock (_instance._projectEmitBaselinesGuard)
+            lock (instance._projectEmitBaselinesGuard)
             {
-                return _instance._projectBaselines[id].EmitBaseline;
+                return instance._projectBaselines[id].EmitBaseline;
+            }
+        }
+
+        public bool HasProjectEmitBaseline(ProjectId id)
+        {
+            lock (instance._projectEmitBaselinesGuard)
+            {
+                return instance._projectBaselines.ContainsKey(id);
             }
         }
 
         public ImmutableArray<IDisposable> GetBaselineModuleReaders()
-            => _instance.GetBaselineModuleReaders();
+        {
+            lock (instance._projectEmitBaselinesGuard)
+            {
+                return instance._initialBaselineModuleReaders.Values.SelectMany(entry => new IDisposable[] { entry.metadata, entry.pdb }).ToImmutableArray();
+            }
+        }
 
         public PendingUpdate? GetPendingSolutionUpdate()
-            => _instance._pendingUpdate;
+            => instance._pendingUpdate;
 
         public void SetTelemetryLogger(Action<FunctionId, LogMessage> logger, Func<int> getNextId)
-            => _instance._reportTelemetry = data => DebuggingSessionTelemetry.Log(data, logger, getNextId);
+            => instance._reportTelemetry = data => DebuggingSessionTelemetry.Log(data, logger, getNextId);
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
@@ -116,6 +116,9 @@ internal sealed class DebuggingSessionTelemetry(Guid solutionSessionId)
                 // Ids of all projects whose binaries were successfully updated during the session.
                 map["ProjectIdsWithAppliedChanges"] = editSessionData.Committed ? editSessionData.ProjectsWithValidDelta.Select(ProjectIdToPii) : "";
 
+                // Ids of all projects whose binaries had their initial baselines updated (the projects were rebuilt during debugging session).
+                map["ProjectIdsWithUpdatedBaselines"] = editSessionData.ProjectsWithUpdatedBaselines.Select(ProjectIdToPii);
+
                 // Total milliseconds it took to emit the delta in this edit session.
                 map["EmitDifferenceMilliseconds"] = (long)editSessionData.EmitDifferenceTime.TotalMilliseconds;
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
@@ -221,6 +221,7 @@ internal sealed class EditAndContinueService : IEditAndContinueService
     public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(
         DebuggingSessionId sessionId,
         Solution solution,
+        IImmutableSet<ProjectId> runningProjects,
         ActiveStatementSpanProvider activeStatementSpanProvider,
         CancellationToken cancellationToken)
     {
@@ -230,7 +231,7 @@ internal sealed class EditAndContinueService : IEditAndContinueService
             return ValueTaskFactory.FromResult(EmitSolutionUpdateResults.Empty);
         }
 
-        return debuggingSession.EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, cancellationToken);
+        return debuggingSession.EmitSolutionUpdateAsync(solution, runningProjects, activeStatementSpanProvider, cancellationToken);
     }
 
     public void CommitSolutionUpdate(DebuggingSessionId sessionId)
@@ -247,6 +248,14 @@ internal sealed class EditAndContinueService : IEditAndContinueService
         Contract.ThrowIfNull(debuggingSession);
 
         debuggingSession.DiscardSolutionUpdate();
+    }
+
+    public void UpdateBaselines(DebuggingSessionId sessionId, Solution solution, ImmutableArray<ProjectId> rebuiltProjects)
+    {
+        var debuggingSession = TryGetDebuggingSession(sessionId);
+        Contract.ThrowIfNull(debuggingSession);
+
+        debuggingSession.UpdateBaselines(solution, rebuiltProjects);
     }
 
     public ValueTask<ImmutableArray<ImmutableArray<ActiveStatementSpan>>> GetBaseActiveStatementSpansAsync(DebuggingSessionId sessionId, Solution solution, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/EditAndContinue/EditSessionTelemetry.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSessionTelemetry.cs
@@ -18,6 +18,7 @@ internal sealed class EditSessionTelemetry
         public readonly ImmutableArray<(ushort EditKind, ushort SyntaxKind, Guid projectId)> RudeEdits = telemetry._rudeEdits.AsImmutable();
         public readonly ImmutableArray<string> EmitErrorIds = telemetry._emitErrorIds.AsImmutable();
         public readonly ImmutableArray<Guid> ProjectsWithValidDelta = telemetry._projectsWithValidDelta.AsImmutable();
+        public readonly ImmutableArray<Guid> ProjectsWithUpdatedBaselines = telemetry._projectsWithUpdatedBaselines.AsImmutable();
         public readonly EditAndContinueCapabilities Capabilities = telemetry._capabilities;
         public readonly bool HadCompilationErrors = telemetry._hadCompilationErrors;
         public readonly bool HadRudeEdits = telemetry._hadRudeEdits;
@@ -38,6 +39,7 @@ internal sealed class EditSessionTelemetry
     private readonly HashSet<(ushort, ushort, Guid)> _rudeEdits = [];
     private readonly HashSet<string> _emitErrorIds = [];
     private readonly HashSet<Guid> _projectsWithValidDelta = [];
+    private readonly HashSet<Guid> _projectsWithUpdatedBaselines = [];
 
     private bool _hadCompilationErrors;
     private bool _hadRudeEdits;
@@ -58,6 +60,7 @@ internal sealed class EditSessionTelemetry
             _rudeEdits.Clear();
             _emitErrorIds.Clear();
             _projectsWithValidDelta.Clear();
+            _projectsWithUpdatedBaselines.Clear();
             _hadCompilationErrors = false;
             _hadRudeEdits = false;
             _hadValidChanges = false;
@@ -145,4 +148,7 @@ internal sealed class EditSessionTelemetry
 
     public void LogCommitted()
         => _committed = true;
+
+    public void LogUpdatedBaseline(Guid projectTelemetryId)
+        => _projectsWithUpdatedBaselines.Add(projectTelemetryId);
 }

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -2,16 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -36,6 +31,12 @@ internal readonly struct EmitSolutionUpdateResults
 
         [DataMember]
         public required DiagnosticData? SyntaxError { get; init; }
+
+        [DataMember]
+        public required ImmutableArray<ProjectId> ProjectsToRestart { get; init; }
+
+        [DataMember]
+        public required ImmutableArray<ProjectId> ProjectsToRebuild { get; init; }
 
         internal ImmutableArray<ManagedHotReloadDiagnostic> GetAllDiagnostics()
         {
@@ -82,12 +83,14 @@ internal readonly struct EmitSolutionUpdateResults
         ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.None, []),
         Diagnostics = [],
         RudeEdits = [],
-        SyntaxError = null
+        SyntaxError = null,
+        ProjectsToRestart = [],
+        ProjectsToRebuild = [],
     };
 
     /// <summary>
     /// Solution snapshot to resolve diagnostics in.
-    /// Note that this might be a different snapshot from the one passed to <see cref="IEditAndContinueService.EmitSolutionUpdateAsync(DebuggingSessionId, Solution, ActiveStatementSpanProvider, CancellationToken)"/>,
+    /// Note that this might be a different snapshot from the one passed to EmitSolutionUpdateAsync,
     /// with source generator files refreshed.
     ///
     /// Null only for empty results.
@@ -99,6 +102,9 @@ internal readonly struct EmitSolutionUpdateResults
     public required ImmutableArray<ProjectDiagnostics> RudeEdits { get; init; }
     public required Diagnostic? SyntaxError { get; init; }
 
+    public required ImmutableArray<ProjectId> ProjectsToRestart { get; init; }
+    public required ImmutableArray<ProjectId> ProjectsToRebuild { get; init; }
+
     public Data Dehydrate()
         => Solution == null
         ? new()
@@ -106,14 +112,18 @@ internal readonly struct EmitSolutionUpdateResults
             ModuleUpdates = ModuleUpdates,
             Diagnostics = [],
             RudeEdits = [],
-            SyntaxError = null
+            SyntaxError = null,
+            ProjectsToRestart = [],
+            ProjectsToRebuild = [],
         }
         : new()
         {
             ModuleUpdates = ModuleUpdates,
             Diagnostics = Diagnostics.ToDiagnosticData(Solution),
             RudeEdits = RudeEdits.ToDiagnosticData(Solution),
-            SyntaxError = GetSyntaxErrorData()
+            SyntaxError = GetSyntaxErrorData(),
+            ProjectsToRestart = ProjectsToRestart,
+            ProjectsToRebuild = ProjectsToRebuild,
         };
 
     private DiagnosticData? GetSyntaxErrorData()
@@ -128,25 +138,21 @@ internal readonly struct EmitSolutionUpdateResults
         return DiagnosticData.Create(SyntaxError, Solution.GetRequiredDocument(SyntaxError.Location.SourceTree));
     }
 
-    private IEnumerable<Project> GetProjectsContainingBlockingRudeEdits(Solution solution)
-        => RudeEdits
-            .Where(static e => e.Diagnostics.HasBlockingRudeEdits())
-            .Select(static e => e.ProjectId)
-            .Distinct()
-            .OrderBy(static id => id)
-            .Select(solution.GetRequiredProject);
+
 
     /// <summary>
     /// Returns projects that need to be rebuilt and/or restarted due to blocking rude edits in order to apply changes.
     /// </summary>
-    /// <param name="isRunningProject">Identifies projects that have been launched.</param>
+    /// <param name="runningProjects">Identifies projects that have been launched.</param>
     /// <param name="projectsToRestart">Running projects that have to be restarted.</param>
     /// <param name="projectsToRebuild">Projects whose source have been updated and need to be rebuilt.</param>
-    public void GetProjectsToRebuildAndRestart(
+    internal static void GetProjectsToRebuildAndRestart(
         Solution solution,
-        Func<Project, bool> isRunningProject,
-        ISet<Project> projectsToRestart,
-        ISet<Project> projectsToRebuild)
+        ModuleUpdates moduleUpdates,
+        IEnumerable<ProjectDiagnostics> rudeEdits,
+        IImmutableSet<ProjectId> runningProjects,
+        out ImmutableArray<ProjectId> projectsToRestart,
+        out ImmutableArray<ProjectId> projectsToRebuild)
     {
         var graph = solution.GetProjectDependencyGraph();
 
@@ -157,23 +163,24 @@ internal readonly struct EmitSolutionUpdateResults
         // We need to repeat this process until we find a fixed point.
 
         using var _1 = ArrayBuilder<Project>.GetInstance(out var traversalStack);
-
-        projectsToRestart.Clear();
-        projectsToRebuild.Clear();
+        using var _2 = PooledHashSet<ProjectId>.GetInstance(out var projectsToRestartBuilder);
+        using var _3 = ArrayBuilder<ProjectId>.GetInstance(out var projectsToRebuildBuilder);
 
         foreach (var projectWithRudeEdit in GetProjectsContainingBlockingRudeEdits(solution))
         {
-            if (AddImpactedRunningProjects(projectsToRestart, projectWithRudeEdit))
+            if (AddImpactedRunningProjects(projectsToRestartBuilder, projectWithRudeEdit))
             {
-                projectsToRebuild.Add(projectWithRudeEdit);
+                projectsToRebuildBuilder.Add(projectWithRudeEdit.Id);
             }
         }
 
         // At this point the restart set contains all running projects directly affected by rude edits.
         // Next, find projects that were successfully updated and affect running projects.
 
-        if (ModuleUpdates.Updates.IsEmpty || projectsToRestart.IsEmpty())
+        if (moduleUpdates.Updates.IsEmpty || projectsToRestartBuilder.Count == 0)
         {
+            projectsToRestart = [.. projectsToRestartBuilder];
+            projectsToRebuild = [.. projectsToRebuildBuilder];
             return;
         }
 
@@ -185,14 +192,15 @@ internal readonly struct EmitSolutionUpdateResults
         // If an updated project does not affect reset set in a given iteration, it stays in the set
         // because it may affect reset set later on, after another running project is added to it.
 
-        using var _2 = PooledHashSet<Project>.GetInstance(out var updatedProjects);
-        using var _3 = ArrayBuilder<Project>.GetInstance(out var updatedProjectsToRemove);
-        foreach (var update in ModuleUpdates.Updates)
+        using var _4 = PooledHashSet<Project>.GetInstance(out var updatedProjects);
+        using var _5 = ArrayBuilder<Project>.GetInstance(out var updatedProjectsToRemove);
+
+        foreach (var update in moduleUpdates.Updates)
         {
             updatedProjects.Add(solution.GetRequiredProject(update.ProjectId));
         }
 
-        using var _4 = ArrayBuilder<Project>.GetInstance(out var impactedProjects);
+        using var _6 = ArrayBuilder<ProjectId>.GetInstance(out var impactedProjects);
 
         while (true)
         {
@@ -201,11 +209,11 @@ internal readonly struct EmitSolutionUpdateResults
             foreach (var updatedProject in updatedProjects)
             {
                 if (AddImpactedRunningProjects(impactedProjects, updatedProject) &&
-                    impactedProjects.Any(projectsToRestart.Contains))
+                    impactedProjects.Any(projectsToRestartBuilder.Contains))
                 {
-                    projectsToRestart.AddRange(impactedProjects);
+                    projectsToRestartBuilder.AddRange(impactedProjects);
                     updatedProjectsToRemove.Add(updatedProject);
-                    projectsToRebuild.Add(updatedProject);
+                    projectsToRebuildBuilder.Add(updatedProject.Id);
                 }
 
                 impactedProjects.Clear();
@@ -221,9 +229,11 @@ internal readonly struct EmitSolutionUpdateResults
             updatedProjectsToRemove.Clear();
         }
 
+        projectsToRestart = [.. projectsToRestartBuilder];
+        projectsToRebuild = [.. projectsToRebuildBuilder];
         return;
 
-        bool AddImpactedRunningProjects(ICollection<Project> impactedProjects, Project initialProject)
+        bool AddImpactedRunningProjects(ICollection<ProjectId> impactedProjects, Project initialProject)
         {
             Debug.Assert(traversalStack.Count == 0);
             traversalStack.Push(initialProject);
@@ -233,9 +243,9 @@ internal readonly struct EmitSolutionUpdateResults
             while (traversalStack.Count > 0)
             {
                 var project = traversalStack.Pop();
-                if (isRunningProject(project))
+                if (runningProjects.Contains(project.Id))
                 {
-                    impactedProjects.Add(project);
+                    impactedProjects.Add(project.Id);
                     added = true;
                 }
 
@@ -247,6 +257,14 @@ internal readonly struct EmitSolutionUpdateResults
 
             return added;
         }
+
+        IEnumerable<Project> GetProjectsContainingBlockingRudeEdits(Solution solution)
+            => rudeEdits
+                .Where(static e => e.Diagnostics.HasBlockingRudeEdits())
+                .Select(static e => e.ProjectId)
+                .Distinct()
+                .OrderBy(static id => id)
+                .Select(solution.GetRequiredProject);
     }
 
     public ImmutableArray<Diagnostic> GetAllDiagnostics()

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -138,8 +138,6 @@ internal readonly struct EmitSolutionUpdateResults
         return DiagnosticData.Create(SyntaxError, Solution.GetRequiredDocument(SyntaxError.Location.SourceTree));
     }
 
-
-
     /// <summary>
     /// Returns projects that need to be rebuilt and/or restarted due to blocking rude edits in order to apply changes.
     /// </summary>

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,10 +20,11 @@ internal interface IEditAndContinueWorkspaceService : IWorkspaceService
 internal interface IEditAndContinueService
 {
     ValueTask<ImmutableArray<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
-    ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(DebuggingSessionId sessionId, Solution solution, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
+    ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(DebuggingSessionId sessionId, Solution solution, IImmutableSet<ProjectId> runningProjects, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
 
     void CommitSolutionUpdate(DebuggingSessionId sessionId);
     void DiscardSolutionUpdate(DebuggingSessionId sessionId);
+    void UpdateBaselines(DebuggingSessionId sessionId, Solution solution, ImmutableArray<ProjectId> rebuiltProjects);
 
     ValueTask<DebuggingSessionId> StartDebuggingSessionAsync(Solution solution, IManagedHotReloadService debuggerService, IPdbMatchingSourceTextProvider sourceTextProvider, ImmutableArray<DocumentId> captureMatchingDocuments, bool captureAllMatchingDocuments, bool reportDiagnostics, CancellationToken cancellationToken);
     void BreakStateOrCapabilitiesChanged(DebuggingSessionId sessionId, bool? inBreakState);

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -27,13 +27,14 @@ internal interface IRemoteEditAndContinueService
     }
 
     ValueTask<ImmutableArray<DiagnosticData>> GetDocumentDiagnosticsAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DocumentId documentId, CancellationToken cancellationToken);
-    ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, CancellationToken cancellationToken);
+    ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, IImmutableSet<ProjectId> runningProjects, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns ids of documents for which diagnostics need to be refreshed in-proc.
     /// </summary>
     ValueTask CommitSolutionUpdateAsync(DebuggingSessionId sessionId, CancellationToken cancellationToken);
     ValueTask DiscardSolutionUpdateAsync(DebuggingSessionId sessionId, CancellationToken cancellationToken);
+    ValueTask UpdateBaselinesAsync(Checksum solutionInfo, DebuggingSessionId sessionId, ImmutableArray<ProjectId> rebuiltProjects, CancellationToken cancellationToken);
 
     ValueTask<DebuggingSessionId> StartDebuggingSessionAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, ImmutableArray<DocumentId> captureMatchingDocuments, bool captureAllMatchingDocuments, bool reportDiagnostics, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.SQLite.Interop;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
@@ -55,6 +57,7 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
 
     public async ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(
         Solution solution,
+        IImmutableSet<ProjectId> runningProjects,
         ActiveStatementSpanProvider activeStatementSpanProvider,
         CancellationToken cancellationToken)
     {
@@ -63,12 +66,12 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
             var client = await RemoteHostClient.TryGetClientAsync(services, cancellationToken).ConfigureAwait(false);
             if (client == null)
             {
-                return (await GetLocalService().EmitSolutionUpdateAsync(sessionId, solution, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false)).Dehydrate();
+                return (await GetLocalService().EmitSolutionUpdateAsync(sessionId, solution, runningProjects, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false)).Dehydrate();
             }
 
             var result = await client.TryInvokeAsync<IRemoteEditAndContinueService, EmitSolutionUpdateResults.Data>(
                 solution,
-                (service, solutionInfo, callbackId, cancellationToken) => service.EmitSolutionUpdateAsync(solutionInfo, callbackId, sessionId, cancellationToken),
+                (service, solutionInfo, callbackId, cancellationToken) => service.EmitSolutionUpdateAsync(solutionInfo, callbackId, sessionId, runningProjects, cancellationToken),
                 callbackTarget: new ActiveStatementSpanProviderCallback(activeStatementSpanProvider),
                 cancellationToken).ConfigureAwait(false);
 
@@ -78,6 +81,8 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
                 Diagnostics = [],
                 RudeEdits = [],
                 SyntaxError = null,
+                ProjectsToRebuild = [],
+                ProjectsToRestart = [],
             };
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
@@ -88,6 +93,8 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
                 Diagnostics = GetInternalErrorDiagnosticData(solution, e),
                 RudeEdits = [],
                 SyntaxError = null,
+                ProjectsToRebuild = [],
+                ProjectsToRestart = [],
             };
         }
     }
@@ -131,6 +138,22 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
         await client.TryInvokeAsync<IRemoteEditAndContinueService>(
             (service, cancellationToken) => service.DiscardSolutionUpdateAsync(sessionId, cancellationToken),
             cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask UpdateBaselinesAsync(Solution solution, ImmutableArray<ProjectId> rebuiltProjects, CancellationToken cancellationToken)
+    {
+        var client = await RemoteHostClient.TryGetClientAsync(services, cancellationToken).ConfigureAwait(false);
+        if (client == null)
+        {
+            GetLocalService().UpdateBaselines(sessionId, solution, rebuiltProjects);
+        }
+        else
+        {
+            var result = await client.TryInvokeAsync<IRemoteEditAndContinueService>(
+                solution,
+                (service, solutionInfo, cancellationToken) => service.UpdateBaselinesAsync(solutionInfo, sessionId, rebuiltProjects, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async ValueTask<ImmutableArray<ImmutableArray<ActiveStatementSpan>>> GetBaseActiveStatementSpansAsync(Solution solution, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Remote;
-using Microsoft.CodeAnalysis.SQLite.Interop;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
@@ -95,7 +95,7 @@ internal sealed class UnitTestingHotReloadService(HostWorkspaceServices services
         Contract.ThrowIfFalse(sessionId != default, "Session has not started");
 
         var results = await _encService
-            .EmitSolutionUpdateAsync(sessionId, solution, s_solutionActiveStatementSpanProvider, cancellationToken)
+            .EmitSolutionUpdateAsync(sessionId, solution, runningProjects: [], s_solutionActiveStatementSpanProvider, cancellationToken)
             .ConfigureAwait(false);
 
         if (results.ModuleUpdates.Status == ModuleUpdateStatus.Ready)

--- a/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -537,19 +537,19 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
 
         if (breakMode)
         {
-            AssertEx.Equal(
+            AssertEx.SequenceEqual(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=3",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges={6A6F7270-0000-4000-8000-000000000000}",
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges={6A6F7270-0000-4000-8000-000000000000}|ProjectIdsWithUpdatedBaselines=",
                 "Debugging_EncSession_EditSession_EmitDeltaErrorId: SessionId=1|EditSessionId=2|ErrorId=ENC1001"
             ], _telemetryLog);
         }
         else
         {
-            AssertEx.Equal(
+            AssertEx.SequenceEqual(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=1|EmptyHotReloadSessionCount=1",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges={6A6F7270-0000-4000-8000-000000000000}",
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges={6A6F7270-0000-4000-8000-000000000000}|ProjectIdsWithUpdatedBaselines=",
                 "Debugging_EncSession_EditSession_EmitDeltaErrorId: SessionId=1|EditSessionId=2|ErrorId=ENC1001"
             ], _telemetryLog);
         }
@@ -659,7 +659,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         AssertEx.Equal(
         [
             "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1",
-            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges="
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines="
         ], _telemetryLog);
     }
 
@@ -717,7 +717,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
             AssertEx.Equal(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=2",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges="
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines="
             ], _telemetryLog);
         }
         else
@@ -725,7 +725,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
             AssertEx.Equal(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=1|EmptyHotReloadSessionCount=0",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges="
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines="
             ], _telemetryLog);
         }
     }
@@ -893,7 +893,7 @@ class C1
         AssertEx.Equal(
         [
             "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1",
-            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=",
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
             "Debugging_EncSession_EditSession_EmitDeltaErrorId: SessionId=1|EditSessionId=2|ErrorId=ENC2016"
         ], _telemetryLog);
     }
@@ -1002,7 +1002,7 @@ class C1
             AssertEx.Equal(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=2",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=",
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
                 "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=110|RudeEditSyntaxKind=8910|RudeEditBlocking=True|RudeEditProjectId={6A6F7270-0000-4000-8000-000000000000}"
             ], _telemetryLog);
         }
@@ -1011,7 +1011,7 @@ class C1
             AssertEx.Equal(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=1|EmptyHotReloadSessionCount=0",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges=",
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
                 "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=110|RudeEditSyntaxKind=8910|RudeEditBlocking=True|RudeEditProjectId={6A6F7270-0000-4000-8000-000000000000}"
             ], _telemetryLog);
         }
@@ -1214,7 +1214,7 @@ class C { int Y => 2; }
             AssertEx.Equal(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=2",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=",
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
                 "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=110|RudeEditSyntaxKind=8875|RudeEditBlocking=True|RudeEditProjectId={6A6F7270-0000-4000-8000-000000000000}"
             ], _telemetryLog);
         }
@@ -1223,7 +1223,7 @@ class C { int Y => 2; }
             AssertEx.Equal(
             [
                 "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=1|EmptyHotReloadSessionCount=0",
-                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges=",
+                "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
                 "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=110|RudeEditSyntaxKind=8875|RudeEditBlocking=True|RudeEditProjectId={6A6F7270-0000-4000-8000-000000000000}"
             ], _telemetryLog);
         }
@@ -1404,6 +1404,14 @@ class C { int Y => 2; }
         CommitSolutionUpdate(debuggingSession);
 
         EndDebuggingSession(debuggingSession);
+
+        AssertEx.SequenceEqual(
+        [
+            "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=2|EmptyHotReloadSessionCount=1",
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=1|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines={6A6F7270-0000-4000-8000-000000000000}",
+            "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=23|RudeEditSyntaxKind=8875|RudeEditBlocking=True|RudeEditProjectId={6A6F7270-0000-4000-8000-000000000000}",
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=3|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges={6A6F7270-0000-4000-8000-000000000000}|ProjectIdsWithUpdatedBaselines="
+        ], _telemetryLog);
     }
 
     [Fact]
@@ -1442,7 +1450,7 @@ class C { int Y => 2; }
         AssertEx.Equal(
         [
             "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1",
-            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=True|HadRudeEdits=False|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges="
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=True|HadRudeEdits=False|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines="
         ], _telemetryLog);
     }
 
@@ -1484,10 +1492,10 @@ class C { int Y => 2; }
 
         AssertEx.SetEqual([moduleId], debuggingSession.GetTestAccessor().GetModulesPreparedForUpdate());
 
-        AssertEx.Equal(
+        AssertEx.SequenceEqual(
         [
             "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1",
-            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=",
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
             "Debugging_EncSession_EditSession_EmitDeltaErrorId: SessionId=1|EditSessionId=2|ErrorId=CS0266"
         ], _telemetryLog);
     }
@@ -2135,7 +2143,7 @@ class G
         AssertEx.Equal(
         [
             "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1",
-            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=",
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
             "Debugging_EncSession_EditSession_EmitDeltaErrorId: SessionId=1|EditSessionId=2|ErrorId=CS8055"
         ], _telemetryLog);
     }
@@ -2535,18 +2543,18 @@ class G
 
         if (breakMode)
         {
-            AssertEx.Equal(
+            AssertEx.SequenceEqual(
             [
                 $"Debugging_EncSession: SolutionSessionId={{00000000-AAAA-AAAA-AAAA-000000000000}}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount={(commitUpdate ? 3 : 2)}",
-                $"Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges={(commitUpdate ? "{6A6F7270-0000-4000-8000-000000000000}" : "")}",
+                $"Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges={(commitUpdate ? "{6A6F7270-0000-4000-8000-000000000000}" : "")}|ProjectIdsWithUpdatedBaselines=",
             ], _telemetryLog);
         }
         else
         {
-            AssertEx.Equal(
+            AssertEx.SequenceEqual(
             [
                 $"Debugging_EncSession: SolutionSessionId={{00000000-AAAA-AAAA-AAAA-000000000000}}|SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=1|EmptyHotReloadSessionCount={(commitUpdate ? 1 : 0)}",
-                $"Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges={(commitUpdate ? "{6A6F7270-0000-4000-8000-000000000000}" : "")}"
+                $"Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges={(commitUpdate ? "{6A6F7270-0000-4000-8000-000000000000}" : "")}|ProjectIdsWithUpdatedBaselines="
             ], _telemetryLog);
         }
     }
@@ -3336,7 +3344,7 @@ class C { int Y => 1; }
         AssertEx.Equal(
         [
             "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1",
-            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=",
+            "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=False|HadValidChanges=True|HadValidInsignificantChanges=False|RudeEditsCount=0|EmitDeltaErrorIdCount=1|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=|ProjectIdsWithUpdatedBaselines=",
             "Debugging_EncSession_EditSession_EmitDeltaErrorId: SessionId=1|EditSessionId=2|ErrorId=ENC1001"
         ], _telemetryLog);
     }

--- a/src/Features/TestUtilities/EditAndContinue/Extensions.cs
+++ b/src/Features/TestUtilities/EditAndContinue/Extensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
         public static ProjectInfo CreateProjectInfo(string projectName, string language = LanguageNames.CSharp)
             => ProjectInfo.Create(
-                ProjectId.CreateNewId(),
+                ProjectId.CreateNewId(debugName: projectName),
                 VersionStamp.Create(),
                 name: projectName,
                 assemblyName: projectName,
@@ -97,6 +97,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     NoCompilationConstants.LanguageName => null,
                     _ => throw ExceptionUtilities.UnexpectedValue(language)
                 },
+                compilationOptions: TestOptions.DebugDll,
                 filePath: projectName + language switch
                 {
                     LanguageNames.CSharp => ".csproj",

--- a/src/Features/TestUtilities/EditAndContinue/MockEditAndContinueService.cs
+++ b/src/Features/TestUtilities/EditAndContinue/MockEditAndContinueService.cs
@@ -23,9 +23,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Func<Solution, IManagedHotReloadService, IPdbMatchingSourceTextProvider, ImmutableArray<DocumentId>, bool, bool, DebuggingSessionId>? StartDebuggingSessionImpl;
 
         public Action? EndDebuggingSessionImpl;
-        public Func<Solution, ActiveStatementSpanProvider, EmitSolutionUpdateResults>? EmitSolutionUpdateImpl;
+        public Func<Solution, IImmutableSet<ProjectId>, ActiveStatementSpanProvider, EmitSolutionUpdateResults>? EmitSolutionUpdateImpl;
         public Action<Document>? OnSourceFileUpdatedImpl;
         public Action? CommitSolutionUpdateImpl;
+        public Action<Solution, ImmutableArray<ProjectId>>? UpdateBaselinesImpl;
         public Action<bool?>? BreakStateOrCapabilitiesChangedImpl;
         public Action? DiscardSolutionUpdateImpl;
         public Func<Document, ActiveStatementSpanProvider, ImmutableArray<Diagnostic>>? GetDocumentDiagnosticsImpl;
@@ -39,8 +40,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public void DiscardSolutionUpdate(DebuggingSessionId sessionId)
             => DiscardSolutionUpdateImpl?.Invoke();
 
-        public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(DebuggingSessionId sessionId, Solution solution, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
-            => new((EmitSolutionUpdateImpl ?? throw new NotImplementedException()).Invoke(solution, activeStatementSpanProvider));
+        public void UpdateBaselines(DebuggingSessionId sessionId, Solution solution, ImmutableArray<ProjectId> rebuiltProjects)
+            => UpdateBaselinesImpl?.Invoke(solution, rebuiltProjects);
+
+        public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(DebuggingSessionId sessionId, Solution solution, IImmutableSet<ProjectId> runningProjects, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
+            => new((EmitSolutionUpdateImpl ?? throw new NotImplementedException()).Invoke(solution, runningProjects, activeStatementSpanProvider));
 
         public void EndDebuggingSession(DebuggingSessionId sessionId)
             => EndDebuggingSessionImpl?.Invoke();

--- a/src/VisualStudio/DevKit/Impl/EditAndContinue/ManagedHotReloadLanguageServiceBridge.cs
+++ b/src/VisualStudio/DevKit/Impl/EditAndContinue/ManagedHotReloadLanguageServiceBridge.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 [ExportBrokeredService(ManagedHotReloadLanguageServiceDescriptor.MonikerName, ManagedHotReloadLanguageServiceDescriptor.ServiceVersion, Audience = ServiceAudience.Local)]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed partial class ManagedHotReloadLanguageServiceBridge(InternalContracts.IManagedHotReloadLanguageService service) : IManagedHotReloadLanguageService, IExportedBrokeredService
+internal sealed partial class ManagedHotReloadLanguageServiceBridge(InternalContracts.IManagedHotReloadLanguageService2 service) : IManagedHotReloadLanguageService2, IExportedBrokeredService
 {
     ServiceRpcDescriptor IExportedBrokeredService.Descriptor
         => ManagedHotReloadLanguageServiceDescriptor.Descriptor;
@@ -43,8 +44,14 @@ internal sealed partial class ManagedHotReloadLanguageServiceBridge(InternalCont
     public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(CancellationToken cancellationToken)
         => (await service.GetUpdatesAsync(cancellationToken).ConfigureAwait(false)).FromContract();
 
+    public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(ImmutableArray<string> runningProjects, CancellationToken cancellationToken)
+        => (await service.GetUpdatesAsync(runningProjects, cancellationToken).ConfigureAwait(false)).FromContract();
+
     public ValueTask CommitUpdatesAsync(CancellationToken cancellationToken)
         => service.CommitUpdatesAsync(cancellationToken);
+
+    public ValueTask UpdateBaselinesAsync(ImmutableArray<string> projectPaths, CancellationToken cancellationToken)
+        => service.UpdateBaselinesAsync(projectPaths, cancellationToken);
 
     public ValueTask DiscardUpdatesAsync(CancellationToken cancellationToken)
         => service.DiscardUpdatesAsync(cancellationToken);

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -141,7 +141,7 @@ internal sealed class RemoteEditAndContinueService : BrokeredServiceBase, IRemot
     /// Remote API.
     /// </summary>
     public ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(
-        Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, CancellationToken cancellationToken)
+        Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, IImmutableSet<ProjectId> runningProjects, CancellationToken cancellationToken)
     {
         return RunServiceAsync(solutionChecksum, async solution =>
         {
@@ -149,7 +149,7 @@ internal sealed class RemoteEditAndContinueService : BrokeredServiceBase, IRemot
 
             try
             {
-                return (await service.EmitSolutionUpdateAsync(sessionId, solution, CreateActiveStatementSpanProvider(callbackId), cancellationToken).ConfigureAwait(false)).Dehydrate();
+                return (await service.EmitSolutionUpdateAsync(sessionId, solution, runningProjects, CreateActiveStatementSpanProvider(callbackId), cancellationToken).ConfigureAwait(false)).Dehydrate();
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
@@ -159,6 +159,8 @@ internal sealed class RemoteEditAndContinueService : BrokeredServiceBase, IRemot
                     Diagnostics = GetUnexpectedUpdateError(solution, e),
                     RudeEdits = [],
                     SyntaxError = null,
+                    ProjectsToRebuild = [],
+                    ProjectsToRestart = [],
                 };
             }
         }, cancellationToken);
@@ -191,6 +193,18 @@ internal sealed class RemoteEditAndContinueService : BrokeredServiceBase, IRemot
         return RunServiceAsync(cancellationToken =>
         {
             GetService().DiscardSolutionUpdate(sessionId);
+            return default;
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Remote API.
+    /// </summary>
+    public ValueTask UpdateBaselinesAsync(Checksum solutionChecksum, DebuggingSessionId sessionId, ImmutableArray<ProjectId> rebuiltProjects, CancellationToken cancellationToken)
+    {
+        return RunServiceAsync(solutionChecksum, solution =>
+        {
+            GetService().UpdateBaselines(sessionId, solution, rebuiltProjects);
             return default;
         }, cancellationToken);
     }


### PR DESCRIPTION
Implements `IManagedHotReloadLanguageService2` interface that allows the debugger to restart a subset of processes when a rude edit is encountered instead of terminating the entire debugging session.

This includes a new overload of `GetUpdatesAsync` that takes a list of running projects and returns sets of projects to restart and to rebuild based on dependency analysis of updated projects. This functionality has already been exposed to dotnet-watch, now it will be available to VS debugger as well.

Adds a new API `UpdateBaselines` that discards the initial baselines of specified projects and commits the current solution snapshot. This is to be called when projects affected by rude edits are rebuilt. The next update will start with a new baseline read from newly built metadata.


