### PR TITLE
Skip CSharpWinForms.DeleteControl on 32 bit release

### DIFF
--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -165,6 +165,7 @@ namespace Roslyn.Test.Utilities
         public static bool IsCoreClr => !IsDesktop;
         public static bool IsCoreClrUnix => IsCoreClr && IsUnix;
         public static bool IsMonoOrCoreClr => IsMonoDesktop || IsCoreClr;
+        public static bool IsBitness64 => IntPtr.Size == 8;
         public static bool RuntimeSupportsCovariantReturnsOfClasses => Type.GetType("System.Runtime.CompilerServices.RuntimeFeature")?.GetField("CovariantReturnsOfClasses") != null;
 
         private static readonly Lazy<bool> s_operatingSystemRestrictsFileNames = new Lazy<bool>(() =>

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp;
@@ -204,32 +205,34 @@ public class CSharpWinForms : AbstractEditorTest
         var actualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
         Assert.Contains(@"public System.Windows.Forms.Button SomeButton;", actualText);
     }
-
-    [ConditionalFact(typeof(Bitness64))]
+    [IdeFact]
     public async Task DeleteControl()
     {
-        var project = ProjectName;
-        await TestServices.SolutionExplorer.OpenFileWithDesignerAsync(project, "Form1.cs", HangMitigatingCancellationToken);
-        await TestServices.Editor.AddWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
-        await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.cs", HangMitigatingCancellationToken);
-        await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.resx", HangMitigatingCancellationToken);
-        await TestServices.Editor.DeleteWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
+        if (ExecutionConditionUtil.IsBitness64)
+        {
+            var project = ProjectName;
+            await TestServices.SolutionExplorer.OpenFileWithDesignerAsync(project, "Form1.cs", HangMitigatingCancellationToken);
+            await TestServices.Editor.AddWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
+            await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.cs", HangMitigatingCancellationToken);
+            await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.resx", HangMitigatingCancellationToken);
+            await TestServices.Editor.DeleteWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
 
-        await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
-            [
-                FeatureAttribute.Workspace,
-                FeatureAttribute.SolutionCrawlerLegacy,
-                FeatureAttribute.DiagnosticService,
-                FeatureAttribute.EditAndContinue,
-                FeatureAttribute.ErrorSquiggles,
-                FeatureAttribute.ErrorList,
-            ],
-            HangMitigatingCancellationToken);
+            await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+                [
+                    FeatureAttribute.Workspace,
+                    FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.DiagnosticService,
+                    FeatureAttribute.EditAndContinue,
+                    FeatureAttribute.ErrorSquiggles,
+                    FeatureAttribute.ErrorList,
+                ],
+                HangMitigatingCancellationToken);
 
-        Assert.Empty(await TestServices.ErrorList.GetBuildErrorsAsync(HangMitigatingCancellationToken));
-        await TestServices.SolutionExplorer.OpenFileAsync(project, "Form1.Designer.cs", HangMitigatingCancellationToken);
-        var actualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
-        Assert.DoesNotContain(@"VisualStudio.Editor.SomeButton.Name = ""SomeButton"";", actualText);
-        Assert.DoesNotContain(@"private System.Windows.Forms.Button SomeButton;", actualText);
+            Assert.Empty(await TestServices.ErrorList.GetBuildErrorsAsync(HangMitigatingCancellationToken));
+            await TestServices.SolutionExplorer.OpenFileAsync(project, "Form1.Designer.cs", HangMitigatingCancellationToken);
+            var actualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
+            Assert.DoesNotContain(@"VisualStudio.Editor.SomeButton.Name = ""SomeButton"";", actualText);
+            Assert.DoesNotContain(@"private System.Windows.Forms.Button SomeButton;", actualText);
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
@@ -205,35 +205,31 @@ public class CSharpWinForms : AbstractEditorTest
         Assert.Contains(@"public System.Windows.Forms.Button SomeButton;", actualText);
     }
 
-    [IdeFact]
+    [ConditionalFact(typeof(Bitness64))]
     public async Task DeleteControl()
     {
-        // Known failure on 32 bit release. Entire phase could eventually be removed. This is a more targeted stopgap until then.
-        if (System.IntPtr.Size != 4)
-        {
-            var project = ProjectName;
-            await TestServices.SolutionExplorer.OpenFileWithDesignerAsync(project, "Form1.cs", HangMitigatingCancellationToken);
-            await TestServices.Editor.AddWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
-            await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.cs", HangMitigatingCancellationToken);
-            await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.resx", HangMitigatingCancellationToken);
-            await TestServices.Editor.DeleteWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
-    
-            await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
-                [
-                    FeatureAttribute.Workspace,
-                    FeatureAttribute.SolutionCrawlerLegacy,
-                    FeatureAttribute.DiagnosticService,
-                    FeatureAttribute.EditAndContinue,
-                    FeatureAttribute.ErrorSquiggles,
-                    FeatureAttribute.ErrorList,
-                ],
-                HangMitigatingCancellationToken);
-    
-            Assert.Empty(await TestServices.ErrorList.GetBuildErrorsAsync(HangMitigatingCancellationToken));
-            await TestServices.SolutionExplorer.OpenFileAsync(project, "Form1.Designer.cs", HangMitigatingCancellationToken);
-            var actualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
-            Assert.DoesNotContain(@"VisualStudio.Editor.SomeButton.Name = ""SomeButton"";", actualText);
-            Assert.DoesNotContain(@"private System.Windows.Forms.Button SomeButton;", actualText);
-        }
+        var project = ProjectName;
+        await TestServices.SolutionExplorer.OpenFileWithDesignerAsync(project, "Form1.cs", HangMitigatingCancellationToken);
+        await TestServices.Editor.AddWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
+        await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.cs", HangMitigatingCancellationToken);
+        await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.resx", HangMitigatingCancellationToken);
+        await TestServices.Editor.DeleteWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
+
+        await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+            [
+                FeatureAttribute.Workspace,
+                FeatureAttribute.SolutionCrawlerLegacy,
+                FeatureAttribute.DiagnosticService,
+                FeatureAttribute.EditAndContinue,
+                FeatureAttribute.ErrorSquiggles,
+                FeatureAttribute.ErrorList,
+            ],
+            HangMitigatingCancellationToken);
+
+        Assert.Empty(await TestServices.ErrorList.GetBuildErrorsAsync(HangMitigatingCancellationToken));
+        await TestServices.SolutionExplorer.OpenFileAsync(project, "Form1.Designer.cs", HangMitigatingCancellationToken);
+        var actualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
+        Assert.DoesNotContain(@"VisualStudio.Editor.SomeButton.Name = ""SomeButton"";", actualText);
+        Assert.DoesNotContain(@"private System.Windows.Forms.Button SomeButton;", actualText);
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
@@ -208,28 +208,32 @@ public class CSharpWinForms : AbstractEditorTest
     [IdeFact]
     public async Task DeleteControl()
     {
-        var project = ProjectName;
-        await TestServices.SolutionExplorer.OpenFileWithDesignerAsync(project, "Form1.cs", HangMitigatingCancellationToken);
-        await TestServices.Editor.AddWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
-        await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.cs", HangMitigatingCancellationToken);
-        await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.resx", HangMitigatingCancellationToken);
-        await TestServices.Editor.DeleteWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
-
-        await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
-            [
-                FeatureAttribute.Workspace,
-                FeatureAttribute.SolutionCrawlerLegacy,
-                FeatureAttribute.DiagnosticService,
-                FeatureAttribute.EditAndContinue,
-                FeatureAttribute.ErrorSquiggles,
-                FeatureAttribute.ErrorList,
-            ],
-            HangMitigatingCancellationToken);
-
-        Assert.Empty(await TestServices.ErrorList.GetBuildErrorsAsync(HangMitigatingCancellationToken));
-        await TestServices.SolutionExplorer.OpenFileAsync(project, "Form1.Designer.cs", HangMitigatingCancellationToken);
-        var actualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
-        Assert.DoesNotContain(@"VisualStudio.Editor.SomeButton.Name = ""SomeButton"";", actualText);
-        Assert.DoesNotContain(@"private System.Windows.Forms.Button SomeButton;", actualText);
+        // Known failure on 32 bit release. Entire phase could eventually be removed. This is a more targeted stopgap until then.
+        if (System.IntPtr.Size != 4)
+        {
+            var project = ProjectName;
+            await TestServices.SolutionExplorer.OpenFileWithDesignerAsync(project, "Form1.cs", HangMitigatingCancellationToken);
+            await TestServices.Editor.AddWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
+            await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.cs", HangMitigatingCancellationToken);
+            await TestServices.SolutionExplorer.SaveFileAsync(project, "Form1.resx", HangMitigatingCancellationToken);
+            await TestServices.Editor.DeleteWinFormButtonAsync("SomeButton", HangMitigatingCancellationToken);
+    
+            await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+                [
+                    FeatureAttribute.Workspace,
+                    FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.DiagnosticService,
+                    FeatureAttribute.EditAndContinue,
+                    FeatureAttribute.ErrorSquiggles,
+                    FeatureAttribute.ErrorList,
+                ],
+                HangMitigatingCancellationToken);
+    
+            Assert.Empty(await TestServices.ErrorList.GetBuildErrorsAsync(HangMitigatingCancellationToken));
+            await TestServices.SolutionExplorer.OpenFileAsync(project, "Form1.Designer.cs", HangMitigatingCancellationToken);
+            var actualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
+            Assert.DoesNotContain(@"VisualStudio.Editor.SomeButton.Name = ""SomeButton"";", actualText);
+            Assert.DoesNotContain(@"private System.Windows.Forms.Button SomeButton;", actualText);
+        }
     }
 }


### PR DESCRIPTION
Refer https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=10331299&view=ms.vss-test-web.build-test-results-tab&runId=112330346&resultId=100876&paneView=debug