### PR TITLE
Fix reproducibility of local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ UnitTestResults.html
 *.nuget.props
 *.nuget.targets
 project.lock.json
-msbuild.binlog
+*.binlog
 *.project.lock.json
 
 *_i.c

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -223,7 +223,10 @@ function Test-Build([string]$rootDir, $dataMap, [string]$logFileName) {
     Write-Host "`tVerified $relativeDir\$fileName"
   }
 
-  if (-not $allGood) {
+  if ($allGood) {
+    Write-Host "Determinism check succeeded"
+  }
+  else {
     Write-Host "Determinism failed for the following binaries:"
     foreach ($name in $errorList) {
       Write-Host "`t$name"

--- a/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
+++ b/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
@@ -65,7 +65,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SegmentedList`1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Internal\Strings.resx" GenerateSource="true" ClassName="Microsoft.CodeAnalysis.Collections.Internal.SR" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Internal\Strings.resx" GenerateSource="true" ClassName="Microsoft.CodeAnalysis.Collections.Internal.SR" ManifestResourceName="Microsoft.CodeAnalysis.Internal.Strings" />
   </ItemGroup>
   <ItemGroup Condition="'$(DefaultLanguageSourceExtension)' != '' AND '$(BuildingInsideVisualStudio)' != 'true'">
     <ExpectedCompile Include="$(MSBuildThisFileDirectory)**\*$(DefaultLanguageSourceExtension)" />


### PR DESCRIPTION
The `test-determinism.cmd` run was failing on my local machine. After a lot of debugging I was able to track it down to a bug in [xliff][xliff].

The full details are in the bug. The summary though is there is a race condition with how the manifest resource name is generated for RESX files when doing local builds in arcade. To work around this I'm just adding an explicit manifest resource name so that the race doesn't come into play.

The race only occurs when the RESX is outside the directory cone of the project that is including it hence only needed to update this file.

[xliff]: https://github.com/dotnet/arcade/issues/15296