### PR TITLE
Inline Hints - Checks if names are equivalent in member access expression

### DIFF
--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
@@ -31,23 +31,22 @@ internal class CSharpInlineParameterNameHintsService : AbstractInlineParameterNa
          SemanticModel semanticModel,
          ISyntaxFactsService syntaxFacts,
          SyntaxNode node,
-         ArrayBuilder<(int position, string? identifierArgument, IParameterSymbol? parameter, HintKind kind)> buffer,
+         ArrayBuilder<(int position, SyntaxNode argument, IParameterSymbol? parameter, HintKind kind)> buffer,
          CancellationToken cancellationToken)
     {
         if (node is BaseArgumentListSyntax argumentList)
         {
-            AddArguments(semanticModel, syntaxFacts, buffer, argumentList, cancellationToken);
+            AddArguments(semanticModel, buffer, argumentList, cancellationToken);
         }
         else if (node is AttributeArgumentListSyntax attributeArgumentList)
         {
-            AddArguments(semanticModel, syntaxFacts, buffer, attributeArgumentList, cancellationToken);
+            AddArguments(semanticModel, buffer, attributeArgumentList, cancellationToken);
         }
     }
 
     private static void AddArguments(
         SemanticModel semanticModel,
-        ISyntaxFactsService syntaxFacts,
-        ArrayBuilder<(int position, string? identifierArgument, IParameterSymbol? parameter, HintKind kind)> buffer,
+        ArrayBuilder<(int position, SyntaxNode argument, IParameterSymbol? parameter, HintKind kind)> buffer,
         AttributeArgumentListSyntax argumentList,
         CancellationToken cancellationToken)
     {
@@ -57,15 +56,13 @@ internal class CSharpInlineParameterNameHintsService : AbstractInlineParameterNa
                 continue;
 
             var parameter = argument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
-            var identifierArgument = GetIdentifierNameFromArgument(argument, syntaxFacts);
-            buffer.Add((argument.Span.Start, identifierArgument, parameter, GetKind(argument.Expression)));
+            buffer.Add((argument.Span.Start, argument, parameter, GetKind(argument.Expression)));
         }
     }
 
     private static void AddArguments(
         SemanticModel semanticModel,
-        ISyntaxFactsService syntaxFacts,
-        ArrayBuilder<(int position, string? identifierArgument, IParameterSymbol? parameter, HintKind kind)> buffer,
+        ArrayBuilder<(int position, SyntaxNode argument, IParameterSymbol? parameter, HintKind kind)> buffer,
         BaseArgumentListSyntax argumentList,
         CancellationToken cancellationToken)
     {
@@ -75,8 +72,7 @@ internal class CSharpInlineParameterNameHintsService : AbstractInlineParameterNa
                 continue;
 
             var parameter = argument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
-            var identifierArgument = GetIdentifierNameFromArgument(argument, syntaxFacts);
-            buffer.Add((argument.Span.Start, identifierArgument, parameter, GetKind(argument.Expression)));
+            buffer.Add((argument.Span.Start, argument, parameter, GetKind(argument.Expression)));
         }
     }
 

--- a/src/Features/VisualBasic/Portable/InlineHints/VisualBasicInlineParameterNameHintsService.vb
+++ b/src/Features/VisualBasic/Portable/InlineHints/VisualBasicInlineParameterNameHintsService.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InlineHints
                 semanticModel As SemanticModel,
                 syntaxFacts As ISyntaxFactsService,
                 node As SyntaxNode,
-                buffer As ArrayBuilder(Of (position As Integer, identifierArgument As String, parameter As IParameterSymbol, kind As HintKind)),
+                buffer As ArrayBuilder(Of (position As Integer, argument As SyntaxNode, parameter As IParameterSymbol, kind As HintKind)),
                 cancellationToken As CancellationToken)
 
             Dim argumentList = TryCast(node, ArgumentListSyntax)
@@ -53,7 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InlineHints
                 End If
 
                 Dim argumentIdentifier = GetIdentifierNameFromArgument(argument, syntaxFacts)
-                buffer.Add((argument.Span.Start, argumentIdentifier, parameter, GetKind(argument.Expression)))
+                buffer.Add((argument.Span.Start, argument, parameter, GetKind(argument.Expression)))
             Next
         End Sub
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/69793