### PR TITLE
Include list of processes that lock file in `can't write file` error message

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3546,7 +3546,7 @@ Give the compiler some way to differentiate the methods. For example, you can gi
     <value>Error opening response file '{0}'</value>
   </data>
   <data name="ERR_CantOpenFileWrite" xml:space="preserve">
-    <value>Cannot open '{0}' for writing -- '{1}'</value>
+    <value>Cannot open '{0}' for writing -- {1}</value>
   </data>
   <data name="ERR_BadBaseNumber" xml:space="preserve">
     <value>Invalid image base number '{0}'</value>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -10305,8 +10305,8 @@ Poskytněte kompilátoru nějaký způsob, jak metody rozlišit. Můžete např�
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">{0} se nedá otevřít pro zápis -- {1}.</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">{0} se nedá otevřít pro zápis -- {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -10305,8 +10305,8 @@ Unterstützen Sie den Compiler bei der Unterscheidung zwischen den Methoden. Daz
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">"{0}" kann nicht zum Schreiben geöffnet werden: "{1}"</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">"{0}" kann nicht zum Schreiben geöffnet werden: "{1}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -10305,8 +10305,8 @@ Indique al compilador alguna forma de diferenciar los métodos. Por ejemplo, pue
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">No se puede abrir '{0}' para escribir: '{1}'</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">No se puede abrir '{0}' para escribir: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -10305,8 +10305,8 @@ Permettez au compilateur de différencier les méthodes. Par exemple, vous pouve
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">Impossible d'ouvrir '{0}' en écriture -- '{1}'</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">Impossible d'ouvrir '{0}' en écriture -- '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -10305,8 +10305,8 @@ Impostare il compilatore in modo tale da distinguere i metodi, ad esempio assegn
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">Non è possibile aprire '{0}' per la scrittura - '{1}'</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">Non è possibile aprire '{0}' per la scrittura - '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -10305,8 +10305,8 @@ C# では out と ref を区別しますが、CLR では同じと認識します
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">ファイル '{0}' を開いて書き込むことができません -- '{1}'</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">ファイル '{0}' を開いて書き込むことができません -- '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -10305,8 +10305,8 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">'{0}'을(를) 쓰기용으로 열 수 없습니다. '{1}'</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">'{0}'을(를) 쓰기용으로 열 수 없습니다. '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -10305,8 +10305,8 @@ Musisz umożliwić kompilatorowi rozróżnienie metod. Możesz na przykład nada
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">Nie można otworzyć „{0}” do zapisu — „{1}”</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">Nie można otworzyć „{0}” do zapisu — „{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -10305,8 +10305,8 @@ Forneça ao compilador alguma forma de diferenciar os métodos. Por exemplo, voc
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">Não é possível abrir "{0}" para escrever -- "{1}"</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">Não é possível abrir "{0}" para escrever -- "{1}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -10306,8 +10306,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">Не удается открыть "{0}" для записи — "{1}".</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">Не удается открыть "{0}" для записи — "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -10305,8 +10305,8 @@ Derleyiciye yöntemleri ayrıştırma yolu verin. Örneğin, bunlara farklı adl
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">'{0}' yazma için açılamıyor -- '{1}'</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">'{0}' yazma için açılamıyor -- '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -10305,8 +10305,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">无法打开“{0}”进行写入 --“{1}”</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">无法打开“{0}”进行写入 --“{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -10305,8 +10305,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantOpenFileWrite">
-        <source>Cannot open '{0}' for writing -- '{1}'</source>
-        <target state="translated">無法開啟 '{0}' 進行寫入 -- '{1}'</target>
+        <source>Cannot open '{0}' for writing -- {1}</source>
+        <target state="needs-review-translation">無法開啟 '{0}' 進行寫入 -- '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadBaseNumber">

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -4799,7 +4799,7 @@ C:\*.cs(100,7): error CS0103: The name 'Goo' does not exist in the current conte
 
             var pattern = @"error CS2012: Cannot open '(?<path>.*)' for writing -- (?<message>.*); file may be locked by '(?<app>.*)' \((?<pid>.*)\)";
             var match = Regex.Match(output, pattern);
-            Assert.True(match.Success, $"Expected:{Environment.NewLine}{pattern}{Environment.NewLine}Actual:{Environment.NewLine}{output}");
+            Assert.True(match.Success, $"Expected pattern:{Environment.NewLine}{pattern}{Environment.NewLine}Actual:{Environment.NewLine}{output}");
             Assert.Equal(filePath, match.Groups["path"].Value);
             Assert.Contains("testhost", match.Groups["app"].Value);
             Assert.Equal(currentProcess.Id, int.Parse(match.Groups["pid"].Value));

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -38,6 +38,7 @@ using Xunit;
 using Basic.Reference.Assemblies;
 using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;
 using static Roslyn.Test.Utilities.SharedResourceHelpers;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 {
@@ -4760,7 +4761,7 @@ C:\*.cs(100,7): error CS0103: The name 'Goo' does not exist in the current conte
         }
 
         [Fact]
-        public void UnableWriteOutput()
+        public void UnableWriteOutput_OutputFileIsDirectory()
         {
             var tempFolder = Temp.CreateDirectory();
             var baseDirectory = tempFolder.ToString();
@@ -4772,7 +4773,36 @@ C:\*.cs(100,7): error CS0103: The name 'Goo' does not exist in the current conte
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             int exitCode = CreateCSharpCompiler(null, baseDirectory, new[] { "/nologo", "/preferreduilang:en", "/t:library", "/out:" + subFolder.ToString(), src.ToString() }).Run(outWriter);
             Assert.Equal(1, exitCode);
-            Assert.True(outWriter.ToString().Trim().StartsWith("error CS2012: Cannot open '" + subFolder.ToString() + "' for writing -- '", StringComparison.Ordinal)); // Cannot create a file when that file already exists.
+            var output = outWriter.ToString().Trim();
+            Assert.StartsWith($"error CS2012: Cannot open '{subFolder}' for writing -- ", output); // Cannot create a file when that file already exists.
+
+            CleanupAllGeneratedFiles(src.Path);
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void UnableWriteOutput_OutputFileLocked()
+        {
+            var tempFolder = Temp.CreateDirectory();
+            var baseDirectory = tempFolder.ToString();
+            var filePath = tempFolder.CreateFile("temp").Path;
+
+            using var _ = new FileStream(filePath, FileMode.Open, FileAccess.Write, FileShare.None);
+            var currentProcess = Process.GetCurrentProcess();
+
+            var src = Temp.CreateFile("a.cs");
+            src.WriteAllText("public class C{}");
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            int exitCode = CreateCSharpCompiler(responseFile: null, baseDirectory, ["/nologo", "/preferreduilang:en", "/t:library", "/out:" + filePath, src.ToString()]).Run(outWriter);
+            Assert.Equal(1, exitCode);
+            var output = outWriter.ToString().Trim();
+
+            var pattern = @"error CS2012: Cannot open '(?<path>.*)' for writing -- (?<message>.*); file may be locked by '(?<app>.*)' \((?<pid>.*)\)";
+            var match = Regex.Match(output, pattern);
+            Assert.True(match.Success, $"Expected:{Environment.NewLine}{pattern}{Environment.NewLine}Actual:{Environment.NewLine}{output}");
+            Assert.Equal(filePath, match.Groups["path"].Value);
+            Assert.Contains("testhost", match.Groups["app"].Value);
+            Assert.Equal(currentProcess.Id, int.Parse(match.Groups["pid"].Value));
 
             CleanupAllGeneratedFiles(src.Path);
         }

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -794,4 +794,7 @@
   <data name="Type0DoesNotHaveExpectedConstructor" xml:space="preserve">
     <value>'{0}' type does not have the expected constructor</value>
   </data>
+  <data name="ExceptionMessage_FileMayBeLockedBy" xml:space="preserve">
+    <value>{0}; file may be locked by {1}</value>
+  </data>
 </root>

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
@@ -118,8 +118,11 @@ namespace Microsoft.CodeAnalysis
                 var lockedBy = FileLockCheck.TryGetLockingProcessInfos(_filePath);
 
                 var message = lockedBy.IsEmpty
-                    ? e.Message
-                    : string.Format(CodeAnalysisResources.ExceptionMessage_FileMayBeLockedBy,
+                    ? (object)e.Message
+                    : new LocalizableResourceString(
+                        nameof(CodeAnalysisResources.ExceptionMessage_FileMayBeLockedBy),
+                        CodeAnalysisResources.ResourceManager,
+                        typeof(CodeAnalysisResources),
                         e.Message,
                         string.Join(", ", lockedBy.Select(info => $"'{info.applicationName}' ({info.processId})")));
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -114,7 +115,15 @@ namespace Microsoft.CodeAnalysis
             private void ReportOpenFileDiagnostic(DiagnosticBag diagnostics, Exception e)
             {
                 var messageProvider = _compiler.MessageProvider;
-                diagnostics.Add(messageProvider.CreateDiagnostic(messageProvider.ERR_CantOpenFileWrite, Location.None, _filePath, e.Message));
+                var lockedBy = FileLockCheck.TryGetLockingProcessInfos(_filePath);
+
+                var message = lockedBy.IsEmpty
+                    ? e.Message
+                    : string.Format(CodeAnalysisResources.ExceptionMessage_FileMayBeLockedBy,
+                        e.Message,
+                        string.Join(", ", lockedBy.Select(info => $"'{info.applicationName}' ({info.processId})")));
+
+                diagnostics.Add(messageProvider.CreateDiagnostic(messageProvider.ERR_CantOpenFileWrite, Location.None, _filePath, message));
             }
         }
     }

--- a/src/Compilers/Core/Portable/InternalUtilities/FileLockCheck.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FileLockCheck.cs
@@ -1,0 +1,227 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Based on https://github.com/dotnet/msbuild/blob/6cd445d84e59a36c7fbb6f50b7a5a62767a6da51/src/Utilities/LockCheck.cs
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Roslyn.Utilities;
+
+/// <summary>
+/// This class implements checking what processes are locking a file on Windows.
+/// It uses the Restart Manager API to do this. Other platforms are skipped.
+/// </summary>
+internal static class FileLockCheck
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FILETIME
+    {
+        public uint dwLowDateTime;
+        public uint dwHighDateTime;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RM_UNIQUE_PROCESS
+    {
+        public uint dwProcessId;
+        public FILETIME ProcessStartTime;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct RM_PROCESS_INFO
+    {
+        private const int CCH_RM_MAX_APP_NAME = 255;
+        private const int CCH_RM_MAX_SVC_NAME = 63;
+
+        internal RM_UNIQUE_PROCESS Process;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_APP_NAME + 1)]
+        public string strAppName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_SVC_NAME + 1)]
+        public string strServiceShortName;
+        internal int ApplicationType;
+        public uint AppStatus;
+        public uint TSSessionId;
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool bRestartable;
+    }
+
+    private const string RestartManagerDll = "rstrtmgr.dll";
+
+    [DllImport(RestartManagerDll, CharSet = CharSet.Unicode)]
+    private static extern int RmRegisterResources(uint pSessionHandle,
+        uint nFiles,
+        string[] rgsFilenames,
+        uint nApplications,
+        [In] RM_UNIQUE_PROCESS[]? rgApplications,
+        uint nServices,
+        string[]? rgsServiceNames);
+
+    /// <summary>
+    /// Starts a new Restart Manager session.
+    /// A maximum of 64 Restart Manager sessions per user session
+    /// can be open on the system at the same time. When this
+    /// function starts a session, it returns a session handle
+    /// and session key that can be used in subsequent calls to
+    /// the Restart Manager API.
+    /// </summary>
+    /// <param name="pSessionHandle">
+    /// A pointer to the handle of a Restart Manager session.
+    /// The session handle can be passed in subsequent calls
+    /// to the Restart Manager API.
+    /// </param>
+    /// <param name="dwSessionFlags">
+    /// Reserved. This parameter should be 0.
+    /// </param>
+    /// <param name="strSessionKey">
+    /// A null-terminated string that contains the session key
+    /// to the new session. The string must be allocated before
+    /// calling the RmStartSession function.
+    /// </param>
+    /// <returns>System error codes that are defined in Winerror.h.</returns>
+    /// <remarks>
+    /// The Rm­­StartSession function doesn’t properly null-terminate
+    /// the session key, even though the function is documented as
+    /// returning a null-terminated string. To work around this bug,
+    /// we pre-fill the buffer with null characters so that whatever
+    /// ends gets written will have a null terminator (namely, one of
+    /// the null characters we placed ahead of time).
+    /// <para>
+    /// see <see href="http://blogs.msdn.com/b/oldnewthing/archive/2012/02/17/10268840.aspx"/>.
+    /// </para>
+    /// </remarks>
+    [DllImport(RestartManagerDll, CharSet = CharSet.Unicode)]
+    private static extern unsafe int RmStartSession(
+        out uint pSessionHandle,
+        int dwSessionFlags,
+        char* strSessionKey);
+
+    /// <summary>
+    /// Ends the Restart Manager session.
+    /// This function should be called by the primary installer that
+    /// has previously started the session by calling the <see cref="RmStartSession"/>
+    /// function. The RmEndSession function can be called by a secondary installer
+    /// that is joined to the session once no more resources need to be registered
+    /// by the secondary installer.
+    /// </summary>
+    /// <param name="pSessionHandle">A handle to an existing Restart Manager session.</param>
+    /// <returns>
+    /// The function can return one of the system error codes that are defined in Winerror.h.
+    /// </returns>
+    [DllImport(RestartManagerDll)]
+    private static extern int RmEndSession(uint pSessionHandle);
+
+    [DllImport(RestartManagerDll, CharSet = CharSet.Unicode)]
+    private static extern int RmGetList(uint dwSessionHandle,
+        out uint pnProcInfoNeeded,
+        ref uint pnProcInfo,
+        [In, Out] RM_PROCESS_INFO[]? rgAffectedApps,
+        ref uint lpdwRebootReasons);
+
+    public static ImmutableArray<(int processId, string applicationName)> TryGetLockingProcessInfos(string path)
+    {
+        if (!PlatformInformation.IsWindows)
+        {
+            return [];
+        }
+
+        try
+        {
+            return GetLockingProcessInfosImpl([path]);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static ImmutableArray<(int processId, string applicationName)> GetLockingProcessInfosImpl(string[] paths)
+    {
+        const int MaxRetries = 6;
+        const int ERROR_MORE_DATA = 234;
+        const uint RM_REBOOT_REASON_NONE = 0;
+
+        uint handle;
+        int res;
+
+        unsafe
+        {
+            char* key = stackalloc char[sizeof(Guid) * 2 + 1];
+            res = RmStartSession(out handle, 0, key);
+        }
+
+        if (res != 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            res = RmRegisterResources(handle, (uint)paths.Length, paths, 0, null, 0, null);
+            if (res != 0)
+            {
+                return [];
+            }
+
+            //
+            // Obtain the list of affected applications/services.
+            //
+            // NOTE: Restart Manager returns the results into the buffer allocated by the caller. The first call to
+            // RmGetList() will return the size of the buffer (i.e. nProcInfoNeeded) the caller needs to allocate.
+            // The caller then needs to allocate the buffer (i.e. rgAffectedApps) and make another RmGetList()
+            // call to ask Restart Manager to write the results into the buffer. However, since Restart Manager
+            // refreshes the list every time RmGetList()is called, it is possible that the size returned by the first
+            // RmGetList()call is not sufficient to hold the results discovered by the second RmGetList() call. Therefore,
+            // it is recommended that the caller follows the following practice to handle this race condition:
+            //
+            //    Use a loop to call RmGetList() in case the buffer allocated according to the size returned in previous
+            //    call is not enough.
+            //
+            uint pnProcInfo = 0;
+            RM_PROCESS_INFO[]? rgAffectedApps = null;
+            int retry = 0;
+            do
+            {
+                uint lpdwRebootReasons = RM_REBOOT_REASON_NONE;
+                res = RmGetList(handle, out uint pnProcInfoNeeded, ref pnProcInfo, rgAffectedApps, ref lpdwRebootReasons);
+                if (res == 0)
+                {
+                    // If pnProcInfo == 0, then there is simply no locking process (found), in this case rgAffectedApps is "null".
+                    if (pnProcInfo == 0)
+                    {
+                        return [];
+                    }
+
+                    Debug.Assert(rgAffectedApps != null);
+
+                    var lockInfos = ArrayBuilder<(int, string)>.GetInstance((int)pnProcInfo);
+                    for (int i = 0; i < pnProcInfo; i++)
+                    {
+                        lockInfos.Add(((int)rgAffectedApps[i].Process.dwProcessId, rgAffectedApps[i].strAppName));
+                    }
+
+                    return lockInfos.ToImmutableAndFree();
+                }
+
+                if (res != ERROR_MORE_DATA)
+                {
+                    return [];
+                }
+
+                pnProcInfo = pnProcInfoNeeded;
+                rgAffectedApps = new RM_PROCESS_INFO[pnProcInfo];
+            }
+            while (res == ERROR_MORE_DATA && retry++ < MaxRetries);
+        }
+        finally
+        {
+            _ = RmEndSession(handle);
+        }
+
+        return [];
+    }
+}

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Hodnota end nesmí být menší než hodnota start. start={0} end={1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Generátor</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -87,6 +87,11 @@
         <target state="translated">"Ende" darf nicht kleiner sein als "Start". start='{0}' end='{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Generator</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -87,6 +87,11 @@
         <target state="translated">'fin' no debe ser menor que 'inicio'. inicio='{0}' fin='{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Generador</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">'end' ne doit pas être inférieur à 'start'. start='{0}'end='{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Générateur</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -87,6 +87,11 @@
         <target state="translated">il valore di 'end' non deve essere minore di quello di 'start'. start='{0}' end='{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Generatore</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -87,6 +87,11 @@
         <target state="translated">'end' は 'start' より小さくすることはできません。start='{0}' end='{1}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">ジェネレーター</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -87,6 +87,11 @@
         <target state="translated">'end'는 'start'보다 작을 수 없습니다. start='{0}' end='{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">생성기</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Wartość „end” nie może być mniejsza niż wartość „start”. start=„{0}” end=„{1}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Generator</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="translated">'end' não deve ser menor que 'start'. start='{0}' end='{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Gerador</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Значение "end" не должно быть меньше, чем "start". start="{0}", end="{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Генератор</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">'bitiş', 'başlangıç' değerinden küçük olmamalıdır. başla='{0}' bitiş='{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">Oluşturucu</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="translated">"end" 不得小于 "start"。start="{0}" end="{1}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">生成器</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="translated">'end' 不可小於 'start'。start='{0}' end='{1}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionMessage_FileMayBeLockedBy">
+        <source>{0}; file may be locked by {1}</source>
+        <target state="new">{0}; file may be locked by {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GeneratorNameColumnHeader">
         <source>Generator</source>
         <target state="translated">產生器</target>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -5061,7 +5061,7 @@ End Class
 
                 Dim pattern = "vbc : error BC2012: can't open '(?<path>.*)' for writing: (?<message>.*); file may be locked by '(?<app>.*)' \((?<pid>.*)\)"
                 Dim match = Regex.Match(output, pattern)
-                Assert.True(match.Success, $"Expected:{Environment.NewLine}{pattern}{Environment.NewLine}Actual:{Environment.NewLine}{output}")
+                Assert.True(match.Success, $"Expected pattern:{Environment.NewLine}{pattern}{Environment.NewLine}Actual:{Environment.NewLine}{output}")
                 Assert.Equal(filePath, match.Groups("path").Value)
                 Assert.Contains("testhost", match.Groups("app").Value)
                 Assert.Equal(currentProcess.Id, Integer.Parse(match.Groups("pid").Value))

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -5026,7 +5026,7 @@ End Class
         End Sub
 
         <Fact()>
-        Public Sub UnableWriteOutput()
+        Public Sub UnableWriteOutput_OutputFileIsDirectory()
             Dim tempFolder = Temp.CreateDirectory()
             Dim baseDirectory = tempFolder.ToString()
             Dim subFolder = tempFolder.CreateDirectory("temp.dll")
@@ -5038,6 +5038,34 @@ End Class
             Dim exitCode As Integer = New MockVisualBasicCompiler(Nothing, baseDirectory, {"/nologo", "/preferreduilang:en", "/t:library", "/out:" & subFolder.ToString(), src.ToString()}).Run(outWriter, Nothing)
             Assert.Equal(1, exitCode)
             Assert.True(outWriter.ToString().Contains("error BC2012: can't open '" & subFolder.ToString() & "' for writing: ")) ' Cannot create a file when that file already exists.
+
+            CleanupAllGeneratedFiles(src.Path)
+        End Sub
+
+        <ConditionalFact(GetType(WindowsOnly))>
+        Public Sub UnableWriteOutput_OutputFileLocked()
+            Dim tempFolder = Temp.CreateDirectory()
+            Dim baseDirectory = tempFolder.ToString()
+            Dim filePath = tempFolder.CreateFile("temp.dll").Path
+
+            Dim src = Temp.CreateFile("a.vb")
+            src.WriteAllText("Imports System")
+
+            Using New FileStream(filePath, FileMode.Open, FileAccess.Write, FileShare.None)
+                Dim currentProcess = Process.GetCurrentProcess()
+
+                Dim outWriter As New StringWriter()
+                Dim exitCode As Integer = New MockVisualBasicCompiler(Nothing, baseDirectory, {"/nologo", "/preferreduilang:en", "/t:library", "/out:" & filePath, src.ToString()}).Run(outWriter, Nothing)
+                Assert.Equal(1, exitCode)
+                Dim output = outWriter.ToString().Trim()
+
+                Dim pattern = "vbc : error BC2012: can't open '(?<path>.*)' for writing: (?<message>.*); file may be locked by '(?<app>.*)' \((?<pid>.*)\)"
+                Dim match = Regex.Match(output, pattern)
+                Assert.True(match.Success, $"Expected:{Environment.NewLine}{pattern}{Environment.NewLine}Actual:{Environment.NewLine}{output}")
+                Assert.Equal(filePath, match.Groups("path").Value)
+                Assert.Contains("testhost", match.Groups("app").Value)
+                Assert.Equal(currentProcess.Id, Integer.Parse(match.Groups("pid").Value))
+            End Using
 
             CleanupAllGeneratedFiles(src.Path)
         End Sub


### PR DESCRIPTION
Use Win32 APIs to get the list of processes that have the file open. Based on msbuild implementation: https://github.com/dotnet/msbuild/blob/6cd445d84e59a36c7fbb6f50b7a5a62767a6da51/src/Utilities/LockCheck.cs

Related: https://github.com/dotnet/runtime/issues/109927