### PR TITLE
Do not show structure guides on raw string literals

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/StringLiteralExpressionStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/StringLiteralExpressionStructureTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure;
 
 [Trait(Traits.Feature, Traits.Features.Outlining)]
-public class StringLiteralExpressionStructureTests : AbstractCSharpSyntaxNodeStructureTests<LiteralExpressionSyntax>
+public sealed class StringLiteralExpressionStructureTests : AbstractCSharpSyntaxNodeStructureTests<LiteralExpressionSyntax>
 {
     internal override AbstractSyntaxStructureProvider CreateProvider()
         => new StringLiteralExpressionStructureProvider();

--- a/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
 
-internal class CSharpBlockStructureProvider : AbstractBlockStructureProvider
+internal sealed class CSharpBlockStructureProvider : AbstractBlockStructureProvider
 {
     private static ImmutableDictionary<Type, ImmutableArray<AbstractSyntaxStructureProvider>> CreateDefaultNodeProviderMap()
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/StringLiteralExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/StringLiteralExpressionStructureProvider.cs
@@ -18,35 +18,43 @@ internal sealed class StringLiteralExpressionStructureProvider : AbstractSyntaxN
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        if (node.IsKind(SyntaxKind.StringLiteralExpression) &&
-            !node.ContainsDiagnostics &&
-            CouldBeMultiLine())
+        if (node.IsKind(SyntaxKind.StringLiteralExpression) && !node.ContainsDiagnostics)
         {
-            spans.Add(new BlockSpan(
-                isCollapsible: true,
-                textSpan: node.Span,
-                hintSpan: node.Span,
-                type: BlockTypes.Expression,
-                autoCollapse: true,
-                isDefaultCollapsed: false));
+            var type = GetStringLiteralType();
+            if (type != null)
+            {
+                spans.Add(new BlockSpan(
+                    type,
+                    isCollapsible: true,
+                    textSpan: node.Span,
+                    hintSpan: node.Span,
+                    autoCollapse: true,
+                    isDefaultCollapsed: false));
+            }
         }
 
         return;
 
-        bool CouldBeMultiLine()
+        string? GetStringLiteralType()
         {
+            // We explicitly pick non-structural here as we don't want 'structure' guides shown for raw string literals.
+            // We already have a specialized tagger for those showing the user the left side of it.  So having a
+            // structure guide as well is redundant.
             if (node.Token.Kind() is SyntaxKind.MultiLineRawStringLiteralToken or SyntaxKind.Utf8MultiLineRawStringLiteralToken)
-                return true;
+                return BlockTypes.Nonstructural;
 
             if (node.Token.IsVerbatimStringLiteral())
             {
                 var span = node.Span;
                 var sourceText = node.SyntaxTree.GetText(cancellationToken);
-                return sourceText.Lines.GetLineFromPosition(span.Start).LineNumber !=
-                       sourceText.Lines.GetLineFromPosition(span.End).LineNumber;
+                if (sourceText.Lines.GetLineFromPosition(span.Start).LineNumber !=
+                    sourceText.Lines.GetLineFromPosition(span.End).LineNumber)
+                {
+                    return BlockTypes.Expression;
+                }
             }
 
-            return false;
+            return null;
         }
     }
 }

--- a/src/Features/VisualBasic/Portable/Structure/VisualBasicBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/VisualBasicBlockStructureProvider.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
-    Friend Class VisualBasicBlockStructureProvider
+    Friend NotInheritable Class VisualBasicBlockStructureProvider
         Inherits AbstractBlockStructureProvider
 
         Public Shared Function CreateDefaultNodeStructureProviderMap() As ImmutableDictionary(Of Type, ImmutableArray(Of AbstractSyntaxStructureProvider))


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59598

We don't need a special structure guide here.  We already have the guide we draw, signifying the dedentation of the content.

![image](https://github.com/user-attachments/assets/d58ae22d-2c16-4f9a-9b91-87094720e1f8)
