### PR TITLE
Do not offer to simplify a set to a collection expr when assigning to a non-set interface

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -267,6 +267,14 @@ internal static class UseCollectionExpressionHelpers
                 if (type.Name is nameof(ObservableCollection<int>) or nameof(ReadOnlyObservableCollection<int>))
                     return false;
 
+                // If the original expression was creating a set, but is being assigned to one of the well known
+                // interfaces, then we don't want to convert this.  This is because the set has different semantics than
+                // the linear sequence types.
+                var isetType = compilation.ISetOfTType();
+                var ireadoOnlySetType = compilation.IReadOnlySetOfTType();
+                if (type.AllInterfaces.Any(t => t.OriginalDefinition.Equals(isetType) || t.OriginalDefinition.Equals(ireadoOnlySetType)))
+                    return false;
+
                 return true;
             }
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -271,8 +271,8 @@ internal static class UseCollectionExpressionHelpers
                 // interfaces, then we don't want to convert this.  This is because the set has different semantics than
                 // the linear sequence types.
                 var isetType = compilation.ISetOfTType();
-                var ireadoOnlySetType = compilation.IReadOnlySetOfTType();
-                if (type.AllInterfaces.Any(t => t.OriginalDefinition.Equals(isetType) || t.OriginalDefinition.Equals(ireadoOnlySetType)))
+                var ireadOnlySetType = compilation.IReadOnlySetOfTType();
+                if (type.AllInterfaces.Any(t => t.OriginalDefinition.Equals(isetType) || t.OriginalDefinition.Equals(ireadOnlySetType)))
                     return false;
 
                 return true;

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -25,7 +25,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     {
         await new VerifyCS.Test
         {
-            ReferenceAssemblies = Testing.ReferenceAssemblies.NetCore.NetCoreApp31,
+            ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp31,
             TestCode = testCode,
             FixedCode = fixedCode,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -5881,6 +5881,59 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                     {
                         Dictionary<string, string> a = null;
                         Dictionary<string, string> d = new(a);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp13,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76092")]
+    public async Task TestNotOnSetAssignedToNonSet()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void Main()
+                    {
+                        ICollection<int> a = new HashSet<int>();
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp13,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76092")]
+    public async Task TestOnSetAssignedToSet()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void Main()
+                    {
+                        HashSet<int> a = [|new|] HashSet<int>();
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void Main()
+                    {
+                        HashSet<int> a = [];
                     }
                 }
                 """,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
@@ -144,6 +144,12 @@ internal static class ICompilationExtensions
     public static INamedTypeSymbol? IReadOnlyListOfTType(this Compilation compilation)
         => compilation.GetTypeByMetadataName(typeof(IReadOnlyList<>).FullName!);
 
+    public static INamedTypeSymbol? ISetOfTType(this Compilation compilation)
+        => compilation.GetTypeByMetadataName(typeof(ISet<>).FullName!);
+
+    public static INamedTypeSymbol? IReadOnlySetOfTType(this Compilation compilation)
+        => compilation.GetTypeByMetadataName(typeof(IReadOnlySet<>).FullName!);
+
     public static INamedTypeSymbol? IAsyncEnumerableOfTType(this Compilation compilation)
         => compilation.GetTypeByMetadataName("System.Collections.Generic.IAsyncEnumerable`1");
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76092