### PR TITLE
Fix an allocation regression due to the recent SegmentedList change c…

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/List/SegmentedList.Generic.Tests.Capacity.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/List/SegmentedList.Generic.Tests.Capacity.cs
@@ -140,5 +140,18 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             Assert.Equal(expectedCapacity, list.Capacity);
         }
+
+        [Fact]
+        public void EnsureCapacity_InitialCapacitySlightlyMoreThanHalfSegmentSizeGrowsToFullSegmentSize()
+        {
+            var elementCount = SegmentedArray<T>.TestAccessor.SegmentSize / 2 + 1;
+            var list = new SegmentedList<T>(elementCount);
+
+            Assert.Equal(elementCount, list.Capacity);
+
+            list.EnsureCapacity(elementCount + 1);
+
+            Assert.Equal(SegmentedArray<T>.TestAccessor.SegmentSize, list.Capacity);
+        }
     }
 }

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -520,6 +520,11 @@ namespace Microsoft.CodeAnalysis.Collections
                 // should be DefaultCapacity. Otherwise, the new capacity should be double the current array size.
                 newCapacity = _items.Length == 0 ? DefaultCapacity : _items.Length * 2;
             }
+            else if (_items.Length < SegmentedArrayHelper.GetSegmentSize<T>())
+            {
+                // There is only a single segment that is over half full. Increase it to a full segment.
+                newCapacity = SegmentedArrayHelper.GetSegmentSize<T>();
+            }
             else
             {
                 // If the last segment is fully sized, increase the number of segments by the desired growth rate


### PR DESCRIPTION
…aught by speedometer

The change in https://github.com/dotnet/roslyn/pull/75756 was incorrect when the existing number of items is between SegmentSize /2 (inclusive) and SegmentSize (exclusive). In this case, the size of the newCapacity would end up as exactly the requested capacity, causing a potentially O(n^2) allocation growth pattern if caller was just increasing the requested capacity by one from it's current size.

The fix is just to handle that case directly, and if the existing size falls into that range, to simply set the desired newCapacity to the SegmentSize.