### PR TITLE
Anonymous types in quick info should not have navigation links

### DIFF
--- a/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/StructuralTypeDisplayInfo.cs
+++ b/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/StructuralTypeDisplayInfo.cs
@@ -53,7 +53,7 @@ internal readonly struct StructuralTypeDisplayInfo
                 if (structuralTypeToName.TryGetValue(type, out var name) &&
                     part.ToString() != name)
                 {
-                    newParts.Add(new SymbolDisplayPart(part.Kind, part.Symbol, name));
+                    newParts.Add(new SymbolDisplayPart(part.Kind, symbol: null, name));
                     changed = true;
                     continue;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67185