### PR TITLE
Reduce allocations from NamedTypeSymbol.AddOperators usage

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -1265,10 +1265,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool HasApplicableBooleanOperator(NamedTypeSymbol containingType, string name, TypeSymbol argumentType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, out MethodSymbol @operator)
         {
+            var operators = ArrayBuilder<MethodSymbol>.GetInstance();
             for (var type = containingType; (object)type != null; type = type.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteInfo))
             {
-                var operators = type.GetOperators(name);
-                for (var i = 0; i < operators.Length; i++)
+                operators.Clear();
+                type.AddOperators(name, operators);
+
+                for (var i = 0; i < operators.Count; i++)
                 {
                     var op = operators[i];
                     if (op.ParameterCount == 1 && op.DeclaredAccessibility == Accessibility.Public)
@@ -1277,12 +1280,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (conversion.IsImplicit)
                         {
                             @operator = op;
+                            operators.Free();
                             return true;
                         }
                     }
                 }
             }
 
+            operators.Free();
             @operator = null;
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
@@ -217,15 +217,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            ImmutableArray<MethodSymbol> operators = declaringType.GetOperators(
-                isExplicit ? (isChecked ? WellKnownMemberNames.CheckedExplicitConversionName : WellKnownMemberNames.ExplicitConversionName) : WellKnownMemberNames.ImplicitConversionName);
+            var operators = ArrayBuilder<MethodSymbol>.GetInstance();
+            declaringType.AddOperators(
+                isExplicit ? (isChecked ? WellKnownMemberNames.CheckedExplicitConversionName : WellKnownMemberNames.ExplicitConversionName) : WellKnownMemberNames.ImplicitConversionName,
+                operators);
 
-            var candidates = ArrayBuilder<MethodSymbol>.GetInstance(operators.Length);
+            var candidates = ArrayBuilder<MethodSymbol>.GetInstance(operators.Count);
             candidates.AddRange(operators);
 
             if (isExplicit && isChecked)
             {
-                ImmutableArray<MethodSymbol> operators2 = declaringType.GetOperators(WellKnownMemberNames.ExplicitConversionName);
+                var operators2 = ArrayBuilder<MethodSymbol>.GetInstance();
+                declaringType.AddOperators(WellKnownMemberNames.ExplicitConversionName, operators2);
 
                 // Add regular operators as well.
                 if (operators.IsEmpty)
@@ -254,6 +257,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
+
+                operators2.Free();
             }
 
             foreach (MethodSymbol op in candidates)
@@ -359,6 +364,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            operators.Free();
             candidates.Free();
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -286,7 +286,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
                 bool allowAnyTarget)
             {
-                foreach (MethodSymbol op in declaringType.GetOperators(WellKnownMemberNames.ImplicitConversionName))
+                var operators = ArrayBuilder<MethodSymbol>.GetInstance();
+                declaringType.AddOperators(WellKnownMemberNames.ImplicitConversionName, operators);
+
+                foreach (MethodSymbol op in operators)
                 {
                     // We might have a bad operator and be in an error recovery situation. Ignore it.
                     if (op.ReturnsVoid || op.ParameterCount != 1)
@@ -354,6 +357,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
+
+                operators.Free();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -958,7 +958,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             void getDeclaredOperators(TypeSymbol constrainedToTypeOpt, NamedTypeSymbol type, BinaryOperatorKind kind, string name, ArrayBuilder<BinaryOperatorSignature> operators)
             {
-                foreach (MethodSymbol op in type.GetOperators(name))
+                var typeOperators = ArrayBuilder<MethodSymbol>.GetInstance();
+                type.AddOperators(name, typeOperators);
+
+                foreach (MethodSymbol op in typeOperators)
                 {
                     // If we're in error recovery, we might have bad operators. Just ignore it.
                     if (op.ParameterCount != 2 || op.ReturnsVoid)
@@ -972,6 +975,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.UserDefined | kind, leftOperandType, rightOperandType, resultType, op, constrainedToTypeOpt));
                 }
+
+                typeOperators.Free();
             }
 
             void addLiftedOperators(TypeSymbol constrainedToTypeOpt, BinaryOperatorKind kind, ArrayBuilder<BinaryOperatorSignature> operators)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
@@ -514,7 +514,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             static void getDeclaredOperators(TypeSymbol constrainedToTypeOpt, NamedTypeSymbol type, UnaryOperatorKind kind, string name, ArrayBuilder<UnaryOperatorSignature> operators)
             {
-                foreach (MethodSymbol op in type.GetOperators(name))
+                var typeOperators = ArrayBuilder<MethodSymbol>.GetInstance();
+                type.AddOperators(name, typeOperators);
+
+                foreach (MethodSymbol op in typeOperators)
                 {
                     // If we're in error recovery, we might have bad operators. Just ignore it.
                     if (op.ParameterCount != 1 || op.ReturnsVoid)
@@ -527,6 +530,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     operators.Add(new UnaryOperatorSignature(UnaryOperatorKind.UserDefined | kind, operandType, resultType, op, constrainedToTypeOpt));
                 }
+
+                typeOperators.Free();
             }
 
             void addLiftedOperators(TypeSymbol constrainedToTypeOpt, UnaryOperatorKind kind, ArrayBuilder<UnaryOperatorSignature> operators)

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -204,17 +204,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #nullable disable
 
         /// <summary>
-        /// Get the operators for this type by their metadata name
+        /// Adds the operators for this type by their metadata name to <paramref name="operators"/>
         /// </summary>
-        internal ImmutableArray<MethodSymbol> GetOperators(string name)
+        internal void AddOperators(string name, ArrayBuilder<MethodSymbol> operators)
         {
             ImmutableArray<Symbol> candidates = GetSimpleNonTypeMembers(name);
             if (candidates.IsEmpty)
-            {
-                return ImmutableArray<MethodSymbol>.Empty;
-            }
+                return;
 
-            var operators = ArrayBuilder<MethodSymbol>.GetInstance(candidates.Length);
             foreach (var candidate in candidates)
             {
                 if (candidate is MethodSymbol { MethodKind: MethodKind.UserDefinedOperator or MethodKind.Conversion } method)
@@ -222,8 +219,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     operators.Add(method);
                 }
             }
-
-            return operators.ToImmutableAndFree();
         }
 
         /// <summary>


### PR DESCRIPTION
This method is internal and returned an ImmutableArray. Instead, modify the callers to pass in an ArrayBuilder, as all of them simply enumerate over the returned contents, and don't need to store or create an immutable array from the contents.

This shows up as about 1.5% of total allocations in the codeanalysis process in the scrolling speedometer test.

This feels familiar, so maybe I tried something against this code and didn't end up checking it in earlier, but I'm not really seeing any downside with proceeding here.

Test insertion (commit 1) started here: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10617892&view=results

*** relevant prior allocations from the scrolling speedometer ***
![image](https://github.com/user-attachments/assets/2bdedd6a-c2d6-40c7-95e3-ca55042b21bf) 