### PR TITLE
When converting to raw strings, do not change \r\n sequences if not explicitly requested by the user

### DIFF
--- a/src/Features/CSharp/Portable/ConvertToRawString/CanConvertParams.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/CanConvertParams.cs
@@ -6,9 +6,14 @@ using Microsoft.CodeAnalysis.CodeActions;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertToRawString;
 
-internal readonly struct CanConvertParams(CodeActionPriority priority, bool canBeSingleLine, bool canBeMultiLineWithoutLeadingWhiteSpaces)
+internal readonly struct CanConvertParams(
+    CodeActionPriority priority,
+    bool canBeSingleLine,
+    bool canBeMultiLineWithoutLeadingWhiteSpaces,
+    bool containsEscapedEndOfLineCharacter)
 {
     public CodeActionPriority Priority { get; } = priority;
     public bool CanBeSingleLine { get; } = canBeSingleLine;
     public bool CanBeMultiLineWithoutLeadingWhiteSpaces { get; } = canBeMultiLineWithoutLeadingWhiteSpaces;
+    public bool ContainsEscapedEndOfLineCharacter { get; } = containsEscapedEndOfLineCharacter;
 }

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertInterpolatedStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertInterpolatedStringToRawStringCodeRefactoringProvider.cs
@@ -77,6 +77,7 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
 
         var priority = CodeActionPriority.Low;
         var canBeSingleLine = true;
+        var containsEscapedEndOfLineCharacter = false;
         foreach (var content in stringExpression.Contents)
         {
             if (content is InterpolationSyntax interpolation)
@@ -86,8 +87,10 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
                     var characters = TryConvertToVirtualChars(interpolation.FormatClause.FormatStringToken);
 
                     // Ensure that all characters in the string are those we can convert.
-                    if (!ConvertToRawStringHelpers.CanConvert(characters))
+                    if (!ConvertToRawStringHelpers.CanConvert(characters, out var chunkContainsEscapedEndOfLineCharacter))
                         return false;
+
+                    containsEscapedEndOfLineCharacter |= chunkContainsEscapedEndOfLineCharacter;
                 }
 
                 if (canBeSingleLine && !document.Text.AreOnSameLine(interpolation.OpenBraceToken, interpolation.CloseBraceToken))
@@ -98,8 +101,10 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
                 var characters = TryConvertToVirtualChars(interpolatedStringText);
 
                 // Ensure that all characters in the string are those we can convert.
-                if (!ConvertToRawStringHelpers.CanConvert(characters))
+                if (!ConvertToRawStringHelpers.CanConvert(characters, out var chunkContainsEscapedEndOfLineCharacter))
                     return false;
+
+                containsEscapedEndOfLineCharacter |= chunkContainsEscapedEndOfLineCharacter;
 
                 if (canBeSingleLine)
                 {
@@ -167,7 +172,8 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
             canBeMultiLineWithoutLeadingWhiteSpaces = !cleaned.IsEquivalentTo(converted);
         }
 
-        convertParams = new CanConvertParams(priority, canBeSingleLine, canBeMultiLineWithoutLeadingWhiteSpaces);
+        convertParams = new CanConvertParams(
+            priority, canBeSingleLine, canBeMultiLineWithoutLeadingWhiteSpaces, containsEscapedEndOfLineCharacter);
         return true;
     }
 
@@ -178,7 +184,7 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
         SyntaxFormattingOptions formattingOptions,
         CancellationToken cancellationToken)
     {
-        if (kind == ConvertToRawKind.SingleLine)
+        if (kind.HasFlag(ConvertToRawKind.SingleLine))
             return ConvertToSingleLineRawString();
 
         var indentationOptions = new IndentationOptions(formattingOptions);
@@ -231,7 +237,7 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
             var rawStringExpression = GetInitialMultiLineRawInterpolatedString(stringExpression, formattingOptions);
 
             // If requested, cleanup the whitespace in the expression.
-            var cleanedExpression = kind == ConvertToRawKind.MultiLineWithoutLeadingWhitespace
+            var cleanedExpression = kind.HasFlag(ConvertToRawKind.MultiLineWithoutLeadingWhitespace)
                 ? CleanInterpolatedString(rawStringExpression, cancellationToken)
                 : rawStringExpression;
 

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertInterpolatedStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertInterpolatedStringToRawStringCodeRefactoringProvider.cs
@@ -184,7 +184,7 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
         SyntaxFormattingOptions formattingOptions,
         CancellationToken cancellationToken)
     {
-        if (kind.HasFlag(ConvertToRawKind.SingleLine))
+        if ((kind & ConvertToRawKind.SingleLine) == ConvertToRawKind.SingleLine)
             return ConvertToSingleLineRawString();
 
         var indentationOptions = new IndentationOptions(formattingOptions);
@@ -237,7 +237,7 @@ internal sealed partial class ConvertInterpolatedStringToRawStringProvider
             var rawStringExpression = GetInitialMultiLineRawInterpolatedString(stringExpression, formattingOptions);
 
             // If requested, cleanup the whitespace in the expression.
-            var cleanedExpression = kind.HasFlag(ConvertToRawKind.MultiLineWithoutLeadingWhitespace)
+            var cleanedExpression = (kind & ConvertToRawKind.MultiLineWithoutLeadingWhitespace) == ConvertToRawKind.MultiLineWithoutLeadingWhitespace
                 ? CleanInterpolatedString(rawStringExpression, cancellationToken)
                 : rawStringExpression;
 

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
@@ -145,7 +145,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         var characters = CSharpVirtualCharService.Instance.TryConvertToVirtualChars(token);
         Contract.ThrowIfTrue(characters.IsDefaultOrEmpty);
 
-        if (kind.HasFlag(ConvertToRawKind.SingleLine))
+        if ((kind & ConvertToRawKind.SingleLine) == ConvertToRawKind.SingleLine)
             return ConvertToSingleLineRawString();
 
         var indentationOptions = new IndentationOptions(formattingOptions);
@@ -203,7 +203,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         SyntaxToken ConvertToMultiLineRawIndentedString(string indentation)
         {
             // If the user asked to remove whitespace then do so now.
-            if (kind.HasFlag(ConvertToRawKind.MultiLineWithoutLeadingWhitespace))
+            if ((kind & ConvertToRawKind.MultiLineWithoutLeadingWhitespace) == ConvertToRawKind.MultiLineWithoutLeadingWhitespace)
                 characters = CleanupWhitespace(characters);
 
             // Have to make sure we have a delimiter longer than any quote sequence in the string.

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
@@ -54,7 +54,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
 
         var characters = CSharpVirtualCharService.Instance.TryConvertToVirtualChars(token);
 
-        if (!ConvertToRawStringHelpers.CanConvert(characters))
+        if (!ConvertToRawStringHelpers.CanConvert(characters, out var containsEscapedEndOfLineCharacter))
             return false;
 
         // TODO(cyrusn): Should we offer this on empty strings... seems undesirable as you'd end with a gigantic 
@@ -100,7 +100,8 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         // invoking this on lots of strings that they have no interest in converting.
         var priority = AllEscapesAreQuotes(characters) ? CodeActionPriority.Default : CodeActionPriority.Low;
 
-        convertParams = new CanConvertParams(priority, canBeSingleLine, canBeMultiLineWithoutLeadingWhiteSpaces);
+        convertParams = new CanConvertParams(
+            priority, canBeSingleLine, canBeMultiLineWithoutLeadingWhiteSpaces, containsEscapedEndOfLineCharacter);
         return true;
 
         static bool HasLeadingWhitespace(VirtualCharSequence characters)
@@ -144,7 +145,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         var characters = CSharpVirtualCharService.Instance.TryConvertToVirtualChars(token);
         Contract.ThrowIfTrue(characters.IsDefaultOrEmpty);
 
-        if (kind == ConvertToRawKind.SingleLine)
+        if (kind.HasFlag(ConvertToRawKind.SingleLine))
             return ConvertToSingleLineRawString();
 
         var indentationOptions = new IndentationOptions(formattingOptions);
@@ -202,7 +203,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         SyntaxToken ConvertToMultiLineRawIndentedString(string indentation)
         {
             // If the user asked to remove whitespace then do so now.
-            if (kind == ConvertToRawKind.MultiLineWithoutLeadingWhitespace)
+            if (kind.HasFlag(ConvertToRawKind.MultiLineWithoutLeadingWhitespace))
                 characters = CleanupWhitespace(characters);
 
             // Have to make sure we have a delimiter longer than any quote sequence in the string.

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertStringToRawStringCodeRefactoringProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,23 +23,21 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp.ConvertToRawString;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertToRawString), Shared]
-internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider : SyntaxEditorBasedCodeRefactoringProvider
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider() : SyntaxEditorBasedCodeRefactoringProvider
 {
-    private static readonly BidirectionalMap<ConvertToRawKind, string> s_kindToEquivalenceKeyMap =
-        new(
-        [
-            KeyValuePairUtil.Create(ConvertToRawKind.SingleLine, nameof(ConvertToRawKind.SingleLine)),
-            KeyValuePairUtil.Create(ConvertToRawKind.MultiLineIndented, nameof(ConvertToRawKind.MultiLineIndented)),
-            KeyValuePairUtil.Create(ConvertToRawKind.MultiLineWithoutLeadingWhitespace, nameof(ConvertToRawKind.MultiLineWithoutLeadingWhitespace)),
-        ]);
+    private static readonly string[] s_kindToEquivalenceKeyMap;
+
+    static ConvertStringToRawStringCodeRefactoringProvider()
+    {
+        var count = (int)ConvertToRawKind.ContainsEscapedEndOfLineCharacter * 2;
+        s_kindToEquivalenceKeyMap = new string[count];
+        for (var i = 0; i < count; i++)
+            s_kindToEquivalenceKeyMap[i] = i.ToString(CultureInfo.InvariantCulture);
+    }
 
     private static readonly ImmutableArray<IConvertStringProvider> s_convertStringProviders = [ConvertRegularStringToRawStringProvider.Instance, ConvertInterpolatedStringToRawStringProvider.Instance];
-
-    [ImportingConstructor]
-    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-    public ConvertStringToRawStringCodeRefactoringProvider()
-    {
-    }
 
     protected override ImmutableArray<FixAllScope> SupportedFixAllScopes => AllFixAllScopes;
 
@@ -84,13 +83,17 @@ internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider : 
 
         var priority = convertParams.Priority;
 
+        var kind = convertParams.ContainsEscapedEndOfLineCharacter
+            ? ConvertToRawKind.ContainsEscapedEndOfLineCharacter
+            : 0;
+
         if (convertParams.CanBeSingleLine)
         {
             context.RegisterRefactoring(
                 CodeAction.Create(
                     CSharpFeaturesResources.Convert_to_raw_string,
-                    cancellationToken => UpdateDocumentAsync(document, parentExpression, ConvertToRawKind.SingleLine, provider, cancellationToken),
-                    s_kindToEquivalenceKeyMap[ConvertToRawKind.SingleLine],
+                    cancellationToken => UpdateDocumentAsync(document, parentExpression, kind | ConvertToRawKind.SingleLine, provider, cancellationToken),
+                    s_kindToEquivalenceKeyMap[(int)(kind | ConvertToRawKind.SingleLine)],
                     priority),
                 token.Span);
         }
@@ -99,8 +102,8 @@ internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider : 
             context.RegisterRefactoring(
                 CodeAction.Create(
                     CSharpFeaturesResources.Convert_to_raw_string,
-                    cancellationToken => UpdateDocumentAsync(document, parentExpression, ConvertToRawKind.MultiLineIndented, provider, cancellationToken),
-                    s_kindToEquivalenceKeyMap[ConvertToRawKind.MultiLineIndented],
+                    cancellationToken => UpdateDocumentAsync(document, parentExpression, kind | ConvertToRawKind.MultiLineIndented, provider, cancellationToken),
+                    s_kindToEquivalenceKeyMap[(int)(kind | ConvertToRawKind.MultiLineIndented)],
                     priority),
                 token.Span);
 
@@ -109,8 +112,8 @@ internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider : 
                 context.RegisterRefactoring(
                     CodeAction.Create(
                         CSharpFeaturesResources.without_leading_whitespace_may_change_semantics,
-                        cancellationToken => UpdateDocumentAsync(document, parentExpression, ConvertToRawKind.MultiLineWithoutLeadingWhitespace, provider, cancellationToken),
-                        s_kindToEquivalenceKeyMap[ConvertToRawKind.MultiLineWithoutLeadingWhitespace],
+                        cancellationToken => UpdateDocumentAsync(document, parentExpression, kind | ConvertToRawKind.MultiLineWithoutLeadingWhitespace, provider, cancellationToken),
+                        s_kindToEquivalenceKeyMap[(int)(kind | ConvertToRawKind.MultiLineWithoutLeadingWhitespace)],
                         priority),
                     token.Span);
             }
@@ -141,7 +144,7 @@ internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider : 
     {
         // Get the kind to be fixed from the equivalenceKey for the FixAll operation
         Debug.Assert(equivalenceKey != null);
-        var kind = s_kindToEquivalenceKeyMap[equivalenceKey];
+        var kind = (ConvertToRawKind)int.Parse(equivalenceKey, CultureInfo.InvariantCulture);
 
         var formattingOptions = await document.GetSyntaxFormattingOptionsAsync(cancellationToken).ConfigureAwait(false);
         var parsedDocument = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
@@ -155,8 +158,15 @@ internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider : 
                 if (!CanConvert(parsedDocument, expression, formattingOptions, out var canConvertParams, out var provider, cancellationToken))
                     continue;
 
-                // Ensure we have a matching kind to fix for this literal
-                var hasMatchingKind = kind switch
+                // If the user started on a string that didn't have an explicit \n in it, then don't update other string
+                // literals that do.  Note: if they did start on a string with an explicit \n, then we should update all
+                // other literals, regardless of whether they had an explicit \n or not.
+                if (!kind.HasFlag(ConvertToRawKind.ContainsEscapedEndOfLineCharacter) && canConvertParams.ContainsEscapedEndOfLineCharacter)
+                    continue;
+
+                // Ensure we have a matching kind to fix for this literal.
+                // Remove the end of line flag so we can trivially switch on the rest below.
+                var hasMatchingKind = (kind & ~ConvertToRawKind.ContainsEscapedEndOfLineCharacter) switch
                 {
                     ConvertToRawKind.SingleLine => canConvertParams.CanBeSingleLine,
                     ConvertToRawKind.MultiLineIndented => !canConvertParams.CanBeSingleLine,

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertStringToRawStringCodeRefactoringProvider.cs
@@ -161,7 +161,7 @@ internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider() 
                 // If the user started on a string that didn't have an explicit \n in it, then don't update other string
                 // literals that do.  Note: if they did start on a string with an explicit \n, then we should update all
                 // other literals, regardless of whether they had an explicit \n or not.
-                if (!kind.HasFlag(ConvertToRawKind.ContainsEscapedEndOfLineCharacter) && canConvertParams.ContainsEscapedEndOfLineCharacter)
+                if ((kind & ConvertToRawKind.ContainsEscapedEndOfLineCharacter) == 0 && canConvertParams.ContainsEscapedEndOfLineCharacter)
                     continue;
 
                 // Ensure we have a matching kind to fix for this literal.

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertToRawKind.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertToRawKind.cs
@@ -2,11 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.CSharp.ConvertToRawString;
 
+[Flags]
 internal enum ConvertToRawKind
 {
-    SingleLine,
-    MultiLineIndented,
-    MultiLineWithoutLeadingWhitespace,
+    SingleLine = 1 << 0,
+    MultiLineIndented = 1 << 1,
+    MultiLineWithoutLeadingWhitespace = 1 << 2,
+
+    ContainsEscapedEndOfLineCharacter = 1 << 3,
 }

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertToRawStringHelpers.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertToRawStringHelpers.cs
@@ -75,6 +75,11 @@ internal static class ConvertToRawStringHelpers
         return false;
     }
 
+    /// <summary>
+    /// Returns if this sequence of characters can be converted to a raw string.  If it can, also returns if it
+    /// contained an explicitly escaped newline (like <c>\r\n</c>) within it.  It it can't convert, then the value of
+    /// <paramref name="containsEscapedEndOfLineCharacter"/> is undefined.
+    /// </summary>
     public static bool CanConvert(VirtualCharSequence characters, out bool containsEscapedEndOfLineCharacter)
     {
         containsEscapedEndOfLineCharacter = false;

--- a/src/Features/CSharpTest/ConvertToRawString/ConvertInterpolatedStringToRawString_FixAllTests.cs
+++ b/src/Features/CSharpTest/ConvertToRawString/ConvertInterpolatedStringToRawString_FixAllTests.cs
@@ -270,10 +270,7 @@ public class ConvertInterpolatedStringToRawString_FixAllTests : AbstractCSharpCo
                 var singleLine1 = $"a";
                 var singleLine2 = @$"goo""bar";
 
-                var multiLine1 = $"""
-                    goo
-                    bar
-                    """;
+                var multiLine1 = $"goo\r\nbar";
                 var multiLine2 = $"""
                     goo
                     bar
@@ -296,10 +293,7 @@ public class ConvertInterpolatedStringToRawString_FixAllTests : AbstractCSharpCo
                 var singleLine1 = $"a";
                 var singleLine2 = @$"goo""bar";
 
-                var multiLine1 = $"""
-                    goo
-                    bar
-                    """;
+                var multiLine1 = $"goo\r\nbar";
                 var multiLine2 = $"""
                     goo
                     bar

--- a/src/Features/CSharpTest/ConvertToRawString/ConvertRegularStringToRawString_FixAllTests.cs
+++ b/src/Features/CSharpTest/ConvertToRawString/ConvertRegularStringToRawString_FixAllTests.cs
@@ -7,13 +7,14 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.ConvertToRawString;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToRawString;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsConvertToRawString)]
 [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
-public class ConvertRegularStringToRawString_FixAllTests : AbstractCSharpCodeActionTest_NoEditor
+public sealed class ConvertRegularStringToRawString_FixAllTests : AbstractCSharpCodeActionTest_NoEditor
 {
     protected override CodeRefactoringProvider CreateCodeRefactoringProvider(TestWorkspace workspace, TestParameters parameters)
         => new ConvertStringToRawStringCodeRefactoringProvider();
@@ -270,10 +271,7 @@ public class ConvertRegularStringToRawString_FixAllTests : AbstractCSharpCodeAct
                 var singleLine1 = "a";
                 var singleLine2 = @"goo""bar";
 
-                var multiLine1 = """
-                    goo
-                    bar
-                    """;
+                var multiLine1 = "goo\r\nbar";
                 var multiLine2 = """
                     goo
                     bar
@@ -296,10 +294,7 @@ public class ConvertRegularStringToRawString_FixAllTests : AbstractCSharpCodeAct
                 var singleLine1 = "a";
                 var singleLine2 = @"goo""bar";
 
-                var multiLine1 = """
-                    goo
-                    bar
-                    """;
+                var multiLine1 = "goo\r\nbar";
                 var multiLine2 = """
                     goo
                     bar
@@ -970,5 +965,76 @@ public class ConvertRegularStringToRawString_FixAllTests : AbstractCSharpCodeAct
                 }
             }
             """", index: 1);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70209")]
+    public async Task FixAllInDocument_MultiLineShouldNotImpactExplicitEscapedString()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var description = {|FixAllInDocument:|}@"
+
+            ";
+
+                    var second = Regex.Replace(description, "(\r?\n)", "$1$1");
+                }
+            }
+            """,
+            """"
+            class C
+            {
+                void M()
+                {
+                    var description = """
+
+
+            
+                        """;
+            
+                    var second = Regex.Replace(description, "(\r?\n)", "$1$1");
+                }
+            }
+            """");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70209")]
+    public async Task FixAllInDocument_EscapedCanAffectMultiLine()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var description = @"
+
+            ";
+
+                    var second = Regex.Replace(description, {|FixAllInDocument:|}"(\r\n)", "$1$1");
+                }
+            }
+            """,
+            """"
+            class C
+            {
+                void M()
+                {
+                    var description = """
+
+
+
+                        """;
+            
+                    var second = Regex.Replace(description, """
+                        (
+                        )
+                        """, "$1$1");
+                }
+            }
+            """");
     }
 }

--- a/src/Features/CSharpTest/ConvertToRawString/ConvertRegularStringToRawString_FixAllTests.cs
+++ b/src/Features/CSharpTest/ConvertToRawString/ConvertRegularStringToRawString_FixAllTests.cs
@@ -1037,4 +1037,46 @@ public sealed class ConvertRegularStringToRawString_FixAllTests : AbstractCSharp
             }
             """");
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70209")]
+    public async Task FixAllInDocument_EscapedCanAffectMultiLine2()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var description = @"
+
+            ";
+
+                    var second = Regex.Replace(description, {|FixAllInDocument:|}"(\r\n)", "$1$1");
+                    var third = Regex.Replace(description, "(\r\n)", "$1$1");
+                }
+            }
+            """,
+            """"
+            class C
+            {
+                void M()
+                {
+                    var description = """
+
+
+
+                        """;
+            
+                    var second = Regex.Replace(description, """
+                        (
+                        )
+                        """, "$1$1");
+                    var third = Regex.Replace(description, """
+                        (
+                        )
+                        """, "$1$1");
+                }
+            }
+            """");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70209