### PR TITLE
Allow non-constant expressions to affect control flow analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -117,25 +117,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        public override BoundNode Visit(BoundNode node)
-        {
-            // Except for some patterns (`is var x` always matches)
-            // and constant expressions (which are handled by the caller),
-            // there is no need to scan the contents of an expression, as expressions
-            // do not contribute to reachability analysis
-            if (node is BoundIsPatternExpression)
-            {
-                return base.Visit(node);
-            }
-
-            if (!(node is BoundExpression))
-            {
-                return base.Visit(node);
-            }
-
-            return null;
-        }
-
         protected override ImmutableArray<PendingBranch> Scan(ref bool badRegion)
         {
             this.Diagnostics.Clear();  // clear reported diagnostics

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -119,9 +119,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode Visit(BoundNode node)
         {
+            // Except for some patterns (`is var x` always matches)
+            // and constant expressions (which are handled by the caller),
             // there is no need to scan the contents of an expression, as expressions
-            // do not contribute to reachability analysis (except for constants, which
-            // are handled by the caller).
+            // do not contribute to reachability analysis
+            if (node is BoundIsPatternExpression)
+            {
+                return base.Visit(node);
+            }
+
             if (!(node is BoundExpression))
             {
                 return base.Visit(node);

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowTests.cs
@@ -5446,13 +5446,32 @@ class C
         }
         else
         {
-            x = x + 1; // reachable, and x is definitely assigned here
+            x = x + 1; // unreachable
         }
 
         Console.WriteLine(j);
     }
 }
 ";
+            CreateCompilationWithMscorlib461(source).VerifyDiagnostics(
+                // (13,13): warning CS0162: Unreachable code detected
+                //             x = x + 1;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "x").WithLocation(13, 13));
+        }
+
+        [Fact, WorkItem(14651, "https://github.com/dotnet/roslyn/issues/14651")]
+        public void IrrefutablePattern_2()
+        {
+            var source = """
+class C
+{
+    void TestFunc(int i)
+    {
+        if (i is int j) { }
+        System.Console.WriteLine(j);
+    }
+}
+""";
             CreateCompilationWithMscorlib461(source).VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/IterationJumpYieldStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/IterationJumpYieldStatementTests.cs
@@ -1352,5 +1352,26 @@ public class Test
         }
 
         #endregion
+
+        [Fact]
+        public void IfIsVarPattern()
+        {
+            var analysisResults = CompileAndAnalyzeControlAndDataFlowStatements("""
+class C
+{
+    static void M()
+    {
+/*<bind>*/
+        while (1 is var x)
+        {
+        }
+/*</bind>*/
+    }
+}
+""");
+            var controlFlowAnalysisResults = analysisResults.controlFlowAnalysis;
+            Assert.True(controlFlowAnalysisResults.StartPointIsReachable);
+            Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
@@ -25069,7 +25069,7 @@ class Helper1<T>
         }
         else
         {
-            System.Console.Write(2);
+            System.Console.Write(2); // 1
         }
     }
 }
@@ -25085,7 +25085,7 @@ class Helper2
         }
         else
         {
-            System.Console.Write(4);
+            System.Console.Write(4); // 2
         }
     }
 }
@@ -25112,7 +25112,13 @@ class Program
                 comp,
                 expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "113" : null,
                 verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).
-            VerifyDiagnostics();
+            VerifyDiagnostics(
+                // (14,13): warning CS0162: Unreachable code detected
+                //             System.Console.Write(2); // 1
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(14, 13),
+                // (30,13): warning CS0162: Unreachable code detected
+                //             System.Console.Write(4); // 2
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(30, 13));
 
             verifier.VerifyIL("Helper1<T>.Test1(T)",
 @"

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests2.cs
@@ -1459,18 +1459,21 @@ class Program1
     {
         int j;
         const string s = null;
-        if (s is string { Length: 3 })
+        if (s is string { Length: 3 }) // 1
         {
-            System.Console.WriteLine(j);
+            System.Console.WriteLine(j); // 2
         }
     }
 }
 ";
             var compilation = CreatePatternCompilation(source);
             compilation.VerifyDiagnostics(
-                // (7,13): warning CS8416: The given expression never matches the provided pattern.
-                //         if (s is string { Length: 3 })
-                Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, "s is string { Length: 3 }").WithLocation(7, 13)
+                // 0.cs(7,13): warning CS8519: The given expression never matches the provided pattern.
+                //         if (s is string { Length: 3 }) // 1
+                Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, "s is string { Length: 3 }").WithLocation(7, 13),
+                // 0.cs(9,13): warning CS0162: Unreachable code detected
+                //             System.Console.WriteLine(j); // 2
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(9, 13)
                 );
         }
 
@@ -1485,21 +1488,24 @@ class Program1
         int j;
         const int N = 3;
         const int M = 3;
-        if (N is M)
+        if (N is M) // 1
         {
         }
         else
         {
-            System.Console.WriteLine(j);
+            System.Console.WriteLine(j); // 2
         }
     }
 }
 ";
             var compilation = CreatePatternCompilation(source);
             compilation.VerifyDiagnostics(
-                // (8,13): warning CS8417: The given expression always matches the provided constant.
-                //         if (N is M)
-                Diagnostic(ErrorCode.WRN_GivenExpressionAlwaysMatchesConstant, "N is M").WithLocation(8, 13)
+                // 0.cs(8,13): warning CS8520: The given expression always matches the provided constant.
+                //         if (N is M) // 1
+                Diagnostic(ErrorCode.WRN_GivenExpressionAlwaysMatchesConstant, "N is M").WithLocation(8, 13),
+                // 0.cs(13,13): warning CS0162: Unreachable code detected
+                //             System.Console.WriteLine(j); // 2
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(13, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests3.cs
@@ -6493,7 +6493,10 @@ class C
                 Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, "s is string t").WithLocation(12, 15),
                 // (17,13): warning CS8793: The given expression always matches the provided pattern.
                 //         if (s is not string t) return;
-                Diagnostic(ErrorCode.WRN_GivenExpressionAlwaysMatchesPattern, "s is not string t").WithLocation(17, 13));
+                Diagnostic(ErrorCode.WRN_GivenExpressionAlwaysMatchesPattern, "s is not string t").WithLocation(17, 13),
+                // (18,9): warning CS0162: Unreachable code detected
+                //         WriteLine(t.Length);
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "WriteLine").WithLocation(18, 9));
             var verifier = CompileAndVerify(source, expectedOutput: "");
             var expectedIL =
 @"{
@@ -6765,7 +6768,10 @@ class C
                 Diagnostic(ErrorCode.WRN_GivenExpressionAlwaysMatchesPattern, $"i is {pattern}").WithLocation(12, 15),
                 // (17,13): warning CS8519: The given expression never matches the provided pattern.
                 //         if (i is not (2 and int t)) return;
-                Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, $"i is not ({pattern})").WithLocation(17, 13)
+                Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, $"i is not ({pattern})").WithLocation(17, 13),
+                // (17,39): warning CS0162: Unreachable code detected
+                //         if (i is not (2 and int t)) return;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "return")
                 );
             var verifier = CompileAndVerify(source, expectedOutput: "22");
             var expectedIL =
@@ -6823,7 +6829,10 @@ class C
                 Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, $"i is {pattern}").WithLocation(12, 15),
                 // (17,13): warning CS8519: The given expression never matches the provided pattern.
                 //         if (i is not (2 and int t)) return;
-                Diagnostic(ErrorCode.WRN_GivenExpressionAlwaysMatchesPattern, $"i is not ({pattern})").WithLocation(17, 13)
+                Diagnostic(ErrorCode.WRN_GivenExpressionAlwaysMatchesPattern, $"i is not ({pattern})").WithLocation(17, 13),
+                // (18,9): warning CS0162: Unreachable code detected
+                //         Write(t.ToString());
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "Write").WithLocation(18, 9)
             );
             var verifier = CompileAndVerify(comp, expectedOutput: "");
             var expectedIL =

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
@@ -5181,5 +5181,21 @@ System.Func<int> x = () =>
                 // System.Func<int> x = () =>
                 Diagnostic(ErrorCode.ERR_AnonymousReturnExpected, "=>").WithArguments("lambda expression", "System.Func<int>").WithLocation(3, 25));
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76059")]
+        public void FlowAnalysis_VarPattern_Two()
+        {
+            var source = """
+M();
+
+int M()
+{
+    while (M2() is var number1 && M2() is var number2) { }
+}
+int M2() => throw null;
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_Scope.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_Scope.cs
@@ -7168,7 +7168,10 @@ public class X
             compilation.VerifyDiagnostics(
                 // (17,9): error CS0103: The name 'x1' does not exist in the current context
                 //         x1++;
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(17, 9)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(17, 9),
+                // (17,9): warning CS0162: Unreachable code detected
+                //         x1++;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "x1").WithLocation(17, 9)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -7491,7 +7494,10 @@ public class X
             compilation.VerifyDiagnostics(
                 // (18,9): error CS0103: The name 'x1' does not exist in the current context
                 //         x1++;
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(18, 9)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(18, 9),
+                // (18,9): warning CS0162: Unreachable code detected
+                //         x1++;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "x1").WithLocation(18, 9)
                 );
 
             var tree = compilation.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -293,7 +293,7 @@ class C
         }
         else
         {
-            x.ToString();
+            x.ToString(); // 3
         }
     }
     void Test2(object x)
@@ -305,19 +305,25 @@ class C
         }
         else
         {
-            x.ToString();
+            x.ToString(); // 4
         }
     }
 }
 ");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Dereference of a possibly null reference.
+                // 0.cs(8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
-                // (9,13): warning CS8602: Dereference of a possibly null reference.
+                // 0.cs(9,13): warning CS8602: Dereference of a possibly null reference.
                 //             c /*T:object?*/ .ToString(); // warn 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(9, 13)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(9, 13),
+                // 0.cs(14,13): warning CS0162: Unreachable code detected
+                //             x.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "x").WithLocation(14, 13),
+                // 0.cs(26,13): warning CS0162: Unreachable code detected
+                //             x.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "x").WithLocation(26, 13)
                 );
         }
 
@@ -335,7 +341,7 @@ class C
         }
         else
         {
-            x.ToString();
+            x.ToString(); // 2
         }
     }
     void Test2(object x)
@@ -346,16 +352,22 @@ class C
         }
         else
         {
-            x.ToString();
+            x.ToString(); // 3
         }
     }
 }
 ");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Dereference of a possibly null reference.
+                // 0.cs(8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
+                // 0.cs(12,13): warning CS0162: Unreachable code detected
+                //             x.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "x").WithLocation(12, 13),
+                // 0.cs(23,13): warning CS0162: Unreachable code detected
+                //             x.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "x").WithLocation(23, 13)
                 );
         }
 
@@ -571,15 +583,18 @@ class C
         }
         else
         {
-            s.ToString();
+            s.ToString(); // 2
         }
     }
 }";
             var comp = CreateNullableCompilation(source);
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Dereference of a possibly null reference.
+                // 0.cs(7,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 13)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 13),
+                // 0.cs(11,13): warning CS0162: Unreachable code detected
+                //             s.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "s").WithLocation(11, 13)
                 );
         }
 
@@ -1467,9 +1482,12 @@ class Test
 }";
             var comp = CreateNullableCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,13): warning CS8519: The given expression never matches the provided pattern.
+                // 0.cs(6,13): warning CS8519: The given expression never matches the provided pattern.
                 //         if (2 is 3)
-                Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, "2 is 3").WithLocation(6, 13));
+                Diagnostic(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, "2 is 3").WithLocation(6, 13),
+                // 0.cs(7,13): warning CS0162: Unreachable code detected
+                //             o = null;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "o").WithLocation(7, 13));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76059
Will confirm with LDM before opening this for review.

Although patterns are not constants, we are able to analyze their control flow. 
For instance, "a match to a var pattern always succeeds with a simple_designation." ([see](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-8.0/patterns.md#var-pattern)).
This analysis is done during DAG construction (we figure out which labels are reachable) and handled in `AbstractFlowAnalysis.VisitIsPatternExpression` to construct the right conditional state (where one branch may be unreachable).

Relates to https://github.com/dotnet/roslyn/issues/14651