### PR TITLE
Add a couple common type sizes to SegmentedArrayHelper's size/shift/offsetmask methods so those values can be inlined.

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedArrayHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedArrayHelperTests.cs
@@ -17,6 +17,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 {
     public class SegmentedArrayHelperTests
     {
+        [StructLayout(LayoutKind.Sequential, Size = 1)]
+        private struct Size1 { }
+
         [StructLayout(LayoutKind.Sequential, Size = 2)]
         private struct Size2 { }
 
@@ -44,10 +47,14 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         [StructLayout(LayoutKind.Sequential, Size = 40)]
         private struct Size40 { }
 
+        [StructLayout(LayoutKind.Sequential, Size = 64)]
+        private struct Size64 { }
+
         public static IEnumerable<object[]> ExplicitSizeTypes
         {
             get
             {
+                yield return new object[] { typeof(Size1) };
                 yield return new object[] { typeof(Size2) };
                 yield return new object[] { typeof(Size4) };
                 yield return new object[] { typeof(Size8) };
@@ -57,6 +64,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 yield return new object[] { typeof(Size28) };
                 yield return new object[] { typeof(Size32) };
                 yield return new object[] { typeof(Size40) };
+                yield return new object[] { typeof(Size64) };
             }
         }
 

--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 // Hard code common values since not all versions of the .NET JIT support reducing this computation to a
                 // constant value at runtime. Values are validated against the reference implementation in
                 // CalculateSegmentSize in unit tests.
+                1 => 65536,
+                2 => 32768,
                 4 => 16384,
                 8 => 8192,
                 12 => 4096,
@@ -31,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 28 => 2048,
                 32 => 2048,
                 40 => 2048,
+                64 => 1024,
 #if NETCOREAPP3_0_OR_GREATER
                 _ => InlineCalculateSegmentSize(Unsafe.SizeOf<T>()),
 #else
@@ -47,6 +50,8 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 // Hard code common values since not all versions of the .NET JIT support reducing this computation to a
                 // constant value at runtime. Values are validated against the reference implementation in
                 // CalculateSegmentSize in unit tests.
+                1 => 16,
+                2 => 15,
                 4 => 14,
                 8 => 13,
                 12 => 12,
@@ -55,6 +60,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 28 => 11,
                 32 => 11,
                 40 => 11,
+                64 => 10,
 #if NETCOREAPP3_0_OR_GREATER
                 _ => InlineCalculateSegmentShift(Unsafe.SizeOf<T>()),
 #else
@@ -71,6 +77,8 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 // Hard code common values since not all versions of the .NET JIT support reducing this computation to a
                 // constant value at runtime. Values are validated against the reference implementation in
                 // CalculateSegmentSize in unit tests.
+                1 => 65535,
+                2 => 32767,
                 4 => 16383,
                 8 => 8191,
                 12 => 4095,
@@ -79,6 +87,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 28 => 2047,
                 32 => 2047,
                 40 => 2047,
+                64 => 1023,
 #if NETCOREAPP3_0_OR_GREATER
                 _ => InlineCalculateOffsetMask(Unsafe.SizeOf<T>()),
 #else


### PR DESCRIPTION
This isn't super significant, but about 175ms of CPU are accounted for these methods in the scrolling speedometer test in our OOP. I believe those should go away completely as these are the only common values that weren't already being handled when I manually debugged the product.

*** relevant speedometer CPU usage before this change ***
![image](https://github.com/user-attachments/assets/2b01cbc5-ae7f-42b6-8185-4dfd9433404e)
