### PR TITLE
Reuse segments during SegmentedDictionary growth

### DIFF
--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -899,10 +899,10 @@ namespace Microsoft.CodeAnalysis.Collections
             Debug.Assert(_entries.Length > 0, "_entries should be non-empty");
             Debug.Assert(newSize >= _entries.Length);
 
-            var entries = new SegmentedArray<Entry>(newSize);
-
             var count = _count;
-            SegmentedArray.Copy(_entries, entries, count);
+
+            // Rather than creating a copy of _entries, instead reuse as much of it's data as possible.
+            var entries = CreateNewSegmentedArrayReusingOldSegments(_entries, newSize);
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _buckets = new SegmentedArray<int>(newSize);
@@ -919,6 +919,28 @@ namespace Microsoft.CodeAnalysis.Collections
             }
 
             _entries = entries;
+        }
+
+        private static SegmentedArray<Entry> CreateNewSegmentedArrayReusingOldSegments(SegmentedArray<Entry> oldArray, int newSize)
+        {
+            var segments = SegmentedCollectionsMarshal.AsSegments(oldArray);
+
+            var oldSegmentCount = segments.Length;
+            var newSegmentCount = (newSize + SegmentedArrayHelper.GetSegmentSize<Entry>() - 1) >> SegmentedArrayHelper.GetSegmentShift<Entry>();
+
+            // Grow the array of segments, if necessary
+            Array.Resize(ref segments, newSegmentCount);
+
+            // Resize all segments to full segment size from the last old segment to the next to last
+            // new segment.
+            for (var i = oldSegmentCount - 1; i < newSegmentCount - 1; i++)
+                Array.Resize(ref segments[i], SegmentedArrayHelper.GetSegmentSize<Entry>());
+
+            // Resize the last segment
+            var lastSegmentSize = newSize - ((newSegmentCount - 1) << SegmentedArrayHelper.GetSegmentShift<Entry>());
+            Array.Resize(ref segments[newSegmentCount - 1], lastSegmentSize);
+
+            return SegmentedCollectionsMarshal.AsSegmentedArray(newSize, segments);
         }
 
         /// <summary>

--- a/src/Tools/IdeCoreBenchmarks/SegmentedDictionaryBenchmarks_Add.cs
+++ b/src/Tools/IdeCoreBenchmarks/SegmentedDictionaryBenchmarks_Add.cs
@@ -26,7 +26,7 @@ namespace IdeCoreBenchmarks
             _largeItems = new LargeStruct[Count];
             _enormousItems = new EnormousStruct[Count];
 
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 _intItems[i] = i;
                 _objectItems[i] = new object();
@@ -34,7 +34,6 @@ namespace IdeCoreBenchmarks
                 _enormousItems[i] = new EnormousStruct() { s1 = _largeItems[i] };
             }
         }
-
 
         [Benchmark]
         public void AddIntToList()

--- a/src/Tools/IdeCoreBenchmarks/SegmentedDictionaryBenchmarks_Add.cs
+++ b/src/Tools/IdeCoreBenchmarks/SegmentedDictionaryBenchmarks_Add.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis.Collections;
+
+namespace IdeCoreBenchmarks
+{
+    [MemoryDiagnoser]
+    public class SegmentedDictionaryBenchmarks_Add
+    {
+        [Params(1_000, 10_000, 100_000, 1_000_000)]
+        public int Count { get; set; }
+
+        private int[]? _intItems;
+        private object[]? _objectItems;
+        private LargeStruct[]? _largeItems;
+        private EnormousStruct[]? _enormousItems;
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _intItems = new int[Count];
+            _objectItems = new object[Count];
+            _largeItems = new LargeStruct[Count];
+            _enormousItems = new EnormousStruct[Count];
+
+            for (int i = 0; i < Count; i++)
+            {
+                _intItems[i] = i;
+                _objectItems[i] = new object();
+                _largeItems[i] = new LargeStruct() { s1 = new MediumStruct() { i1 = i } };
+                _enormousItems[i] = new EnormousStruct() { s1 = _largeItems[i] };
+            }
+        }
+
+
+        [Benchmark]
+        public void AddIntToList()
+            => AddToList(_intItems!);
+
+        [Benchmark]
+        public void AddObjectToList()
+            => AddToList(_objectItems!);
+
+        [Benchmark]
+        public void AddLargeStructToList()
+            => AddToList(_largeItems!);
+
+        [Benchmark]
+        public void AddEnormousStructToList()
+            => AddToList(_enormousItems!);
+
+        private void AddToList<T>(T[] items) where T : notnull
+        {
+            var dict = new SegmentedDictionary<T, T>();
+            var iterations = Count;
+
+            for (var i = 0; i < iterations; i++)
+                dict.Add(items[i], items[i]);
+        }
+
+        private struct MediumStruct
+        {
+            public int i1 { get; set; }
+            public int i2 { get; set; }
+            public int i3 { get; set; }
+            public int i4 { get; set; }
+            public int i5 { get; set; }
+        }
+
+        private struct LargeStruct
+        {
+            public MediumStruct s1 { get; set; }
+            public MediumStruct s2 { get; set; }
+            public MediumStruct s3 { get; set; }
+            public MediumStruct s4 { get; set; }
+        }
+
+        private struct EnormousStruct
+        {
+            public LargeStruct s1 { get; set; }
+            public LargeStruct s2 { get; set; }
+            public LargeStruct s3 { get; set; }
+            public LargeStruct s4 { get; set; }
+            public LargeStruct s5 { get; set; }
+            public LargeStruct s6 { get; set; }
+            public LargeStruct s7 { get; set; }
+            public LargeStruct s8 { get; set; }
+            public LargeStruct s9 { get; set; }
+            public LargeStruct s10 { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Mimics changes done in https://github.com/dotnet/roslyn/pull/75661 to enable segment reuse in SegmentedDictionary.

*** allocations seen in speedometer test due to this reallocation ***
![image](https://github.com/user-attachments/assets/760441b1-2003-4d58-8d65-bb9c321d74a9)

*** old allocations from added benchmark ***
![image](https://github.com/user-attachments/assets/204d012a-fbba-462b-a28c-23e387a7ca7c)

*** new allocations from added benchmark ***
![image](https://github.com/user-attachments/assets/281e2416-b5e0-48db-b2e0-91b19485f8b3)