### PR TITLE
Disable 'use interpolated string' with raw strings

### DIFF
--- a/src/Features/CSharp/Portable/ConvertToInterpolatedString/CSharpConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToInterpolatedString/CSharpConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -12,15 +12,11 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.CSharp.ConvertToInterpolatedString;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertConcatenationToInterpolatedString), Shared]
-internal sealed class CSharpConvertConcatenationToInterpolatedStringRefactoringProvider :
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpConvertConcatenationToInterpolatedStringRefactoringProvider() :
     AbstractConvertConcatenationToInterpolatedStringRefactoringProvider<ExpressionSyntax>
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpConvertConcatenationToInterpolatedStringRefactoringProvider()
-    {
-    }
-
     protected override bool SupportsInterpolatedStringHandler(Compilation compilation)
         => compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler") != null;
 

--- a/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -1388,4 +1388,26 @@ class C
             ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69721")]
+    public async Task TestWithRawString()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """"
+                struct ValueTuple
+                {
+                    public void Goo()
+                    {
+                        var someVariable = "Some text";
+
+                        var fullText = someVariable [||]+ """
+                            Appended line
+                            """;
+                    }
+                }
+                """",
+            LanguageVersion = LanguageVersion.CSharp11,
+        }.RunAsync();
+    }
 }

--- a/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -1389,7 +1389,7 @@ class C
         }.RunAsync();
     }
 
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69721")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/61256")]
     public async Task TestWithRawString()
     {
         await new VerifyCS.Test

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1196,6 +1196,13 @@ internal class CSharpSyntaxFacts : ISyntaxFacts
     public bool IsVerbatimStringLiteral(SyntaxToken token)
         => token.IsVerbatimStringLiteral();
 
+    public bool IsRawStringLiteral(SyntaxToken token)
+        => token.Kind() is
+            SyntaxKind.SingleLineRawStringLiteralToken or
+            SyntaxKind.MultiLineRawStringLiteralToken or
+            SyntaxKind.Utf8SingleLineRawStringLiteralToken or
+            SyntaxKind.Utf8MultiLineRawStringLiteralToken;
+
     public bool IsNumericLiteral(SyntaxToken token)
         => token.Kind() == SyntaxKind.NumericLiteralToken;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -162,6 +162,7 @@ internal interface ISyntaxFacts
 
     bool IsNumericLiteral(SyntaxToken token);
     bool IsVerbatimStringLiteral(SyntaxToken token);
+    bool IsRawStringLiteral(SyntaxToken token);
 
     bool IsUsingOrExternOrImport([NotNullWhen(true)] SyntaxNode? node);
     bool IsGlobalAssemblyAttribute([NotNullWhen(true)] SyntaxNode? node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1252,6 +1252,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return False
         End Function
 
+        Public Function IsRawStringLiteral(token As SyntaxToken) As Boolean Implements ISyntaxFacts.IsRawStringLiteral
+            ' VB does not have raw strings
+            Return False
+        End Function
+
         Public Function GetArgumentsOfObjectCreationExpression(node As SyntaxNode) As SeparatedSyntaxList(Of SyntaxNode) Implements ISyntaxFacts.GetArgumentsOfObjectCreationExpression
             Dim argumentList = DirectCast(node, ObjectCreationExpressionSyntax).ArgumentList
             Return If(argumentList Is Nothing, Nothing, GetArgumentsOfArgumentList(argumentList))


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61256