### PR TITLE
Workaround failing official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -308,6 +308,7 @@ extends:
                        /p:DotnetPublishUsingPipelines=true
                        /p:IgnoreIbcMergeErrors=true
                        /p:GenerateSbom=true
+                       /p:ForceAzureComSources=true
           condition: succeeded()
 
         - template: /eng/common/templates-official/steps/generate-sbom.yml@self

--- a/eng/InternalTools.props
+++ b/eng/InternalTools.props
@@ -10,6 +10,15 @@
           $(RestoreSources);
           https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
         </RestoreSources>
+
+        <!-- Workaround for https://github.com/dotnet/dnceng/issues/4441. -->
+        <RestoreSources Condition="'$(ForceAzureComSources)' == 'true'">
+          https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
+          https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json;
+          https://pkgs.dev.azure.com/devdiv/_packaging/Engineering/nuget/v3/index.json;
+          https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
+          https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
+        </RestoreSources>
     </PropertyGroup>
     
     <ItemGroup Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'">


### PR DESCRIPTION
Related: https://github.com/dotnet/dnceng/issues/4441
Official build run of this PR: https://dev.azure.com/dnceng/internal/_build/results?buildId=2581358&view=results

No idea why, but when the `eng/common/internal/Tools.csproj` project is being restored as part of the "restore internal tools", it works with the arcade-provided NuGet feeds. But when that same project is being restored as part of the "build" step, it reports 401 (Unauthorized) for the visualstudio.com feeds - replacing them with the azure.com equivalents fixes the problem.

(Note that technically the second restore of that project as part of the build step is unnecessary, but I didn't find a simple way to disable it.)