### PR TITLE
Disable 'use coalesce expression' when statements cross a PP boundary

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCoalesceExpression/CSharpUseCoalesceExpressionForIfNullStatementCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCoalesceExpression/CSharpUseCoalesceExpressionForIfNullStatementCheckDiagnosticAnalyzer.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis.Analyzers.UseCoalesceExpression;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
@@ -17,7 +15,7 @@ using Microsoft.CodeAnalysis.LanguageService;
 namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UseCoalesceExpression;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal class CSharpUseCoalesceExpressionForIfNullStatementCheckDiagnosticAnalyzer :
+internal sealed class CSharpUseCoalesceExpressionForIfNullStatementCheckDiagnosticAnalyzer :
     AbstractUseCoalesceExpressionForIfNullStatementCheckDiagnosticAnalyzer<
         SyntaxKind,
         ExpressionSyntax,

--- a/src/Analyzers/CSharp/Tests/UseCoalesceExpression/UseCoalesceExpressionForIfNullStatementCheckTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCoalesceExpression/UseCoalesceExpressionForIfNullStatementCheckTests.cs
@@ -17,7 +17,7 @@ using VerifyCS = CSharpCodeFixVerifier<
     CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider>;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsUseCoalesceExpression)]
-public class UseCoalesceExpressionForIfNullStatementCheckTests
+public sealed class UseCoalesceExpressionForIfNullStatementCheckTests
 {
     [Fact]
     public async Task TestLocalDeclaration_ThrowStatement()
@@ -678,6 +678,31 @@ public class UseCoalesceExpressionForIfNullStatementCheckTests
             {
             }
             """
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70514")]
+    public async Task TestNotAcrossPreprocessorRegion()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                #define DEBUG
+
+                class C
+                {
+                    void M()
+                    {
+                        var item = FindItem() as C;
+                #if DEBUG
+                        if (item == null)
+                            throw new System.InvalidOperationException();
+                #endif
+                    }
+
+                    object FindItem() => null;
+                }
+                """,
         }.RunAsync();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70514