### PR TITLE
Threading fixes

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -613,9 +613,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             if (_lazyExportedTypes.IsDefault)
             {
-                _lazyExportedTypes = CalculateExportedTypes();
+                var initialized = ImmutableInterlocked.InterlockedInitialize(ref _lazyExportedTypes, CalculateExportedTypes());
 
-                if (_lazyExportedTypes.Length > 0)
+                if (initialized && _lazyExportedTypes.Length > 0)
                 {
                     ReportExportedTypeNameCollisions(_lazyExportedTypes, diagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
@@ -97,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private void EnsureAttributeArgumentsAreLoaded()
         {
-            if (_lazyConstructorArguments.IsDefault || _lazyNamedArguments.IsDefault)
+            if (RoslynImmutableInterlocked.VolatileRead(in _lazyConstructorArguments).IsDefault || RoslynImmutableInterlocked.VolatileRead(in _lazyNamedArguments).IsDefault)
             {
                 TypedConstant[]? lazyConstructorArguments = null;
                 KeyValuePair<string, TypedConstant>[]? lazyNamedArguments = null;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEGlobalNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEGlobalNamespaceSymbol.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
 using System;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
@@ -81,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         protected override void EnsureAllMembersLoaded()
         {
-            if (lazyTypes == null || lazyNamespaces == null)
+            if (Volatile.Read(ref lazyTypes) == null || Volatile.Read(ref lazyNamespaces) == null)
             {
                 IEnumerable<IGrouping<string, TypeDefinitionHandle>> groups;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -131,24 +131,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             public bool IsExplicitFinalizerOverride => (_bits & IsExplicitFinalizerOverrideBit) != 0;
             public bool IsExplicitClassOverride => (_bits & IsExplicitClassOverrideBit) != 0;
             public bool IsExplicitOverrideIsPopulated => (_bits & IsExplicitOverrideIsPopulatedBit) != 0;
-            public bool IsObsoleteAttributePopulated => (_bits & IsObsoleteAttributePopulatedBit) != 0;
-            public bool IsCustomAttributesPopulated => (_bits & IsCustomAttributesPopulatedBit) != 0;
-            public bool IsUseSiteDiagnosticPopulated => (_bits & IsUseSiteDiagnosticPopulatedBit) != 0;
-            public bool IsConditionalPopulated => (_bits & IsConditionalPopulatedBit) != 0;
-            public bool IsOverriddenOrHiddenMembersPopulated => (_bits & IsOverriddenOrHiddenMembersPopulatedBit) != 0;
+            public bool IsObsoleteAttributePopulated => (Volatile.Read(ref _bits) & IsObsoleteAttributePopulatedBit) != 0;
+            public bool IsCustomAttributesPopulated => (Volatile.Read(ref _bits) & IsCustomAttributesPopulatedBit) != 0;
+            public bool IsUseSiteDiagnosticPopulated => (Volatile.Read(ref _bits) & IsUseSiteDiagnosticPopulatedBit) != 0;
+            public bool IsConditionalPopulated => (Volatile.Read(ref _bits) & IsConditionalPopulatedBit) != 0;
+            public bool IsOverriddenOrHiddenMembersPopulated => (Volatile.Read(ref _bits) & IsOverriddenOrHiddenMembersPopulatedBit) != 0;
             public bool IsReadOnly => (_bits & IsReadOnlyBit) != 0;
             public bool IsReadOnlyPopulated => (_bits & IsReadOnlyPopulatedBit) != 0;
             public bool DoesNotReturn => (_bits & DoesNotReturnBit) != 0;
             public bool IsDoesNotReturnPopulated => (_bits & IsDoesNotReturnPopulatedBit) != 0;
-            public bool IsMemberNotNullPopulated => (_bits & IsMemberNotNullPopulatedBit) != 0;
+            public bool IsMemberNotNullPopulated => (Volatile.Read(ref _bits) & IsMemberNotNullPopulatedBit) != 0;
             public bool IsInitOnly => (_bits & IsInitOnlyBit) != 0;
             public bool IsInitOnlyPopulated => (_bits & IsInitOnlyPopulatedBit) != 0;
-            public bool IsUnmanagedCallersOnlyAttributePopulated => (_bits & IsUnmanagedCallersOnlyAttributePopulatedBit) != 0;
+            public bool IsUnmanagedCallersOnlyAttributePopulated => (Volatile.Read(ref _bits) & IsUnmanagedCallersOnlyAttributePopulatedBit) != 0;
             public bool HasSetsRequiredMembers => (_bits & HasSetsRequiredMembersBit) != 0;
             public bool HasSetsRequiredMembersPopulated => (_bits & HasSetsRequiredMembersPopulatedBit) != 0;
             public bool IsUnscopedRef => (_bits & IsUnscopedRefBit) != 0;
             public bool IsUnscopedRefPopulated => (_bits & IsUnscopedRefPopulatedBit) != 0;
-            public bool IsOverloadResolutionPriorityPopulated => (_bits & OverloadResolutionPriorityPopulatedBit) != 0;
+            public bool IsOverloadResolutionPriorityPopulated => (Volatile.Read(ref _bits) & OverloadResolutionPriorityPopulatedBit) != 0;
 
 #if DEBUG
             static PackedFlags()

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -15,6 +15,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -1260,7 +1261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private void EnsureAllMembersAreLoaded()
         {
-            if (_lazyMembersByName == null)
+            if (Volatile.Read(ref _lazyMembersByName) == null)
             {
                 LoadMembers();
             }
@@ -1270,7 +1271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             ArrayBuilder<Symbol> members = null;
 
-            if (_lazyMembersInDeclarationOrder.IsDefault)
+            if (RoslynImmutableInterlocked.VolatileRead(ref _lazyMembersInDeclarationOrder).IsDefault)
             {
                 EnsureNestedTypesAreLoaded();
 
@@ -1440,7 +1441,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
             }
 
-            if (_lazyMembersByName == null)
+            if (Volatile.Read(ref _lazyMembersByName) == null)
             {
                 if (members == null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
@@ -125,11 +125,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         protected override void EnsureAllMembersLoaded()
         {
-            var typesByNS = _typesByNS;
+            var typesByNS = Volatile.Read(ref _typesByNS);
 
-            if (lazyTypes == null || lazyNamespaces == null)
+            if (typesByNS == null)
             {
-                System.Diagnostics.Debug.Assert(typesByNS != null);
+                Debug.Assert(lazyNamespaces != null && lazyTypes != null);
+            }
+            else
+            {
                 LoadAllMembers(typesByNS);
                 Interlocked.Exchange(ref _typesByNS, null);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -128,28 +128,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 ThreadSafeFlagOperations.Set(ref _bits, IsUseSiteDiagnosticPopulatedBit);
             }
 
-            public readonly bool IsUseSiteDiagnosticPopulated => (_bits & IsUseSiteDiagnosticPopulatedBit) != 0;
+            public readonly bool IsUseSiteDiagnosticPopulated => (Volatile.Read(in _bits) & IsUseSiteDiagnosticPopulatedBit) != 0;
 
             public void SetObsoleteAttributePopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsObsoleteAttributePopulatedBit);
             }
 
-            public readonly bool IsObsoleteAttributePopulated => (_bits & IsObsoleteAttributePopulatedBit) != 0;
+            public readonly bool IsObsoleteAttributePopulated => (Volatile.Read(in _bits) & IsObsoleteAttributePopulatedBit) != 0;
 
             public void SetCustomAttributesPopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsCustomAttributesPopulatedBit);
             }
 
-            public readonly bool IsCustomAttributesPopulated => (_bits & IsCustomAttributesPopulatedBit) != 0;
+            public readonly bool IsCustomAttributesPopulated => (Volatile.Read(in _bits) & IsCustomAttributesPopulatedBit) != 0;
 
             public void SetOverloadResolutionPriorityPopulated()
             {
                 ThreadSafeFlagOperations.Set(ref _bits, IsOverloadResolutionPriorityPopulatedBit);
             }
 
-            public readonly bool IsOverloadResolutionPriorityPopulated => (_bits & IsOverloadResolutionPriorityPopulatedBit) != 0;
+            public readonly bool IsOverloadResolutionPriorityPopulated => (Volatile.Read(in _bits) & IsOverloadResolutionPriorityPopulatedBit) != 0;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -152,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             Debug.Assert(!inProgress.ContainsReference(this));
             Debug.Assert(!inProgress.Any() || ReferenceEquals(inProgress.Head.ContainingSymbol, this.ContainingSymbol));
 
-            if (_lazyDeclaredConstraintTypes.IsDefault)
+            if (RoslynImmutableInterlocked.VolatileRead(ref _lazyDeclaredConstraintTypes).IsDefault)
             {
                 ImmutableArray<TypeWithAnnotations> declaredConstraintTypes;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -96,15 +96,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             {
                 if (_lazyTypeParameters.IsDefault)
                 {
-                    if (!IsGenericMethod)
-                    {
-                        _lazyTypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
-                    }
-                    else
-                    {
-                        ImmutableInterlocked.InterlockedCompareExchange(ref _lazyTypeParameters,
-                            this.RetargetingTranslator.Retarget(_underlyingMethod.TypeParameters), default(ImmutableArray<TypeParameterSymbol>));
-                    }
+                    ImmutableInterlocked.InterlockedInitialize(ref _lazyTypeParameters,
+                        !IsGenericMethod
+                            ? ImmutableArray<TypeParameterSymbol>.Empty
+                            : this.RetargetingTranslator.Retarget(_underlyingMethod.TypeParameters));
                 }
 
                 return _lazyTypeParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -66,15 +66,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             {
                 if (_lazyTypeParameters.IsDefault)
                 {
-                    if (this.Arity == 0)
-                    {
-                        _lazyTypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
-                    }
-                    else
-                    {
-                        ImmutableInterlocked.InterlockedCompareExchange(ref _lazyTypeParameters,
-                            this.RetargetingTranslator.Retarget(_underlyingType.TypeParameters), default(ImmutableArray<TypeParameterSymbol>));
-                    }
+                    ImmutableInterlocked.InterlockedInitialize(ref _lazyTypeParameters,
+                        this.Arity == 0
+                            ? ImmutableArray<TypeParameterSymbol>.Empty
+                            : this.RetargetingTranslator.Retarget(_underlyingType.TypeParameters));
                 }
 
                 return _lazyTypeParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.Cci;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -181,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void ComputeParameters()
         {
-            if (_lazyParameters != null)
+            if (!RoslynImmutableInterlocked.VolatileRead(in _lazyParameters).IsDefault)
             {
                 return;
             }
@@ -211,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             lock (_declarationDiagnostics)
             {
-                if (_lazyParameters != null)
+                if (!_lazyParameters.IsDefault)
                 {
                     diagnostics.Free();
                     return;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _declarationDependencies.AddAll(diagnostics.DependenciesBag);
                 diagnostics.Free();
                 _lazyIsVarArg = isVararg;
-                _lazyParameters = parameters;
+                RoslynImmutableInterlocked.VolatileWrite(ref _lazyParameters, parameters);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -99,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void EnsureMapAndTypeParameters()
         {
-            if (!_lazyTypeParameters.IsDefault)
+            if (!RoslynImmutableInterlocked.VolatileRead(ref _lazyTypeParameters).IsDefault)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -96,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void EnsureMapAndTypeParameters()
         {
-            if (!_lazyTypeParameters.IsDefault)
+            if (!RoslynImmutableInterlocked.VolatileRead(ref _lazyTypeParameters).IsDefault)
             {
                 return;
             }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -369,11 +370,11 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal Cci.DebugSourceInfo GetDebugSourceInfo()
         {
-            if (_lazyChecksum.IsDefault)
+            if (RoslynImmutableInterlocked.VolatileRead(ref _lazyChecksum).IsDefault)
             {
                 var text = this.GetText();
-                _lazyChecksum = text.GetChecksum();
                 _lazyHashAlgorithm = text.ChecksumAlgorithm;
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyChecksum, text.GetChecksum());
             }
 
             Debug.Assert(!_lazyChecksum.IsDefault);

--- a/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
+++ b/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
@@ -620,5 +620,18 @@ namespace Microsoft.CodeAnalysis.Collections
             Interlocked.MemoryBarrier();
             return value;
         }
+
+        /// <summary>
+        /// Writes to an ImmutableArray location, ensuring that a write barrier is inserted to prevent any prior writes from being reordered after this write.
+        /// </summary>
+        /// <remarks>
+        /// This method is not intended to be used to provide read barriers.
+        /// </remarks>
+        public static void VolatileWrite<T>(ref ImmutableArray<T> location, ImmutableArray<T> value)
+        {
+            // When Volatile.WriteBarrier() is available in .NET 10, it can be used here.
+            Interlocked.MemoryBarrier();
+            location = value;
+        }
     }
 }

--- a/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
+++ b/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Collections
 {
@@ -604,6 +605,20 @@ namespace Microsoft.CodeAnalysis.Collections
 
                 priorCollection = interlockedResult; // we already have a volatile read that we can reuse for the next loop
             }
+        }
+
+        /// <summary>
+        /// Reads from an ImmutableArray location, ensuring that a read barrier is inserted to prevent any subsequent reads from being reordered before this read.
+        /// </summary>
+        /// <remarks>
+        /// This method is not intended to be used to provide write barriers.
+        /// </remarks>
+        public static ImmutableArray<T> VolatileRead<T>(ref readonly ImmutableArray<T> location)
+        {
+            var value = location;
+            // When Volatile.ReadBarrier() is available in .NET 10, it can be used here.
+            Interlocked.MemoryBarrier();
+            return value;
         }
     }
 }


### PR DESCRIPTION
We have a few theoretical races in some of our threading code, as detailed in https://github.com/dotnet/roslyn/issues/75759. I've audited our uses of `ImmutableArray` as backing fields for this pattern, fixing it up where I find issues, as well as a couple of other threading issues that I found while looking at things named `lazy` in our codebase.