### PR TITLE
Use partial analysis results to filter out analyzers that need to be executed.

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
@@ -177,7 +177,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     if (completedAnalyzersForFile != null && completedAnalyzersForFile.Contains(analyzer))
                         continue;
 
-                    // Don't include the analyzer if it has executed for this span in the file
+                    // Don't include the analyzer if it has executed for this span/file/syntactic combination. Typically this span corresponds
+                    //  to a single line in the file to get lightbulb information. Requests for the compiler analyzer occasionally expand this
+                    //  range to the containing member.
                     if (IsContributingToMatchingPartialFileAnalysis_NoLock(analyzer, analysisScope.FilterFileOpt, analysisScope.FilterSpanOpt, analysisScope.OriginalFilterFile, analysisScope.OriginalFilterSpan, analysisScope.IsSyntacticSingleFileAnalysis))
                         continue;
 
@@ -188,6 +190,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
+        // Determines whether the analyzer has had a completed partial analysis for the given file/span/syntactic combination.
         private bool IsContributingToMatchingPartialFileAnalysis_NoLock(DiagnosticAnalyzer analyzer, SourceOrAdditionalFile? filterFile, TextSpan? filterSpan, SourceOrAdditionalFile? originalFilterFile, TextSpan? originalFilterSpan, bool isSyntacticSingleFileAnalysis)
         {
             if (_partialFileAnalysisAnalyzers == null || filterFile == null || originalFilterFile == null)
@@ -202,6 +205,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return false;
         }
 
+        // Caches that this analyzer has had a completed partial analysis for the given file/span/syntactic combination.
+        // The actual results are stored in the _local*DiagnosticsOpt members.
         private void ContributeToPartialFileAnalysis_NoLock(DiagnosticAnalyzer analyzer, SourceOrAdditionalFile filterFile, TextSpan? filterSpan, SourceOrAdditionalFile originalFilterFile, TextSpan? originalFilterSpan, bool isSyntacticSingleFileAnalysis)
         {
             _partialFileAnalysisAnalyzers ??= new List<(SourceOrAdditionalFile, TextSpan?, SourceOrAdditionalFile, TextSpan?, bool, HashSet<DiagnosticAnalyzer>)>();

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -969,10 +969,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private AnalysisScope? GetPendingAnalysisScope(AnalysisScope analysisScope)
         {
-            (SourceOrAdditionalFile file, bool syntax)? filterScope = analysisScope.FilterFileOpt.HasValue ?
-                (analysisScope.FilterFileOpt.Value, analysisScope.IsSyntacticSingleFileAnalysis) :
-                null;
-            var pendingAnalyzers = _analysisResultBuilder.GetPendingAnalyzers(analysisScope.Analyzers, filterScope);
+            var pendingAnalyzers = _analysisResultBuilder.GetPendingAnalyzers(analysisScope);
             if (pendingAnalyzers.IsEmpty)
             {
                 // All analyzers have already executed on the requested scope.


### PR DESCRIPTION
Speedometer scrolling test is showing a huge amount of CPU  in MethodCompiler::CompileMethod and AnalyzerDriver.ProcessCompilationEventsCoreAsync. These method are used by several features to get diagnostics, one being lightbulbs. It appears this system already caches diagnostics, but wasn't using those results for partial file analysis. This PR just keeps track of analyzers that have generated results for span based analysis, and uses those results if a subsequent matching request comes in on the same compilation.

1st test insertion build (based on commit 1): https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/594706
2nd test insertion build (based on commit 3): https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/594883
3rd test insertion build (based on commit 3): https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/595116

The amount of time spent in both CompileMethod and ProcessCompilationEventsCoreAsync varies between runs, in some of the runs they are improved with this change, in some, they are unaffected. However, the lightbulb speedometer test consistently shows a marked improvement, as outlined in one of the comments in this PR. That improvement is consistent between runs, albeit for a bit contrived scenario (repeatedly invoking completion in the same location without modifying the document).