### PR TITLE
Avoid reusing temps whose refs might be captured

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator_RefSafety.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator_RefSafety.cs
@@ -1,0 +1,158 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeGen;
+
+internal partial class CodeGenerator
+{
+    private static bool MightEscapeTemporaryRefs(BoundCall node, bool used, AddressKind? receiverAddressKind)
+    {
+        return MightEscapeTemporaryRefs(
+            used: used,
+            returnType: node.Type,
+            returnRefKind: node.Method.RefKind,
+            receiverType: !node.Method.RequiresInstanceReceiver ? null : node.ReceiverOpt?.Type,
+            receiverScope: node.Method.TryGetThisParameter(out var thisParameter) ? thisParameter?.EffectiveScope : null,
+            receiverAddressKind: receiverAddressKind,
+            isReceiverReadOnly: node.Method.IsEffectivelyReadOnly,
+            parameters: node.Method.Parameters,
+            arguments: node.Arguments,
+            argsToParamsOpt: node.ArgsToParamsOpt,
+            expanded: node.Expanded);
+    }
+
+    private static bool MightEscapeTemporaryRefs(BoundObjectCreationExpression node, bool used)
+    {
+        return MightEscapeTemporaryRefs(
+            used: used,
+            returnType: node.Type,
+            returnRefKind: RefKind.None,
+            receiverType: null,
+            receiverScope: null,
+            receiverAddressKind: null,
+            isReceiverReadOnly: false,
+            parameters: node.Constructor.Parameters,
+            arguments: node.Arguments,
+            argsToParamsOpt: node.ArgsToParamsOpt,
+            expanded: node.Expanded);
+    }
+
+    private static bool MightEscapeTemporaryRefs(BoundFunctionPointerInvocation node, bool used)
+    {
+        FunctionPointerMethodSymbol method = node.FunctionPointer.Signature;
+        return MightEscapeTemporaryRefs(
+            used: used,
+            returnType: node.Type,
+            returnRefKind: method.RefKind,
+            receiverType: null,
+            receiverScope: null,
+            receiverAddressKind: null,
+            isReceiverReadOnly: false,
+            parameters: method.Parameters,
+            arguments: node.Arguments,
+            argsToParamsOpt: default,
+            expanded: false);
+    }
+
+    private static bool MightEscapeTemporaryRefs(
+        bool used,
+        TypeSymbol returnType,
+        RefKind returnRefKind,
+        TypeSymbol? receiverType,
+        ScopedKind? receiverScope,
+        AddressKind? receiverAddressKind,
+        bool isReceiverReadOnly,
+        ImmutableArray<ParameterSymbol> parameters,
+        ImmutableArray<BoundExpression> arguments,
+        ImmutableArray<int> argsToParamsOpt,
+        bool expanded)
+    {
+        Debug.Assert(receiverAddressKind is null || receiverType is not null);
+
+        int writableRefs = 0;
+        int readonlyRefs = 0;
+
+        if (used && (returnRefKind != RefKind.None || returnType.IsRefLikeOrAllowsRefLikeType()))
+        {
+            writableRefs++;
+        }
+
+        if (receiverType is not null)
+        {
+            receiverScope ??= ScopedKind.None;
+            if (receiverAddressKind is { } a && !IsAnyReadOnly(a) && receiverScope == ScopedKind.None)
+            {
+                writableRefs++;
+            }
+            else if (receiverType.IsRefLikeOrAllowsRefLikeType() && receiverScope != ScopedKind.ScopedValue)
+            {
+                if (isReceiverReadOnly || receiverType.IsReadOnly)
+                {
+                    readonlyRefs++;
+                }
+                else
+                {
+                    writableRefs++;
+                }
+            }
+            else if (receiverAddressKind != null && receiverScope == ScopedKind.None)
+            {
+                readonlyRefs++;
+            }
+        }
+
+        if (shouldReturnTrue(writableRefs, readonlyRefs))
+        {
+            return true;
+        }
+
+        for (var arg = 0; arg < arguments.Length; arg++)
+        {
+            var parameter = Binder.GetCorrespondingParameter(
+                arg,
+                parameters,
+                argsToParamsOpt,
+                expanded);
+
+            if (parameter is not null)
+            {
+                if (parameter.RefKind.IsWritableReference() && parameter.EffectiveScope == ScopedKind.None)
+                {
+                    writableRefs++;
+                }
+                else if (parameter.Type.IsRefLikeOrAllowsRefLikeType() && parameter.EffectiveScope != ScopedKind.ScopedValue)
+                {
+                    if (parameter.Type.IsReadOnly || !parameter.RefKind.IsWritableReference())
+                    {
+                        readonlyRefs++;
+                    }
+                    else
+                    {
+                        writableRefs++;
+                    }
+                }
+                else if (parameter.RefKind != RefKind.None && parameter.EffectiveScope == ScopedKind.None)
+                {
+                    readonlyRefs++;
+                }
+            }
+
+            if (shouldReturnTrue(writableRefs, readonlyRefs))
+            {
+                return true;
+            }
+        }
+
+        return false;
+
+        static bool shouldReturnTrue(int writableRefs, int readonlyRefs)
+        {
+            return writableRefs > 0 && (writableRefs + readonlyRefs) > 1;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -673,6 +673,8 @@ oneMoreTime:
             {
                 EmitUninstrumentedBlock(block);
             }
+
+            ReleaseBlockTemps();
         }
 
         private void EmitInstrumentedBlock(BoundBlockInstrumentation instrumentation, BoundBlock block)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -1112,7 +1112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (isComReceiver)
             {
-                RewriteArgumentsForComCall(parameters, actualArguments, refKinds, temps);
+                RewriteArgumentsForComCall(parameters, actualArguments, refKinds);
             }
 
             // * The refkind map is now filled out to match the arguments.
@@ -1599,8 +1599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void RewriteArgumentsForComCall(
             ImmutableArray<ParameterSymbol> parameters,
             BoundExpression[] actualArguments, //already re-ordered to match parameters
-            ArrayBuilder<RefKind> argsRefKindsBuilder,
-            ArrayBuilder<LocalSymbol> temporariesBuilder)
+            ArrayBuilder<RefKind> argsRefKindsBuilder)
         {
             Debug.Assert(actualArguments != null);
             Debug.Assert(actualArguments.Length == parameters.Length);
@@ -1640,13 +1639,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 actualArguments[argIndex] = new BoundSequence(
                     argument.Syntax,
-                    locals: ImmutableArray<LocalSymbol>.Empty,
-                    sideEffects: ImmutableArray.Create<BoundExpression>(boundAssignmentToTemp),
+                    locals: [boundTemp.LocalSymbol],
+                    sideEffects: [boundAssignmentToTemp],
                     value: boundTemp,
                     type: boundTemp.Type);
                 argsRefKindsBuilder[argIndex] = RefKind.Ref;
-
-                temporariesBuilder.Add(boundTemp.LocalSymbol);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (indexer.ContainingType.IsComImport)
             {
-                RewriteArgumentsForComCall(parameters, actualArguments, refKinds, temps);
+                RewriteArgumentsForComCall(parameters, actualArguments, refKinds);
             }
 
             Debug.Assert(actualArguments.All(static arg => arg is not null));

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -887,7 +887,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundCall(
                 Syntax, receiver, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, method, args,
                 argumentNamesOpt: default(ImmutableArray<String?>), argumentRefKindsOpt: refKinds, isDelegateCall: false, expanded: false, invokedAsExtensionMethod: false,
-                argsToParamsOpt: ImmutableArray<int>.Empty, defaultArguments: default(BitVector), resultKind: LookupResultKind.Viable, type: method.ReturnType)
+                argsToParamsOpt: default, defaultArguments: default(BitVector), resultKind: LookupResultKind.Viable, type: method.ReturnType)
             { WasCompilerGenerated = true };
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -861,7 +861,8 @@ class Program
   // Code size       72 (0x48)
   .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  ldc.i4.s   42
   IL_0002:  stloc.0
   IL_0003:  ldloca.s   V_0
@@ -870,22 +871,22 @@ class Program
   IL_000b:  call       ""void System.Console.WriteLine(int)""
   IL_0010:  newobj     ""Program..ctor()""
   IL_0015:  ldc.i4.5
-  IL_0016:  stloc.0
-  IL_0017:  ldloca.s   V_0
+  IL_0016:  stloc.1
+  IL_0017:  ldloca.s   V_1
   IL_0019:  ldc.i4.6
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
+  IL_001a:  stloc.2
+  IL_001b:  ldloca.s   V_2
   IL_001d:  call       ""int Program.this[in int, in int].get""
   IL_0022:  call       ""void System.Console.WriteLine(int)""
   IL_0027:  ldc.i4.s   42
-  IL_0029:  stloc.0
-  IL_002a:  ldloca.s   V_0
+  IL_0029:  stloc.1
+  IL_002a:  ldloca.s   V_1
   IL_002c:  call       ""ref readonly int Program.M(in int)""
   IL_0031:  ldind.i4
   IL_0032:  call       ""void System.Console.WriteLine(int)""
   IL_0037:  ldc.i4.s   42
-  IL_0039:  stloc.0
-  IL_003a:  ldloca.s   V_0
+  IL_0039:  stloc.2
+  IL_003a:  ldloca.s   V_2
   IL_003c:  call       ""ref readonly int Program.M(in int)""
   IL_0041:  ldind.i4
   IL_0042:  call       ""void System.Console.WriteLine(int)""

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -9554,7 +9554,8 @@ static class Program
                                     System.ReadOnlySpan<int> V_3,
                                     int V_4,
                                     int[] V_5,
-                                    System.Span<int> V_6)
+                                    System.Span<int> V_6,
+                                    System.Span<int> V_7)
                       IL_0000:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=8_Align=4 <PrivateImplementationDetails>.34FB5C825DE7CA4AEA6E712F19D439C1DA0C92C37B423936C5F618545CA4FA1F4"
                       IL_0005:  call       "System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)"
                       IL_000a:  stloc.0
@@ -9590,8 +9591,8 @@ static class Program
                       IL_0056:  ldloca.s   V_3
                       IL_0058:  ldloc.s    V_5
                       IL_005a:  newobj     "System.Span<int>..ctor(int[])"
-                      IL_005f:  stloc.s    V_6
-                      IL_0061:  ldloca.s   V_6
+                      IL_005f:  stloc.s    V_7
+                      IL_0061:  ldloca.s   V_7
                       IL_0063:  ldloc.s    V_4
                       IL_0065:  ldloca.s   V_3
                       IL_0067:  call       "int System.ReadOnlySpan<int>.Length.get"
@@ -11607,7 +11608,8 @@ static class Program
                                 T[] V_2,
                                 System.Span<T> V_3,
                                 System.Span<T> V_4,
-                                System.Span<T> V_5)
+                                System.Span<T> V_5,
+                                System.Span<T> V_6)
                   IL_0000:  ldarg.0
                   IL_0001:  ldarg.1
                   IL_0002:  stloc.0
@@ -11643,8 +11645,8 @@ static class Program
                   IL_004e:  ldloca.s   V_4
                   IL_0050:  ldloc.2
                   IL_0051:  newobj     "System.Span<T>..ctor(T[])"
-                  IL_0056:  stloc.s    V_5
-                  IL_0058:  ldloca.s   V_5
+                  IL_0056:  stloc.s    V_6
+                  IL_0058:  ldloca.s   V_6
                   IL_005a:  ldloc.1
                   IL_005b:  ldloca.s   V_4
                   IL_005d:  call       "int System.Span<T>.Length.get"
@@ -33775,7 +33777,8 @@ partial class Program
                                 System.ReadOnlySpan<int> V_3,
                                 int V_4,
                                 int[] V_5,
-                                System.Span<int> V_6)
+                                System.Span<int> V_6,
+                                System.Span<int> V_7)
                   IL_0000:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12_Align=4 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D4"
                   IL_0005:  call       "System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)"
                   IL_000a:  stloc.0
@@ -33817,8 +33820,8 @@ partial class Program
                   IL_006d:  ldloca.s   V_3
                   IL_006f:  ldloc.s    V_5
                   IL_0071:  newobj     "System.Span<int>..ctor(int[])"
-                  IL_0076:  stloc.s    V_6
-                  IL_0078:  ldloca.s   V_6
+                  IL_0076:  stloc.s    V_7
+                  IL_0078:  ldloca.s   V_7
                   IL_007a:  ldloc.s    V_4
                   IL_007c:  ldloca.s   V_3
                   IL_007e:  call       "int System.ReadOnlySpan<int>.Length.get"
@@ -34383,7 +34386,8 @@ partial class Program
                                 int V_3,
                                 Base[] V_4,
                                 System.ReadOnlySpan<Base> V_5,
-                                System.Span<Base> V_6)
+                                System.Span<Base> V_6,
+                                System.Span<Base> V_7)
                   IL_0000:  ldc.i4.1
                   IL_0001:  newarr     "Derived"
                   IL_0006:  dup
@@ -34435,8 +34439,8 @@ partial class Program
                   IL_006a:  ldloca.s   V_5
                   IL_006c:  ldloc.s    V_4
                   IL_006e:  newobj     "System.Span<Base>..ctor(Base[])"
-                  IL_0073:  stloc.s    V_6
-                  IL_0075:  ldloca.s   V_6
+                  IL_0073:  stloc.s    V_7
+                  IL_0075:  ldloca.s   V_7
                   IL_0077:  ldloc.3
                   IL_0078:  ldloca.s   V_5
                   IL_007a:  call       "int System.ReadOnlySpan<Base>.Length.get"
@@ -35049,7 +35053,8 @@ partial class Program
                                 int[] V_3,
                                 System.ReadOnlySpan<int> V_4,
                                 System.ReadOnlySpan<int> V_5,
-                                System.Span<int> V_6)
+                                System.Span<int> V_6,
+                                System.Span<int> V_7)
                   IL_0000:  ldc.i4.2
                   IL_0001:  newarr     "int"
                   IL_0006:  dup
@@ -35101,8 +35106,8 @@ partial class Program
                   IL_005f:  ldloca.s   V_5
                   IL_0061:  ldloc.3
                   IL_0062:  newobj     "System.Span<int>..ctor(int[])"
-                  IL_0067:  stloc.s    V_6
-                  IL_0069:  ldloca.s   V_6
+                  IL_0067:  stloc.s    V_7
+                  IL_0069:  ldloca.s   V_7
                   IL_006b:  ldloc.2
                   IL_006c:  ldloca.s   V_5
                   IL_006e:  call       "int System.ReadOnlySpan<int>.Length.get"
@@ -35330,7 +35335,8 @@ partial class Program
                                 System.ReadOnlySpan<int> V_6,
                                 System.Runtime.CompilerServices.TaskAwaiter<int[]> V_7,
                                 System.Span<int> V_8,
-                                System.Exception V_9)
+                                System.Span<int> V_9,
+                                System.Exception V_10)
                   IL_0000:  ldarg.0
                   IL_0001:  ldfld      "int C.<Main>d__0.<>1__state"
                   IL_0006:  stloc.0
@@ -35425,8 +35431,8 @@ partial class Program
                     IL_00ea:  ldarg.0
                     IL_00eb:  ldfld      "int[] C.<Main>d__0.<>7__wrap4"
                     IL_00f0:  newobj     "System.Span<int>..ctor(int[])"
-                    IL_00f5:  stloc.s    V_8
-                    IL_00f7:  ldloca.s   V_8
+                    IL_00f5:  stloc.s    V_9
+                    IL_00f7:  ldloca.s   V_9
                     IL_00f9:  ldloc.s    V_4
                     IL_00fb:  ldloca.s   V_6
                     IL_00fd:  call       "int System.ReadOnlySpan<int>.Length.get"
@@ -35505,13 +35511,13 @@ partial class Program
                   }
                   catch System.Exception
                   {
-                    IL_01c5:  stloc.s    V_9
+                    IL_01c5:  stloc.s    V_10
                     IL_01c7:  ldarg.0
                     IL_01c8:  ldc.i4.s   -2
                     IL_01ca:  stfld      "int C.<Main>d__0.<>1__state"
                     IL_01cf:  ldarg.0
                     IL_01d0:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
-                    IL_01d5:  ldloc.s    V_9
+                    IL_01d5:  ldloc.s    V_10
                     IL_01d7:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
                     IL_01dc:  leave.s    IL_01f1
                   }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/InlineArrayTests.cs
@@ -7339,13 +7339,14 @@ class Program
             verifier.VerifyIL("Program.<M2>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      208 (0xd0)
+  // Code size      209 (0xd1)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
                 System.Span<int> V_3,
-                System.Exception V_4)
+                System.Span<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<M2>d__2.<>1__state""
   IL_0006:  stloc.0
@@ -7377,7 +7378,7 @@ class Program
     IL_0041:  ldloca.s   V_2
     IL_0043:  ldarg.0
     IL_0044:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<M2>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<M2>d__2)""
-    IL_0049:  leave      IL_00cf
+    IL_0049:  leave      IL_00d0
     IL_004e:  ldarg.0
     IL_004f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<M2>d__2.<>u__1""
     IL_0054:  stloc.2
@@ -7402,36 +7403,36 @@ class Program
     IL_0087:  ldc.i4.0
     IL_0088:  ldloc.1
     IL_0089:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
-    IL_008e:  stloc.3
-    IL_008f:  ldloca.s   V_3
-    IL_0091:  ldc.i4.0
-    IL_0092:  call       ""ref int System.Span<int>.this[int].get""
-    IL_0097:  ldc.i4.s   111
-    IL_0099:  stind.i4
-    IL_009a:  ldarg.0
-    IL_009b:  ldnull
-    IL_009c:  stfld      ""C Program.<M2>d__2.<>7__wrap1""
-    IL_00a1:  leave.s    IL_00bc
+    IL_008e:  stloc.s    V_4
+    IL_0090:  ldloca.s   V_4
+    IL_0092:  ldc.i4.0
+    IL_0093:  call       ""ref int System.Span<int>.this[int].get""
+    IL_0098:  ldc.i4.s   111
+    IL_009a:  stind.i4
+    IL_009b:  ldarg.0
+    IL_009c:  ldnull
+    IL_009d:  stfld      ""C Program.<M2>d__2.<>7__wrap1""
+    IL_00a2:  leave.s    IL_00bd
   }
   catch System.Exception
   {
-    IL_00a3:  stloc.s    V_4
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldc.i4.s   -2
-    IL_00a8:  stfld      ""int Program.<M2>d__2.<>1__state""
-    IL_00ad:  ldarg.0
-    IL_00ae:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M2>d__2.<>t__builder""
-    IL_00b3:  ldloc.s    V_4
-    IL_00b5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00ba:  leave.s    IL_00cf
+    IL_00a4:  stloc.s    V_5
+    IL_00a6:  ldarg.0
+    IL_00a7:  ldc.i4.s   -2
+    IL_00a9:  stfld      ""int Program.<M2>d__2.<>1__state""
+    IL_00ae:  ldarg.0
+    IL_00af:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M2>d__2.<>t__builder""
+    IL_00b4:  ldloc.s    V_5
+    IL_00b6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00bb:  leave.s    IL_00d0
   }
-  IL_00bc:  ldarg.0
-  IL_00bd:  ldc.i4.s   -2
-  IL_00bf:  stfld      ""int Program.<M2>d__2.<>1__state""
-  IL_00c4:  ldarg.0
-  IL_00c5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M2>d__2.<>t__builder""
-  IL_00ca:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_00cf:  ret
+  IL_00bd:  ldarg.0
+  IL_00be:  ldc.i4.s   -2
+  IL_00c0:  stfld      ""int Program.<M2>d__2.<>1__state""
+  IL_00c5:  ldarg.0
+  IL_00c6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M2>d__2.<>t__builder""
+  IL_00cb:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00d0:  ret
 }
 ");
         }
@@ -7482,7 +7483,8 @@ class Program
                 int V_2,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
                 System.Span<int> V_4,
-                System.Exception V_5)
+                System.Span<int> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<M2>d__2.<>1__state""
   IL_0006:  stloc.0
@@ -7547,8 +7549,8 @@ class Program
     IL_0098:  ldloc.2
     IL_0099:  sub
     IL_009a:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
-    IL_009f:  stloc.s    V_4
-    IL_00a1:  ldloca.s   V_4
+    IL_009f:  stloc.s    V_5
+    IL_00a1:  ldloca.s   V_5
     IL_00a3:  ldc.i4.0
     IL_00a4:  call       ""ref int System.Span<int>.this[int].get""
     IL_00a9:  ldc.i4.s   111
@@ -7560,13 +7562,13 @@ class Program
   }
   catch System.Exception
   {
-    IL_00b5:  stloc.s    V_5
+    IL_00b5:  stloc.s    V_6
     IL_00b7:  ldarg.0
     IL_00b8:  ldc.i4.s   -2
     IL_00ba:  stfld      ""int Program.<M2>d__2.<>1__state""
     IL_00bf:  ldarg.0
     IL_00c0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M2>d__2.<>t__builder""
-    IL_00c5:  ldloc.s    V_5
+    IL_00c5:  ldloc.s    V_6
     IL_00c7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_00cc:  leave.s    IL_00e1
   }
@@ -7630,7 +7632,8 @@ class Program
                 System.Runtime.CompilerServices.TaskAwaiter<System.Range> V_5,
                 System.Index V_6,
                 System.Span<int> V_7,
-                System.Exception V_8)
+                System.Span<int> V_8,
+                System.Exception V_9)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<M2>d__2.<>1__state""
   IL_0006:  stloc.0
@@ -7711,8 +7714,8 @@ class Program
     IL_00cc:  ldloc.3
     IL_00cd:  ldloc.s    V_4
     IL_00cf:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
-    IL_00d4:  stloc.s    V_7
-    IL_00d6:  ldloca.s   V_7
+    IL_00d4:  stloc.s    V_8
+    IL_00d6:  ldloca.s   V_8
     IL_00d8:  ldc.i4.0
     IL_00d9:  call       ""ref int System.Span<int>.this[int].get""
     IL_00de:  ldc.i4.s   111
@@ -7724,13 +7727,13 @@ class Program
   }
   catch System.Exception
   {
-    IL_00ea:  stloc.s    V_8
+    IL_00ea:  stloc.s    V_9
     IL_00ec:  ldarg.0
     IL_00ed:  ldc.i4.s   -2
     IL_00ef:  stfld      ""int Program.<M2>d__2.<>1__state""
     IL_00f4:  ldarg.0
     IL_00f5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M2>d__2.<>t__builder""
-    IL_00fa:  ldloc.s    V_8
+    IL_00fa:  ldloc.s    V_9
     IL_00fc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0101:  leave.s    IL_0116
   }
@@ -7795,7 +7798,8 @@ class Program
                 int V_2,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
                 System.Span<int> V_4,
-                System.Exception V_5)
+                System.Span<int> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<M2>d__2.<>1__state""
   IL_0006:  stloc.0
@@ -7872,8 +7876,8 @@ class Program
     IL_00c5:  ldarg.0
     IL_00c6:  ldfld      ""int Program.<M2>d__2.<>7__wrap2""
     IL_00cb:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
-    IL_00d0:  stloc.s    V_4
-    IL_00d2:  ldloca.s   V_4
+    IL_00d0:  stloc.s    V_5
+    IL_00d2:  ldloca.s   V_5
     IL_00d4:  ldarg.0
     IL_00d5:  ldfld      ""int Program.<M2>d__2.<>7__wrap3""
     IL_00da:  call       ""ref int System.Span<int>.this[int].get""
@@ -7886,13 +7890,13 @@ class Program
   }
   catch System.Exception
   {
-    IL_00ea:  stloc.s    V_5
+    IL_00ea:  stloc.s    V_6
     IL_00ec:  ldarg.0
     IL_00ed:  ldc.i4.s   -2
     IL_00ef:  stfld      ""int Program.<M2>d__2.<>1__state""
     IL_00f4:  ldarg.0
     IL_00f5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M2>d__2.<>t__builder""
-    IL_00fa:  ldloc.s    V_5
+    IL_00fa:  ldloc.s    V_6
     IL_00fc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0101:  leave.s    IL_0116
   }
@@ -7961,7 +7965,8 @@ class Program
                 System.Index V_6,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_7,
                 System.ReadOnlySpan<int> V_8,
-                System.Exception V_9)
+                System.ReadOnlySpan<int> V_9,
+                System.Exception V_10)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<M1>d__1.<>1__state""
   IL_0006:  stloc.0
@@ -8051,8 +8056,8 @@ class Program
     IL_00ee:  ldarg.0
     IL_00ef:  ldfld      ""int Program.<M1>d__1.<>7__wrap2""
     IL_00f4:  call       ""System.ReadOnlySpan<int> System.ReadOnlySpan<int>.Slice(int, int)""
-    IL_00f9:  stloc.s    V_8
-    IL_00fb:  ldloca.s   V_8
+    IL_00f9:  stloc.s    V_9
+    IL_00fb:  ldloca.s   V_9
     IL_00fd:  ldloc.s    V_5
     IL_00ff:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
     IL_0104:  ldind.i4
@@ -8061,13 +8066,13 @@ class Program
   }
   catch System.Exception
   {
-    IL_0108:  stloc.s    V_9
+    IL_0108:  stloc.s    V_10
     IL_010a:  ldarg.0
     IL_010b:  ldc.i4.s   -2
     IL_010d:  stfld      ""int Program.<M1>d__1.<>1__state""
     IL_0112:  ldarg.0
     IL_0113:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Program.<M1>d__1.<>t__builder""
-    IL_0118:  ldloc.s    V_9
+    IL_0118:  ldloc.s    V_10
     IL_011a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
     IL_011f:  leave.s    IL_0135
   }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -10216,6 +10216,875 @@ public struct Vec4
                 Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "1").WithLocation(18, 22));
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes()
+        {
+            var source = """
+                var r1 = new R(111);
+                var r2 = new R(222);
+                Report(r1.F, r2.F);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                ref struct R(in int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics()
+                // Needs two int temps.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       43 (0x2b)
+                      .maxstack  2
+                      .locals init (R V_0, //r2
+                                    int V_1,
+                                    int V_2)
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.1
+                      IL_0003:  ldloca.s   V_1
+                      IL_0005:  newobj     "R..ctor(in int)"
+                      IL_000a:  ldc.i4     0xde
+                      IL_000f:  stloc.2
+                      IL_0010:  ldloca.s   V_2
+                      IL_0012:  newobj     "R..ctor(in int)"
+                      IL_0017:  stloc.0
+                      IL_0018:  ldfld      "ref readonly int R.F"
+                      IL_001d:  ldind.i4
+                      IL_001e:  ldloc.0
+                      IL_001f:  ldfld      "ref readonly int R.F"
+                      IL_0024:  ldind.i4
+                      IL_0025:  call       "void Program.<<Main>$>g__Report|0_0(int, int)"
+                      IL_002a:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_CannotEscape_NonRefStruct()
+        {
+            var source = """
+                var r1 = new R(111);
+                var r2 = new R(222);
+
+                struct R(in int x)
+                {
+                    public readonly int F = x;
+                }
+                """;
+            CompileAndVerify(source)
+                .VerifyDiagnostics()
+                // One int temp is enough.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       26 (0x1a)
+                      .maxstack  1
+                      .locals init (int V_0)
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.0
+                      IL_0003:  ldloca.s   V_0
+                      IL_0005:  newobj     "R..ctor(in int)"
+                      IL_000a:  pop
+                      IL_000b:  ldc.i4     0xde
+                      IL_0010:  stloc.0
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  newobj     "R..ctor(in int)"
+                      IL_0018:  pop
+                      IL_0019:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_CannotEscape_UnusedResult()
+        {
+            var source = """
+                new R(111);
+                new R(222);
+
+                ref struct R
+                {
+                    public R(in int x) { }
+                }
+                """;
+            CompileAndVerify(source)
+                .VerifyDiagnostics()
+                // One int temp is enough.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       26 (0x1a)
+                      .maxstack  1
+                      .locals init (int V_0)
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.0
+                      IL_0003:  ldloca.s   V_0
+                      IL_0005:  newobj     "R..ctor(in int)"
+                      IL_000a:  pop
+                      IL_000b:  ldc.i4     0xde
+                      IL_0010:  stloc.0
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  newobj     "R..ctor(in int)"
+                      IL_0018:  pop
+                      IL_0019:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_CannotEscape_ScopedParameter()
+        {
+            var source = """
+                var r1 = new R(111);
+                var r2 = new R(222);
+                Use(r1, r2);
+
+                static void Use(R x, R y) { }
+
+                ref struct R
+                {
+                    public R(scoped in int x) { }
+                }
+                """;
+            CompileAndVerify(source)
+                .VerifyDiagnostics()
+                // One int temp is enough.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       31 (0x1f)
+                      .maxstack  2
+                      .locals init (R V_0, //r2
+                                    int V_1)
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.1
+                      IL_0003:  ldloca.s   V_1
+                      IL_0005:  newobj     "R..ctor(scoped in int)"
+                      IL_000a:  ldc.i4     0xde
+                      IL_000f:  stloc.1
+                      IL_0010:  ldloca.s   V_1
+                      IL_0012:  newobj     "R..ctor(scoped in int)"
+                      IL_0017:  stloc.0
+                      IL_0018:  ldloc.0
+                      IL_0019:  call       "void Program.<<Main>$>g__Use|0_0(R, R)"
+                      IL_001e:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_NestedBlock()
+        {
+            var source = """
+                {
+                    var r1 = new R(111);
+                    var r2 = new R(222);
+                    Report(r1.F, r2.F);
+                }
+                {
+                    var r1 = new R(333);
+                    var r2 = new R(444);
+                    Report(r1.F, r2.F);
+                }
+
+                static void Report(int x, int y) => System.Console.Write($"{x} {y} ");
+
+                ref struct R(in int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222 333 444"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics()
+                // Two int and two R temps are enough.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       88 (0x58)
+                      .maxstack  2
+                      .locals init (R V_0, //r2
+                                    int V_1,
+                                    int V_2,
+                                    R V_3) //r2
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.1
+                      IL_0003:  ldloca.s   V_1
+                      IL_0005:  newobj     "R..ctor(in int)"
+                      IL_000a:  ldc.i4     0xde
+                      IL_000f:  stloc.2
+                      IL_0010:  ldloca.s   V_2
+                      IL_0012:  newobj     "R..ctor(in int)"
+                      IL_0017:  stloc.0
+                      IL_0018:  ldfld      "ref readonly int R.F"
+                      IL_001d:  ldind.i4
+                      IL_001e:  ldloc.0
+                      IL_001f:  ldfld      "ref readonly int R.F"
+                      IL_0024:  ldind.i4
+                      IL_0025:  call       "void Program.<<Main>$>g__Report|0_0(int, int)"
+                      IL_002a:  ldc.i4     0x14d
+                      IL_002f:  stloc.1
+                      IL_0030:  ldloca.s   V_1
+                      IL_0032:  newobj     "R..ctor(in int)"
+                      IL_0037:  ldc.i4     0x1bc
+                      IL_003c:  stloc.2
+                      IL_003d:  ldloca.s   V_2
+                      IL_003f:  newobj     "R..ctor(in int)"
+                      IL_0044:  stloc.3
+                      IL_0045:  ldfld      "ref readonly int R.F"
+                      IL_004a:  ldind.i4
+                      IL_004b:  ldloc.3
+                      IL_004c:  ldfld      "ref readonly int R.F"
+                      IL_0051:  ldind.i4
+                      IL_0052:  call       "void Program.<<Main>$>g__Report|0_0(int, int)"
+                      IL_0057:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_CannotEscape_ComCall()
+        {
+            var source = """
+                using System.Runtime.InteropServices;
+
+                I i = new C();
+                i.M(111);
+                i.M(222);
+
+                [ComImport, Guid("96A2DE64-6D44-4DA5-BBA4-25F5F07E0E6B")]
+                interface I
+                {
+                    void M(ref int i);
+                }
+
+                class C : I
+                {
+                    void I.M(ref int i) { }
+                }
+                """;
+            CompileAndVerify(source)
+                .VerifyDiagnostics()
+                // One int temp is enough.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       30 (0x1e)
+                      .maxstack  3
+                      .locals init (int V_0)
+                      IL_0000:  newobj     "C..ctor()"
+                      IL_0005:  dup
+                      IL_0006:  ldc.i4.s   111
+                      IL_0008:  stloc.0
+                      IL_0009:  ldloca.s   V_0
+                      IL_000b:  callvirt   "void I.M(ref int)"
+                      IL_0010:  ldc.i4     0xde
+                      IL_0015:  stloc.0
+                      IL_0016:  ldloca.s   V_0
+                      IL_0018:  callvirt   "void I.M(ref int)"
+                      IL_001d:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_ComCall()
+        {
+            var source = """
+                using System.Diagnostics.CodeAnalysis;
+                using System.Runtime.InteropServices;
+
+                I i = new C();
+                var r1 = i.M(111);
+                var r2 = i.M(222);
+                Report(r1.F, r2.F);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                [ComImport, Guid("96A2DE64-6D44-4DA5-BBA4-25F5F07E0E6B")]
+                interface I
+                {
+                    R M([UnscopedRef] ref int i);
+                }
+
+                class C : I
+                {
+                    R I.M([UnscopedRef] ref int i)
+                    {
+                        var r = new R();
+                        r.F = ref i;
+                        return r;
+                    }
+                }
+
+                ref struct R
+                {
+                    public ref int F;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics()
+                // Needs two int temps.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       51 (0x33)
+                      .maxstack  3
+                      .locals init (R V_0, //r1
+                                    R V_1, //r2
+                                    int V_2,
+                                    int V_3)
+                      IL_0000:  newobj     "C..ctor()"
+                      IL_0005:  dup
+                      IL_0006:  ldc.i4.s   111
+                      IL_0008:  stloc.2
+                      IL_0009:  ldloca.s   V_2
+                      IL_000b:  callvirt   "R I.M(ref int)"
+                      IL_0010:  stloc.0
+                      IL_0011:  ldc.i4     0xde
+                      IL_0016:  stloc.3
+                      IL_0017:  ldloca.s   V_3
+                      IL_0019:  callvirt   "R I.M(ref int)"
+                      IL_001e:  stloc.1
+                      IL_001f:  ldloc.0
+                      IL_0020:  ldfld      "ref int R.F"
+                      IL_0025:  ldind.i4
+                      IL_0026:  ldloc.1
+                      IL_0027:  ldfld      "ref int R.F"
+                      IL_002c:  ldind.i4
+                      IL_002d:  call       "void Program.<<Main>$>g__Report|0_0(int, int)"
+                      IL_0032:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_NoTemp()
+        {
+            var source = """
+                var x1 = 111;
+                var r1 = new R(x1);
+                var x2 = 222;
+                var r2 = new R(x2);
+                Report(r1.F, r2.F);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                ref struct R(in int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics()
+                // No int temps needed.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       43 (0x2b)
+                      .maxstack  2
+                      .locals init (int V_0, //x1
+                                    int V_1, //x2
+                                    R V_2) //r2
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.0
+                      IL_0003:  ldloca.s   V_0
+                      IL_0005:  newobj     "R..ctor(in int)"
+                      IL_000a:  ldc.i4     0xde
+                      IL_000f:  stloc.1
+                      IL_0010:  ldloca.s   V_1
+                      IL_0012:  newobj     "R..ctor(in int)"
+                      IL_0017:  stloc.2
+                      IL_0018:  ldfld      "ref readonly int R.F"
+                      IL_001d:  ldind.i4
+                      IL_001e:  ldloc.2
+                      IL_001f:  ldfld      "ref readonly int R.F"
+                      IL_0024:  ldind.i4
+                      IL_0025:  call       "void Program.<<Main>$>g__Report|0_0(int, int)"
+                      IL_002a:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_RValue()
+        {
+            var source = """
+                var r1 = new R(F1());
+                var r2 = new R(F2());
+                Report(r1.F, r2.F);
+
+                static int F1() => 111;
+                static int F2() => 222;
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                ref struct R(in int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics()
+                // Needs two int temps.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       46 (0x2e)
+                      .maxstack  2
+                      .locals init (R V_0, //r2
+                                    int V_1,
+                                    int V_2)
+                      IL_0000:  call       "int Program.<<Main>$>g__F1|0_0()"
+                      IL_0005:  stloc.1
+                      IL_0006:  ldloca.s   V_1
+                      IL_0008:  newobj     "R..ctor(in int)"
+                      IL_000d:  call       "int Program.<<Main>$>g__F2|0_1()"
+                      IL_0012:  stloc.2
+                      IL_0013:  ldloca.s   V_2
+                      IL_0015:  newobj     "R..ctor(in int)"
+                      IL_001a:  stloc.0
+                      IL_001b:  ldfld      "ref readonly int R.F"
+                      IL_0020:  ldind.i4
+                      IL_0021:  ldloc.0
+                      IL_0022:  ldfld      "ref readonly int R.F"
+                      IL_0027:  ldind.i4
+                      IL_0028:  call       "void Program.<<Main>$>g__Report|0_2(int, int)"
+                      IL_002d:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_Assignment()
+        {
+            var source = """
+                var r1 = new R(100);
+                r1 = new R(101);
+                var r2 = new R(200);
+                r2 = new R(201);
+                Report(r1.F, r2.F);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                ref struct R(in int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("101 201"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics()
+                // Needs at least two int temps.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       68 (0x44)
+                      .maxstack  2
+                      .locals init (R V_0, //r2
+                                    int V_1,
+                                    int V_2,
+                                    int V_3)
+                      IL_0000:  ldc.i4.s   100
+                      IL_0002:  stloc.1
+                      IL_0003:  ldloca.s   V_1
+                      IL_0005:  newobj     "R..ctor(in int)"
+                      IL_000a:  pop
+                      IL_000b:  ldc.i4.s   101
+                      IL_000d:  stloc.1
+                      IL_000e:  ldloca.s   V_1
+                      IL_0010:  newobj     "R..ctor(in int)"
+                      IL_0015:  ldc.i4     0xc8
+                      IL_001a:  stloc.2
+                      IL_001b:  ldloca.s   V_2
+                      IL_001d:  newobj     "R..ctor(in int)"
+                      IL_0022:  stloc.0
+                      IL_0023:  ldc.i4     0xc9
+                      IL_0028:  stloc.3
+                      IL_0029:  ldloca.s   V_3
+                      IL_002b:  newobj     "R..ctor(in int)"
+                      IL_0030:  stloc.0
+                      IL_0031:  ldfld      "ref readonly int R.F"
+                      IL_0036:  ldind.i4
+                      IL_0037:  ldloc.0
+                      IL_0038:  ldfld      "ref readonly int R.F"
+                      IL_003d:  ldind.i4
+                      IL_003e:  call       "void Program.<<Main>$>g__Report|0_0(int, int)"
+                      IL_0043:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_PatternMatch()
+        {
+            var source = """
+                if (new R(111) is { } r1 && new R(222) is { } r2)
+                {
+                    Report(r1.F, r2.F);
+                }
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                ref struct R(in int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics()
+                // Needs two int temps.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       45 (0x2d)
+                      .maxstack  2
+                      .locals init (R V_0, //r1
+                                    R V_1, //r2
+                                    int V_2,
+                                    int V_3)
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.2
+                      IL_0003:  ldloca.s   V_2
+                      IL_0005:  newobj     "R..ctor(in int)"
+                      IL_000a:  stloc.0
+                      IL_000b:  ldc.i4     0xde
+                      IL_0010:  stloc.3
+                      IL_0011:  ldloca.s   V_3
+                      IL_0013:  newobj     "R..ctor(in int)"
+                      IL_0018:  stloc.1
+                      IL_0019:  ldloc.0
+                      IL_001a:  ldfld      "ref readonly int R.F"
+                      IL_001f:  ldind.i4
+                      IL_0020:  ldloc.1
+                      IL_0021:  ldfld      "ref readonly int R.F"
+                      IL_0026:  ldind.i4
+                      IL_0027:  call       "void Program.<<Main>$>g__Report|0_0(int, int)"
+                      IL_002c:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_Initializer()
+        {
+            var source = """
+                var r1 = new R() { F = ref M(111) };
+                var r2 = new R() { F = ref M(222) };
+                Report(r1.F, r2.F);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                static ref readonly int M(in int x) => ref x;
+
+                ref struct R
+                {
+                    public ref readonly int F;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_ViaOutParameter()
+        {
+            var source = """
+                scoped R r1, r2;
+                M(111, out r1);
+                M(222, out r2);
+                Report(r1.F, r2.F);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                static void M(in int x, out R r) => r = new R(x);
+
+                ref struct R(in int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_CannotEscape_ViaOutDiscard()
+        {
+            var source = """
+                M(111, out _);
+                M(222, out _);
+
+                static void M(in int x, out R r) => r = default;
+
+                ref struct R;
+                """;
+            CompileAndVerify(source)
+                .VerifyDiagnostics()
+                // One int temp would be enough. But currently the emit layer does not see the argument is a discard.
+                .VerifyIL("<top-level-statements-entry-point>", """
+                    {
+                      // Code size       28 (0x1c)
+                      .maxstack  2
+                      .locals init (R V_0,
+                                    int V_1,
+                                    int V_2)
+                      IL_0000:  ldc.i4.s   111
+                      IL_0002:  stloc.1
+                      IL_0003:  ldloca.s   V_1
+                      IL_0005:  ldloca.s   V_0
+                      IL_0007:  call       "void Program.<<Main>$>g__M|0_0(in int, out R)"
+                      IL_000c:  ldc.i4     0xde
+                      IL_0011:  stloc.2
+                      IL_0012:  ldloca.s   V_2
+                      IL_0014:  ldloca.s   V_0
+                      IL_0016:  call       "void Program.<<Main>$>g__M|0_0(in int, out R)"
+                      IL_001b:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_InstanceMethod()
+        {
+            var source = """
+                using System.Diagnostics.CodeAnalysis;
+
+                scoped var r1 = new R();
+                scoped var r2 = new R();
+                r1.Set(111);
+                r2.Set(222);
+                Report(r1.F, r2.F);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                ref struct R
+                {
+                    public ref readonly int F;
+
+                    public void Set([UnscopedRef] in int x) => F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.FailsPEVerify)
+                .VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_FunctionPointer()
+        {
+            var source = """
+                unsafe
+                {
+                    delegate*<in int, R> f = &M;
+                    var r1 = f(111);
+                    var r2 = f(222);
+                    Report(r1.F, r2.F);
+                }
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                static R M(in int x) => new R(in x);
+
+                ref struct R(ref readonly int x)
+                {
+                    public ref readonly int F = ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_RefAssignment()
+        {
+            var source = """
+                ref readonly int x = ref 111.M();
+                ref readonly int y = ref 222.M();
+
+                Report(x, y);
+
+                static void Report(int x, int y) => System.Console.WriteLine($"{x} {y}");
+
+                static class E
+                {
+                    public static ref readonly int M(this in int x) => ref x;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_Receiver()
+        {
+            var source = """
+                using System.Diagnostics.CodeAnalysis;
+
+                class C
+                {
+                    static S M1() => new S { F = 111 };
+
+                    static void M2(ref int x, ref int y) => System.Console.WriteLine($"{x} {y}");
+
+                    static void Main()
+                    {
+                        M2(ref M1().Ref(), ref new S { F = 222 }.Ref());
+                    }
+                }
+
+                struct S
+                {
+                    public int F;
+
+                    [UnscopedRef] public ref int Ref() => ref F;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_Receiver_ReadOnlyContext_01()
+        {
+            var source = """
+                using System.Diagnostics.CodeAnalysis;
+
+                new S { F = 111 }.M3();
+
+                struct S
+                {
+                    public int F;
+
+                    [UnscopedRef] public ref int Ref() => ref F;
+
+                    public readonly void M3()
+                    {
+                        M2(ref Ref(), ref new S { F = 222 }.Ref());
+                    }
+
+                    static void M2(ref int x, ref int y) => System.Console.WriteLine($"{x} {y}");
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics(
+                    // (13,16): warning CS8656: Call to non-readonly member 'S.Ref()' from a 'readonly' member results in an implicit copy of 'this'.
+                    //         M2(ref Ref(), ref new S { F = 222 }.Ref());
+                    Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "Ref").WithArguments("S.Ref()", "this").WithLocation(13, 16));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_CannotEscape_Receiver_ReadOnlyContext_02()
+        {
+            var source = """
+                using System.Diagnostics.CodeAnalysis;
+
+                static S M1() => new S { F = 111 };
+
+                M1().M3();
+
+                struct S
+                {
+                    public int F;
+
+                    [UnscopedRef] public readonly ref readonly int Ref() => ref F;
+
+                    public readonly void M3()
+                    {
+                        M2(in Ref(), new S { F = 222 });
+                    }
+
+                    static void M2(in int x, S y) => System.Console.WriteLine($"{x} {y.F}");
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics()
+                // One S temp is enough.
+                .VerifyIL("S.M3", """
+                    {
+                      // Code size       33 (0x21)
+                      .maxstack  3
+                      .locals init (S V_0)
+                      IL_0000:  ldarg.0
+                      IL_0001:  call       "readonly ref readonly int S.Ref()"
+                      IL_0006:  ldloca.s   V_0
+                      IL_0008:  initobj    "S"
+                      IL_000e:  ldloca.s   V_0
+                      IL_0010:  ldc.i4     0xde
+                      IL_0015:  stfld      "int S.F"
+                      IL_001a:  ldloc.0
+                      IL_001b:  call       "void S.M2(in int, S)"
+                      IL_0020:  ret
+                    }
+                    """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67435")]
+        public void RefTemp_Escapes_Receiver_ReadOnlyContext_03()
+        {
+            var source = """
+                using System.Diagnostics.CodeAnalysis;
+
+                class C
+                {
+                    static S M1() => new S { F = 111 };
+
+                    static void M2(in int x, in int y) => System.Console.WriteLine($"{x} {y}");
+
+                    static void Main()
+                    {
+                        M2(in M1().Ref(), in new S { F = 222 }.Ref());
+                    }
+                }
+
+                public struct S
+                {
+                    public int F;
+
+                    [UnscopedRef] public readonly ref readonly int Ref() => ref F;
+                }
+                """;
+            CompileAndVerify(source,
+                expectedOutput: RefFieldTests.IncludeExpectedOutput("111 222"),
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Fails)
+                .VerifyDiagnostics();
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72873")]
         public void Utf8Addition()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -412,22 +412,23 @@ F()
   // Code size       33 (0x21)
   .maxstack  4
   .locals init (IA V_0,
-  int V_1,
-  int V_2)
+                int V_1,
+                int V_2,
+                int V_3)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  call       ""int[] B.F()""
   IL_0007:  ldc.i4.0
   IL_0008:  ldelem.i4
-  IL_0009:  stloc.2
+  IL_0009:  stloc.1
   IL_000a:  ldloc.0
-  IL_000b:  ldloc.2
-  IL_000c:  stloc.1
-  IL_000d:  ldloca.s   V_1
+  IL_000b:  ldloc.1
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
   IL_000f:  ldloc.0
-  IL_0010:  ldloc.2
-  IL_0011:  stloc.1
-  IL_0012:  ldloca.s   V_1
+  IL_0010:  ldloc.1
+  IL_0011:  stloc.3
+  IL_0012:  ldloca.s   V_3
   IL_0014:  callvirt   ""int IA.P[ref int].get""
   IL_0019:  ldc.i4.1
   IL_001a:  add
@@ -461,23 +462,24 @@ F()
   // Code size       33 (0x21)
   .maxstack  4
   .locals init (int V_0,
-  int V_1,
-  int V_2)
+                int V_1,
+                int V_2,
+                int V_3)
   IL_0000:  ldarg.0
   IL_0001:  call       ""int[] B.F()""
   IL_0006:  ldc.i4.0
   IL_0007:  ldelem.i4
-  IL_0008:  stloc.1
+  IL_0008:  stloc.0
   IL_0009:  dup
-  IL_000a:  ldloc.1
-  IL_000b:  stloc.0
-  IL_000c:  ldloca.s   V_0
+  IL_000a:  ldloc.0
+  IL_000b:  stloc.2
+  IL_000c:  ldloca.s   V_2
   IL_000e:  callvirt   ""int IA.P[ref int].get""
-  IL_0013:  stloc.2
-  IL_0014:  ldloc.1
-  IL_0015:  stloc.0
-  IL_0016:  ldloca.s   V_0
-  IL_0018:  ldloc.2
+  IL_0013:  stloc.1
+  IL_0014:  ldloc.0
+  IL_0015:  stloc.3
+  IL_0016:  ldloca.s   V_3
+  IL_0018:  ldloc.1
   IL_0019:  ldc.i4.1
   IL_001a:  add
   IL_001b:  callvirt   ""void IA.P[ref int].set""
@@ -730,70 +732,74 @@ F()
 0, 3");
             compilation2.VerifyIL("C.MissingArg(IA)",
 @"{
-  // Code size       39 (0x27)
+  // Code size       41 (0x29)
   .maxstack  5
   .locals init (int V_0,
-  int V_1,
-  int V_2,
-  int V_3)
+                int V_1,
+                int V_2,
+                int V_3,
+                int V_4,
+                int V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldsfld     ""int C.x""
-  IL_0006:  stloc.2
+  IL_0006:  stloc.0
   IL_0007:  dup
-  IL_0008:  ldloc.2
-  IL_0009:  stloc.0
-  IL_000a:  ldloca.s   V_0
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.2
+  IL_000a:  ldloca.s   V_2
   IL_000c:  ldc.i4.0
-  IL_000d:  stloc.1
-  IL_000e:  ldloca.s   V_1
+  IL_000d:  stloc.3
+  IL_000e:  ldloca.s   V_3
   IL_0010:  callvirt   ""int IA.P[ref int, ref int].get""
-  IL_0015:  stloc.3
-  IL_0016:  ldloc.2
-  IL_0017:  stloc.0
-  IL_0018:  ldloca.s   V_0
-  IL_001a:  ldc.i4.0
-  IL_001b:  stloc.1
-  IL_001c:  ldloca.s   V_1
-  IL_001e:  ldloc.3
-  IL_001f:  ldc.i4.1
-  IL_0020:  add
-  IL_0021:  callvirt   ""void IA.P[ref int, ref int].set""
-  IL_0026:  ret
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.0
+  IL_0017:  stloc.s    V_4
+  IL_0019:  ldloca.s   V_4
+  IL_001b:  ldc.i4.0
+  IL_001c:  stloc.s    V_5
+  IL_001e:  ldloca.s   V_5
+  IL_0020:  ldloc.1
+  IL_0021:  ldc.i4.1
+  IL_0022:  add
+  IL_0023:  callvirt   ""void IA.P[ref int, ref int].set""
+  IL_0028:  ret
 }");
             compilation2.VerifyIL("C.ValueArgs(IA)",
 @"{
-  // Code size       47 (0x2f)
+  // Code size       48 (0x30)
   .maxstack  5
   .locals init (int V_0,
-  int V_1,
-  int V_2,
-  int V_3,
-  int V_4)
+                int V_1,
+                int V_2,
+                int V_3,
+                int V_4,
+                int V_5,
+                int V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldsfld     ""int C.x""
-  IL_0006:  stloc.2
+  IL_0006:  stloc.0
   IL_0007:  ldsfld     ""int C.y""
-  IL_000c:  stloc.3
+  IL_000c:  stloc.1
   IL_000d:  dup
-  IL_000e:  ldloc.2
-  IL_000f:  stloc.0
-  IL_0010:  ldloca.s   V_0
-  IL_0012:  ldloc.3
-  IL_0013:  stloc.1
-  IL_0014:  ldloca.s   V_1
-  IL_0016:  callvirt   ""int IA.P[ref int, ref int].get""
-  IL_001b:  stloc.s    V_4
-  IL_001d:  ldloc.2
-  IL_001e:  stloc.0
-  IL_001f:  ldloca.s   V_0
-  IL_0021:  ldloc.3
-  IL_0022:  stloc.1
-  IL_0023:  ldloca.s   V_1
-  IL_0025:  ldloc.s    V_4
-  IL_0027:  ldc.i4.1
-  IL_0028:  add
-  IL_0029:  callvirt   ""void IA.P[ref int, ref int].set""
-  IL_002e:  ret
+  IL_000e:  ldloc.0
+  IL_000f:  stloc.3
+  IL_0010:  ldloca.s   V_3
+  IL_0012:  ldloc.1
+  IL_0013:  stloc.s    V_4
+  IL_0015:  ldloca.s   V_4
+  IL_0017:  callvirt   ""int IA.P[ref int, ref int].get""
+  IL_001c:  stloc.2
+  IL_001d:  ldloc.0
+  IL_001e:  stloc.s    V_5
+  IL_0020:  ldloca.s   V_5
+  IL_0022:  ldloc.1
+  IL_0023:  stloc.s    V_6
+  IL_0025:  ldloca.s   V_6
+  IL_0027:  ldloc.2
+  IL_0028:  ldc.i4.1
+  IL_0029:  add
+  IL_002a:  callvirt   ""void IA.P[ref int, ref int].set""
+  IL_002f:  ret
 }");
             compilation2.VerifyIL("C.RefArgs(IA)",
 @"{


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67435.