### PR TITLE
Use VisitRvalue to visit a function pointer

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -3741,7 +3741,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitFunctionPointerInvocation(BoundFunctionPointerInvocation node)
         {
-            Visit(node.InvokedExpression);
+            VisitRvalue(node.InvokedExpression);
             VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, node.FunctionPointer.Signature);
             return null;
         }


### PR DESCRIPTION
Closes #75933

Plain Visit() can leave us in a conditional state. We want to unsplit before unconditionally visiting the fnptr arguments, when it is immediately invoked, for example.

<details>
    <summary>Debug mode error stack without this change</summary>

```log
  Message: 
System.InvalidOperationException : !IsConditionalState

  Stack Trace: 
ThrowingTraceListener.Fail(String message, String detailMessage) line 26
TraceInternal.Fail(String message, String detailMessage)
Debug.Fail(String message, String detailMessage)
DefiniteAssignmentPass.CheckAssigned(Symbol symbol, SyntaxNode node) line 1153
DefiniteAssignmentPass.VisitLocal(BoundLocal node) line 2368
BoundLocal.Accept(BoundTreeVisitor visitor) line 4539
BoundTreeVisitor.Visit(BoundNode node) line 151
AbstractFlowPass`2.VisitExpressionOrPatternWithoutStackGuard(BoundNode node) line 375
BoundTreeVisitor.VisitExpressionOrPatternWithStackGuard(Int32& recursionDepth, BoundNode node) line 213
AbstractFlowPass`2.VisitWithStackGuard(BoundNode node) line 366
AbstractFlowPass`2.VisitAlways(BoundNode node) line 354
AbstractFlowPass`2.Visit(BoundNode node) line 343
AbstractFlowPass`2.VisitRvalue(BoundExpression node, Boolean isKnownToBeAnLvalue) line 662
DefiniteAssignmentPass.VisitRvalue(BoundExpression node, Boolean isKnownToBeAnLvalue) line 320
AbstractFlowPass`2.VisitArgumentsBeforeCall(ImmutableArray`1 arguments, ImmutableArray`1 refKindsOpt) line 1531
AbstractFlowPass`2.VisitArguments(ImmutableArray`1 arguments, ImmutableArray`1 refKindsOpt, MethodSymbol method) line 1519
AbstractFlowPass`2.VisitFunctionPointerInvocation(BoundFunctionPointerInvocation node) line 3745
BoundFunctionPointerInvocation.Accept(BoundTreeVisitor visitor) line 1467
BoundTreeVisitor.Visit(BoundNode node) line 151
AbstractFlowPass`2.VisitExpressionOrPatternWithoutStackGuard(BoundNode node) line 375
BoundTreeVisitor.VisitExpressionOrPatternWithStackGuard(BoundNode node) line 243
BoundTreeVisitor.VisitExpressionOrPatternWithStackGuard(Int32& recursionDepth, BoundNode node) line 217
AbstractFlowPass`2.VisitWithStackGuard(BoundNode node) line 366
AbstractFlowPass`2.VisitAlways(BoundNode node) line 354
AbstractFlowPass`2.Visit(BoundNode node) line 343
AbstractFlowPass`2.VisitRvalue(BoundExpression node, Boolean isKnownToBeAnLvalue) line 662
DefiniteAssignmentPass.VisitRvalue(BoundExpression node, Boolean isKnownToBeAnLvalue) line 320
AbstractFlowPass`2.VisitExpressionStatement(BoundExpressionStatement node) line 1327
BoundExpressionStatement.Accept(BoundTreeVisitor visitor) line 3681
BoundTreeVisitor.Visit(BoundNode node) line 151
AbstractFlowPass`2.VisitWithStackGuard(BoundNode node) line 369
AbstractFlowPass`2.VisitAlways(BoundNode node) line 354
AbstractFlowPass`2.Visit(BoundNode node) line 343
AbstractFlowPass`2.VisitStatement(BoundStatement statement) line 672
DefiniteAssignmentPass.VisitStatementsWithLocalFunctions(BoundBlock block) line 2203
DefiniteAssignmentPass.VisitBlock(BoundBlock node) line 2138
BoundBlock.Accept(BoundTreeVisitor visitor) line 3325
BoundTreeVisitor.Visit(BoundNode node) line 151
AbstractFlowPass`2.VisitWithStackGuard(BoundNode node) line 369
AbstractFlowPass`2.VisitAlways(BoundNode node) line 354
AbstractFlowPass`2.Visit(BoundNode node) line 343
AbstractFlowPass`2.Scan(Boolean& badRegion) line 424
DefiniteAssignmentPass.Scan(Boolean& badRegion) line 371
AbstractFlowPass`2.Analyze(Boolean& badRegion, Optional`1 initialState) line 447
DefiniteAssignmentPass.Analyze(Boolean& badRegion, DiagnosticBag diagnostics) line 682
DefiniteAssignmentPass.<Analyze>g__analyze|41_0(Boolean strictAnalysis, <>c__DisplayClass41_0&) line 639
DefiniteAssignmentPass.Analyze(CSharpCompilation compilation, MethodSymbol member, BoundNode node, DiagnosticBag diagnostics, ImmutableArray`1& implicitlyInitializedFieldsOpt, Boolean requireOutParamsAssigned) line 552
FlowAnalysisPass.Analyze(CSharpCompilation compilation, MethodSymbol method, BoundBlock block, DiagnosticBag diagnostics, Boolean& needsImplicitReturn, ImmutableArray`1& implicitlyInitializedFieldsOpt) line 216
FlowAnalysisPass.Rewrite(MethodSymbol method, BoundBlock block, TypeCompilationState compilationState, BindingDiagnosticBag diagnostics, Boolean hasTrailingExpression, Boolean originalBodyNested) line 51
MethodCompiler.CompileMethod(MethodSymbol methodSymbol, Int32 methodOrdinal, ProcessedFieldInitializers& processedInitializers, SynthesizedSubmissionFields previousSubmissionFields, TypeCompilationState compilationState) line 1099
MethodCompiler.CompileNamedType(NamedTypeSymbol containingType) line 537
<>c__DisplayClass25_0.<CompileNamedTypeAsync>b__0() line 439
<>c__DisplayClass5_0.<WithCurrentUICulture>b__0() line 139
ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
MethodCompiler.WaitForWorkers() line 338
MethodCompiler.CompileMethodBodies(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuiltOpt, Boolean emittingPdb, Boolean hasDeclarationErrors, Boolean emitMethodBodies, BindingDiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken) line 160
CSharpCompilation.CompileMethods(CommonPEModuleBuilder moduleBuilder, Boolean emittingPdb, DiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken) line 3503
Compilation.Emit(Stream peStream, Stream metadataPEStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, RebuildData rebuildData, CompilationTestData testData, CancellationToken cancellationToken) line 2967
Compilation.Emit(Stream peStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, Stream metadataPEStream, RebuildData rebuildData, CancellationToken cancellationToken) line 2908
Compilation.Emit(Stream peStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, Stream metadataPEStream, CancellationToken cancellationToken) line 2796
DiagnosticExtensions.GetEmitDiagnostics[TCompilation](TCompilation c, EmitOptions options, IEnumerable`1 manifestResources) line 367
DiagnosticExtensions.VerifyEmitDiagnostics[TCompilation](TCompilation c, EmitOptions options, DiagnosticDescription[] expected) line 356
DiagnosticExtensions.VerifyEmitDiagnostics[TCompilation](TCompilation c, DiagnosticDescription[] expected) line 373
FunctionPointerTests.BoolLiteralInvocation_01() line 4173
```
</details>
