### PR TITLE
Ensure NFW gets reported before result is reported to client and remove async listener in queue

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptRequestExecutionQueueProvider.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptRequestExecutionQueueProvider.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript;
 [ExportStatelessLspService(typeof(IRequestExecutionQueueProvider<RequestContext>), ProtocolConstants.TypeScriptLanguageContract), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, true)]
-internal sealed class VSTypeScriptRequestExecutionQueueProvider(IAsynchronousOperationListenerProvider asynchronousOperationListenerProvider) : IRequestExecutionQueueProvider<RequestContext>
+internal sealed class VSTypeScriptRequestExecutionQueueProvider() : IRequestExecutionQueueProvider<RequestContext>
 {
     public IRequestExecutionQueue<RequestContext> CreateRequestExecutionQueue(AbstractLanguageServer<RequestContext> languageServer, ILspLogger logger, AbstractHandlerProvider handlerProvider)
     {
-        var queue = new RoslynRequestExecutionQueue(languageServer, logger, handlerProvider, asynchronousOperationListenerProvider);
+        var queue = new RoslynRequestExecutionQueue(languageServer, logger, handlerProvider);
         queue.Start();
         return queue;
     }

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -424,12 +424,12 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
     /// Provides an extensibility point to log or otherwise inspect errors thrown from non-mutating requests,
     /// which would otherwise be lost to the fire-and-forget task in the queue.
     /// </summary>
-    /// <param name="nonMutatingRequestTask">The task to be inspected.</param>
+    /// <param name="requestTask">The task to be inspected.</param>
     /// <param name="rethrowExceptions">If exceptions should be re-thrown.</param>
-    /// <returns>The task from <paramref name="nonMutatingRequestTask"/>, to allow chained calls if needed.</returns>
-    public virtual Task WrapStartRequestTaskAsync(Task nonMutatingRequestTask, bool rethrowExceptions)
+    /// <returns>The task from <paramref name="requestTask"/>, to allow chained calls if needed.</returns>
+    public virtual Task WrapStartRequestTaskAsync(Task requestTask, bool rethrowExceptions)
     {
-        return nonMutatingRequestTask;
+        return requestTask;
     }
 
     /// <summary>

--- a/src/LanguageServer/Protocol/LspServices/RequestTelemetryScope.cs
+++ b/src/LanguageServer/Protocol/LspServices/RequestTelemetryScope.cs
@@ -52,7 +52,10 @@ internal sealed class RequestTelemetryScope(string name, RequestTelemetryLogger 
     {
         if (exception is StreamJsonRpc.LocalRpcException localRpcException && localRpcException.ErrorCode == LspErrorCodes.ContentModified)
         {
-            // Content modified exceptions are expected and should not be reported as NFWs.
+            // We throw content modified exceptions when asked to resolve code lens / inlay hints associated with a solution version we no longer have.
+            // This generally happens when the project changes underneath us.  The client is eventually told to refresh,
+            // but they can send us resolve requests for prior versions before they see the refresh.
+            // There is no need to report these exceptions as NFW since they are expected to occur in normal workflows.
             return;
         }
 

--- a/src/LanguageServer/Protocol/RequestExecutionQueueProvider.cs
+++ b/src/LanguageServer/Protocol/RequestExecutionQueueProvider.cs
@@ -6,7 +6,6 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.CodeAnalysis.LanguageServer;
@@ -14,11 +13,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer;
 [ExportCSharpVisualBasicStatelessLspService(typeof(IRequestExecutionQueueProvider<RequestContext>)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, true)]
-internal sealed class RequestExecutionQueueProvider(IAsynchronousOperationListenerProvider asynchronousOperationListenerProvider) : IRequestExecutionQueueProvider<RequestContext>
+internal sealed class RequestExecutionQueueProvider() : IRequestExecutionQueueProvider<RequestContext>
 {
     public IRequestExecutionQueue<RequestContext> CreateRequestExecutionQueue(AbstractLanguageServer<RequestContext> languageServer, ILspLogger logger, AbstractHandlerProvider handlerProvider)
     {
-        var queue = new RoslynRequestExecutionQueue(languageServer, logger, handlerProvider, asynchronousOperationListenerProvider);
+        var queue = new RoslynRequestExecutionQueue(languageServer, logger, handlerProvider);
         queue.Start();
         return queue;
     }

--- a/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
+++ b/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
@@ -33,7 +33,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             }
             catch (Exception) when (!rethrowExceptions)
             {
-                // The caller has asked us to not rethrow, so swallow the exception.
+                // The caller has asked us to not rethrow, so swallow the exception to avoid bringing down the queue.
+                // The queue item task itself already handles reporting the exception (if any).
             }
         }
 

--- a/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
+++ b/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
@@ -27,21 +27,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         public override async Task WrapStartRequestTaskAsync(Task requestTask, bool rethrowExceptions)
         {
-            if (rethrowExceptions)
+            try
             {
                 await requestTask.ConfigureAwait(false);
             }
-            else
+            catch (Exception) when (!rethrowExceptions)
             {
                 // The caller has asked us to not rethrow, so swallow the exception.
-                try
-                {
-                    await requestTask.ConfigureAwait(false);
-                }
-                catch (Exception)
-                {
-                    // Swallow the exception so it does not bubble up into the queue.
-                }
             }
         }
 

--- a/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
+++ b/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
@@ -5,63 +5,40 @@
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CommonLanguageServerProtocol.Framework;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer
 {
     internal sealed class RoslynRequestExecutionQueue : RequestExecutionQueue<RequestContext>
     {
         private readonly IInitializeManager _initializeManager;
-        private readonly IAsynchronousOperationListener _listener;
 
         /// <summary>
         /// Serial access is guaranteed by the queue.
         /// </summary>
         private CultureInfo? _cultureInfo;
 
-        public RoslynRequestExecutionQueue(AbstractLanguageServer<RequestContext> languageServer, ILspLogger logger, AbstractHandlerProvider handlerProvider, IAsynchronousOperationListenerProvider provider)
+        public RoslynRequestExecutionQueue(AbstractLanguageServer<RequestContext> languageServer, ILspLogger logger, AbstractHandlerProvider handlerProvider)
             : base(languageServer, logger, handlerProvider)
         {
             _initializeManager = languageServer.GetLspServices().GetRequiredService<IInitializeManager>();
-            _listener = provider.GetListener(FeatureAttribute.LanguageServer);
         }
 
-        public override async Task WrapStartRequestTaskAsync(Task nonMutatingRequestTask, bool rethrowExceptions)
+        public override async Task WrapStartRequestTaskAsync(Task requestTask, bool rethrowExceptions)
         {
-            using var token = _listener.BeginAsyncOperation(nameof(WrapStartRequestTaskAsync));
             if (rethrowExceptions)
             {
-                try
-                {
-                    await nonMutatingRequestTask.ConfigureAwait(false);
-                }
-                catch (StreamJsonRpc.LocalRpcException localRpcException) when (localRpcException.ErrorCode == LspErrorCodes.ContentModified)
-                {
-                    // Content modified exceptions are expected and should not be reported as NFWs.
-                    throw;
-                }
-                // If we had an exception, we want to record a NFW for it AND propogate it out to the queue so it can be handled appropriately.
-                catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, ErrorSeverity.Critical))
-                {
-                    throw ExceptionUtilities.Unreachable();
-                }
+                await requestTask.ConfigureAwait(false);
             }
             else
             {
-                // The caller has asked us to not rethrow, so record a NFW and swallow.
+                // The caller has asked us to not rethrow, so swallow the exception.
                 try
                 {
-                    await nonMutatingRequestTask.ConfigureAwait(false);
+                    await requestTask.ConfigureAwait(false);
                 }
-                catch (StreamJsonRpc.LocalRpcException localRpcException) when (localRpcException.ErrorCode == LspErrorCodes.ContentModified)
-                {
-                    // Content modified exceptions are expected and should not be reported as NFWs.
-                }
-                catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, ErrorSeverity.Critical))
+                catch (Exception)
                 {
                     // Swallow the exception so it does not bubble up into the queue.
                 }

--- a/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
@@ -10,14 +10,12 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
-using static Microsoft.CodeAnalysis.LanguageServer.UnitTests.LocaleTests;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 {
@@ -152,7 +150,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             var didReport = false;
             FatalError.OverwriteHandler((exception, severity, dumps) =>
             {
-                if (exception.Message == nameof(HandlerTests) || exception.InnerException.Message == nameof(HandlerTests))
+                if (exception.Message == nameof(HandlerTests) || exception.InnerException?.Message == nameof(HandlerTests))
                 {
                     didReport = true;
                 }
@@ -163,11 +161,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 
             await Assert.ThrowsAnyAsync<Exception>(async ()
                 => await server.ExecuteRequestAsync<TestRequestWithDocument, TestConfigurableResponse>(TestConfigurableDocumentHandler.MethodName, request, CancellationToken.None));
-
-            var provider = server.TestWorkspace.ExportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
-            await provider.WaitAllDispatcherOperationAndTasksAsync(
-                server.TestWorkspace,
-                FeatureAttribute.LanguageServer);
 
             Assert.True(didReport);
         }
@@ -185,7 +178,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             var didReport = false;
             FatalError.OverwriteHandler((exception, severity, dumps) =>
             {
-                if (exception.Message == nameof(HandlerTests) || exception.InnerException.Message == nameof(HandlerTests))
+                if (exception.Message == nameof(HandlerTests) || exception.InnerException?.Message == nameof(HandlerTests))
                 {
                     didReport = true;
                 }
@@ -196,11 +189,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 
             await Assert.ThrowsAnyAsync<Exception>(async ()
                 => await server.ExecuteRequestAsync<TestRequestWithDocument, TestConfigurableResponse>(TestConfigurableDocumentHandler.MethodName, request, CancellationToken.None));
-
-            var provider = server.TestWorkspace.ExportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
-            await provider.WaitAllDispatcherOperationAndTasksAsync(
-                server.TestWorkspace,
-                FeatureAttribute.LanguageServer);
 
             Assert.False(didReport);
         }
@@ -218,7 +206,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             var didReport = false;
             FatalError.OverwriteHandler((exception, severity, dumps) =>
             {
-                if (exception.Message == nameof(HandlerTests) || exception.InnerException.Message == nameof(HandlerTests))
+                if (exception.Message == nameof(HandlerTests) || exception.InnerException?.Message == nameof(HandlerTests))
                 {
                     didReport = true;
                 }
@@ -248,7 +236,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             var didReport = false;
             FatalError.OverwriteHandler((exception, severity, dumps) =>
             {
-                if (exception.Message == nameof(HandlerTests) || exception.InnerException.Message == nameof(HandlerTests))
+                if (exception.Message == nameof(HandlerTests) || exception.InnerException?.Message == nameof(HandlerTests))
                 {
                     didReport = true;
                 }
@@ -259,11 +247,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 
             await Assert.ThrowsAnyAsync<Exception>(async ()
                 => await server.ExecuteRequestAsync<TestRequestWithDocument, TestConfigurableResponse>(TestConfigurableDocumentHandler.MethodName, request, CancellationToken.None));
-
-            var provider = server.TestWorkspace.ExportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
-            await provider.WaitAllDispatcherOperationAndTasksAsync(
-                server.TestWorkspace,
-                FeatureAttribute.LanguageServer);
 
             Assert.False(didReport);
         }
@@ -281,7 +264,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             var didReport = false;
             FatalError.OverwriteHandler((exception, severity, dumps) =>
             {
-                if (exception.Message == nameof(HandlerTests) || exception.InnerException.Message == nameof(HandlerTests))
+                if (exception.Message == nameof(HandlerTests) || exception.InnerException?.Message == nameof(HandlerTests))
                 {
                     didReport = true;
                 }


### PR DESCRIPTION
Should resolve https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2224584

Optprof web application tests have been failing for a while in VS.  Tim tracked down the issue to an async listener introduced in https://github.com/dotnet/roslyn/pull/74530/ 

The never completing listener were requests for workspace diagnostics.  This is actually expected for workspace diagnostics requests, as they are held open indefinitely if nothing changes (see https://github.com/dotnet/roslyn/blob/main/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs#L94).   So as long as workspace diagnostics requests function this way, it is easy to get into a situation where there are async listeners that never complete.

The queue async listener was introduced to ensure that unit tests could reliably verify if the NFW handler was called (as handling the exception happened after the response was returned to the client).

To resolve this issue I did a couple things
1.  Move reporting NFW for request exceptions into the telemetry reporting scope.  Importantly this scope is called before the result is sent back to the client.  This allows unit tests to simply wait for the request to complete before checking if the NFW handler was called (no need for an async listener).
2.  Removing the async listener from the queue now that no unit tests need to wait for an action to occur in the queue.


TODO - validate optprof