### PR TITLE
Reduce formatting allocation in CodeAnalysis process in scrolling speedometer

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -223,6 +223,11 @@ internal abstract partial class AbstractFormatEngine
 
         using (Logger.LogBlock(FunctionId.Formatting_CollectTokenOperation, cancellationToken))
         {
+            // Grow the SegmentedList in a single allocation if the resultant list is going to be
+            // significantly larger than it's existing Capacity.
+            if (tokenStream.TokenCount > 2 * list.Capacity)
+                list.EnsureCapacity(tokenStream.TokenCount);
+
             foreach (var (index, currentToken, nextToken) in tokenStream.TokenIterator)
             {
                 cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
TokenPairWithOperations[] accounts for 2.4% of total allocations in the test. Locally reproducing this demonstrated that there is usually a small number of tokens that are added, but occasionally a much larger token count is added. Doing a single shot allocation in the case where we are significantly increasing the SegmentedList size is more efficient than growing organically by adding single items.

![image](https://github.com/user-attachments/assets/eefb791d-3360-4ed9-9a49-1d8f30ecd136)