### PR TITLE
Fix LangVersion computation on non-English locales

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -20,7 +20,7 @@
         to determine the correct language version.
     -->
     <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
-                                         '$(_MaxSupportedLangVersion)' == ''">$([MSBuild]::Add(9, $([MSBuild]::Subtract($(_TargetFrameworkVersionWithoutV), 5)))).0</_MaxSupportedLangVersion>
+                                         '$(_MaxSupportedLangVersion)' == ''">$([MSBuild]::Add(9, $([MSBuild]::Subtract($(_TargetFrameworkVersionWithoutV.Split('.')[0]), 5)))).0</_MaxSupportedLangVersion>
 
     <!-- Cap _MaxSupportedLangVersion if it exceeds _MaxAvailableLangVersion -->
     <_MaxAvailableLangVersion>13.0</_MaxAvailableLangVersion>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -18,6 +18,7 @@
       - Pattern: .NET 5.0 uses C# 9.0, .NET 6.0 uses C# 10.0, and so on.
       - Starting from C# 9.0 for .NET 5.0, we add the difference between the major .NET version and 5 
         to determine the correct language version.
+      NOTE: `.Split('.')[0]` needed due to https://github.com/dotnet/msbuild/issues/9757.
     -->
     <_MaxSupportedLangVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
                                          '$(_MaxSupportedLangVersion)' == ''">$([MSBuild]::Add(9, $([MSBuild]::Subtract($(_TargetFrameworkVersionWithoutV.Split('.')[0]), 5)))).0</_MaxSupportedLangVersion>


### PR DESCRIPTION
Fixes failing Spanish leg in roslyn-CI after https://github.com/dotnet/roslyn/pull/75795.

Given `$(_TargetFrameworkVersionWithoutV)` = `5.0`, the subtraction `$([MSBuild]::Subtract($(_TargetFrameworkVersionWithoutV), 5))` evaluates to `45` (I guess because the period in `5.0` is not interpreted as decimal separator but as thousands separator instead). Adding `.Split('.')[0]` makes sure only the major version is taken and the subtraction works.