### PR TITLE
Handle `using var` in redundant assignment removal

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -10072,4 +10072,33 @@ parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSh
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72829")]
+    public async Task RemoveRedundantAssignment_PreservesUsingVar()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    {|FixAllInDocument:int items = 0;|}
+                    items = 42;
+                    System.Console.WriteLine(items);
+                    using var _ = System.IO.File.OpenRead("test.txt");
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M()
+                {
+                    int items = 42;
+                    System.Console.WriteLine(items);
+                    using var _ = System.IO.File.OpenRead("test.txt");
+                }
+            }
+            """);
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpReplaceDiscardDeclarationsWithAssignmentsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpReplaceDiscardDeclarationsWithAssignmentsService.cs
@@ -49,6 +49,12 @@ internal sealed class CSharpReplaceDiscardDeclarationsWithAssignmentsService : I
                 case LocalDeclarationStatementSyntax localDeclarationStatement:
                     if (localDeclarationStatement.Declaration.Variables.Any(IsDiscardDeclaration))
                     {
+                        // Skip replacing discard declarations in "using var"
+                        if (localDeclarationStatement.UsingKeyword != default)
+                        {
+                            continue;
+                        }
+
                         RemoveDiscardHelper.ProcessDeclarationStatement(localDeclarationStatement, editor);
                     }
 


### PR DESCRIPTION
- Adds a test to ensure redundant assignment removal respects the `using var` statement.
- Fixes #72829.

On changing an unused variable to discard `CSharpReplaceDiscardDeclarationsWithAssignmentsService.ReplaceAsync()` ensures that instead of local declarations, simple discards are used. Without an exception for using statements, this end up changing `using var _` within the scope to be replaced with `_` regardless of any relation to the variable targeted by the suggestion. This change adds a filter to the method, preserving using statements and the disposal they provide.