### PR TITLE
Reduce some allocations from remote classification serialization

### DIFF
--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -259,7 +259,14 @@ internal readonly struct SerializableClassifiedSpansAndHighlightSpan(
     public readonly TextSpan HighlightSpan = highlightSpan;
 
     public static SerializableClassifiedSpansAndHighlightSpan Dehydrate(ClassifiedSpansAndHighlightSpan classifiedSpansAndHighlightSpan)
-        => new(SerializableClassifiedSpans.Dehydrate(classifiedSpansAndHighlightSpan.ClassifiedSpans), classifiedSpansAndHighlightSpan.HighlightSpan);
+    {
+        using var _ = Classifier.GetPooledList(out var temp);
+
+        foreach (var span in classifiedSpansAndHighlightSpan.ClassifiedSpans)
+            temp.Add(span);
+
+        return new(SerializableClassifiedSpans.Dehydrate(temp), classifiedSpansAndHighlightSpan.HighlightSpan);
+    }
 
     public ClassifiedSpansAndHighlightSpan Rehydrate()
         => new(this.ClassifiedSpans.Rehydrate(), this.HighlightSpan);

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -69,11 +69,11 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
     [DataMember(Order = 1)]
     public readonly ImmutableArray<int> ClassificationTriples = classificationTriples;
 
-    internal static SerializableClassifiedSpans Dehydrate(ImmutableArray<ClassifiedSpan> classifiedSpans)
+    internal static SerializableClassifiedSpans Dehydrate(SegmentedList<ClassifiedSpan> classifiedSpans)
     {
         using var _1 = PooledDictionary<string, int>.GetInstance(out var classificationTypeToId);
         using var _2 = ArrayBuilder<string>.GetInstance(out var classificationTypes);
-        var classificationTriples = new FixedSizeArrayBuilder<int>(classifiedSpans.Length * 3);
+        var classificationTriples = new FixedSizeArrayBuilder<int>(classifiedSpans.Count * 3);
 
         foreach (var classifiedSpan in classifiedSpans)
         {

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -86,9 +86,18 @@ internal sealed partial class RemoteSemanticClassificationService : BrokeredServ
         var classifiedSpans = await TryGetOrReadCachedSemanticClassificationsAsync(
             documentKey, type, checksum, cancellationToken).ConfigureAwait(false);
         var textSpanIntervalTree = new TextSpanMutableIntervalTree(textSpans);
-        return classifiedSpans.IsDefault
-            ? null
-            : SerializableClassifiedSpans.Dehydrate(classifiedSpans.WhereAsArray(c => textSpanIntervalTree.HasIntervalThatIntersectsWith(c.TextSpan)));
+
+        if (classifiedSpans.IsDefault)
+            return null;
+
+        using var _ = Classifier.GetPooledList(out var temp);
+        foreach (var span in classifiedSpans)
+        {
+            if (textSpanIntervalTree.HasIntervalThatIntersectsWith(span.TextSpan))
+                temp.Add(span);
+        }
+
+        return SerializableClassifiedSpans.Dehydrate(temp);
     }
 
     private static async ValueTask CacheClassificationsAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -57,7 +57,7 @@ internal sealed partial class RemoteSemanticClassificationService : BrokeredServ
                 _workQueue.AddWork((document, type, options));
             }
 
-            return SerializableClassifiedSpans.Dehydrate([.. temp]);
+            return SerializableClassifiedSpans.Dehydrate(temp);
         }, cancellationToken);
     }
 }


### PR DESCRIPTION
SerializableClassifiedSpans.Dehydrate was previously taking in an ImmutableArray, causing several callers to allocate. Instead, it can take in a SegmentedList, which several of the callers already have, and if not, a pooled instance can be obtained and populated.

ClassifiedSpan[] shows up as 5.4% of allocations in our CodeAnalysis process in the platform's scrolling speedometer test.

![image](https://github.com/user-attachments/assets/43c72dc1-928c-476d-bbd6-e0d3d65cb3dc)