### PR TITLE
Format labeled statements when colon is typed

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -2467,35 +2467,41 @@ int         nextLine            =           30          ;$$
             SyntaxKind.ColonToken);
     }
 
-    [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537804")]
+    [Fact]
+    [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537804")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/13981")]
     public async Task Colon_Label()
     {
-        var code = @"namespace ClassLibrary1
-{
-    public class Class1
-    {
-        void Test()
-        {
-                    label   :$$
-        }
-    }
-}";
+        var code = """
+            namespace ClassLibrary1
+            {
+                public class Class1
+                {
+                    void Test()
+                    {
+                                label   :$$
+                    }
+                }
+            }
+            """;
 
-        var expected = @"namespace ClassLibrary1
-{
-    public class Class1
-    {
-        void Test()
-        {
-                    label   :
-        }
-    }
-}";
+        var expected = """
+            namespace ClassLibrary1
+            {
+                public class Class1
+                {
+                    void Test()
+                    {
+                    label:
+                    }
+                }
+            }
+            """;
 
         await AutoFormatOnColonAsync(
             code,
             expected,
-            SyntaxKind.None);
+            SyntaxKind.OpenBraceToken);
     }
 
     [WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538793")]

--- a/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Formatting;
 [Order(Before = PredefinedCompletionNames.CompletionCommandHandler)]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal partial class FormatCommandHandler(
+internal sealed partial class FormatCommandHandler(
     ITextUndoHistoryRegistry undoHistoryRegistry,
     IEditorOperationsFactoryService editorOperationsFactoryService,
     IGlobalOptionService globalOptions) :

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/FormattingRangeHelper.cs
@@ -270,15 +270,14 @@ internal static class FormattingRangeHelper
         // don't do anything if there is no proper parent
         var parent = endToken.Parent;
         if (parent == null || parent.Kind() == SyntaxKind.SkippedTokensTrivia)
-        {
             return null;
-        }
 
         // cases such as namespace, type, enum, method almost any top level elements
         if (IsColonInSwitchLabel(endToken))
-        {
-            return ValueTuple.Create(GetPreviousTokenIfNotFirstTokenInTree(parent.GetFirstToken()), parent.GetLastToken());
-        }
+            return (GetPreviousTokenIfNotFirstTokenInTree(parent.GetFirstToken()), parent.GetLastToken());
+
+        if (endToken.Kind() == SyntaxKind.ColonToken && parent is LabeledStatementSyntax)
+            return (GetPreviousTokenIfNotFirstTokenInTree(parent.GetFirstToken()), parent.GetLastToken());
 
         return null;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/13981
Fixes https://github.com/dotnet/roslyn/issues/63601