### PR TITLE
Send over the new sourcetext's content checksum when sending notification of textchanges

### DIFF
--- a/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
+++ b/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
@@ -221,7 +221,7 @@ internal sealed class SolutionChecksumUpdater
         //
         // otherwise, it will do the normal behavior of getting full text from VS side. this optimization saves
         // times we need to do full text synchronization for typing scenario.
-        using var _ = ArrayBuilder<(DocumentId id, Checksum textChecksum, ImmutableArray<TextChange> changes)>.GetInstance(out var builder);
+        using var _ = ArrayBuilder<(DocumentId id, Checksum textChecksum, ImmutableArray<TextChange> changes, Checksum newTextChecksum)>.GetInstance(out var builder);
 
         foreach (var (oldDocument, newDocument) in values)
         {
@@ -242,9 +242,10 @@ internal sealed class SolutionChecksumUpdater
                 continue;
 
             var state = await oldDocument.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
+            var newState = await newDocument.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
 
             var textChanges = newText.GetTextChanges(oldText).AsImmutable();
-            builder.Add((oldDocument.Id, state.Text, textChanges));
+            builder.Add((oldDocument.Id, state.Text, textChanges, newState.Text));
         }
 
         if (builder.Count == 0)

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -89,14 +89,14 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             // update text
             var newText = oldText.WithChanges(new TextChange(TextSpan.FromBounds(0, 0), "/* test */"));
 
-            // sync
-            await client.TryInvokeAsync<IRemoteAssetSynchronizationService>(
-                (service, cancellationToken) => service.SynchronizeTextChangesAsync([(oldDocument.Id, oldState.Text, newText.GetTextChanges(oldText).AsImmutable())], cancellationToken),
-                CancellationToken.None);
-
             // apply change to solution
             var newDocument = oldDocument.WithText(newText);
             var newState = await newDocument.State.GetStateChecksumsAsync(CancellationToken.None);
+
+            // sync
+            await client.TryInvokeAsync<IRemoteAssetSynchronizationService>(
+                (service, cancellationToken) => service.SynchronizeTextChangesAsync([(oldDocument.Id, oldState.Text, newText.GetTextChanges(oldText).AsImmutable(), newState.Text)], cancellationToken),
+                CancellationToken.None);
 
             // check that text already exist in remote side
             Assert.True(client.TestData.WorkspaceManager.SolutionAssetCache.TryGetAsset<SerializableSourceText>(newState.Text, out var serializableRemoteText));

--- a/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
@@ -57,12 +57,12 @@ internal sealed class SerializableSourceText
     public readonly Checksum ContentChecksum;
 
     public SerializableSourceText(TemporaryStorageTextHandle storageHandle)
-        : this(storageHandle, text: null, Checksum.From(storageHandle.ContentHash))
+        : this(storageHandle, text: null, Checksum.Create(storageHandle.ContentHash))
     {
     }
 
     public SerializableSourceText(SourceText text, ImmutableArray<byte> contentHash)
-        : this(storageHandle: null, text, Checksum.From(contentHash))
+        : this(storageHandle: null, text, Checksum.Create(contentHash))
     {
     }
 
@@ -81,7 +81,7 @@ internal sealed class SerializableSourceText
 
 #if DEBUG
         var computedContentHash = TryGetText()?.GetContentHash() ?? _storageHandle!.ContentHash;
-        Debug.Assert(contentChecksum == Checksum.From(computedContentHash));
+        Debug.Assert(contentChecksum == Checksum.Create(computedContentHash));
 #endif
     }
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
@@ -57,26 +57,31 @@ internal sealed class SerializableSourceText
     public readonly Checksum ContentChecksum;
 
     public SerializableSourceText(TemporaryStorageTextHandle storageHandle)
-        : this(storageHandle, text: null, storageHandle.ContentHash)
+        : this(storageHandle, text: null, Checksum.From(storageHandle.ContentHash))
     {
     }
 
     public SerializableSourceText(SourceText text, ImmutableArray<byte> contentHash)
-        : this(storageHandle: null, text, contentHash)
+        : this(storageHandle: null, text, Checksum.From(contentHash))
     {
     }
 
-    private SerializableSourceText(TemporaryStorageTextHandle? storageHandle, SourceText? text, ImmutableArray<byte> contentHash)
+    public SerializableSourceText(SourceText text, Checksum contentChecksum)
+        : this(storageHandle: null, text, contentChecksum)
+    {
+    }
+
+    private SerializableSourceText(TemporaryStorageTextHandle? storageHandle, SourceText? text, Checksum contentChecksum)
     {
         Debug.Assert(storageHandle is null != text is null);
 
         _storageHandle = storageHandle;
         _text = text;
-        ContentChecksum = Checksum.Create(contentHash);
+        ContentChecksum = contentChecksum;
 
 #if DEBUG
         var computedContentHash = TryGetText()?.GetContentHash() ?? _storageHandle!.ContentHash;
-        Debug.Assert(contentHash.SequenceEqual(computedContentHash));
+        Debug.Assert(contentChecksum == Checksum.From(computedContentHash));
 #endif
     }
 

--- a/src/Workspaces/Remote/Core/IRemoteAssetSynchronizationService.cs
+++ b/src/Workspaces/Remote/Core/IRemoteAssetSynchronizationService.cs
@@ -26,7 +26,7 @@ internal interface IRemoteAssetSynchronizationService
     /// <em>entire</em> contents of the file over.
     /// </summary>
     ValueTask SynchronizeTextChangesAsync(
-        ImmutableArray<(DocumentId documentId, Checksum baseTextChecksum, ImmutableArray<TextChange> textChanges)> changes,
+        ImmutableArray<(DocumentId documentId, Checksum baseTextChecksum, ImmutableArray<TextChange> textChanges, Checksum newTextChecksum)> changes,
         CancellationToken cancellationToken);
 
     /// <summary>


### PR DESCRIPTION
Calculation of this on the server was taking quite a bit of CPU (about 11.6% in the scrolling speedometer during the typing scenario). Instead, pass this data over as part of the text change notification, similar to what SerializableSourceText's serialization code does.

![image](https://github.com/user-attachments/assets/1fa1b48e-e7e7-475a-a3e1-9e440837f666)