### PR TITLE
Update the Copilot powered Inline Rename UX

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -34,13 +34,17 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
     private readonly IGlobalOptionService _globalOptionService;
     private readonly IThreadingContext _threadingContext;
     private readonly IAsynchronousOperationListener _asyncListener;
+
+    /// <summary>
+    /// Cancellation token source for <see cref="ISmartRenameSessionWrapper.GetSuggestionsAsync(ImmutableDictionary{string, ImmutableArray{ValueTuple{string, string}}}, CancellationToken)"/>.
+    /// Each call uses a new instance. Mutliple calls are allowed only if previous call failed or was canceled.
+    /// </summary>
     private CancellationTokenSource _cancellationTokenSource = new();
     private bool _isDisposed;
     private TimeSpan AutomaticFetchDelay => _smartRenameSession.AutomaticFetchDelay;
     private TimeSpan _semanticContextDelay;
     private bool _semanticContextError;
     private bool _semanticContextUsed;
-    private Task? _getSuggestionsTask;
 
     /// <summary>
     /// Backing field for <see cref="IsInProgress"/>.
@@ -179,7 +183,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         var listenerToken = _asyncListener.BeginAsyncOperation(nameof(_smartRenameSession.GetSuggestionsAsync));
         _cancellationTokenSource.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
-        _getSuggestionsTask = GetSuggestionsTaskAsync(isAutomaticOnInitialization, _cancellationTokenSource.Token).CompletesAsyncOperation(listenerToken);
+        _ = GetSuggestionsTaskAsync(isAutomaticOnInitialization, _cancellationTokenSource.Token).CompletesAsyncOperation(listenerToken);
     }
 
     private async Task GetSuggestionsTaskAsync(bool isAutomaticOnInitialization, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -171,6 +171,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         try
         {
             this.IsInPreparation = true;
+            NotifyPropertyChanged(nameof(IsInProgress));
             if (isAutomaticOnInitialization)
             {
                 await Task.Delay(_smartRenameSession.AutomaticFetchDelay, cancellationToken)
@@ -217,6 +218,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         finally
         {
             this.IsInPreparation = false;
+            NotifyPropertyChanged(nameof(IsInProgress));
         }
     }
 
@@ -297,8 +299,8 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
 
     /// <summary>
     /// When smart rename operates in explicit mode, this method gets the suggestions.
-    /// When smart rename operates in automatic mode, this method toggles the automatic suggestions, 
-    /// and gets the suggestions if it was just enabled.
+    /// When smart rename operates in automatic mode, this method toggles the automatic suggestions:
+    /// gets the suggestions if it was just enabled, and cancels the ongoing request if it was just disabled.
     /// </summary>
     public void ToggleOrTriggerSuggestions()
     {
@@ -308,6 +310,10 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
             if (this.IsAutomaticSuggestionsEnabled)
             {
                 this.FetchSuggestions(isAutomaticOnInitialization: false);
+            }
+            else
+            {
+                _cancellationTokenSource?.Cancel();
             }
             NotifyPropertyChanged(nameof(IsSuggestionsPanelExpanded));
             NotifyPropertyChanged(nameof(IsAutomaticSuggestionsEnabled));

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -193,10 +193,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         {
             _cancellationTokenSource.Cancel();
         }
-        finally
-        {
-            _cancellationTokenSource.Dispose();
-        }
+        catch { }
         _cancellationTokenSource = new CancellationTokenSource();
         GetSuggestionsTaskAsync(isAutomaticOnInitialization, _cancellationTokenSource.Token).CompletesAsyncOperation(listenerToken);
     }
@@ -318,7 +315,11 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
 
     public void Cancel()
     {
-        _cancellationTokenSource.Cancel();
+        try
+        {
+            _cancellationTokenSource.Cancel();
+        }
+        catch { }
         // It's needed by editor-side telemetry.
         _smartRenameSession.OnCancel();
         PostTelemetry(isCommit: false);
@@ -338,8 +339,11 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         _smartRenameSession.PropertyChanged -= SessionPropertyChanged;
         BaseViewModel.PropertyChanged -= BaseViewModelPropertyChanged;
         _smartRenameSession.Dispose();
-        _cancellationTokenSource.Cancel();
-        _cancellationTokenSource.Dispose();
+        try
+        {
+            _cancellationTokenSource.Cancel();
+        }
+        catch { }
     }
 
     /// <summary>
@@ -381,7 +385,11 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         if (e.PropertyName == nameof(BaseViewModel.IdentifierText))
         {
             // User is typing the new identifier name, cancel the ongoing request to get suggestions.
-            _cancellationTokenSource.Cancel();
+            try
+            {
+                _cancellationTokenSource.Cancel();
+            }
+            catch { }
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -178,8 +178,9 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
 
     private async Task GetSuggestionsTaskAsync(bool isAutomaticOnInitialization, CancellationToken cancellationToken)
     {
-        _threadingContext.ThrowIfNotOnUIThread();
         RoslynDebug.Assert(!this.IsInPreparation);
+        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
         try
         {
             this.IsInPreparation = true;
@@ -228,6 +229,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         }
         finally
         {
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(_threadingContext.DisposalToken);
             this.IsInPreparation = false;
         }
     }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -189,11 +189,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         }
 
         var listenerToken = _asyncListener.BeginAsyncOperation(nameof(_smartRenameSession.GetSuggestionsAsync));
-        try
-        {
-            _cancellationTokenSource.Cancel();
-        }
-        catch { }
+        _cancellationTokenSource.Cancel();
         _cancellationTokenSource = new CancellationTokenSource();
         GetSuggestionsTaskAsync(isAutomaticOnInitialization, _cancellationTokenSource.Token).CompletesAsyncOperation(listenerToken);
     }
@@ -315,11 +311,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
 
     public void Cancel()
     {
-        try
-        {
-            _cancellationTokenSource.Cancel();
-        }
-        catch { }
+        _cancellationTokenSource.Cancel();
         // It's needed by editor-side telemetry.
         _smartRenameSession.OnCancel();
         PostTelemetry(isCommit: false);
@@ -339,11 +331,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         _smartRenameSession.PropertyChanged -= SessionPropertyChanged;
         BaseViewModel.PropertyChanged -= BaseViewModelPropertyChanged;
         _smartRenameSession.Dispose();
-        try
-        {
-            _cancellationTokenSource.Cancel();
-        }
-        catch { }
+        _cancellationTokenSource.Cancel();
     }
 
     /// <summary>
@@ -385,11 +373,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         if (e.PropertyName == nameof(BaseViewModel.IdentifierText))
         {
             // User is typing the new identifier name, cancel the ongoing request to get suggestions.
-            try
-            {
-                _cancellationTokenSource.Cancel();
-            }
-            catch { }
+            _cancellationTokenSource.Cancel();
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -38,7 +38,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
     private bool _isDisposed;
     private TimeSpan AutomaticFetchDelay => _smartRenameSession.AutomaticFetchDelay;
     private Task _getSuggestionsTask = Task.CompletedTask;
-    private bool IsInPreparation = false;
+    private bool _isInPreparation = false;
     private TimeSpan _semanticContextDelay;
     private bool _semanticContextError;
     private bool _semanticContextUsed;
@@ -52,6 +52,16 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
     public bool IsAvailable => _smartRenameSession.IsAvailable;
 
     public bool HasSuggestions => _smartRenameSession.HasSuggestions;
+
+    public bool IsInPreparation
+    {
+        get => _isInPreparation;
+        set
+        {
+            _isInPreparation = value;
+            NotifyPropertyChanged(nameof(IsInProgress)); // UI is bound to IsInProgress
+        }
+    }
 
     public bool IsInProgress => IsInPreparation || _smartRenameSession.IsInProgress;
 
@@ -171,7 +181,6 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         try
         {
             this.IsInPreparation = true;
-            NotifyPropertyChanged(nameof(IsInProgress));
             if (isAutomaticOnInitialization)
             {
                 await Task.Delay(_smartRenameSession.AutomaticFetchDelay, cancellationToken)
@@ -218,7 +227,6 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         finally
         {
             this.IsInPreparation = false;
-            NotifyPropertyChanged(nameof(IsInProgress));
         }
     }
 


### PR DESCRIPTION
There is a slight delay prior to making Copilot request. Additionally, Roslyn might be gathering references and definition to add semantic context to the prompt.
Our UX designer recommended that we should be showing the progress bar while this is happening.

Before:
![roslyn rename progress delay](https://github.com/user-attachments/assets/e36120f9-5eb2-4ac3-9381-40cf2c69e3ab)

After:
![roslyn rename progress fixed](https://github.com/user-attachments/assets/f980e41e-873a-42e3-b6c8-e6556e899163)



Additionally, I saw that pressing Ctrl+Space to cancel ongoing request did not work, so I fixed it. In the "before" screenshot, I hit Ctrl+Space to cancel the request, then arrow down to scroll through suggestions, which were not visible
Before:
![roslyn rename hidden suggestions](https://github.com/user-attachments/assets/9a93fa0a-2682-44fe-9f77-b9dd9da15672)

After:
![roslyn rename abort fixed](https://github.com/user-attachments/assets/61adca8a-e9c5-4cb2-803a-3301d0e7f35e)

