### PR TITLE
Set state of enumerator object to "after" during disposal

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
@@ -89,3 +89,32 @@ class C
     }
 }
 ```
+
+## Set state of enumerator object to "after" during disposal
+
+***Introduced in Visual Studio 2022 version 17.13***
+
+The state machine for enumerators incorrectly allowed resuming execution after the enumerator was disposed.  
+Now, `MoveNext()` on a disposed enumerator properly returns `false` without executing any more user code.
+
+```csharp
+var enumerator = C.GetEnumerator();
+
+Console.Write(enumerator.MoveNext()); // prints True
+Console.Write(enumerator.Current); // prints 1
+
+enumerator.Dispose();
+
+Console.Write(enumerator.MoveNext()); // now prints False
+
+class C
+{
+    public static IEnumerator<int> GetEnumerator()
+    {
+        yield return 1;
+        Console.Write("not executed after disposal")
+        yield return 2;
+    }
+}
+```
+

--- a/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
@@ -1,0 +1,37 @@
+# Breaking changes in Roslyn after .NET 9.0.100 through .NET 10.0.100
+
+This document lists known breaking changes in Roslyn after .NET 9 general release (.NET SDK version 9.0.100) through .NET 10 general release (.NET SDK version 10.0.100).
+
+## Set state of enumerator object to "after" during disposal
+
+***Introduced in Visual Studio 2022 version 17.13***
+
+The state machine for enumerators incorrectly allowed resuming execution after the enumerator was disposed.  
+Now, `MoveNext()` on a disposed enumerator properly returns `false` without executing any more user code.
+
+```vb
+Imports System
+Imports System.Collections.Generic
+
+Module Program
+    Sub Main()
+        Dim enumerator = C.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext()) ' prints True
+        Console.Write(enumerator.Current)    ' prints 1
+
+        enumerator.Dispose()
+
+        Console.Write(enumerator.MoveNext()) ' now prints False
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function GetEnumerator() As IEnumerator(Of Integer)
+        Yield 1
+        Console.Write("not executed after disposal")
+        Yield 2
+    End Function
+End Class
+```
+

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -158,11 +158,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             F.CurrentFunction = disposeMethod;
             var rootFrame = _currentFinallyFrame;
 
+            // TODO2
             if (rootFrame.knownStates == null)
             {
                 // nothing to finalize
                 var disposeBody = F.Block(
                                     GenerateAllHoistedLocalsCleanup(),
+                                    F.Assignment(F.Field(F.This(), stateField), F.Literal(StateMachineState.FinishedState)),
                                     F.Return());
 
                 F.CloseMethod(disposeBody);
@@ -177,6 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     F.Assignment(F.Local(stateLocal), F.Field(F.This(), stateField)),
                                     EmitFinallyFrame(rootFrame, state),
                                     GenerateAllHoistedLocalsCleanup(),
+                                    //F.Assignment(F.Field(F.This(), stateField), F.Literal(StateMachineState.FinishedState)),
                                     F.Return());
 
                 F.CloseMethod(disposeBody);
@@ -287,6 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override BoundStatement GenerateReturn(bool finished)
         {
+            // TODO2
             BoundLiteral result = this.F.Literal(!finished);
 
             if (_tryNestingLevel == 0)

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -158,7 +158,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             F.CurrentFunction = disposeMethod;
             var rootFrame = _currentFinallyFrame;
 
-            // TODO2
             if (rootFrame.knownStates == null)
             {
                 // nothing to finalize
@@ -179,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     F.Assignment(F.Local(stateLocal), F.Field(F.This(), stateField)),
                                     EmitFinallyFrame(rootFrame, state),
                                     GenerateAllHoistedLocalsCleanup(),
-                                    //F.Assignment(F.Field(F.This(), stateField), F.Literal(StateMachineState.FinishedState)),
+                                    F.Assignment(F.Field(F.This(), stateField), F.Literal(StateMachineState.FinishedState)),
                                     F.Return());
 
                 F.CloseMethod(disposeBody);
@@ -290,7 +289,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override BoundStatement GenerateReturn(bool finished)
         {
-            // TODO2
             BoundLiteral result = this.F.Literal(!finished);
 
             if (_tryNestingLevel == 0)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
@@ -7568,7 +7568,7 @@ public class Program
 } // end of class Program");
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.Iterator)]
         public void YieldReturnCorrectDisplayClasseAreCreated()
         {
             var source =
@@ -7604,416 +7604,419 @@ public class C {
 
             VerifyTypeIL(compilation, "C", @"
 .class public auto ansi beforefieldinit C
-	extends [mscorlib]System.Object
+    extends [mscorlib]System.Object
 {
-	// Nested Types
-	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public int32 a
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2059
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c__DisplayClass0_0'::.ctor
-	} // end of class <>c__DisplayClass0_0
-	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_1'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public int32 b
-		.field public int32 c
-		.field public class C/'<>c__DisplayClass0_0' 'CS$<>8__locals1'
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2059
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c__DisplayClass0_1'::.ctor
-	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_2'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public int32 d
-		.field public class C/'<>c__DisplayClass0_1' 'CS$<>8__locals2'
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2059
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c__DisplayClass0_2'::.ctor
-		.method assembly hidebysig 
-			instance void '<M>b__0' () cil managed 
-		{
-			// Method begins at RVA 0x2061
-			// Code size 53 (0x35)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
-			IL_0006: ldfld class C/'<>c__DisplayClass0_0' C/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
-			IL_000b: ldfld int32 C/'<>c__DisplayClass0_0'::a
-			IL_0010: ldarg.0
-			IL_0011: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
-			IL_0016: ldfld int32 C/'<>c__DisplayClass0_1'::b
-			IL_001b: add
-			IL_001c: ldarg.0
-			IL_001d: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
-			IL_0022: ldfld int32 C/'<>c__DisplayClass0_1'::c
-			IL_0027: add
-			IL_0028: ldarg.0
-			IL_0029: ldfld int32 C/'<>c__DisplayClass0_2'::d
-			IL_002e: add
-			IL_002f: call void [mscorlib]System.Console::WriteLine(int32)
-			IL_0034: ret
-		} // end of method '<>c__DisplayClass0_2'::'<M>b__0'
-	} // end of class <>c__DisplayClass0_2
-	.class nested private auto ansi sealed beforefieldinit '<M>d__0'
-		extends [mscorlib]System.Object
-		implements class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,
-		           [mscorlib]System.Collections.IEnumerable,
-		           class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
-		           [mscorlib]System.IDisposable,
-		           [mscorlib]System.Collections.IEnumerator
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field private int32 '<>1__state'
-		.field private int32 '<>2__current'
-		.field private int32 '<>l__initialThreadId'
-		.field private class C/'<>c__DisplayClass0_0' '<>8__1'
-		.field private class C/'<>c__DisplayClass0_1' '<>8__2'
-		.field private class C/'<>c__DisplayClass0_2' '<>8__3'
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor (
-				int32 '<>1__state'
-			) cil managed 
-		{
-			.custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-				01 00 00 00
-			)
-			// Method begins at RVA 0x2097
-			// Code size 25 (0x19)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldarg.1
-			IL_0008: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_000d: ldarg.0
-			IL_000e: call int32 [mscorlib]System.Environment::get_CurrentManagedThreadId()
-			IL_0013: stfld int32 C/'<M>d__0'::'<>l__initialThreadId'
-			IL_0018: ret
-		} // end of method '<M>d__0'::.ctor
-		.method private final hidebysig newslot virtual 
-			instance void System.IDisposable.Dispose () cil managed 
-		{
-			.custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-				01 00 00 00
-			)
-			.override method instance void [mscorlib]System.IDisposable::Dispose()
-			// Method begins at RVA 0x20b1
-			// Code size 22 (0x16)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: ldnull
-			IL_0002: stfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
-			IL_0007: ldarg.0
-			IL_0008: ldnull
-			IL_0009: stfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
-			IL_000e: ldarg.0
-			IL_000f: ldnull
-			IL_0010: stfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
-			IL_0015: ret
-		} // end of method '<M>d__0'::System.IDisposable.Dispose
-		.method private final hidebysig newslot virtual 
-			instance bool MoveNext () cil managed 
-		{
-			.override method instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-			// Method begins at RVA 0x20c8
-			// Code size 342 (0x156)
-			.maxstack 2
-			.locals init (
-				[0] int32
-			)
-			IL_0000: ldarg.0
-			IL_0001: ldfld int32 C/'<M>d__0'::'<>1__state'
-			IL_0006: stloc.0
-			IL_0007: ldloc.0
-			IL_0008: switch (IL_002f, IL_005d, IL_0090, IL_00b3, IL_00ca, IL_00ed, IL_0120, IL_0135)
-			IL_002d: ldc.i4.0
-			IL_002e: ret
-			IL_002f: ldarg.0
-			IL_0030: ldc.i4.m1
-			IL_0031: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_0036: ldarg.0
-			IL_0037: newobj instance void C/'<>c__DisplayClass0_0'::.ctor()
-			IL_003c: stfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
-			IL_0041: ldarg.0
-			IL_0042: ldfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
-			IL_0047: ldc.i4.1
-			IL_0048: stfld int32 C/'<>c__DisplayClass0_0'::a
-			IL_004d: ldarg.0
-			IL_004e: ldc.i4.1
-			IL_004f: stfld int32 C/'<M>d__0'::'<>2__current'
-			IL_0054: ldarg.0
-			IL_0055: ldc.i4.1
-			IL_0056: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_005b: ldc.i4.1
-			IL_005c: ret
-			IL_005d: ldarg.0
-			IL_005e: ldc.i4.m1
-			IL_005f: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_0064: ldarg.0
-			IL_0065: newobj instance void C/'<>c__DisplayClass0_1'::.ctor()
-			IL_006a: stfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
-			IL_006f: ldarg.0
-			IL_0070: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
-			IL_0075: ldarg.0
-			IL_0076: ldfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
-			IL_007b: stfld class C/'<>c__DisplayClass0_0' C/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
-			IL_0080: ldarg.0
-			IL_0081: ldc.i4.2
-			IL_0082: stfld int32 C/'<M>d__0'::'<>2__current'
-			IL_0087: ldarg.0
-			IL_0088: ldc.i4.2
-			IL_0089: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_008e: ldc.i4.1
-			IL_008f: ret
-			IL_0090: ldarg.0
-			IL_0091: ldc.i4.m1
-			IL_0092: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_0097: ldarg.0
-			IL_0098: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
-			IL_009d: ldc.i4.2
-			IL_009e: stfld int32 C/'<>c__DisplayClass0_1'::b
-			IL_00a3: ldarg.0
-			IL_00a4: ldc.i4.3
-			IL_00a5: stfld int32 C/'<M>d__0'::'<>2__current'
-			IL_00aa: ldarg.0
-			IL_00ab: ldc.i4.3
-			IL_00ac: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_00b1: ldc.i4.1
-			IL_00b2: ret
-			IL_00b3: ldarg.0
-			IL_00b4: ldc.i4.m1
-			IL_00b5: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_00ba: ldarg.0
-			IL_00bb: ldc.i4.4
-			IL_00bc: stfld int32 C/'<M>d__0'::'<>2__current'
-			IL_00c1: ldarg.0
-			IL_00c2: ldc.i4.4
-			IL_00c3: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_00c8: ldc.i4.1
-			IL_00c9: ret
-			IL_00ca: ldarg.0
-			IL_00cb: ldc.i4.m1
-			IL_00cc: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_00d1: ldarg.0
-			IL_00d2: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
-			IL_00d7: ldc.i4.3
-			IL_00d8: stfld int32 C/'<>c__DisplayClass0_1'::c
-			IL_00dd: ldarg.0
-			IL_00de: ldc.i4.5
-			IL_00df: stfld int32 C/'<M>d__0'::'<>2__current'
-			IL_00e4: ldarg.0
-			IL_00e5: ldc.i4.5
-			IL_00e6: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_00eb: ldc.i4.1
-			IL_00ec: ret
-			IL_00ed: ldarg.0
-			IL_00ee: ldc.i4.m1
-			IL_00ef: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_00f4: ldarg.0
-			IL_00f5: newobj instance void C/'<>c__DisplayClass0_2'::.ctor()
-			IL_00fa: stfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
-			IL_00ff: ldarg.0
-			IL_0100: ldfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
-			IL_0105: ldarg.0
-			IL_0106: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
-			IL_010b: stfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
-			IL_0110: ldarg.0
-			IL_0111: ldc.i4.6
-			IL_0112: stfld int32 C/'<M>d__0'::'<>2__current'
-			IL_0117: ldarg.0
-			IL_0118: ldc.i4.6
-			IL_0119: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_011e: ldc.i4.1
-			IL_011f: ret
-			IL_0120: ldarg.0
-			IL_0121: ldc.i4.m1
-			IL_0122: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_0127: ldarg.0
-			IL_0128: ldfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
-			IL_012d: ldc.i4.4
-			IL_012e: stfld int32 C/'<>c__DisplayClass0_2'::d
-			IL_0133: br.s IL_00dd
-			IL_0135: ldarg.0
-			IL_0136: ldc.i4.m1
-			IL_0137: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_013c: ldarg.0
-			IL_013d: ldfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
-			IL_0142: pop
-			IL_0143: ldarg.0
-			IL_0144: ldnull
-			IL_0145: stfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
-			IL_014a: ldarg.0
-			IL_014b: ldnull
-			IL_014c: stfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
-			IL_0151: br IL_0064
-		} // end of method '<M>d__0'::MoveNext
-		.method private final hidebysig specialname newslot virtual 
-			instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.get_Current' () cil managed 
-		{
-			.custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-				01 00 00 00
-			)
-			.override method instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-			// Method begins at RVA 0x222a
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: ldfld int32 C/'<M>d__0'::'<>2__current'
-			IL_0006: ret
-		} // end of method '<M>d__0'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'
-		.method private final hidebysig newslot virtual 
-			instance void System.Collections.IEnumerator.Reset () cil managed 
-		{
-			.custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-				01 00 00 00
-			)
-			.override method instance void [mscorlib]System.Collections.IEnumerator::Reset()
-			// Method begins at RVA 0x2232
-			// Code size 6 (0x6)
-			.maxstack 8
-			IL_0000: newobj instance void [mscorlib]System.NotSupportedException::.ctor()
-			IL_0005: throw
-		} // end of method '<M>d__0'::System.Collections.IEnumerator.Reset
-		.method private final hidebysig specialname newslot virtual 
-			instance object System.Collections.IEnumerator.get_Current () cil managed 
-		{
-			.custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-				01 00 00 00
-			)
-			.override method instance object [mscorlib]System.Collections.IEnumerator::get_Current()
-			// Method begins at RVA 0x2239
-			// Code size 12 (0xc)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: ldfld int32 C/'<M>d__0'::'<>2__current'
-			IL_0006: box [mscorlib]System.Int32
-			IL_000b: ret
-		} // end of method '<M>d__0'::System.Collections.IEnumerator.get_Current
-		.method private final hidebysig newslot virtual 
-			instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> 'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator' () cil managed 
-		{
-			.custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-				01 00 00 00
-			)
-			.override method instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-			// Method begins at RVA 0x2248
-			// Code size 43 (0x2b)
-			.maxstack 2
-			.locals init (
-				[0] class C/'<M>d__0'
-			)
-			IL_0000: ldarg.0
-			IL_0001: ldfld int32 C/'<M>d__0'::'<>1__state'
-			IL_0006: ldc.i4.s -2
-			IL_0008: bne.un.s IL_0022
-			IL_000a: ldarg.0
-			IL_000b: ldfld int32 C/'<M>d__0'::'<>l__initialThreadId'
-			IL_0010: call int32 [mscorlib]System.Environment::get_CurrentManagedThreadId()
-			IL_0015: bne.un.s IL_0022
-			IL_0017: ldarg.0
-			IL_0018: ldc.i4.0
-			IL_0019: stfld int32 C/'<M>d__0'::'<>1__state'
-			IL_001e: ldarg.0
-			IL_001f: stloc.0
-			IL_0020: br.s IL_0029
-			IL_0022: ldc.i4.0
-			IL_0023: newobj instance void C/'<M>d__0'::.ctor(int32)
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: ret
-		} // end of method '<M>d__0'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'
-		.method private final hidebysig newslot virtual 
-			instance class [mscorlib]System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator () cil managed 
-		{
-			.custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-				01 00 00 00
-			)
-			.override method instance class [mscorlib]System.Collections.IEnumerator [mscorlib]System.Collections.IEnumerable::GetEnumerator()
-			// Method begins at RVA 0x227f
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> C/'<M>d__0'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'()
-			IL_0006: ret
-		} // end of method '<M>d__0'::System.Collections.IEnumerable.GetEnumerator
-		// Properties
-		.property instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.Current'()
-		{
-			.get instance int32 C/'<M>d__0'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'()
-		}
-		.property instance object System.Collections.IEnumerator.Current()
-		{
-			.get instance object C/'<M>d__0'::System.Collections.IEnumerator.get_Current()
-		}
-	} // end of class <M>d__0
-	// Methods
-	.method public hidebysig 
-		instance class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> M () cil managed 
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(class [mscorlib]System.Type) = (
-			01 00 09 43 2b 3c 4d 3e 64 5f 5f 30 00 00
-		)
-		// Method begins at RVA 0x2050
-		// Code size 8 (0x8)
-		.maxstack 8
-		IL_0000: ldc.i4.s -2
-		IL_0002: newobj instance void C/'<M>d__0'::.ctor(int32)
-		IL_0007: ret
-	} // end of method C::M
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2059
-		// Code size 7 (0x7)
-		.maxstack 8
-		IL_0000: ldarg.0
-		IL_0001: call instance void [mscorlib]System.Object::.ctor()
-		IL_0006: ret
-	} // end of method C::.ctor
+    // Nested Types
+    .class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
+        extends [mscorlib]System.Object
+    {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+            01 00 00 00
+        )
+        // Fields
+        .field public int32 a
+        // Methods
+        .method public hidebysig specialname rtspecialname 
+            instance void .ctor () cil managed 
+        {
+            // Method begins at RVA 0x2059
+            // Code size 7 (0x7)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: call instance void [mscorlib]System.Object::.ctor()
+            IL_0006: ret
+        } // end of method '<>c__DisplayClass0_0'::.ctor
+    } // end of class <>c__DisplayClass0_0
+    .class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_1'
+        extends [mscorlib]System.Object
+    {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+            01 00 00 00
+        )
+        // Fields
+        .field public int32 b
+        .field public int32 c
+        .field public class C/'<>c__DisplayClass0_0' 'CS$<>8__locals1'
+        // Methods
+        .method public hidebysig specialname rtspecialname 
+            instance void .ctor () cil managed 
+        {
+            // Method begins at RVA 0x2059
+            // Code size 7 (0x7)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: call instance void [mscorlib]System.Object::.ctor()
+            IL_0006: ret
+        } // end of method '<>c__DisplayClass0_1'::.ctor
+    } // end of class <>c__DisplayClass0_1
+    .class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_2'
+        extends [mscorlib]System.Object
+    {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+            01 00 00 00
+        )
+        // Fields
+        .field public int32 d
+        .field public class C/'<>c__DisplayClass0_1' 'CS$<>8__locals2'
+        // Methods
+        .method public hidebysig specialname rtspecialname 
+            instance void .ctor () cil managed 
+        {
+            // Method begins at RVA 0x2059
+            // Code size 7 (0x7)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: call instance void [mscorlib]System.Object::.ctor()
+            IL_0006: ret
+        } // end of method '<>c__DisplayClass0_2'::.ctor
+        .method assembly hidebysig 
+            instance void '<M>b__0' () cil managed 
+        {
+            // Method begins at RVA 0x2061
+            // Code size 53 (0x35)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
+            IL_0006: ldfld class C/'<>c__DisplayClass0_0' C/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
+            IL_000b: ldfld int32 C/'<>c__DisplayClass0_0'::a
+            IL_0010: ldarg.0
+            IL_0011: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
+            IL_0016: ldfld int32 C/'<>c__DisplayClass0_1'::b
+            IL_001b: add
+            IL_001c: ldarg.0
+            IL_001d: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
+            IL_0022: ldfld int32 C/'<>c__DisplayClass0_1'::c
+            IL_0027: add
+            IL_0028: ldarg.0
+            IL_0029: ldfld int32 C/'<>c__DisplayClass0_2'::d
+            IL_002e: add
+            IL_002f: call void [mscorlib]System.Console::WriteLine(int32)
+            IL_0034: ret
+        } // end of method '<>c__DisplayClass0_2'::'<M>b__0'
+    } // end of class <>c__DisplayClass0_2
+    .class nested private auto ansi sealed beforefieldinit '<M>d__0'
+        extends [mscorlib]System.Object
+        implements class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,
+                   [mscorlib]System.Collections.IEnumerable,
+                   class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
+                   [mscorlib]System.IDisposable,
+                   [mscorlib]System.Collections.IEnumerator
+    {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+            01 00 00 00
+        )
+        // Fields
+        .field private int32 '<>1__state'
+        .field private int32 '<>2__current'
+        .field private int32 '<>l__initialThreadId'
+        .field private class C/'<>c__DisplayClass0_0' '<>8__1'
+        .field private class C/'<>c__DisplayClass0_1' '<>8__2'
+        .field private class C/'<>c__DisplayClass0_2' '<>8__3'
+        // Methods
+        .method public hidebysig specialname rtspecialname 
+            instance void .ctor (
+                int32 '<>1__state'
+            ) cil managed 
+        {
+            .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+                01 00 00 00
+            )
+            // Method begins at RVA 0x2097
+            // Code size 25 (0x19)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: call instance void [mscorlib]System.Object::.ctor()
+            IL_0006: ldarg.0
+            IL_0007: ldarg.1
+            IL_0008: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_000d: ldarg.0
+            IL_000e: call int32 [mscorlib]System.Environment::get_CurrentManagedThreadId()
+            IL_0013: stfld int32 C/'<M>d__0'::'<>l__initialThreadId'
+            IL_0018: ret
+        } // end of method '<M>d__0'::.ctor
+        .method private final hidebysig newslot virtual 
+            instance void System.IDisposable.Dispose () cil managed 
+        {
+            .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+                01 00 00 00
+            )
+            .override method instance void [mscorlib]System.IDisposable::Dispose()
+            // Method begins at RVA 0x20b1
+            // Code size 30 (0x1e)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: ldnull
+            IL_0002: stfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
+            IL_0007: ldarg.0
+            IL_0008: ldnull
+            IL_0009: stfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
+            IL_000e: ldarg.0
+            IL_000f: ldnull
+            IL_0010: stfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
+            IL_0015: ldarg.0
+            IL_0016: ldc.i4.s -2
+            IL_0018: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_001d: ret
+        } // end of method '<M>d__0'::System.IDisposable.Dispose
+        .method private final hidebysig newslot virtual 
+            instance bool MoveNext () cil managed 
+        {
+            .override method instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+            // Method begins at RVA 0x20d0
+            // Code size 342 (0x156)
+            .maxstack 2
+            .locals init (
+                [0] int32
+            )
+            IL_0000: ldarg.0
+            IL_0001: ldfld int32 C/'<M>d__0'::'<>1__state'
+            IL_0006: stloc.0
+            IL_0007: ldloc.0
+            IL_0008: switch (IL_002f, IL_005d, IL_0090, IL_00b3, IL_00ca, IL_00ed, IL_0120, IL_0135)
+            IL_002d: ldc.i4.0
+            IL_002e: ret
+            IL_002f: ldarg.0
+            IL_0030: ldc.i4.m1
+            IL_0031: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_0036: ldarg.0
+            IL_0037: newobj instance void C/'<>c__DisplayClass0_0'::.ctor()
+            IL_003c: stfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
+            IL_0041: ldarg.0
+            IL_0042: ldfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
+            IL_0047: ldc.i4.1
+            IL_0048: stfld int32 C/'<>c__DisplayClass0_0'::a
+            IL_004d: ldarg.0
+            IL_004e: ldc.i4.1
+            IL_004f: stfld int32 C/'<M>d__0'::'<>2__current'
+            IL_0054: ldarg.0
+            IL_0055: ldc.i4.1
+            IL_0056: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_005b: ldc.i4.1
+            IL_005c: ret
+            IL_005d: ldarg.0
+            IL_005e: ldc.i4.m1
+            IL_005f: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_0064: ldarg.0
+            IL_0065: newobj instance void C/'<>c__DisplayClass0_1'::.ctor()
+            IL_006a: stfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
+            IL_006f: ldarg.0
+            IL_0070: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
+            IL_0075: ldarg.0
+            IL_0076: ldfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
+            IL_007b: stfld class C/'<>c__DisplayClass0_0' C/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
+            IL_0080: ldarg.0
+            IL_0081: ldc.i4.2
+            IL_0082: stfld int32 C/'<M>d__0'::'<>2__current'
+            IL_0087: ldarg.0
+            IL_0088: ldc.i4.2
+            IL_0089: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_008e: ldc.i4.1
+            IL_008f: ret
+            IL_0090: ldarg.0
+            IL_0091: ldc.i4.m1
+            IL_0092: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_0097: ldarg.0
+            IL_0098: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
+            IL_009d: ldc.i4.2
+            IL_009e: stfld int32 C/'<>c__DisplayClass0_1'::b
+            IL_00a3: ldarg.0
+            IL_00a4: ldc.i4.3
+            IL_00a5: stfld int32 C/'<M>d__0'::'<>2__current'
+            IL_00aa: ldarg.0
+            IL_00ab: ldc.i4.3
+            IL_00ac: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_00b1: ldc.i4.1
+            IL_00b2: ret
+            IL_00b3: ldarg.0
+            IL_00b4: ldc.i4.m1
+            IL_00b5: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_00ba: ldarg.0
+            IL_00bb: ldc.i4.4
+            IL_00bc: stfld int32 C/'<M>d__0'::'<>2__current'
+            IL_00c1: ldarg.0
+            IL_00c2: ldc.i4.4
+            IL_00c3: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_00c8: ldc.i4.1
+            IL_00c9: ret
+            IL_00ca: ldarg.0
+            IL_00cb: ldc.i4.m1
+            IL_00cc: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_00d1: ldarg.0
+            IL_00d2: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
+            IL_00d7: ldc.i4.3
+            IL_00d8: stfld int32 C/'<>c__DisplayClass0_1'::c
+            IL_00dd: ldarg.0
+            IL_00de: ldc.i4.5
+            IL_00df: stfld int32 C/'<M>d__0'::'<>2__current'
+            IL_00e4: ldarg.0
+            IL_00e5: ldc.i4.5
+            IL_00e6: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_00eb: ldc.i4.1
+            IL_00ec: ret
+            IL_00ed: ldarg.0
+            IL_00ee: ldc.i4.m1
+            IL_00ef: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_00f4: ldarg.0
+            IL_00f5: newobj instance void C/'<>c__DisplayClass0_2'::.ctor()
+            IL_00fa: stfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
+            IL_00ff: ldarg.0
+            IL_0100: ldfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
+            IL_0105: ldarg.0
+            IL_0106: ldfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
+            IL_010b: stfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
+            IL_0110: ldarg.0
+            IL_0111: ldc.i4.6
+            IL_0112: stfld int32 C/'<M>d__0'::'<>2__current'
+            IL_0117: ldarg.0
+            IL_0118: ldc.i4.6
+            IL_0119: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_011e: ldc.i4.1
+            IL_011f: ret
+            IL_0120: ldarg.0
+            IL_0121: ldc.i4.m1
+            IL_0122: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_0127: ldarg.0
+            IL_0128: ldfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
+            IL_012d: ldc.i4.4
+            IL_012e: stfld int32 C/'<>c__DisplayClass0_2'::d
+            IL_0133: br.s IL_00dd
+            IL_0135: ldarg.0
+            IL_0136: ldc.i4.m1
+            IL_0137: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_013c: ldarg.0
+            IL_013d: ldfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
+            IL_0142: pop
+            IL_0143: ldarg.0
+            IL_0144: ldnull
+            IL_0145: stfld class C/'<>c__DisplayClass0_2' C/'<M>d__0'::'<>8__3'
+            IL_014a: ldarg.0
+            IL_014b: ldnull
+            IL_014c: stfld class C/'<>c__DisplayClass0_1' C/'<M>d__0'::'<>8__2'
+            IL_0151: br IL_0064
+        } // end of method '<M>d__0'::MoveNext
+        .method private final hidebysig specialname newslot virtual 
+            instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.get_Current' () cil managed 
+        {
+            .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+                01 00 00 00
+            )
+            .override method instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+            // Method begins at RVA 0x2232
+            // Code size 7 (0x7)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: ldfld int32 C/'<M>d__0'::'<>2__current'
+            IL_0006: ret
+        } // end of method '<M>d__0'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'
+        .method private final hidebysig newslot virtual 
+            instance void System.Collections.IEnumerator.Reset () cil managed 
+        {
+            .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+                01 00 00 00
+            )
+            .override method instance void [mscorlib]System.Collections.IEnumerator::Reset()
+            // Method begins at RVA 0x223a
+            // Code size 6 (0x6)
+            .maxstack 8
+            IL_0000: newobj instance void [mscorlib]System.NotSupportedException::.ctor()
+            IL_0005: throw
+        } // end of method '<M>d__0'::System.Collections.IEnumerator.Reset
+        .method private final hidebysig specialname newslot virtual 
+            instance object System.Collections.IEnumerator.get_Current () cil managed 
+        {
+            .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+                01 00 00 00
+            )
+            .override method instance object [mscorlib]System.Collections.IEnumerator::get_Current()
+            // Method begins at RVA 0x2241
+            // Code size 12 (0xc)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: ldfld int32 C/'<M>d__0'::'<>2__current'
+            IL_0006: box [mscorlib]System.Int32
+            IL_000b: ret
+        } // end of method '<M>d__0'::System.Collections.IEnumerator.get_Current
+        .method private final hidebysig newslot virtual 
+            instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> 'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator' () cil managed 
+        {
+            .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+                01 00 00 00
+            )
+            .override method instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+            // Method begins at RVA 0x2250
+            // Code size 43 (0x2b)
+            .maxstack 2
+            .locals init (
+                [0] class C/'<M>d__0'
+            )
+            IL_0000: ldarg.0
+            IL_0001: ldfld int32 C/'<M>d__0'::'<>1__state'
+            IL_0006: ldc.i4.s -2
+            IL_0008: bne.un.s IL_0022
+            IL_000a: ldarg.0
+            IL_000b: ldfld int32 C/'<M>d__0'::'<>l__initialThreadId'
+            IL_0010: call int32 [mscorlib]System.Environment::get_CurrentManagedThreadId()
+            IL_0015: bne.un.s IL_0022
+            IL_0017: ldarg.0
+            IL_0018: ldc.i4.0
+            IL_0019: stfld int32 C/'<M>d__0'::'<>1__state'
+            IL_001e: ldarg.0
+            IL_001f: stloc.0
+            IL_0020: br.s IL_0029
+            IL_0022: ldc.i4.0
+            IL_0023: newobj instance void C/'<M>d__0'::.ctor(int32)
+            IL_0028: stloc.0
+            IL_0029: ldloc.0
+            IL_002a: ret
+        } // end of method '<M>d__0'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'
+        .method private final hidebysig newslot virtual 
+            instance class [mscorlib]System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator () cil managed 
+        {
+            .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+                01 00 00 00
+            )
+            .override method instance class [mscorlib]System.Collections.IEnumerator [mscorlib]System.Collections.IEnumerable::GetEnumerator()
+            // Method begins at RVA 0x2287
+            // Code size 7 (0x7)
+            .maxstack 8
+            IL_0000: ldarg.0
+            IL_0001: call instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> C/'<M>d__0'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'()
+            IL_0006: ret
+        } // end of method '<M>d__0'::System.Collections.IEnumerable.GetEnumerator
+        // Properties
+        .property instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.Current'()
+        {
+            .get instance int32 C/'<M>d__0'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'()
+        }
+        .property instance object System.Collections.IEnumerator.Current()
+        {
+            .get instance object C/'<M>d__0'::System.Collections.IEnumerator.get_Current()
+        }
+    } // end of class <M>d__0
+    // Methods
+    .method public hidebysig 
+        instance class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> M () cil managed 
+    {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(class [mscorlib]System.Type) = (
+            01 00 09 43 2b 3c 4d 3e 64 5f 5f 30 00 00
+        )
+        // Method begins at RVA 0x2050
+        // Code size 8 (0x8)
+        .maxstack 8
+        IL_0000: ldc.i4.s -2
+        IL_0002: newobj instance void C/'<M>d__0'::.ctor(int32)
+        IL_0007: ret
+    } // end of method C::M
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor () cil managed 
+    {
+        // Method begins at RVA 0x2059
+        // Code size 7 (0x7)
+        .maxstack 8
+        IL_0000: ldarg.0
+        IL_0001: call instance void [mscorlib]System.Object::.ctor()
+        IL_0006: ret
+    } // end of method C::.ctor
 } // end of class C");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -3025,9 +3025,12 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "42 42").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -3058,12 +3061,15 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "ran ran True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "string C.<Produce>d__0.<values2>5__2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -3095,12 +3101,15 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "ran ran True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "string C.<Produce>d__0.<s>5__2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -3133,12 +3142,15 @@ class C
             var verifier = CompileAndVerify(comp, expectedOutput: "100 100 True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "int[] C.<Produce>d__0.<values2>5__2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -3186,12 +3198,15 @@ public class C
             var verifier = CompileAndVerify(src, expectedOutput: "42 value value True").VerifyDiagnostics();
             verifier.VerifyIL("C.<M>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "string C.<M>d__0.<s>5__2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<M>d__0.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -3239,12 +3254,15 @@ public class C
             var verifier = CompileAndVerify(src, expectedOutput: "42 value value True").VerifyDiagnostics();
             verifier.VerifyIL("C.<M>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "string C.<M>d__0.<s>5__2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<M>d__0.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -3314,9 +3332,12 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "42 4242").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -3344,9 +3365,12 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "value value value").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -3381,9 +3405,12 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "42 42").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -3418,10 +3445,13 @@ class C
 """;
             var verifier = CompileAndVerify(src, expectedOutput: "42").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__2.System.IDisposable.Dispose()", """
-{
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+ {
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<Produce>d__2.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -3680,9 +3710,12 @@ public class C
             var verifier = CompileAndVerify(src, expectedOutput: "10 42 42").VerifyDiagnostics();
             verifier.VerifyIL("C.<M>d__0<T>.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<M>d__0<T>.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -3739,9 +3772,12 @@ public class C
             var verifier = CompileAndVerify(src, expectedOutput: "10 42 42", references: [libComp.EmitToImageReference()]).VerifyDiagnostics();
             verifier.VerifyIL("C.<M>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<M>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -3856,12 +3892,15 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "values2 values2 values3 values3 True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "string C.<Produce>d__0.<values2>5__2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -3887,9 +3926,12 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "ran ran").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -4031,12 +4073,15 @@ public struct Buffer4<T>
             var verifier = CompileAndVerify(comp, expectedOutput: "FalseTrue", verify: Verification.Skipped).VerifyDiagnostics();
             verifier.VerifyIL("Program.<Test>d__1.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "C Program.<Test>d__1.<>7__wrap2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int Program.<Test>d__1.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -4070,12 +4115,15 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "ran ran True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        8 (0x8)
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      "string C.<Produce>d__0.<s>5__2"
-  IL_0007:  ret
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -4125,24 +4173,24 @@ class C
         public void AddVariableCleanup_StringLocal_MoveNextAfterDispose()
         {
             string src = """
-var values = new C<int>([42, 43]);
+var values = new C<string>([" one ", " two "]);
 var enumerator = values.GetEnumerator();
-assert(enumerator.MoveNext());
-assert(enumerator.Current == 43);
+System.Console.Write(enumerator.MoveNext());
+System.Console.Write(enumerator.Current);
 
+System.Console.Write("disposing ");
 enumerator.Dispose();
-System.Console.Write(" disposed ");
+System.Console.Write("disposed ");
 
-assert(!enumerator.MoveNext());
-
-static void assert(bool b) { if (!b) throw new System.Exception(); }
+System.Console.Write(enumerator.MoveNext());
+System.Console.Write(enumerator.Current);
 
 class C<T>
 {
     private sealed class Node
     {
-        internal readonly T _value; // Value of the node.
-        internal Node _next; // Next pointer.
+        internal readonly T _value;
+        internal Node _next;
 
         internal Node(T value)
         {
@@ -4174,8 +4222,6 @@ class C<T>
     private static System.Collections.Generic.IEnumerator<T> GetEnumerator(Node head)
     {
         Node current = head;
-        if (current is null) System.Console.Write(" empty ");
-
         while (current != null)
         {
             yield return current._value;
@@ -4185,16 +4231,68 @@ class C<T>
     }
 }
 """;
-            // TODO2 crash
-            var verifier = CompileAndVerify(src, expectedOutput: "ran ran True").VerifyDiagnostics();
-            verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
+            var verifier = CompileAndVerify(src, expectedOutput: "True two disposing disposed False two").VerifyDiagnostics();
+            verifier.VerifyIL("C<T>.<GetEnumerator>d__4.System.Collections.IEnumerator.MoveNext()", """
 {
-  // Code size        8 (0x8)
+  // Code size      107 (0x6b)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0010
+  IL_000a:  ldloc.0
+  IL_000b:  ldc.i4.1
+  IL_000c:  beq.s      IL_003f
+  IL_000e:  ldc.i4.0
+  IL_000f:  ret
+  IL_0010:  ldarg.0
+  IL_0011:  ldc.i4.m1
+  IL_0012:  stfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
+  IL_0017:  ldarg.0
+  IL_0018:  ldarg.0
+  IL_0019:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.head"
+  IL_001e:  stfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
+  IL_0023:  br.s       IL_0061
+  IL_0025:  ldarg.0
+  IL_0026:  ldarg.0
+  IL_0027:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
+  IL_002c:  ldfld      "T C<T>.Node._value"
+  IL_0031:  stfld      "T C<T>.<GetEnumerator>d__4.<>2__current"
+  IL_0036:  ldarg.0
+  IL_0037:  ldc.i4.1
+  IL_0038:  stfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
+  IL_003d:  ldc.i4.1
+  IL_003e:  ret
+  IL_003f:  ldarg.0
+  IL_0040:  ldc.i4.m1
+  IL_0041:  stfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
+  IL_0046:  ldarg.0
+  IL_0047:  ldarg.0
+  IL_0048:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
+  IL_004d:  ldfld      "C<T>.Node C<T>.Node._next"
+  IL_0052:  stfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
+  IL_0057:  ldstr      "AFTER"
+  IL_005c:  call       "void System.Console.Write(string)"
+  IL_0061:  ldarg.0
+  IL_0062:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
+  IL_0067:  brtrue.s   IL_0025
+  IL_0069:  ldc.i4.0
+  IL_006a:  ret
+}
+""");
+            verifier.VerifyIL("C<T>.<GetEnumerator>d__4.System.IDisposable.Dispose()", """
+{
+  // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
-  IL_0002:  stfld      "string C.<Produce>d__0.<values2>5__2"
-  IL_0007:  ret
+  IL_0002:  stfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
+  IL_000f:  ret
 }
 """);
         }
@@ -4225,19 +4323,144 @@ class C
     }
 }
 """;
-            CreateCompilation(src).VerifyEmitDiagnostics();
-            // TODO2 we incorrectly resume execution after disposal
-            var verifier = CompileAndVerify(src, expectedOutput: "True one disposed True two").VerifyDiagnostics();
+            var verifier = CompileAndVerify(src, expectedOutput: "True one disposed False one").VerifyDiagnostics();
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
 
-        // TODO2 document breaking change
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")]
+        public void StateAfterMoveNext_YieldReturn_IEnumerable()
+        {
+            // When a yield return statement is encountered ... The state of the enumerator object is changed to suspended.
+            // If the state of the enumerator object is suspended, invoking Dispose: ... Changes the state to after.
+            string src = """
+var enumerator = C.Produce().GetEnumerator();
+
+System.Console.Write(enumerator.MoveNext());
+System.Console.Write(enumerator.Current);
+
+enumerator.Dispose();
+System.Console.Write("disposed ");
+
+System.Console.Write(enumerator.MoveNext());
+System.Console.Write(enumerator.Current);
+
+class C
+{
+    public static System.Collections.Generic.IEnumerable<string> Produce()
+    {
+        yield return " one ";
+        yield return " two ";
+    }
+}
+""";
+            var verifier = CompileAndVerify(src, expectedOutput: "True one disposed False one").VerifyDiagnostics();
+            verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0008:  ret
+}
+""");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")]
+        public void StateAfterMoveNext_DisposeTwice()
+        {
+            // If the state of the enumerator object is after, invoking Dispose has no affect.
+            string src = """
+var enumerator = C.GetEnumerator();
+
+System.Console.Write(enumerator.MoveNext());
+System.Console.Write(enumerator.Current);
+
+enumerator.Dispose();
+System.Console.Write("disposed ");
+
+enumerator.Dispose();
+System.Console.Write("disposed2 ");
+
+System.Console.Write(enumerator.MoveNext());
+System.Console.Write(enumerator.Current);
+
+class C
+{
+    public static System.Collections.Generic.IEnumerator<string> GetEnumerator()
+    {
+        string local = "";
+        yield return " one ";
+        local.ToString();
+    }
+}
+""";
+            // Note: we actually set the state to "after"/"finished" and cleanup hoisted locals again
+            var verifier = CompileAndVerify(src, expectedOutput: "True one disposed disposed2 False one").VerifyDiagnostics();
+            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
+{
+  // Code size       75 (0x4b)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0010
+  IL_000a:  ldloc.0
+  IL_000b:  ldc.i4.1
+  IL_000c:  beq.s      IL_0036
+  IL_000e:  ldc.i4.0
+  IL_000f:  ret
+  IL_0010:  ldarg.0
+  IL_0011:  ldc.i4.m1
+  IL_0012:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0017:  ldarg.0
+  IL_0018:  ldstr      ""
+  IL_001d:  stfld      "string C.<GetEnumerator>d__0.<local>5__2"
+  IL_0022:  ldarg.0
+  IL_0023:  ldstr      " one "
+  IL_0028:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
+  IL_002d:  ldarg.0
+  IL_002e:  ldc.i4.1
+  IL_002f:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0034:  ldc.i4.1
+  IL_0035:  ret
+  IL_0036:  ldarg.0
+  IL_0037:  ldc.i4.m1
+  IL_0038:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_003d:  ldarg.0
+  IL_003e:  ldfld      "string C.<GetEnumerator>d__0.<local>5__2"
+  IL_0043:  callvirt   "string object.ToString()"
+  IL_0048:  pop
+  IL_0049:  ldc.i4.0
+  IL_004a:  ret
+}
+""");
+            verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
+{
+  // Code size       16 (0x10)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldnull
+  IL_0002:  stfld      "string C.<GetEnumerator>d__0.<local>5__2"
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.s   -2
+  IL_000a:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_000f:  ret
+}
+""");
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")]
         public void StateAfterMoveNext_YieldBreak()
         {
@@ -4318,9 +4541,12 @@ class C
 
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -4390,9 +4616,12 @@ class C
 
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -4469,9 +4698,12 @@ class C
 
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -4657,9 +4889,12 @@ class C
 
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }
@@ -4688,6 +4923,11 @@ System.Console.Write(enumerator.Current);
 System.Console.Write(enumerator.MoveNext());
 System.Console.Write(enumerator.Current);
 
+enumerator.Dispose();
+
+System.Console.Write(enumerator.MoveNext());
+System.Console.Write(enumerator.Current);
+
 class C
 {
     public static System.Collections.Generic.IEnumerator<string> GetEnumerator(bool b)
@@ -4705,7 +4945,7 @@ class C
 }
 """;
             // We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
-            var verifier = CompileAndVerify(src, expectedOutput: "True one finally exception one False one").VerifyDiagnostics();
+            var verifier = CompileAndVerify(src, expectedOutput: "True one finally exception one False one False one").VerifyDiagnostics();
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
 {
   // Code size       72 (0x48)
@@ -4752,9 +4992,12 @@ class C
 
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0008:  ret
 }
 """);
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
+    [CompilerTrait(CompilerFeature.Iterator)]
     public class CodeGenIterators : CSharpTestBase
     {
         [Fact]
@@ -4808,6 +4809,9 @@ catch (System.Exception)
     System.Console.Write(object.ReferenceEquals(enumerable, enumerable.GetEnumerator()));
 }
 
+enumerator.Dispose();
+System.Console.Write(object.ReferenceEquals(enumerable, enumerable.GetEnumerator()));
+
 class C
 {
     public static System.Collections.Generic.IEnumerable<int> Produce()
@@ -4819,7 +4823,7 @@ class C
 """;
             // We're not setting the state to "after"/"finished"
             // Tracked by https://github.com/dotnet/roslyn/issues/76089
-            CompileAndVerify(src2, expectedOutput: "TrueTrueFalse").VerifyDiagnostics();
+            CompileAndVerify(src2, expectedOutput: "TrueTrueFalseTrue").VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -4245,56 +4245,6 @@ class C<T>
 }
 """;
             var verifier = CompileAndVerify(src, expectedOutput: "True two disposing disposed False two").VerifyDiagnostics();
-            verifier.VerifyIL("C<T>.<GetEnumerator>d__4.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size      107 (0x6b)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_003f
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  stfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
-  IL_0017:  ldarg.0
-  IL_0018:  ldarg.0
-  IL_0019:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.head"
-  IL_001e:  stfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
-  IL_0023:  br.s       IL_0061
-  IL_0025:  ldarg.0
-  IL_0026:  ldarg.0
-  IL_0027:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
-  IL_002c:  ldfld      "T C<T>.Node._value"
-  IL_0031:  stfld      "T C<T>.<GetEnumerator>d__4.<>2__current"
-  IL_0036:  ldarg.0
-  IL_0037:  ldc.i4.1
-  IL_0038:  stfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
-  IL_003d:  ldc.i4.1
-  IL_003e:  ret
-  IL_003f:  ldarg.0
-  IL_0040:  ldc.i4.m1
-  IL_0041:  stfld      "int C<T>.<GetEnumerator>d__4.<>1__state"
-  IL_0046:  ldarg.0
-  IL_0047:  ldarg.0
-  IL_0048:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
-  IL_004d:  ldfld      "C<T>.Node C<T>.Node._next"
-  IL_0052:  stfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
-  IL_0057:  ldstr      "AFTER"
-  IL_005c:  call       "void System.Console.Write(string)"
-  IL_0061:  ldarg.0
-  IL_0062:  ldfld      "C<T>.Node C<T>.<GetEnumerator>d__4.<current>5__2"
-  IL_0067:  brtrue.s   IL_0025
-  IL_0069:  ldc.i4.0
-  IL_006a:  ret
-}
-""");
             verifier.VerifyIL("C<T>.<GetEnumerator>d__4.System.IDisposable.Dispose()", """
 {
   // Code size       16 (0x10)
@@ -4375,17 +4325,8 @@ class C
     }
 }
 """;
-            var verifier = CompileAndVerify(src, expectedOutput: "True one disposed False one").VerifyDiagnostics();
-            verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      "int C.<Produce>d__0.<>1__state"
-  IL_0008:  ret
-}
-""");
+            CompileAndVerify(src, expectedOutput: "True one disposed False one").VerifyDiagnostics();
+
             // Verify GetEnumerator
             string src2 = """
 var enumerable = C.Produce();
@@ -4449,46 +4390,6 @@ class C
 """;
             // Note: we actually set the state to "after"/"finished" and cleanup hoisted locals again
             var verifier = CompileAndVerify(src, expectedOutput: "True one disposed disposed2 False one").VerifyDiagnostics();
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size       75 (0x4b)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_0036
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0017:  ldarg.0
-  IL_0018:  ldstr      ""
-  IL_001d:  stfld      "string C.<GetEnumerator>d__0.<local>5__2"
-  IL_0022:  ldarg.0
-  IL_0023:  ldstr      " one "
-  IL_0028:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_002d:  ldarg.0
-  IL_002e:  ldc.i4.1
-  IL_002f:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0034:  ldc.i4.1
-  IL_0035:  ret
-  IL_0036:  ldarg.0
-  IL_0037:  ldc.i4.m1
-  IL_0038:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_003d:  ldarg.0
-  IL_003e:  ldfld      "string C.<GetEnumerator>d__0.<local>5__2"
-  IL_0043:  callvirt   "string object.ToString()"
-  IL_0048:  pop
-  IL_0049:  ldc.i4.0
-  IL_004a:  ret
-}
-""");
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
   // Code size       16 (0x10)
@@ -4530,67 +4431,8 @@ class C
     }
 }
 """;
-            var verifier = CompileAndVerify(src, expectedOutput: "True one False one False one").VerifyDiagnostics();
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size      100 (0x64)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  switch    (
-        IL_001b,
-        IL_0036,
-        IL_005b)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0022:  ldarg.0
-  IL_0023:  ldstr      " one "
-  IL_0028:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_002d:  ldarg.0
-  IL_002e:  ldc.i4.1
-  IL_002f:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0034:  ldc.i4.1
-  IL_0035:  ret
-  IL_0036:  ldarg.0
-  IL_0037:  ldc.i4.m1
-  IL_0038:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_003d:  ldarg.0
-  IL_003e:  ldfld      "bool C.<GetEnumerator>d__0.b"
-  IL_0043:  brfalse.s  IL_0047
-  IL_0045:  ldc.i4.0
-  IL_0046:  ret
-  IL_0047:  ldarg.0
-  IL_0048:  ldstr      " two "
-  IL_004d:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_0052:  ldarg.0
-  IL_0053:  ldc.i4.2
-  IL_0054:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0059:  ldc.i4.1
-  IL_005a:  ret
-  IL_005b:  ldarg.0
-  IL_005c:  ldc.i4.m1
-  IL_005d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0062:  ldc.i4.0
-  IL_0063:  ret
-}
-""");
+            CompileAndVerify(src, expectedOutput: "True one False one False one").VerifyDiagnostics();
 
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0008:  ret
-}
-""");
             // Verify GetEnumerator
             string src2 = """
 var enumerable = C.Produce(true);
@@ -4642,53 +4484,8 @@ class C
     }
 }
 """;
-            var verifier = CompileAndVerify(src, expectedOutput: "True one done False one False one").VerifyDiagnostics();
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size       62 (0x3e)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_002b
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0017:  ldarg.0
-  IL_0018:  ldstr      " one "
-  IL_001d:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0029:  ldc.i4.1
-  IL_002a:  ret
-  IL_002b:  ldarg.0
-  IL_002c:  ldc.i4.m1
-  IL_002d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0032:  ldstr      "done "
-  IL_0037:  call       "void System.Console.Write(string)"
-  IL_003c:  ldc.i4.0
-  IL_003d:  ret
-}
-""");
+            CompileAndVerify(src, expectedOutput: "True one done False one False one").VerifyDiagnostics();
 
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0008:  ret
-}
-""");
             // Verify GetEnumerator
             string src2 = """
 var enumerable = C.Produce(true);
@@ -4746,52 +4543,8 @@ class C
     }
 }
 """;
-            var verifier = CompileAndVerify(src, expectedOutput: "True one exception one False one").VerifyDiagnostics();
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size       61 (0x3d)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_002b
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0017:  ldarg.0
-  IL_0018:  ldstr      " one "
-  IL_001d:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0029:  ldc.i4.1
-  IL_002a:  ret
-  IL_002b:  ldarg.0
-  IL_002c:  ldc.i4.m1
-  IL_002d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0032:  ldstr      "exception"
-  IL_0037:  newobj     "System.Exception..ctor(string)"
-  IL_003c:  throw
-}
-""");
+            CompileAndVerify(src, expectedOutput: "True one exception one False one").VerifyDiagnostics();
 
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0008:  ret
-}
-""");
             // Verify GetEnumerator
             string src2 = """
 var enumerable = C.Produce();
@@ -4903,6 +4656,19 @@ class C
   IL_0022:  ret
 }
 """);
+            verifier.VerifyIL("C.<GetEnumerator>d__0.<>m__Finally1()", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.m1
+  IL_0002:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0007:  ldstr      "exception"
+  IL_000c:  newobj     "System.Exception..ctor(string)"
+  IL_0011:  throw
+}
+""");
+
             // Verify GetEnumerator
             string src2 = """
 var enumerable = C.Produce();
@@ -4975,81 +4741,8 @@ class C
     }
 }
 """;
-            var verifier = CompileAndVerify(src, expectedOutput: "True one finally False one False one").VerifyDiagnostics();
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size      117 (0x75)
-  .maxstack  2
-  .locals init (bool V_0,
-                int V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0006:  stloc.1
-  IL_0007:  ldloc.1
-  IL_0008:  switch    (
-        IL_001b,
-        IL_0036,
-        IL_006a)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0022:  ldarg.0
-  IL_0023:  ldstr      " one "
-  IL_0028:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_002d:  ldarg.0
-  IL_002e:  ldc.i4.1
-  IL_002f:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0034:  ldc.i4.1
-  IL_0035:  ret
-  IL_0036:  ldarg.0
-  IL_0037:  ldc.i4.m1
-  IL_0038:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  .try
-  {
-    IL_003d:  ldarg.0
-    IL_003e:  ldfld      "bool C.<GetEnumerator>d__0.b"
-    IL_0043:  brfalse.s  IL_0049
-    IL_0045:  ldc.i4.0
-    IL_0046:  stloc.0
-    IL_0047:  leave.s    IL_0073
-    IL_0049:  leave.s    IL_0056
-  }
-  finally
-  {
-    IL_004b:  ldstr      "finally "
-    IL_0050:  call       "void System.Console.Write(string)"
-    IL_0055:  endfinally
-  }
-  IL_0056:  ldarg.0
-  IL_0057:  ldstr      " two "
-  IL_005c:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_0061:  ldarg.0
-  IL_0062:  ldc.i4.2
-  IL_0063:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0068:  ldc.i4.1
-  IL_0069:  ret
-  IL_006a:  ldarg.0
-  IL_006b:  ldc.i4.m1
-  IL_006c:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0071:  ldc.i4.0
-  IL_0072:  ret
-  IL_0073:  ldloc.0
-  IL_0074:  ret
-}
-""");
+            CompileAndVerify(src, expectedOutput: "True one finally False one False one").VerifyDiagnostics();
 
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0008:  ret
-}
-""");
             // Verify GetEnumerator
             string src2 = """
 var enumerable = C.Produce(true);
@@ -5128,61 +4821,7 @@ class C
     }
 }
 """;
-            var verifier = CompileAndVerify(src, expectedOutput: "True one finally exception one False one False one").VerifyDiagnostics();
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size       72 (0x48)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_002b
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0017:  ldarg.0
-  IL_0018:  ldstr      " one "
-  IL_001d:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0029:  ldc.i4.1
-  IL_002a:  ret
-  IL_002b:  ldarg.0
-  IL_002c:  ldc.i4.m1
-  IL_002d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  .try
-  {
-    IL_0032:  ldstr      "exception"
-    IL_0037:  newobj     "System.Exception..ctor(string)"
-    IL_003c:  throw
-  }
-  finally
-  {
-    IL_003d:  ldstr      "finally "
-    IL_0042:  call       "void System.Console.Write(string)"
-    IL_0047:  endfinally
-  }
-}
-""");
-
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0008:  ret
-}
-""");
+            CompileAndVerify(src, expectedOutput: "True one finally exception one False one False one").VerifyDiagnostics();
 
             // Verify GetEnumerator
             string src2 = """
@@ -5255,7 +4894,7 @@ class C
         try
         {
             yield return " one ";
-            throw new System.Exception("exception");
+            if (b) throw new System.Exception("exception");
         }
         finally
         {
@@ -5264,10 +4903,11 @@ class C
     }
 }
 """;
+            // Note: we generate a `fault { Dispose(); }`, but only if there is a `yield` in a `try`, which is surprising
             var verifier = CompileAndVerify(src, expectedOutput: "True one finally exception one False one").VerifyDiagnostics();
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
 {
-  // Code size       83 (0x53)
+  // Code size      101 (0x65)
   .maxstack  2
   .locals init (bool V_0,
                 int V_1)
@@ -5283,7 +4923,7 @@ class C
     IL_000c:  beq.s      IL_0037
     IL_000e:  ldc.i4.0
     IL_000f:  stloc.0
-    IL_0010:  leave.s    IL_0051
+    IL_0010:  leave.s    IL_0063
     IL_0012:  ldarg.0
     IL_0013:  ldc.i4.m1
     IL_0014:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
@@ -5298,22 +4938,30 @@ class C
     IL_002e:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
     IL_0033:  ldc.i4.1
     IL_0034:  stloc.0
-    IL_0035:  leave.s    IL_0051
+    IL_0035:  leave.s    IL_0063
     IL_0037:  ldarg.0
     IL_0038:  ldc.i4.s   -3
     IL_003a:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_003f:  ldstr      "exception"
-    IL_0044:  newobj     "System.Exception..ctor(string)"
-    IL_0049:  throw
+    IL_003f:  ldarg.0
+    IL_0040:  ldfld      "bool C.<GetEnumerator>d__0.b"
+    IL_0045:  brfalse.s  IL_0052
+    IL_0047:  ldstr      "exception"
+    IL_004c:  newobj     "System.Exception..ctor(string)"
+    IL_0051:  throw
+    IL_0052:  ldarg.0
+    IL_0053:  call       "void C.<GetEnumerator>d__0.<>m__Finally1()"
+    IL_0058:  ldc.i4.0
+    IL_0059:  stloc.0
+    IL_005a:  leave.s    IL_0063
   }
   fault
   {
-    IL_004a:  ldarg.0
-    IL_004b:  call       "void C.<GetEnumerator>d__0.Dispose()"
-    IL_0050:  endfinally
+    IL_005c:  ldarg.0
+    IL_005d:  call       "void C.<GetEnumerator>d__0.Dispose()"
+    IL_0062:  endfinally
   }
-  IL_0051:  ldloc.0
-  IL_0052:  ret
+  IL_0063:  ldloc.0
+  IL_0064:  ret
 }
 """);
 
@@ -5419,106 +5067,7 @@ class C
     }
 }
 """;
-            var verifier = CompileAndVerify(src, expectedOutput: "True one finally True two False two").VerifyDiagnostics();
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
-{
-  // Code size      132 (0x84)
-  .maxstack  2
-  .locals init (bool V_0,
-                int V_1)
-  .try
-  {
-    IL_0000:  ldarg.0
-    IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_0006:  stloc.1
-    IL_0007:  ldloc.1
-    IL_0008:  switch    (
-        IL_001d,
-        IL_0042,
-        IL_0066)
-    IL_0019:  ldc.i4.0
-    IL_001a:  stloc.0
-    IL_001b:  leave.s    IL_0082
-    IL_001d:  ldarg.0
-    IL_001e:  ldc.i4.m1
-    IL_001f:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_0024:  ldarg.0
-    IL_0025:  ldc.i4.s   -3
-    IL_0027:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_002c:  ldarg.0
-    IL_002d:  ldstr      " one "
-    IL_0032:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-    IL_0037:  ldarg.0
-    IL_0038:  ldc.i4.1
-    IL_0039:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_003e:  ldc.i4.1
-    IL_003f:  stloc.0
-    IL_0040:  leave.s    IL_0082
-    IL_0042:  ldarg.0
-    IL_0043:  ldc.i4.s   -3
-    IL_0045:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_004a:  ldarg.0
-    IL_004b:  call       "void C.<GetEnumerator>d__0.<>m__Finally1()"
-    IL_0050:  ldarg.0
-    IL_0051:  ldstr      " two "
-    IL_0056:  stfld      "string C.<GetEnumerator>d__0.<>2__current"
-    IL_005b:  ldarg.0
-    IL_005c:  ldc.i4.2
-    IL_005d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_0062:  ldc.i4.1
-    IL_0063:  stloc.0
-    IL_0064:  leave.s    IL_0082
-    IL_0066:  ldarg.0
-    IL_0067:  ldc.i4.m1
-    IL_0068:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-    IL_006d:  ldstr      "not executed after disposal"
-    IL_0072:  call       "void System.Console.Write(string)"
-    IL_0077:  ldc.i4.0
-    IL_0078:  stloc.0
-    IL_0079:  leave.s    IL_0082
-  }
-  fault
-  {
-    IL_007b:  ldarg.0
-    IL_007c:  call       "void C.<GetEnumerator>d__0.Dispose()"
-    IL_0081:  endfinally
-  }
-  IL_0082:  ldloc.0
-  IL_0083:  ret
-}
-""");
-
-            verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
-{
-  // Code size       35 (0x23)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  ldc.i4.s   -3
-  IL_000a:  beq.s      IL_0010
-  IL_000c:  ldloc.0
-  IL_000d:  ldc.i4.1
-  IL_000e:  bne.un.s   IL_001a
-  IL_0010:  nop
-  .try
-  {
-    IL_0011:  leave.s    IL_001a
-  }
-  finally
-  {
-    IL_0013:  ldarg.0
-    IL_0014:  call       "void C.<GetEnumerator>d__0.<>m__Finally1()"
-    IL_0019:  endfinally
-  }
-  IL_001a:  ldarg.0
-  IL_001b:  ldc.i4.s   -2
-  IL_001d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
-  IL_0022:  ret
-}
-""");
+            CompileAndVerify(src, expectedOutput: "True one finally True two False two").VerifyDiagnostics();
 
             // Verify GetEnumerator
             string src2 = """

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -445,7 +445,7 @@ class Program
 ");
             compilation.VerifyIL("Program.<Int0>d__0.System.IDisposable.Dispose()", @"
 {
-  // Code size       76 (0x4c)
+  // Code size       84 (0x54)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -510,7 +510,10 @@ class Program
     IL_0045:  call       ""void Program.<Int0>d__0.<>m__Finally1()""
     IL_004a:  endfinally
   }
-  IL_004b:  ret
+  IL_004b:  ldarg.0
+  IL_004c:  ldc.i4.s   -2
+  IL_004e:  stfld      ""int Program.<Int0>d__0.<>1__state""
+  IL_0053:  ret
 }
 ");
         }
@@ -3489,7 +3492,7 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "value value ran True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size       34 (0x22)
+  // Code size       42 (0x2a)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -3515,7 +3518,10 @@ class C
   IL_001a:  ldarg.0
   IL_001b:  ldnull
   IL_001c:  stfld      "string C.<Produce>d__0.<s>5__2"
-  IL_0021:  ret
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.s   -2
+  IL_0024:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0029:  ret
 }
 """);
         }
@@ -3562,7 +3568,7 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "value value exception True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size       34 (0x22)
+  // Code size       42 (0x2a)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -3588,7 +3594,10 @@ class C
   IL_001a:  ldarg.0
   IL_001b:  ldnull
   IL_001c:  stfld      "string C.<Produce>d__0.<s>5__2"
-  IL_0021:  ret
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.s   -2
+  IL_0024:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_0029:  ret
 }
 """);
         }
@@ -3976,7 +3985,7 @@ class C
             var verifier = CompileAndVerify(src, expectedOutput: "value value outer True").VerifyDiagnostics();
             verifier.VerifyIL("C.<Produce>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size       55 (0x37)
+  // Code size       63 (0x3f)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -4021,7 +4030,10 @@ class C
   IL_002f:  ldarg.0
   IL_0030:  ldnull
   IL_0031:  stfld      "string C.<Produce>d__0.<s>5__2"
-  IL_0036:  ret
+  IL_0036:  ldarg.0
+  IL_0037:  ldc.i4.s   -2
+  IL_0039:  stfld      "int C.<Produce>d__0.<>1__state"
+  IL_003e:  ret
 }
 """);
         }
@@ -4753,12 +4765,10 @@ class C
     }
 }
 """;
-            CreateCompilation(src).VerifyEmitDiagnostics();
-            // We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
             var verifier = CompileAndVerify(src, expectedOutput: "True one disposing exception disposed False one").VerifyDiagnostics();
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size       27 (0x1b)
+  // Code size       35 (0x23)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -4781,7 +4791,10 @@ class C
     IL_0014:  call       "void C.<GetEnumerator>d__0.<>m__Finally1()"
     IL_0019:  endfinally
   }
-  IL_001a:  ret
+  IL_001a:  ldarg.0
+  IL_001b:  ldc.i4.s   -2
+  IL_001d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0022:  ret
 }
 """);
         }
@@ -5042,7 +5055,6 @@ class C
     }
 }
 """;
-            // We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
             var verifier = CompileAndVerify(src, expectedOutput: "True one finally exception one False one").VerifyDiagnostics();
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.Collections.IEnumerator.MoveNext()", """
 {
@@ -5098,7 +5110,7 @@ class C
 
             verifier.VerifyIL("C.<GetEnumerator>d__0.System.IDisposable.Dispose()", """
 {
-  // Code size       27 (0x1b)
+  // Code size       35 (0x23)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -5121,7 +5133,10 @@ class C
     IL_0014:  call       "void C.<GetEnumerator>d__0.<>m__Finally1()"
     IL_0019:  endfinally
   }
-  IL_001a:  ret
+  IL_001a:  ldarg.0
+  IL_001b:  ldc.i4.s   -2
+  IL_001d:  stfld      "int C.<GetEnumerator>d__0.<>1__state"
+  IL_0022:  ret
 }
 """);
         }

--- a/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
+    [CompilerTrait(CompilerFeature.Iterator, CompilerFeature.Async, CompilerFeature.AsyncStreams)]
     public class EditAndContinueStateMachineTests(ITestOutputHelper logger) : EditAndContinueTestBase
     {
         private readonly ITestOutputHelper _logger = logger;
@@ -4747,7 +4748,7 @@ class C
 
             v0.VerifyIL("C.<F>d__0.System.IDisposable.Dispose", @"
 {
-  // Code size       33 (0x21)
+  // Code size       41 (0x29)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -4773,12 +4774,15 @@ class C
     IL_001d:  endfinally
   }
   IL_001e:  br.s       IL_0020
-  IL_0020:  ret
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.s   -2
+  IL_0023:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0028:  ret
 }
 ");
             diff1.VerifyIL("C.<F>d__0.System.IDisposable.Dispose", @"
 {
-  // Code size      108 (0x6c)
+  // Code size      116 (0x74)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -4843,7 +4847,10 @@ class C
     IL_0068:  endfinally
   }
   IL_0069:  br.s       IL_006b
-  IL_006b:  ret
+  IL_006b:  ldarg.0
+  IL_006c:  ldc.i4.s   -2
+  IL_006e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0073:  ret
 }
 ");
 
@@ -5176,7 +5183,7 @@ class C
 
             v0.VerifyIL("C.<F>d__0.System.IDisposable.Dispose", @"
 {
-  // Code size       40 (0x28)
+  // Code size       48 (0x30)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -5205,12 +5212,15 @@ class C
   IL_0020:  ldarg.0
   IL_0021:  ldnull
   IL_0022:  stfld      ""System.IDisposable C.<F>d__0.<x>5__1""
-  IL_0027:  ret
+  IL_0027:  ldarg.0
+  IL_0028:  ldc.i4.s   -2
+  IL_002a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_002f:  ret
 }
 ");
             diff1.VerifyIL("C.<F>d__0.System.IDisposable.Dispose", @"
 {
-  // Code size       42 (0x2a)
+  // Code size       50 (0x32)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -5241,7 +5251,10 @@ class C
   IL_0022:  ldarg.0
   IL_0023:  ldnull
   IL_0024:  stfld      ""System.IDisposable C.<F>d__0.<x>5__1""
-  IL_0029:  ret
+  IL_0029:  ldarg.0
+  IL_002a:  ldc.i4.s   -2
+  IL_002c:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0031:  ret
 }
 ");
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PrimaryConstructorTests.cs
@@ -16822,253 +16822,256 @@ class C(int y)
             verifier1.VerifyTypeIL("C",
 (@"
 .class private auto ansi beforefieldinit C
-    extends [netstandard]System.Object
+	extends [netstandard]System.Object
 {
-    // Nested Types
-    .class nested private auto ansi sealed beforefieldinit '<M>d__2'
-    	extends [netstandard]System.Object
-    	implements class [netstandard]System.Collections.Generic.IEnumerable`1<int32>,
-    		        [netstandard]System.Collections.IEnumerable,
-    		        class [netstandard]System.Collections.Generic.IEnumerator`1<int32>,
+	// Nested Types
+	.class nested private auto ansi sealed beforefieldinit '<M>d__2'
+		extends [netstandard]System.Object
+		implements class [netstandard]System.Collections.Generic.IEnumerable`1<int32>,
+		           [netstandard]System.Collections.IEnumerable,
+		           class [netstandard]System.Collections.Generic.IEnumerator`1<int32>,
 " +
 (RuntimeUtilities.IsCoreClrRuntime ?
 @"			           [netstandard]System.Collections.IEnumerator,
 			           [netstandard]System.IDisposable" :
 @"			           [netstandard]System.IDisposable,
 			           [netstandard]System.Collections.IEnumerator") + @"
-    {
-    	.custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-    		01 00 00 00
-    	)
-    	// Fields
-    	.field private int32 '<>1__state'
-    	.field private int32 '<>2__current'
-    	.field private int32 '<>l__initialThreadId'
-    	.field public class C '<>4__this'
-    	// Methods
-    	.method public hidebysig specialname rtspecialname 
-    		instance void .ctor (
-    			int32 '<>1__state'
-    		) cil managed 
-    	{
-    		.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-    			01 00 00 00
-    		)
-    		// Method begins at RVA 0x20df
-    		// Code size 25 (0x19)
-    		.maxstack 8
-    		IL_0000: ldarg.0
-    		IL_0001: call instance void [netstandard]System.Object::.ctor()
-    		IL_0006: ldarg.0
-    		IL_0007: ldarg.1
-    		IL_0008: stfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_000d: ldarg.0
-    		IL_000e: call int32 [netstandard]System.Environment::get_CurrentManagedThreadId()
-    		IL_0013: stfld int32 C/'<M>d__2'::'<>l__initialThreadId'
-    		IL_0018: ret
-    	} // end of method '<M>d__2'::.ctor
-    	.method private final hidebysig newslot virtual 
-    		instance void System.IDisposable.Dispose () cil managed 
-    	{
-    		.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-    			01 00 00 00
-    		)
-    		.override method instance void [netstandard]System.IDisposable::Dispose()
-    		// Method begins at RVA 0x20f9
-    		// Code size 1 (0x1)
-    		.maxstack 8
-    		IL_0000: ret
-    	} // end of method '<M>d__2'::System.IDisposable.Dispose
-    	.method private final hidebysig newslot virtual 
-    		instance bool MoveNext () cil managed 
-    	{
-    		.override method instance bool [netstandard]System.Collections.IEnumerator::MoveNext()
-    		// Method begins at RVA 0x20fc
-    		// Code size 95 (0x5f)
-    		.maxstack 2
-    		.locals init (
-    			[0] int32,
-    			[1] class C
-    		)
-    		IL_0000: ldarg.0
-    		IL_0001: ldfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_0006: stloc.0
-    		IL_0007: ldarg.0
-    		IL_0008: ldfld class C C/'<M>d__2'::'<>4__this'
-    		IL_000d: stloc.1
-    		IL_000e: ldloc.0
-    		IL_000f: switch (IL_0022, IL_003a, IL_0056)
-    		IL_0020: ldc.i4.0
-    		IL_0021: ret
-    		IL_0022: ldarg.0
-    		IL_0023: ldc.i4.m1
-    		IL_0024: stfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_0029: ldarg.0
-    		IL_002a: ldc.i4.s 9
-    		IL_002c: stfld int32 C/'<M>d__2'::'<>2__current'
-    		IL_0031: ldarg.0
-    		IL_0032: ldc.i4.1
-    		IL_0033: stfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_0038: ldc.i4.1
-    		IL_0039: ret
-    		IL_003a: ldarg.0
-    		IL_003b: ldc.i4.m1
-    		IL_003c: stfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_0041: ldarg.0
-    		IL_0042: ldloc.1
-    		IL_0043: ldfld int32 C::'<y>P'
-    		IL_0048: stfld int32 C/'<M>d__2'::'<>2__current'
-    		IL_004d: ldarg.0
-    		IL_004e: ldc.i4.2
-    		IL_004f: stfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_0054: ldc.i4.1
-    		IL_0055: ret
-    		IL_0056: ldarg.0
-    		IL_0057: ldc.i4.m1
-    		IL_0058: stfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_005d: ldc.i4.0
-    		IL_005e: ret
-    	} // end of method '<M>d__2'::MoveNext
-    	.method private final hidebysig specialname newslot virtual 
-    		instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.get_Current' () cil managed 
-    	{
-    		.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-    			01 00 00 00
-    		)
-    		.override method instance !0 class [netstandard]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-    		// Method begins at RVA 0x2167
-    		// Code size 7 (0x7)
-    		.maxstack 8
-    		IL_0000: ldarg.0
-    		IL_0001: ldfld int32 C/'<M>d__2'::'<>2__current'
-    		IL_0006: ret
-    	} // end of method '<M>d__2'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'
-    	.method private final hidebysig newslot virtual 
-    		instance void System.Collections.IEnumerator.Reset () cil managed 
-    	{
-    		.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-    			01 00 00 00
-    		)
-    		.override method instance void [netstandard]System.Collections.IEnumerator::Reset()
-    		// Method begins at RVA 0x216f
-    		// Code size 6 (0x6)
-    		.maxstack 8
-    		IL_0000: newobj instance void [netstandard]System.NotSupportedException::.ctor()
-    		IL_0005: throw
-    	} // end of method '<M>d__2'::System.Collections.IEnumerator.Reset
-    	.method private final hidebysig specialname newslot virtual 
-    		instance object System.Collections.IEnumerator.get_Current () cil managed 
-    	{
-    		.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-    			01 00 00 00
-    		)
-    		.override method instance object [netstandard]System.Collections.IEnumerator::get_Current()
-    		// Method begins at RVA 0x2176
-    		// Code size 12 (0xc)
-    		.maxstack 8
-    		IL_0000: ldarg.0
-    		IL_0001: ldfld int32 C/'<M>d__2'::'<>2__current'
-    		IL_0006: box [netstandard]System.Int32
-    		IL_000b: ret
-    	} // end of method '<M>d__2'::System.Collections.IEnumerator.get_Current
-    	.method private final hidebysig newslot virtual 
-    		instance class [netstandard]System.Collections.Generic.IEnumerator`1<int32> 'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator' () cil managed 
-    	{
-    		.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-    			01 00 00 00
-    		)
-    		.override method instance class [netstandard]System.Collections.Generic.IEnumerator`1<!0> class [netstandard]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-    		// Method begins at RVA 0x2184
-    		// Code size 55 (0x37)
-    		.maxstack 2
-    		.locals init (
-    			[0] class C/'<M>d__2'
-    		)
-    		IL_0000: ldarg.0
-    		IL_0001: ldfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_0006: ldc.i4.s -2
-    		IL_0008: bne.un.s IL_0022
-    		IL_000a: ldarg.0
-    		IL_000b: ldfld int32 C/'<M>d__2'::'<>l__initialThreadId'
-    		IL_0010: call int32 [netstandard]System.Environment::get_CurrentManagedThreadId()
-    		IL_0015: bne.un.s IL_0022
-    		IL_0017: ldarg.0
-    		IL_0018: ldc.i4.0
-    		IL_0019: stfld int32 C/'<M>d__2'::'<>1__state'
-    		IL_001e: ldarg.0
-    		IL_001f: stloc.0
-    		IL_0020: br.s IL_0035
-    		IL_0022: ldc.i4.0
-    		IL_0023: newobj instance void C/'<M>d__2'::.ctor(int32)
-    		IL_0028: stloc.0
-    		IL_0029: ldloc.0
-    		IL_002a: ldarg.0
-    		IL_002b: ldfld class C C/'<M>d__2'::'<>4__this'
-    		IL_0030: stfld class C C/'<M>d__2'::'<>4__this'
-    		IL_0035: ldloc.0
-    		IL_0036: ret
-    	} // end of method '<M>d__2'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'
-    	.method private final hidebysig newslot virtual 
-    		instance class [netstandard]System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator () cil managed 
-    	{
-    		.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
-    			01 00 00 00
-    		)
-    		.override method instance class [netstandard]System.Collections.IEnumerator [netstandard]System.Collections.IEnumerable::GetEnumerator()
-    		// Method begins at RVA 0x21c7
-    		// Code size 7 (0x7)
-    		.maxstack 8
-    		IL_0000: ldarg.0
-    		IL_0001: call instance class [netstandard]System.Collections.Generic.IEnumerator`1<int32> C/'<M>d__2'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'()
-    		IL_0006: ret
-    	} // end of method '<M>d__2'::System.Collections.IEnumerable.GetEnumerator
-    	// Properties
-    	.property instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.Current'()
-    	{
-    		.get instance int32 C/'<M>d__2'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'()
-    	}
-    	.property instance object System.Collections.IEnumerator.Current()
-    	{
-    		.get instance object C/'<M>d__2'::System.Collections.IEnumerator.get_Current()
-    	}
-    } // end of class <M>d__2
-    // Fields
-    .field private int32 '<y>P'
-    .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-    	01 00 00 00
-    )
-    // Methods
-    .method public hidebysig specialname rtspecialname 
-    	instance void .ctor (
-    		int32 y
-    	) cil managed 
-    {
-    	// Method begins at RVA 0x20c0
-    	// Code size 14 (0xe)
-    	.maxstack 8
-    	IL_0000: ldarg.0
-    	IL_0001: ldarg.1
-    	IL_0002: stfld int32 C::'<y>P'
-    	IL_0007: ldarg.0
-    	IL_0008: call instance void [netstandard]System.Object::.ctor()
-    	IL_000d: ret
-    } // end of method C::.ctor
-    .method public hidebysig 
-    	instance class [netstandard]System.Collections.Generic.IEnumerable`1<int32> M () cil managed 
-    {
-    	.custom instance void [netstandard]System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(class [netstandard]System.Type) = (
-    		01 00 09 43 2b 3c 4d 3e 64 5f 5f 32 00 00
-    	)
-    	// Method begins at RVA 0x20cf
-    	// Code size 15 (0xf)
-    	.maxstack 8
-    	IL_0000: ldc.i4.s -2
-    	IL_0002: newobj instance void C/'<M>d__2'::.ctor(int32)
-    	IL_0007: dup
-    	IL_0008: ldarg.0
-    	IL_0009: stfld class C C/'<M>d__2'::'<>4__this'
-    	IL_000e: ret
-    } // end of method C::M
+	{
+		.custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field private int32 '<>1__state'
+		.field private int32 '<>2__current'
+		.field private int32 '<>l__initialThreadId'
+		.field public class C '<>4__this'
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				int32 '<>1__state'
+			) cil managed 
+		{
+			.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+				01 00 00 00
+			)
+			// Method begins at RVA 0x20df
+			// Code size 25 (0x19)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [netstandard]System.Object::.ctor()
+			IL_0006: ldarg.0
+			IL_0007: ldarg.1
+			IL_0008: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_000d: ldarg.0
+			IL_000e: call int32 [netstandard]System.Environment::get_CurrentManagedThreadId()
+			IL_0013: stfld int32 C/'<M>d__2'::'<>l__initialThreadId'
+			IL_0018: ret
+		} // end of method '<M>d__2'::.ctor
+		.method private final hidebysig newslot virtual 
+			instance void System.IDisposable.Dispose () cil managed 
+		{
+			.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+				01 00 00 00
+			)
+			.override method instance void [netstandard]System.IDisposable::Dispose()
+			// Method begins at RVA 0x20f9
+			// Code size 9 (0x9)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.s -2
+			IL_0003: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0008: ret
+		} // end of method '<M>d__2'::System.IDisposable.Dispose
+		.method private final hidebysig newslot virtual 
+			instance bool MoveNext () cil managed 
+		{
+			.override method instance bool [netstandard]System.Collections.IEnumerator::MoveNext()
+			// Method begins at RVA 0x2104
+			// Code size 95 (0x5f)
+			.maxstack 2
+			.locals init (
+				[0] int32,
+				[1] class C
+			)
+			IL_0000: ldarg.0
+			IL_0001: ldfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld class C C/'<M>d__2'::'<>4__this'
+			IL_000d: stloc.1
+			IL_000e: ldloc.0
+			IL_000f: switch (IL_0022, IL_003a, IL_0056)
+			IL_0020: ldc.i4.0
+			IL_0021: ret
+			IL_0022: ldarg.0
+			IL_0023: ldc.i4.m1
+			IL_0024: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0029: ldarg.0
+			IL_002a: ldc.i4.s 9
+			IL_002c: stfld int32 C/'<M>d__2'::'<>2__current'
+			IL_0031: ldarg.0
+			IL_0032: ldc.i4.1
+			IL_0033: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0038: ldc.i4.1
+			IL_0039: ret
+			IL_003a: ldarg.0
+			IL_003b: ldc.i4.m1
+			IL_003c: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0041: ldarg.0
+			IL_0042: ldloc.1
+			IL_0043: ldfld int32 C::'<y>P'
+			IL_0048: stfld int32 C/'<M>d__2'::'<>2__current'
+			IL_004d: ldarg.0
+			IL_004e: ldc.i4.2
+			IL_004f: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0054: ldc.i4.1
+			IL_0055: ret
+			IL_0056: ldarg.0
+			IL_0057: ldc.i4.m1
+			IL_0058: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_005d: ldc.i4.0
+			IL_005e: ret
+		} // end of method '<M>d__2'::MoveNext
+		.method private final hidebysig specialname newslot virtual 
+			instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.get_Current' () cil managed 
+		{
+			.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+				01 00 00 00
+			)
+			.override method instance !0 class [netstandard]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+			// Method begins at RVA 0x216f
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: ldfld int32 C/'<M>d__2'::'<>2__current'
+			IL_0006: ret
+		} // end of method '<M>d__2'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'
+		.method private final hidebysig newslot virtual 
+			instance void System.Collections.IEnumerator.Reset () cil managed 
+		{
+			.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+				01 00 00 00
+			)
+			.override method instance void [netstandard]System.Collections.IEnumerator::Reset()
+			// Method begins at RVA 0x2177
+			// Code size 6 (0x6)
+			.maxstack 8
+			IL_0000: newobj instance void [netstandard]System.NotSupportedException::.ctor()
+			IL_0005: throw
+		} // end of method '<M>d__2'::System.Collections.IEnumerator.Reset
+		.method private final hidebysig specialname newslot virtual 
+			instance object System.Collections.IEnumerator.get_Current () cil managed 
+		{
+			.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+				01 00 00 00
+			)
+			.override method instance object [netstandard]System.Collections.IEnumerator::get_Current()
+			// Method begins at RVA 0x217e
+			// Code size 12 (0xc)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: ldfld int32 C/'<M>d__2'::'<>2__current'
+			IL_0006: box [netstandard]System.Int32
+			IL_000b: ret
+		} // end of method '<M>d__2'::System.Collections.IEnumerator.get_Current
+		.method private final hidebysig newslot virtual 
+			instance class [netstandard]System.Collections.Generic.IEnumerator`1<int32> 'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator' () cil managed 
+		{
+			.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+				01 00 00 00
+			)
+			.override method instance class [netstandard]System.Collections.Generic.IEnumerator`1<!0> class [netstandard]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+			// Method begins at RVA 0x218c
+			// Code size 55 (0x37)
+			.maxstack 2
+			.locals init (
+				[0] class C/'<M>d__2'
+			)
+			IL_0000: ldarg.0
+			IL_0001: ldfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0006: ldc.i4.s -2
+			IL_0008: bne.un.s IL_0022
+			IL_000a: ldarg.0
+			IL_000b: ldfld int32 C/'<M>d__2'::'<>l__initialThreadId'
+			IL_0010: call int32 [netstandard]System.Environment::get_CurrentManagedThreadId()
+			IL_0015: bne.un.s IL_0022
+			IL_0017: ldarg.0
+			IL_0018: ldc.i4.0
+			IL_0019: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_001e: ldarg.0
+			IL_001f: stloc.0
+			IL_0020: br.s IL_0035
+			IL_0022: ldc.i4.0
+			IL_0023: newobj instance void C/'<M>d__2'::.ctor(int32)
+			IL_0028: stloc.0
+			IL_0029: ldloc.0
+			IL_002a: ldarg.0
+			IL_002b: ldfld class C C/'<M>d__2'::'<>4__this'
+			IL_0030: stfld class C C/'<M>d__2'::'<>4__this'
+			IL_0035: ldloc.0
+			IL_0036: ret
+		} // end of method '<M>d__2'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'
+		.method private final hidebysig newslot virtual 
+			instance class [netstandard]System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator () cil managed 
+		{
+			.custom instance void [netstandard]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = (
+				01 00 00 00
+			)
+			.override method instance class [netstandard]System.Collections.IEnumerator [netstandard]System.Collections.IEnumerable::GetEnumerator()
+			// Method begins at RVA 0x21cf
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance class [netstandard]System.Collections.Generic.IEnumerator`1<int32> C/'<M>d__2'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'()
+			IL_0006: ret
+		} // end of method '<M>d__2'::System.Collections.IEnumerable.GetEnumerator
+		// Properties
+		.property instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.Current'()
+		{
+			.get instance int32 C/'<M>d__2'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'()
+		}
+		.property instance object System.Collections.IEnumerator.Current()
+		{
+			.get instance object C/'<M>d__2'::System.Collections.IEnumerator.get_Current()
+		}
+	} // end of class <M>d__2
+	// Fields
+	.field private int32 '<y>P'
+	.custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			int32 y
+		) cil managed 
+	{
+		// Method begins at RVA 0x20c0
+		// Code size 14 (0xe)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: stfld int32 C::'<y>P'
+		IL_0007: ldarg.0
+		IL_0008: call instance void [netstandard]System.Object::.ctor()
+		IL_000d: ret
+	} // end of method C::.ctor
+	.method public hidebysig 
+		instance class [netstandard]System.Collections.Generic.IEnumerable`1<int32> M () cil managed 
+	{
+		.custom instance void [netstandard]System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(class [netstandard]System.Type) = (
+			01 00 09 43 2b 3c 4d 3e 64 5f 5f 32 00 00
+		)
+		// Method begins at RVA 0x20cf
+		// Code size 15 (0xf)
+		.maxstack 8
+		IL_0000: ldc.i4.s -2
+		IL_0002: newobj instance void C/'<M>d__2'::.ctor(int32)
+		IL_0007: dup
+		IL_0008: ldarg.0
+		IL_0009: stfld class C C/'<M>d__2'::'<>4__this'
+		IL_000e: ret
+	} // end of method C::M
 } // end of class C
 ").Replace("[netstandard]", RuntimeUtilities.IsCoreClrRuntime ? "[netstandard]" : "[mscorlib]"));
 
@@ -17093,7 +17096,7 @@ class C(int y)
 			           [netstandard]System.IDisposable" :
 @"			           [netstandard]System.IDisposable,
 			           [netstandard]System.Collections.IEnumerator") + @"
-    {
+	{
 		.custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
 			01 00 00 00
 		)
@@ -17133,15 +17136,18 @@ class C(int y)
 			)
 			.override method instance void [netstandard]System.IDisposable::Dispose()
 			// Method begins at RVA 0x2108
-			// Code size 1 (0x1)
+			// Code size 9 (0x9)
 			.maxstack 8
-			IL_0000: ret
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.s -2
+			IL_0003: stfld int32 C/'<M>d__2'::'<>1__state'
+			IL_0008: ret
 		} // end of method '<M>d__2'::System.IDisposable.Dispose
 		.method private final hidebysig newslot virtual 
 			instance bool MoveNext () cil managed 
 		{
 			.override method instance bool [netstandard]System.Collections.IEnumerator::MoveNext()
-			// Method begins at RVA 0x210c
+			// Method begins at RVA 0x2114
 			// Code size 102 (0x66)
 			.maxstack 2
 			.locals init (
@@ -17196,7 +17202,7 @@ class C(int y)
 				01 00 00 00
 			)
 			.override method instance !0 class [netstandard]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-			// Method begins at RVA 0x217e
+			// Method begins at RVA 0x2186
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -17210,7 +17216,7 @@ class C(int y)
 				01 00 00 00
 			)
 			.override method instance void [netstandard]System.Collections.IEnumerator::Reset()
-			// Method begins at RVA 0x2186
+			// Method begins at RVA 0x218e
 			// Code size 6 (0x6)
 			.maxstack 8
 			IL_0000: newobj instance void [netstandard]System.NotSupportedException::.ctor()
@@ -17223,7 +17229,7 @@ class C(int y)
 				01 00 00 00
 			)
 			.override method instance object [netstandard]System.Collections.IEnumerator::get_Current()
-			// Method begins at RVA 0x218d
+			// Method begins at RVA 0x2195
 			// Code size 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -17238,7 +17244,7 @@ class C(int y)
 				01 00 00 00
 			)
 			.override method instance class [netstandard]System.Collections.Generic.IEnumerator`1<!0> class [netstandard]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x21a4
 			// Code size 55 (0x37)
 			.maxstack 2
 			.locals init (
@@ -17275,7 +17281,7 @@ class C(int y)
 				01 00 00 00
 			)
 			.override method instance class [netstandard]System.Collections.IEnumerator [netstandard]System.Collections.IEnumerable::GetEnumerator()
-			// Method begins at RVA 0x21df
+			// Method begins at RVA 0x21e7
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -18269,15 +18275,18 @@ class C(int y)
 				)
 				.override method instance void [netstandard]System.IDisposable::Dispose()
 				// Method begins at RVA 0x212c
-				// Code size 1 (0x1)
+				// Code size 9 (0x9)
 				.maxstack 8
-				IL_0000: ret
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.s -2
+				IL_0003: stfld int32 C/'<>c__DisplayClass0_0'/'<<-ctor>g__local|1>d'::'<>1__state'
+				IL_0008: ret
 			} // end of method '<<-ctor>g__local|1>d'::System.IDisposable.Dispose
 			.method private final hidebysig newslot virtual 
 				instance bool MoveNext () cil managed 
 			{
 				.override method instance bool [netstandard]System.Collections.IEnumerator::MoveNext()
-				// Method begins at RVA 0x2130
+				// Method begins at RVA 0x2138
 				// Code size 95 (0x5f)
 				.maxstack 2
 				.locals init (
@@ -18330,7 +18339,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance !0 class [netstandard]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-				// Method begins at RVA 0x219b
+				// Method begins at RVA 0x21a3
 				// Code size 7 (0x7)
 				.maxstack 8
 				IL_0000: ldarg.0
@@ -18344,7 +18353,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance void [netstandard]System.Collections.IEnumerator::Reset()
-				// Method begins at RVA 0x21a3
+				// Method begins at RVA 0x21ab
 				// Code size 6 (0x6)
 				.maxstack 8
 				IL_0000: newobj instance void [netstandard]System.NotSupportedException::.ctor()
@@ -18357,7 +18366,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance object [netstandard]System.Collections.IEnumerator::get_Current()
-				// Method begins at RVA 0x21aa
+				// Method begins at RVA 0x21b2
 				// Code size 12 (0xc)
 				.maxstack 8
 				IL_0000: ldarg.0
@@ -18372,7 +18381,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance class [netstandard]System.Collections.Generic.IEnumerator`1<!0> class [netstandard]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-				// Method begins at RVA 0x21b8
+				// Method begins at RVA 0x21c0
 				// Code size 55 (0x37)
 				.maxstack 2
 				.locals init (
@@ -18409,7 +18418,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance class [netstandard]System.Collections.IEnumerator [netstandard]System.Collections.IEnumerable::GetEnumerator()
-				// Method begins at RVA 0x21fb
+				// Method begins at RVA 0x2203
 				// Code size 7 (0x7)
 				.maxstack 8
 				IL_0000: ldarg.0
@@ -18564,15 +18573,18 @@ class C(int y)
 				)
 				.override method instance void [netstandard]System.IDisposable::Dispose()
 				// Method begins at RVA 0x2162
-				// Code size 1 (0x1)
+				// Code size 9 (0x9)
 				.maxstack 8
-				IL_0000: ret
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.s -2
+				IL_0003: stfld int32 C/'<>c__DisplayClass0_0'/'<<-ctor>g__local|1>d'::'<>1__state'
+				IL_0008: ret
 			} // end of method '<<-ctor>g__local|1>d'::System.IDisposable.Dispose
 			.method private final hidebysig newslot virtual 
 				instance bool MoveNext () cil managed 
 			{
 				.override method instance bool [netstandard]System.Collections.IEnumerator::MoveNext()
-				// Method begins at RVA 0x2164
+				// Method begins at RVA 0x216c
 				// Code size 102 (0x66)
 				.maxstack 2
 				.locals init (
@@ -18627,7 +18639,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance !0 class [netstandard]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-				// Method begins at RVA 0x21d6
+				// Method begins at RVA 0x21de
 				// Code size 7 (0x7)
 				.maxstack 8
 				IL_0000: ldarg.0
@@ -18641,7 +18653,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance void [netstandard]System.Collections.IEnumerator::Reset()
-				// Method begins at RVA 0x21de
+				// Method begins at RVA 0x21e6
 				// Code size 6 (0x6)
 				.maxstack 8
 				IL_0000: newobj instance void [netstandard]System.NotSupportedException::.ctor()
@@ -18654,7 +18666,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance object [netstandard]System.Collections.IEnumerator::get_Current()
-				// Method begins at RVA 0x21e5
+				// Method begins at RVA 0x21ed
 				// Code size 12 (0xc)
 				.maxstack 8
 				IL_0000: ldarg.0
@@ -18669,7 +18681,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance class [netstandard]System.Collections.Generic.IEnumerator`1<!0> class [netstandard]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-				// Method begins at RVA 0x21f4
+				// Method begins at RVA 0x21fc
 				// Code size 55 (0x37)
 				.maxstack 2
 				.locals init (
@@ -18706,7 +18718,7 @@ class C(int y)
 					01 00 00 00
 				)
 				.override method instance class [netstandard]System.Collections.IEnumerator [netstandard]System.Collections.IEnumerable::GetEnumerator()
-				// Method begins at RVA 0x2237
+				// Method begins at RVA 0x223f
 				// Code size 7 (0x7)
 				.maxstack 8
 				IL_0000: ldarg.0

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// <param name="validateExpected">An action to invoke with the emitted IL.</param>
         public void VerifyTypeIL(string typeName, Action<string> validateExpected)
         {
-            var output = new ICSharpCode.Decompiler.PlainTextOutput();
+            var output = new ICSharpCode.Decompiler.PlainTextOutput() { IndentationString = "    " };
             using (var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies))
             {
                 string mainModuleFullName = Emit(testEnvironment, manifestResources: null, EmitOptions.Default);

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
@@ -103,6 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     F.Assignment(F.Field(F.Me, Me.StateField, True), F.Literal(Value)),
                                     F.Goto(breakLabel))).ToArray()
 
+                ' TODO2
                 If (sections.Length > 0) Then
                     F.CloseMethod(F.Block(
                         F.Select(

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
@@ -115,7 +115,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         F.Return()
                         ))
                 Else
-                    F.CloseMethod(F.Return())
+                    F.CloseMethod(F.Block(
+                        F.Assignment(F.Field(F.Me, Me.StateField, True), F.Literal(StateMachineState.FinishedState)),
+                        F.Return()
+                        ))
                 End If
             End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
@@ -103,7 +103,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     F.Assignment(F.Field(F.Me, Me.StateField, True), F.Literal(Value)),
                                     F.Goto(breakLabel))).ToArray()
 
-                ' TODO2
                 If (sections.Length > 0) Then
                     F.CloseMethod(F.Block(
                         F.Select(
@@ -112,6 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         F.Assignment(F.Field(F.Me, Me.StateField, True), F.Literal(StateMachineState.NotStartedOrRunningState)),
                         F.Label(breakLabel),
                         F.ExpressionStatement(F.Call(F.Me, moveNextMethod)),
+                        F.Assignment(F.Field(F.Me, Me.StateField, True), F.Literal(StateMachineState.FinishedState)),
                         F.Return()
                         ))
                 Else

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -3070,7 +3070,9 @@ End Class
     </file>
 </compilation>
 
-            CompileAndVerify(source2, expectedOutput:="True finally True")
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="True finally False")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -3072,6 +3072,5 @@ End Class
 
             CompileAndVerify(source2, expectedOutput:="True finally True")
         End Sub
-        'TODO2 document break in VB too
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -2511,7 +2511,7 @@ End Class
 ")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size       36 (0x24)
+  // Code size       44 (0x2c)
   .maxstack  2
   .locals init (Integer V_0)
   IL_0000:  ldarg.0
@@ -2530,7 +2530,10 @@ End Class
   IL_001c:  ldarg.0
   IL_001d:  call       ""Function C.VB$StateMachine_1_GetEnumerator.MoveNext() As Boolean""
   IL_0022:  pop
-  IL_0023:  ret
+  IL_0023:  ldarg.0
+  IL_0024:  ldc.i4.s   -2
+  IL_0026:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_002b:  ret
 }
 ")
 
@@ -3006,7 +3009,7 @@ End Class
 ")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size       36 (0x24)
+  // Code size       44 (0x2c)
   .maxstack  2
   .locals init (Integer V_0)
   IL_0000:  ldarg.0
@@ -3025,10 +3028,12 @@ End Class
   IL_001c:  ldarg.0
   IL_001d:  call       ""Function C.VB$StateMachine_1_GetEnumerator.MoveNext() As Boolean""
   IL_0022:  pop
-  IL_0023:  ret
+  IL_0023:  ldarg.0
+  IL_0024:  ldc.i4.s   -2
+  IL_0026:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_002b:  ret
 }
 ")
-
 
             ' Verify GetEnumerator
             Dim source2 =
@@ -3065,10 +3070,7 @@ End Class
     </file>
 </compilation>
 
-            ' TODO2 difference from C#, look at the IL
-            ' We're not setting the state to "after"/"finished"
-            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
-            CompileAndVerify(source2, expectedOutput:="True finally False")
+            CompileAndVerify(source2, expectedOutput:="True finally True")
         End Sub
         'TODO2 document break in VB too
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1924,6 +1924,45 @@ End Class
   IL_0008:  ret
 }
 ")
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce()
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(Object.ReferenceEquals(enumerable, enumerator))
+        Console.Write(Not Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        Console.Write(enumerator.MoveNext())
+        Console.Write(Not Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        enumerator.Dispose()
+
+        Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        enumerator.Dispose()
+        enumerator.Dispose()
+
+        Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce() As System.Collections.Generic.IEnumerable(Of Integer)
+        Yield 42
+        Yield 43
+    End Function
+End Class
+    </file>
+</compilation>
+
+            CompileAndVerify(source2, expectedOutput:="TrueTrueTrueTrueTrueTrue")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2008,7 +2047,6 @@ End Class
     </file>
 </compilation>
 
-            ' We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one False one False one")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
 {
@@ -2077,6 +2115,41 @@ End Class
   IL_0008:  ret
 }
 ")
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce(True)
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext())
+        Console.Write(Not Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        Console.Write(Not enumerator.MoveNext())
+        Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce(b As Boolean) As System.Collections.Generic.IEnumerable(Of Integer)
+        Yield 42
+        If b Then
+            Return
+        End If
+        Yield 43
+    End Function
+End Class
+    </file>
+</compilation>
+
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="TrueTrueTrueFalse")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2110,7 +2183,6 @@ End Class
     </file>
 </compilation>
 
-            ' We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one done False one False one")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
 {
@@ -2163,6 +2235,37 @@ End Class
   IL_0008:  ret
 }
 ")
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce(True)
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext())
+        Console.Write(Not Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        Console.Write(Not enumerator.MoveNext())
+        Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce(b As Boolean) As System.Collections.Generic.IEnumerable(Of Integer)
+        Yield 42
+    End Function
+End Class
+    </file>
+</compilation>
+
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="TrueTrueTrueFalse")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2201,7 +2304,6 @@ End Class
     </file>
 </compilation>
 
-            ' We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one exception one False one")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
 {
@@ -2253,6 +2355,41 @@ End Class
   IL_0008:  ret
 }
 ")
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce()
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext())
+        Console.Write(Not Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        Try
+            enumerator.MoveNext()
+        Catch
+            Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+        End Try
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce() As System.Collections.Generic.IEnumerable(Of Integer)
+        Yield 42
+        Throw New Exception("exception")
+    End Function
+End Class
+    </file>
+</compilation>
+
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="TrueTrueFalse")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2396,6 +2533,44 @@ End Class
   IL_0023:  ret
 }
 ")
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce()
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext())
+        Console.Write(Not Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        Try
+            enumerator.Dispose()
+        Catch
+            Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+        End Try
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce() As System.Collections.Generic.IEnumerable(Of Integer)
+        Try
+            Yield 42
+        Finally
+            Throw New Exception("exception")
+        End Try
+    End Function
+End Class
+    </file>
+</compilation>
+
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="TrueTrueFalse")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2436,8 +2611,6 @@ End Class
     </file>
 </compilation>
 
-            ' TODO2 confirm
-            ' We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one finally False one False one")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
 {
@@ -2520,6 +2693,46 @@ End Class
   IL_0008:  ret
 }
 ")
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+Imports System.Collections.Generic
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce(True)
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext())
+        Console.Write(Not Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+
+        Console.Write(Not enumerator.MoveNext())
+        Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce(b As Boolean) As IEnumerable(Of Integer)
+        Yield 42
+        Try
+            If b Then
+                Exit Function
+            End If
+        Finally
+            Console.Write(" finally ")
+        End Try
+        Yield 43
+    End Function
+End Class
+    </file>
+</compilation>
+
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="TrueTrue finally TrueFalse")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2567,8 +2780,6 @@ End Class
     </file>
 </compilation>
 
-            ' TODO2 confirm
-            ' We're not setting the state to "after"/"finished" (we're leaving it as "running") but that is not observable
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one finally exception one False one False one")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
 {
@@ -2632,6 +2843,48 @@ End Class
   IL_0008:  ret
 }
 ")
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+Imports System.Collections.Generic
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce()
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext())
+
+        Try
+            enumerator.MoveNext()
+        Catch ex As Exception
+            Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+        End Try
+
+        enumerator.Dispose()
+        Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce() As IEnumerable(Of Integer)
+        Yield 42
+        Try
+            Throw New Exception("exception")
+        Finally
+            Console.Write(" finally ")
+        End Try
+    End Function
+End Class
+    </file>
+</compilation>
+
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="True finally FalseTrue")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2775,6 +3028,47 @@ End Class
   IL_0023:  ret
 }
 ")
+
+
+            ' Verify GetEnumerator
+            Dim source2 =
+<compilation>
+    <file name="a2.vb">
+Imports System
+Imports System.Collections.Generic
+
+Module Program
+    Sub Main()
+        Dim enumerable = C.Produce()
+        Dim enumerator = enumerable.GetEnumerator()
+
+        Console.Write(enumerator.MoveNext())
+
+        Try
+            enumerator.MoveNext()
+        Catch ex As Exception
+            Console.Write(Object.ReferenceEquals(enumerable, enumerable.GetEnumerator()))
+        End Try
+    End Sub
+End Module
+
+Class C
+    Public Shared Iterator Function Produce() As IEnumerable(Of Integer)
+        Try
+            Yield 42
+            Throw New Exception("exception")
+        Finally
+            Console.Write(" finally ")
+        End Try
+    End Function
+End Class
+    </file>
+</compilation>
+
+            ' TODO2 difference from C#, look at the IL
+            ' We're not setting the state to "after"/"finished"
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76089
+            CompileAndVerify(source2, expectedOutput:="True finally False")
         End Sub
         'TODO2 document break in VB too
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1913,17 +1913,7 @@ End Class
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposed False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_Produce.Dispose()", "
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      ""C.VB$StateMachine_1_Produce.$State As Integer""
-  IL_0008:  ret
-}
-")
+            CompileAndVerify(source, expectedOutput:="True one disposed False one")
 
             ' Verify GetEnumerator
             Dim source2 =
@@ -2000,17 +1990,7 @@ End Class
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposed disposed2 False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0008:  ret
-}
-")
+            CompileAndVerify(source, expectedOutput:="True one disposed disposed2 False one")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2047,74 +2027,7 @@ End Class
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one False one False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
-{
-  // Code size      108 (0x6c)
-  .maxstack  3
-  .locals init (Integer V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  switch    (
-        IL_001b,
-        IL_003a,
-        IL_0061)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  dup
-  IL_001e:  stloc.0
-  IL_001f:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0024:  ldarg.0
-  IL_0025:  ldstr      "" one ""
-  IL_002a:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.1
-  IL_0031:  dup
-  IL_0032:  stloc.0
-  IL_0033:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0038:  ldc.i4.1
-  IL_0039:  ret
-  IL_003a:  ldarg.0
-  IL_003b:  ldc.i4.m1
-  IL_003c:  dup
-  IL_003d:  stloc.0
-  IL_003e:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0043:  ldarg.0
-  IL_0044:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$VB$Local_b As Boolean""
-  IL_0049:  brtrue.s   IL_006a
-  IL_004b:  ldarg.0
-  IL_004c:  ldstr      "" two ""
-  IL_0051:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-  IL_0056:  ldarg.0
-  IL_0057:  ldc.i4.2
-  IL_0058:  dup
-  IL_0059:  stloc.0
-  IL_005a:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_005f:  ldc.i4.1
-  IL_0060:  ret
-  IL_0061:  ldarg.0
-  IL_0062:  ldc.i4.m1
-  IL_0063:  dup
-  IL_0064:  stloc.0
-  IL_0065:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_006a:  ldc.i4.0
-  IL_006b:  ret
-}
-")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0008:  ret
-}
-")
+            CompileAndVerify(source, expectedOutput:="True one False one False one")
 
             ' Verify GetEnumerator
             Dim source2 =
@@ -2183,58 +2096,7 @@ End Class
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one done False one False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
-{
-  // Code size       68 (0x44)
-  .maxstack  3
-  .locals init (Integer V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_002f
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  dup
-  IL_0013:  stloc.0
-  IL_0014:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0019:  ldarg.0
-  IL_001a:  ldstr      "" one ""
-  IL_001f:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-  IL_0024:  ldarg.0
-  IL_0025:  ldc.i4.1
-  IL_0026:  dup
-  IL_0027:  stloc.0
-  IL_0028:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_002d:  ldc.i4.1
-  IL_002e:  ret
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.m1
-  IL_0031:  dup
-  IL_0032:  stloc.0
-  IL_0033:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0038:  ldstr      ""done ""
-  IL_003d:  call       ""Sub System.Console.Write(String)""
-  IL_0042:  ldc.i4.0
-  IL_0043:  ret
-}
-")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0008:  ret
-}
-")
+            CompileAndVerify(source, expectedOutput:="True one done False one False one")
 
             ' Verify GetEnumerator
             Dim source2 =
@@ -2304,57 +2166,7 @@ End Class
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one exception one False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
-{
-  // Code size       67 (0x43)
-  .maxstack  3
-  .locals init (Integer V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_002f
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  dup
-  IL_0013:  stloc.0
-  IL_0014:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0019:  ldarg.0
-  IL_001a:  ldstr      "" one ""
-  IL_001f:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-  IL_0024:  ldarg.0
-  IL_0025:  ldc.i4.1
-  IL_0026:  dup
-  IL_0027:  stloc.0
-  IL_0028:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_002d:  ldc.i4.1
-  IL_002e:  ret
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.m1
-  IL_0031:  dup
-  IL_0032:  stloc.0
-  IL_0033:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0038:  ldstr      ""exception""
-  IL_003d:  newobj     ""Sub System.Exception..ctor(String)""
-  IL_0042:  throw
-}
-")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0008:  ret
-}
-")
+            CompileAndVerify(source, expectedOutput:="True one exception one False one")
 
             ' Verify GetEnumerator
             Dim source2 =
@@ -2432,83 +2244,6 @@ End Class
 </compilation>
 
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposing exception disposed False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
-{
-  // Code size      127 (0x7f)
-  .maxstack  3
-  .locals init (Boolean V_0,
-                Integer V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0006:  stloc.1
-  IL_0007:  ldloc.1
-  IL_0008:  ldc.i4.s   -3
-  IL_000a:  sub
-  IL_000b:  switch    (
-        IL_002f,
-        IL_0024,
-        IL_0024,
-        IL_0026,
-        IL_002f)
-  IL_0024:  ldc.i4.0
-  IL_0025:  ret
-  IL_0026:  ldarg.0
-  IL_0027:  ldc.i4.m1
-  IL_0028:  dup
-  IL_0029:  stloc.1
-  IL_002a:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_002f:  nop
-  .try
-  {
-    IL_0030:  ldloc.1
-    IL_0031:  ldc.i4.s   -3
-    IL_0033:  beq.s      IL_003b
-    IL_0035:  ldloc.1
-    IL_0036:  ldc.i4.1
-    IL_0037:  beq.s      IL_0060
-    IL_0039:  br.s       IL_0048
-    IL_003b:  ldarg.0
-    IL_003c:  ldc.i4.m1
-    IL_003d:  dup
-    IL_003e:  stloc.1
-    IL_003f:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-    IL_0044:  ldc.i4.1
-    IL_0045:  stloc.0
-    IL_0046:  leave.s    IL_007d
-    IL_0048:  ldarg.0
-    IL_0049:  ldstr      "" one ""
-    IL_004e:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-    IL_0053:  ldarg.0
-    IL_0054:  ldc.i4.1
-    IL_0055:  dup
-    IL_0056:  stloc.1
-    IL_0057:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-    IL_005c:  ldc.i4.1
-    IL_005d:  stloc.0
-    IL_005e:  leave.s    IL_007d
-    IL_0060:  ldarg.0
-    IL_0061:  ldc.i4.m1
-    IL_0062:  dup
-    IL_0063:  stloc.1
-    IL_0064:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-    IL_0069:  leave.s    IL_007b
-  }
-  finally
-  {
-    IL_006b:  ldloc.1
-    IL_006c:  ldc.i4.0
-    IL_006d:  bge.s      IL_007a
-    IL_006f:  ldstr      ""exception""
-    IL_0074:  newobj     ""Sub System.Exception..ctor(String)""
-    IL_0079:  throw
-    IL_007a:  endfinally
-  }
-  IL_007b:  ldc.i4.0
-  IL_007c:  ret
-  IL_007d:  ldloc.0
-  IL_007e:  ret
-}
-")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
   // Code size       44 (0x2c)
@@ -2614,88 +2349,7 @@ End Class
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one finally False one False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
-{
-  // Code size      127 (0x7f)
-  .maxstack  3
-  .locals init (Integer V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  switch    (
-        IL_001b,
-        IL_003a,
-        IL_0074)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  dup
-  IL_001e:  stloc.0
-  IL_001f:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0024:  ldarg.0
-  IL_0025:  ldstr      "" one ""
-  IL_002a:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.1
-  IL_0031:  dup
-  IL_0032:  stloc.0
-  IL_0033:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0038:  ldc.i4.1
-  IL_0039:  ret
-  IL_003a:  ldarg.0
-  IL_003b:  ldc.i4.m1
-  IL_003c:  dup
-  IL_003d:  stloc.0
-  IL_003e:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  .try
-  {
-    IL_0043:  ldarg.0
-    IL_0044:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$VB$Local_b As Boolean""
-    IL_0049:  brfalse.s  IL_004d
-    IL_004b:  leave.s    IL_007d
-    IL_004d:  leave.s    IL_005e
-  }
-  finally
-  {
-    IL_004f:  ldloc.0
-    IL_0050:  ldc.i4.0
-    IL_0051:  bge.s      IL_005d
-    IL_0053:  ldstr      ""finally ""
-    IL_0058:  call       ""Sub System.Console.Write(String)""
-    IL_005d:  endfinally
-  }
-  IL_005e:  ldarg.0
-  IL_005f:  ldstr      "" two ""
-  IL_0064:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-  IL_0069:  ldarg.0
-  IL_006a:  ldc.i4.2
-  IL_006b:  dup
-  IL_006c:  stloc.0
-  IL_006d:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0072:  ldc.i4.1
-  IL_0073:  ret
-  IL_0074:  ldarg.0
-  IL_0075:  ldc.i4.m1
-  IL_0076:  dup
-  IL_0077:  stloc.0
-  IL_0078:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_007d:  ldc.i4.0
-  IL_007e:  ret
-}
-")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0008:  ret
-}
-")
+            CompileAndVerify(source, expectedOutput:="True one finally False one False one")
 
             ' Verify GetEnumerator
             Dim source2 =
@@ -2783,69 +2437,7 @@ End Class
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one finally exception one False one False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
-{
-  // Code size       82 (0x52)
-  .maxstack  3
-  .locals init (Integer V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_002f
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  dup
-  IL_0013:  stloc.0
-  IL_0014:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0019:  ldarg.0
-  IL_001a:  ldstr      "" one ""
-  IL_001f:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-  IL_0024:  ldarg.0
-  IL_0025:  ldc.i4.1
-  IL_0026:  dup
-  IL_0027:  stloc.0
-  IL_0028:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_002d:  ldc.i4.1
-  IL_002e:  ret
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.m1
-  IL_0031:  dup
-  IL_0032:  stloc.0
-  IL_0033:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  .try
-  {
-    IL_0038:  ldstr      ""exception""
-    IL_003d:  newobj     ""Sub System.Exception..ctor(String)""
-    IL_0042:  throw
-  }
-  finally
-  {
-    IL_0043:  ldloc.0
-    IL_0044:  ldc.i4.0
-    IL_0045:  bge.s      IL_0051
-    IL_0047:  ldstr      ""finally ""
-    IL_004c:  call       ""Sub System.Console.Write(String)""
-    IL_0051:  endfinally
-  }
-}
-")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   -2
-  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0008:  ret
-}
-")
+            CompileAndVerify(source, expectedOutput:="True one finally exception one False one False one")
 
             ' Verify GetEnumerator
             Dim source2 =
@@ -2921,7 +2513,9 @@ Class C
     Public Shared Iterator Function GetEnumerator(b As Boolean) As System.Collections.Generic.IEnumerator(Of String)
         Try
             Yield " one "
-            Throw New Exception("exception")
+            If b Then
+                Throw New Exception("exception")
+            End If
         Finally
             Console.Write("finally ")
         End Try
@@ -2931,82 +2525,6 @@ End Class
 </compilation>
 
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one finally exception one False one")
-            verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.MoveNext()", "
-{
-  // Code size      133 (0x85)
-  .maxstack  3
-  .locals init (Boolean V_0,
-                Integer V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_0006:  stloc.1
-  IL_0007:  ldloc.1
-  IL_0008:  ldc.i4.s   -3
-  IL_000a:  sub
-  IL_000b:  switch    (
-        IL_002f,
-        IL_0024,
-        IL_0024,
-        IL_0026,
-        IL_002f)
-  IL_0024:  ldc.i4.0
-  IL_0025:  ret
-  IL_0026:  ldarg.0
-  IL_0027:  ldc.i4.m1
-  IL_0028:  dup
-  IL_0029:  stloc.1
-  IL_002a:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-  IL_002f:  nop
-  .try
-  {
-    IL_0030:  ldloc.1
-    IL_0031:  ldc.i4.s   -3
-    IL_0033:  beq.s      IL_003b
-    IL_0035:  ldloc.1
-    IL_0036:  ldc.i4.1
-    IL_0037:  beq.s      IL_0060
-    IL_0039:  br.s       IL_0048
-    IL_003b:  ldarg.0
-    IL_003c:  ldc.i4.m1
-    IL_003d:  dup
-    IL_003e:  stloc.1
-    IL_003f:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-    IL_0044:  ldc.i4.1
-    IL_0045:  stloc.0
-    IL_0046:  leave.s    IL_0083
-    IL_0048:  ldarg.0
-    IL_0049:  ldstr      "" one ""
-    IL_004e:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$Current As String""
-    IL_0053:  ldarg.0
-    IL_0054:  ldc.i4.1
-    IL_0055:  dup
-    IL_0056:  stloc.1
-    IL_0057:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-    IL_005c:  ldc.i4.1
-    IL_005d:  stloc.0
-    IL_005e:  leave.s    IL_0083
-    IL_0060:  ldarg.0
-    IL_0061:  ldc.i4.m1
-    IL_0062:  dup
-    IL_0063:  stloc.1
-    IL_0064:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
-    IL_0069:  ldstr      ""exception""
-    IL_006e:  newobj     ""Sub System.Exception..ctor(String)""
-    IL_0073:  throw
-  }
-  finally
-  {
-    IL_0074:  ldloc.1
-    IL_0075:  ldc.i4.0
-    IL_0076:  bge.s      IL_0082
-    IL_0078:  ldstr      ""finally ""
-    IL_007d:  call       ""Sub System.Console.Write(String)""
-    IL_0082:  endfinally
-  }
-  IL_0083:  ldloc.0
-  IL_0084:  ret
-}
-")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
   // Code size       44 (0x2c)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1866,17 +1866,18 @@ Class C
         Yield " two "
     End Function
 End Class
-
     </file>
 </compilation>
 
-            ' TODO2 bug
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposed True two")
+            Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposed False one")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_0008:  ret
 }
 ")
         End Sub
@@ -1909,18 +1910,20 @@ Class C
         Yield " two "
     End Function
 End Class
-
     </file>
 </compilation>
 
-            ' TODO2 bug
-            Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposed True two")
+            Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposed False one")
             verifier.VerifyIL("C.VB$StateMachine_1_Produce.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
-}")
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_Produce.$State As Integer""
+  IL_0008:  ret
+}
+")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -1961,10 +1964,14 @@ End Class
             Dim verifier = CompileAndVerify(source, expectedOutput:="True one disposed disposed2 False one")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
-}")
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_0008:  ret
+}
+")
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2062,9 +2069,12 @@ End Class
 ")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_0008:  ret
 }
 ")
         End Sub
@@ -2145,9 +2155,12 @@ End Class
 ")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_0008:  ret
 }
 ")
         End Sub
@@ -2232,9 +2245,12 @@ End Class
 ")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_0008:  ret
 }
 ")
         End Sub
@@ -2496,13 +2512,14 @@ End Class
 ")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_0008:  ret
 }
 ")
-
-
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76078")>
@@ -2607,9 +2624,12 @@ End Class
 ")
             verifier.VerifyIL("C.VB$StateMachine_1_GetEnumerator.Dispose()", "
 {
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      ""C.VB$StateMachine_1_GetEnumerator.$State As Integer""
+  IL_0008:  ret
 }
 ")
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -253,9 +253,12 @@ End Class
   IL_0018:  ret
 }
 {
-  // Code size        1 (0x1)
+  // Code size        9 (0x9)
   .maxstack  8
-  IL_0000:  ret
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   -2
+  IL_0003:  stfld      0x04000005
+  IL_0008:  ret
 }
 {
   // Code size       63 (0x3f)

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -13,6 +13,7 @@ Imports Xunit.Abstractions
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
+    <CompilerTrait(CompilerFeature.Iterator, CompilerFeature.Async, CompilerFeature.AsyncStreams)>
     Public Class EditAndContinueStateMachineTests
         Inherits EditAndContinueTestBase
 
@@ -4996,7 +4997,7 @@ End Try</N:3>
 
                 v0.VerifyIL("C.VB$StateMachine_9_F.Dispose", "
 {
-  // Code size       38 (0x26)
+  // Code size       46 (0x2e)
   .maxstack  2
   .locals init (Integer V_0)
   IL_0000:  ldarg.0
@@ -5016,11 +5017,14 @@ End Try</N:3>
   IL_001e:  ldarg.0
   IL_001f:  call       ""Function C.VB$StateMachine_9_F.MoveNext() As Boolean""
   IL_0024:  pop
-  IL_0025:  ret
+  IL_0025:  ldarg.0
+  IL_0026:  ldc.i4.s   -2
+  IL_0028:  stfld      ""C.VB$StateMachine_9_F.$State As Integer""
+  IL_002d:  ret
 }")
                 diff1.VerifyIL("C.VB$StateMachine_9_F.Dispose", "
 {
-  // Code size       78 (0x4e)
+  // Code size       86 (0x56)
   .maxstack  2
   .locals init (Integer V_0)
   IL_0000:  ldarg.0
@@ -5053,7 +5057,10 @@ End Try</N:3>
   IL_0046:  ldarg.0
   IL_0047:  call       ""Function C.VB$StateMachine_9_F.MoveNext() As Boolean""
   IL_004c:  pop
-  IL_004d:  ret
+  IL_004d:  ldarg.0
+  IL_004e:  ldc.i4.s   -2
+  IL_0050:  stfld      ""C.VB$StateMachine_9_F.$State As Integer""
+  IL_0055:  ret
 }")
                 v0.VerifyIL("C.VB$StateMachine_9_F.MoveNext", "
   {
@@ -5499,8 +5506,8 @@ End Using
                     "C: {VB$StateMachine_6_F}")
 
                 v0.VerifyIL("C.VB$StateMachine_6_F.Dispose", "
-  {
-  // Code size       38 (0x26)
+{
+  // Code size       46 (0x2e)
   .maxstack  2
   .locals init (Integer V_0)
   IL_0000:  ldarg.0
@@ -5510,24 +5517,24 @@ End Using
   IL_0008:  ldc.i4.1
   IL_0009:  beq.s      IL_000d
   IL_000b:  br.s       IL_0017
-
   IL_000d:  ldarg.0
   IL_000e:  ldc.i4.s   -3
   IL_0010:  stfld      ""C.VB$StateMachine_6_F.$State As Integer""
   IL_0015:  br.s       IL_001e
-
   IL_0017:  ldarg.0
   IL_0018:  ldc.i4.m1
   IL_0019:  stfld      ""C.VB$StateMachine_6_F.$State As Integer""
-
   IL_001e:  ldarg.0
   IL_001f:  call       ""Function C.VB$StateMachine_6_F.MoveNext() As Boolean""
   IL_0024:  pop
-  IL_0025:  ret
+  IL_0025:  ldarg.0
+  IL_0026:  ldc.i4.s   -2
+  IL_0028:  stfld      ""C.VB$StateMachine_6_F.$State As Integer""
+  IL_002d:  ret
 }")
                 diff1.VerifyIL("C.VB$StateMachine_6_F.Dispose", "
 {
-  // Code size       40 (0x28)
+  // Code size       48 (0x30)
   .maxstack  2
   .locals init (Integer V_0)
   IL_0000:  ldarg.0
@@ -5539,20 +5546,20 @@ End Using
   IL_000a:  ldc.i4.1
   IL_000b:  ble.un.s   IL_000f
   IL_000d:  br.s       IL_0019
-
   IL_000f:  ldarg.0
   IL_0010:  ldc.i4.s   -3
   IL_0012:  stfld      ""C.VB$StateMachine_6_F.$State As Integer""
   IL_0017:  br.s       IL_0020
-
   IL_0019:  ldarg.0
   IL_001a:  ldc.i4.m1
   IL_001b:  stfld      ""C.VB$StateMachine_6_F.$State As Integer""
-
   IL_0020:  ldarg.0
   IL_0021:  call       ""Function C.VB$StateMachine_6_F.MoveNext() As Boolean""
   IL_0026:  pop
-  IL_0027:  ret
+  IL_0027:  ldarg.0
+  IL_0028:  ldc.i4.s   -2
+  IL_002a:  stfld      ""C.VB$StateMachine_6_F.$State As Integer""
+  IL_002f:  ret
 }")
                 v0.VerifyIL("C.VB$StateMachine_6_F.MoveNext", "
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76078
This change is pending on approval for breaking change. This behavior exists as far back as the native compiler.

Note: there are more scenarios left where we don't properly set the state to "after", but the impact is much less impactful. Filed follow-up issue https://github.com/dotnet/roslyn/issues/76089.