### PR TITLE
Update .NET 9 runtime for single machine CI job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,12 @@ variables:
     ${{ else }}:
       value: windows.vs2022preview.amd64
 
+  - name: Vs2022RegularQueueName
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      value: windows.vs2022.amd64.open
+    ${{ else }}:
+      value: windows.vs2022.amd64
+
   - name: UbuntuQueueName
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       value: Build.Ubuntu.2004.Amd64.Open
@@ -107,6 +113,11 @@ parameters:
     default:
       name: $(PoolName)
       demands: ImageOverride -equals $(Vs2022PreviewQueueName)
+  - name: vs2022RegularPool
+    type: object
+    default:
+      name: $(PoolName)
+      demands: ImageOverride -equals $(Vs2022RegularQueueName)
 
 stages:
 - stage: Windows_Debug_Build
@@ -271,7 +282,7 @@ stages:
         jobName: Test_Windows_CoreClr_Debug_Single_Machine
         testArtifactName: Transport_Artifacts_Windows_Debug
         configuration: Debug
-        poolParameters: ${{ parameters.vs2022PreviewPool }}
+        poolParameters: ${{ parameters.vs2022RegularPool }}
         testArguments: -testCoreClr
 
   - template: eng/pipelines/test-windows-job.yml

--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -33,7 +33,7 @@ jobs:
       displayName: 'Install .NET 9 Runtime'
       inputs:
         packageType: runtime
-        version: 9.0.0-preview.3.24172.9
+        version: 9.0.0-rc.2.24473.5
         includePreviewVersions: true
         installationPath: '$(Build.SourcesDirectory)/.dotnet'
 


### PR DESCRIPTION
Fixes this error in the single machine CI leg (which runs only in main branch):

```
Testhost process for source(s) 'D:\a\_work\1\s\artifacts\bin\Roslyn.Compilers.VisualBasic.IOperation.UnitTests\Debug\net9.0\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.dll' exited with error: You must install or update .NET to run this application.
App: D:\a\_work\1\s\artifacts\bin\Roslyn.Compilers.VisualBasic.IOperation.UnitTests\Debug\net9.0\testhost.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '9.0.0-rc.2.24473.5' (x64)
.NET location: D:\a\_work\1\s\.dotnet
The following frameworks were found:
  9.0.0-preview.3.24172.9 at [D:\a\_work\1\s\.dotnet\shared\Microsoft.NETCore.App]
Learn more:
https://aka.ms/dotnet/app-launch-failed
To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=9.0.0-rc.2.24473.5&arch=x64&rid=win-x64&os=win10
. Please check the diagnostic logs for more information.
Test Run Aborted.
```