### PR TITLE
Do not treat Task.Run methods as 'apparent' for 'use var'

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -8,7 +8,12 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal sealed class CSharpUseImplicitTypeDiagnosticAnalyzer : CSharpTypeStyleDiagnosticAnalyzerBase
+internal sealed class CSharpUseImplicitTypeDiagnosticAnalyzer()
+    : CSharpTypeStyleDiagnosticAnalyzerBase(
+        diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+        enforceOnBuild: EnforceOnBuildValues.UseImplicitType,
+        title: s_Title,
+        message: s_Message)
 {
     private static readonly LocalizableString s_Title =
         new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_implicit_type), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources));
@@ -17,12 +22,4 @@ internal sealed class CSharpUseImplicitTypeDiagnosticAnalyzer : CSharpTypeStyleD
         new LocalizableResourceString(nameof(CSharpAnalyzersResources.use_var_instead_of_explicit_type), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources));
 
     protected override CSharpTypeStyleHelper Helper => CSharpUseImplicitTypeHelper.Instance;
-
-    public CSharpUseImplicitTypeDiagnosticAnalyzer()
-        : base(diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
-               enforceOnBuild: EnforceOnBuildValues.UseImplicitType,
-               title: s_Title,
-               message: s_Message)
-    {
-    }
 }

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -3402,4 +3402,36 @@ options: ImplicitTypeEverywhere());
             }
             """, new(options: ImplicitTypeEverywhere()));
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/64902")]
+    public async Task TestNotOnAwaitedTask()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+
+            public class Program
+            {
+                public static async Task Main()
+                {
+                    object test1 = DoSomeWork();
+                    object test2 = await Task.Run(() => DoSomeWork());
+
+                    IEnumerable<object> test3 = DoSomeWorkGeneric();
+                    [|IEnumerable<object>|] test4 = await Task.Run(() => DoSomeWorkGeneric());
+                }
+
+                public static object DoSomeWork()
+                {
+                    return new object();
+                }
+
+                public static IEnumerable<object> DoSomeWorkGeneric()
+                {
+                    return new List<object>();
+                }
+            }
+            """, new(options: ImplicitTypeWhereApparent()));
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/TypeStyle/TypeStyleHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/TypeStyle/TypeStyleHelper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -113,23 +114,21 @@ internal static class TypeStyleHelper
         return false;
     }
 
-    private static bool IsPossibleCreationOrConversionMethod(IMethodSymbol methodSymbol,
+    private static bool IsPossibleCreationOrConversionMethod(
+        IMethodSymbol methodSymbol,
         ITypeSymbol? typeInDeclaration,
         SemanticModel semanticModel,
         ExpressionSyntax containingTypeName,
         CancellationToken cancellationToken)
     {
         if (methodSymbol.ReturnsVoid)
-        {
             return false;
-        }
 
-        var containingType = semanticModel.GetTypeInfo(containingTypeName, cancellationToken).Type;
+        if (semanticModel.GetTypeInfo(containingTypeName, cancellationToken).Type is not INamedTypeSymbol containingType)
+            return false;
 
         // The containing type was determined from an expression of the form ContainingType.MemberName, and the
         // caller verifies that MemberName resolves to a method symbol.
-        Contract.ThrowIfNull(containingType);
-
         return IsPossibleCreationMethod(methodSymbol, typeInDeclaration, containingType)
             || IsPossibleConversionMethod(methodSymbol);
     }
@@ -138,16 +137,34 @@ internal static class TypeStyleHelper
     /// Looks for types that have static methods that return the same type as the container.
     /// e.g: int.Parse, XElement.Load, Tuple.Create etc.
     /// </summary>
-    private static bool IsPossibleCreationMethod(IMethodSymbol methodSymbol,
+    private static bool IsPossibleCreationMethod(
+        IMethodSymbol methodSymbol,
         ITypeSymbol? typeInDeclaration,
-        ITypeSymbol containingType)
+        INamedTypeSymbol containingType)
     {
         if (!methodSymbol.IsStatic)
-        {
             return false;
+
+        // Check the simple case of the type the method is in returning an instance of that type.
+        var returnType = UnwrapTupleType(methodSymbol.ReturnType);
+        if (UnwrapTupleType(containingType).Equals(returnType))
+            return true;
+
+        // Now check for cases like `Tuple.Create(0, true)`.  This is a static factory without type arguments
+        // that returns instances of a generic type.
+        //
+        // We explicitly disallow this for Task.X and ValueTask.X as the final type is generally not apparent due to
+        // complex type inference.
+        if (UnwrapTupleType(typeInDeclaration)?.GetTypeArguments().Length > 0 &&
+            containingType.TypeArguments.Length == 0 &&
+            returnType.Name is not nameof(Task) and not nameof(ValueTask) &&
+            UnwrapTupleType(containingType).Name.Equals(returnType.Name) &&
+            containingType.ContainingNamespace.Equals(returnType.ContainingNamespace))
+        {
+            return true;
         }
 
-        return IsContainerTypeEqualToReturnType(methodSymbol, typeInDeclaration, containingType);
+        return false;
     }
 
     /// <summary>
@@ -162,29 +179,6 @@ internal static class TypeStyleHelper
             : returnType.Name;
 
         return methodSymbol.Name.Equals("To" + returnTypeName, StringComparison.Ordinal);
-    }
-
-    /// <remarks>
-    /// If there are type arguments on either side of assignment, we match type names instead of type equality 
-    /// to account for inferred generic type arguments.
-    /// e.g: Tuple.Create(0, true) returns Tuple&lt;X,y&gt; which isn't the same as type Tuple.
-    /// otherwise, we match for type equivalence
-    /// </remarks>
-    private static bool IsContainerTypeEqualToReturnType(IMethodSymbol methodSymbol,
-        ITypeSymbol? typeInDeclaration,
-        ITypeSymbol containingType)
-    {
-        var returnType = UnwrapTupleType(methodSymbol.ReturnType);
-
-        if (UnwrapTupleType(typeInDeclaration)?.GetTypeArguments().Length > 0 ||
-            containingType.GetTypeArguments().Length > 0)
-        {
-            return UnwrapTupleType(containingType).Name.Equals(returnType.Name);
-        }
-        else
-        {
-            return UnwrapTupleType(containingType).Equals(returnType);
-        }
     }
 
     [return: NotNullIfNotNull(nameof(symbol))]
@@ -220,9 +214,5 @@ internal static class TypeStyleHelper
     }
 
     public static bool IsPredefinedType(TypeSyntax type)
-    {
-        return type is PredefinedTypeSyntax predefinedType
-            ? SyntaxFacts.IsPredefinedType(predefinedType.Keyword.Kind())
-            : false;
-    }
+        => type is PredefinedTypeSyntax predefinedType && SyntaxFacts.IsPredefinedType(predefinedType.Keyword.Kind());
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpUseImplicitTypeHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpUseImplicitTypeHelper.cs
@@ -110,23 +110,11 @@ internal sealed class CSharpUseImplicitTypeHelper : CSharpTypeStyleHelper
                 SyntaxKind.UsingStatement))
         {
             // implicitly typed variables cannot be constants.
-            if ((variableDeclaration.Parent as LocalDeclarationStatementSyntax)?.IsConst == true)
-            {
+            if (variableDeclaration.Parent is LocalDeclarationStatementSyntax { IsConst: true })
                 return false;
-            }
 
-            if (variableDeclaration.Variables.Count != 1)
-            {
+            if (variableDeclaration.Variables is not [{ Initializer.Value: var initializer } variable])
                 return false;
-            }
-
-            var variable = variableDeclaration.Variables[0];
-            if (variable.Initializer == null)
-            {
-                return false;
-            }
-
-            var initializer = variable.Initializer.Value;
 
             // Do not suggest var replacement for stackalloc span expressions.
             // This will change the bound type from a span to a pointer.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64902