### PR TITLE
Update Copilot rename telemetry

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
@@ -53,6 +53,9 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m["CollapseSuggestionsPanelWhenRenameEnds"] = _globalOptionService.GetOption(InlineRenameUIOptionsStorage.CollapseSuggestionsPanel);
                     m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
                     m["smartRenameCorrelationId"] = _smartRenameSession.CorrelationId;
+                    m["smartRenameSemanticContextUsed"] = _semanticContextUsed;
+                    m["smartRenameSemanticContextDelay"] = _semanticContextDelay;
+                    m["smartRenameSemanticContextError"] = _semanticContextError;
                 }));
             }
             else
@@ -65,6 +68,9 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m[nameof(SuggestionsDropdownTelemetry.DropdownButtonClickTimes)] = _suggestionsDropdownTelemetry.DropdownButtonClickTimes;
                     m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
                     m["smartRenameCorrelationId"] = _smartRenameSession.CorrelationId;
+                    m["smartRenameSemanticContextUsed"] = _semanticContextUsed;
+                    m["smartRenameSemanticContextDelay"] = _semanticContextDelay;
+                    m["smartRenameSemanticContextError"] = _semanticContextError;
                 }));
             }
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m[nameof(SuggestionsPanelTelemetry.CollapseSuggestionsPanelWhenRenameStarts)] = _suggestionsPanelTelemetry.CollapseSuggestionsPanelWhenRenameStarts;
                     m["CollapseSuggestionsPanelWhenRenameEnds"] = _globalOptionService.GetOption(InlineRenameUIOptionsStorage.CollapseSuggestionsPanel);
                     m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
+                    m["smartRenameCorrelationId"] = _smartRenameSession.CorrelationId;
                 }));
             }
             else
@@ -63,6 +64,7 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m["UseDropDown"] = true;
                     m[nameof(SuggestionsDropdownTelemetry.DropdownButtonClickTimes)] = _suggestionsDropdownTelemetry.DropdownButtonClickTimes;
                     m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
+                    m["smartRenameCorrelationId"] = _smartRenameSession.CorrelationId;
                 }));
             }
         }

--- a/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionWrapper.cs
+++ b/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionWrapper.cs
@@ -29,6 +29,7 @@ internal readonly struct ISmartRenameSessionWrapper : INotifyPropertyChanged, ID
     private static readonly Func<object, string> s_statusMessageAccessor;
     private static readonly Func<object, bool> s_statusMessageVisibilityAccessor;
     private static readonly Func<object, IReadOnlyList<string>> s_suggestedNamesAccessor;
+    private static readonly Func<object, Guid> s_correlationIdAccessor;
     private static readonly Func<object?, object?>? s_renameContextImmutableListCreateBuilderAccessor;
     private static readonly Action<object, object>? s_renameContextImmutableListBuilderAddAccessor;
     private static readonly Func<object, object>? s_renameContextImmutableListBuilderToArrayAccessor;
@@ -52,6 +53,7 @@ internal readonly struct ISmartRenameSessionWrapper : INotifyPropertyChanged, ID
         s_statusMessageAccessor = LightupHelpers.CreatePropertyAccessor<object, string>(s_wrappedType, nameof(StatusMessage), "");
         s_statusMessageVisibilityAccessor = LightupHelpers.CreatePropertyAccessor<object, bool>(s_wrappedType, nameof(StatusMessageVisibility), false);
         s_suggestedNamesAccessor = LightupHelpers.CreatePropertyAccessor<object, IReadOnlyList<string>>(s_wrappedType, nameof(SuggestedNames), []);
+        s_correlationIdAccessor = LightupHelpers.CreatePropertyAccessor<object, Guid>(s_wrappedType, nameof(CorrelationId), Guid.Empty);
 
         if (s_wrappedRenameContextType is not null)
         {
@@ -93,6 +95,7 @@ internal readonly struct ISmartRenameSessionWrapper : INotifyPropertyChanged, ID
     public string StatusMessage => s_statusMessageAccessor(_instance);
     public bool StatusMessageVisibility => s_statusMessageVisibilityAccessor(_instance);
     public IReadOnlyList<string> SuggestedNames => s_suggestedNamesAccessor(_instance);
+    public Guid CorrelationId => s_correlationIdAccessor(_instance);
 
     public event PropertyChangedEventHandler PropertyChanged
     {


### PR DESCRIPTION
Update Copilot rename telemetry with the following information:
- CorrelationID for correlation with Editor and Copilot telemetry. Defaults to empty GUID if not available (it will be available in 17.13 preview 2)
- Time it took to get context
- Whether context was used and whether there were any errors
![image](https://github.com/user-attachments/assets/c37b57eb-0fda-4c9b-bdd5-698686064b25)
