### PR TITLE
Update filenames in file banners when moving a type to a new file.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/FileHeaders/CSharpFileHeaderHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/FileHeaders/CSharpFileHeaderHelper.cs
@@ -12,14 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp.FileHeaders;
 /// <summary>
 /// Helper class used for working with file headers.
 /// </summary>
-internal sealed class CSharpFileHeaderHelper : AbstractFileHeaderHelper
+internal sealed class CSharpFileHeaderHelper() : AbstractFileHeaderHelper(CSharpSyntaxKinds.Instance)
 {
     public static readonly CSharpFileHeaderHelper Instance = new();
-
-    private CSharpFileHeaderHelper()
-        : base(CSharpSyntaxKinds.Instance)
-    {
-    }
 
     public override string CommentPrefix => "//";
 

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderHelper.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderHelper.cs
@@ -9,16 +9,8 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FileHeaders;
 
-internal abstract class AbstractFileHeaderHelper
+internal abstract class AbstractFileHeaderHelper(ISyntaxKinds syntaxKinds)
 {
-    protected AbstractFileHeaderHelper(ISyntaxKinds syntaxKinds)
-    {
-        SingleLineCommentTriviaKind = syntaxKinds.SingleLineCommentTrivia;
-        MultiLineCommentTriviaKind = syntaxKinds.MultiLineCommentTrivia;
-        WhitespaceTriviaKind = syntaxKinds.WhitespaceTrivia;
-        EndOfLineTriviaKind = syntaxKinds.EndOfLineTrivia;
-    }
-
     /// <summary>
     /// Gets the text prefix indicating a single-line comment.
     /// </summary>
@@ -27,16 +19,16 @@ internal abstract class AbstractFileHeaderHelper
     protected abstract ReadOnlyMemory<char> GetTextContextOfComment(SyntaxTrivia commentTrivia);
 
     /// <inheritdoc cref="ISyntaxKinds.SingleLineCommentTrivia"/>
-    private int SingleLineCommentTriviaKind { get; }
+    private int SingleLineCommentTriviaKind { get; } = syntaxKinds.SingleLineCommentTrivia;
 
     /// <inheritdoc cref="ISyntaxKinds.MultiLineCommentTrivia"/>
-    private int? MultiLineCommentTriviaKind { get; }
+    private int? MultiLineCommentTriviaKind { get; } = syntaxKinds.MultiLineCommentTrivia;
 
     /// <inheritdoc cref="ISyntaxKinds.WhitespaceTrivia"/>
-    private int WhitespaceTriviaKind { get; }
+    private int WhitespaceTriviaKind { get; } = syntaxKinds.WhitespaceTrivia;
 
     /// <inheritdoc cref="ISyntaxKinds.EndOfLineTrivia"/>
-    private int EndOfLineTriviaKind { get; }
+    private int EndOfLineTriviaKind { get; } = syntaxKinds.EndOfLineTrivia;
 
     public FileHeader ParseFileHeader(SyntaxNode root)
     {

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -105,7 +105,7 @@ public sealed partial class MoveTypeTests : CSharpMoveTypeTestsBase
 
         await TestMoveTypeToNewFileAsync(
             code, codeAfterMove, expectedDocumentName,
-            destinationDocumentText, destinationDocumentContainers: ImmutableArray.Create("A", "B"));
+            destinationDocumentText, destinationDocumentContainers: ["A", "B"]);
     }
 
     [WpfFact]
@@ -2011,5 +2011,38 @@ public sealed partial class MoveTypeTests : CSharpMoveTypeTestsBase
             }
             """;
         await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+    }
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/74703")]
+    public async Task TestUpdateFileName()
+    {
+        var code =
+            """
+
+            <Workspace>
+                <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document Folders="A\B" FilePath="Goo.cs">// This is a banner referencing Goo.cs
+            [||]class Class1 { }
+            class Class2 { }
+                    </Document>
+                </Project>
+            </Workspace>
+            """;
+        var codeAfterMove = """
+            // This is a banner referencing Goo.cs
+            class Class2 { }
+                    
+            """;
+
+        var expectedDocumentName = "Class1.cs";
+        var destinationDocumentText = """
+            // This is a banner referencing Class1.cs
+            class Class1 { }
+                    
+            """;
+
+        await TestMoveTypeToNewFileAsync(
+            code, codeAfterMove, expectedDocumentName,
+            destinationDocumentText, destinationDocumentContainers: ["A", "B"]);
     }
 }

--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
@@ -17,9 +17,4 @@ internal sealed class CSharpAddFileBannerCodeRefactoringProvider() : AbstractAdd
 {
     protected override bool IsCommentStartCharacter(char ch)
         => ch == '/';
-
-    protected override SyntaxTrivia CreateTrivia(SyntaxTrivia trivia, string text)
-        => trivia.Kind() is SyntaxKind.SingleLineCommentTrivia or SyntaxKind.MultiLineCommentTrivia or SyntaxKind.SingleLineDocumentationCommentTrivia or SyntaxKind.MultiLineDocumentationCommentTrivia
-            ? SyntaxFactory.Comment(text)
-            : trivia;
 }

--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
@@ -11,28 +11,15 @@ namespace Microsoft.CodeAnalysis.CSharp.AddFileBanner;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp,
     Name = PredefinedCodeRefactoringProviderNames.AddFileBanner), Shared]
-internal class CSharpAddFileBannerCodeRefactoringProvider : AbstractAddFileBannerCodeRefactoringProvider
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class CSharpAddFileBannerCodeRefactoringProvider() : AbstractAddFileBannerCodeRefactoringProvider
 {
-    [ImportingConstructor]
-    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-    public CSharpAddFileBannerCodeRefactoringProvider()
-    {
-    }
-
     protected override bool IsCommentStartCharacter(char ch)
         => ch == '/';
 
     protected override SyntaxTrivia CreateTrivia(SyntaxTrivia trivia, string text)
-    {
-        switch (trivia.Kind())
-        {
-            case SyntaxKind.SingleLineCommentTrivia:
-            case SyntaxKind.MultiLineCommentTrivia:
-            case SyntaxKind.SingleLineDocumentationCommentTrivia:
-            case SyntaxKind.MultiLineDocumentationCommentTrivia:
-                return SyntaxFactory.Comment(text);
-        }
-
-        return trivia;
-    }
+        => trivia.Kind() is SyntaxKind.SingleLineCommentTrivia or SyntaxKind.MultiLineCommentTrivia or SyntaxKind.SingleLineDocumentationCommentTrivia or SyntaxKind.MultiLineDocumentationCommentTrivia
+            ? SyntaxFactory.Comment(text)
+            : trivia;
 }

--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
@@ -15,14 +15,10 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.CSharp.AddFileBanner;
 
 [ExportNewDocumentFormattingProvider(LanguageNames.CSharp), Shared]
-internal class CSharpAddFileBannerNewDocumentFormattingProvider : AbstractAddFileBannerNewDocumentFormattingProvider
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpAddFileBannerNewDocumentFormattingProvider() : AbstractAddFileBannerNewDocumentFormattingProvider
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpAddFileBannerNewDocumentFormattingProvider()
-    {
-    }
-
     protected override SyntaxGenerator SyntaxGenerator => CSharpSyntaxGenerator.Instance;
     protected override SyntaxGeneratorInternal SyntaxGeneratorInternal => CSharpSyntaxGeneratorInternal.Instance;
     protected override AbstractFileHeaderHelper FileHeaderHelper => CSharpFileHeaderHelper.Instance;

--- a/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerCodeRefactoringProvider.cs
@@ -79,7 +79,8 @@ internal abstract class AbstractAddFileBannerCodeRefactoringProvider : SyntaxEdi
                 context.RegisterRefactoring(
                     CodeAction.Create(
                         CodeFixesResources.Add_file_header,
-                        cancellationToken => AddFileBannerHelpers.CopyBannerAsync(destinationDocument: document, sourceDocument: siblingDocument, cancellationToken),
+                        cancellationToken => AddFileBannerHelpers.CopyBannerAsync(
+                            destinationDocument: document, document.FilePath, sourceDocument: siblingDocument, cancellationToken),
                         equivalenceKey: GetEquivalenceKey(siblingDocument, siblingBanner)),
                     new TextSpan(position, length: 0));
                 return;

--- a/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
@@ -29,12 +29,12 @@ internal abstract class AbstractAddFileBannerNewDocumentFormattingProvider : INe
         {
             var newLineTrivia = SyntaxGeneratorInternal.EndOfLine(options.FormattingOptions.NewLine);
             var rootWithFileHeader = await AbstractFileHeaderCodeFixProvider.GetTransformedSyntaxRootAsync(
-                    SyntaxGenerator.SyntaxFacts,
-                    FileHeaderHelper,
-                    newLineTrivia,
-                    document,
-                    fileHeaderTemplate,
-                    cancellationToken).ConfigureAwait(false);
+                SyntaxGenerator.SyntaxFacts,
+                FileHeaderHelper,
+                newLineTrivia,
+                document,
+                fileHeaderTemplate,
+                cancellationToken).ConfigureAwait(false);
 
             return document.WithSyntaxRoot(rootWithFileHeader);
         }

--- a/src/Features/Core/Portable/AddFileBanner/AddFileBannerHelpers.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AddFileBannerHelpers.cs
@@ -2,41 +2,59 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
-using Roslyn.Utilities;
-
 
 namespace Microsoft.CodeAnalysis.AddFileBanner;
 
 internal static class AddFileBannerHelpers
 {
-    private const string BannerFileNamePlaceholder = "{filename}";
-
-    public static string GetBannerTextWithoutFileName(Document document, ImmutableArray<SyntaxTrivia> banner)
+    public static async Task<Document> CopyBannerAsync(
+        Document destinationDocument,
+        Document sourceDocument,
+        CancellationToken cancellationToken)
     {
-        var bannerText = banner.Select(trivia => trivia.ToFullString()).Join(string.Empty);
+        var service = destinationDocument.GetRequiredLanguageService<IFileBannerFactsService>();
 
-        var fileName = IOUtilities.PerformIO(() => Path.GetFileName(document.FilePath));
-        if (!string.IsNullOrEmpty(fileName))
-            bannerText = bannerText.Replace(fileName, BannerFileNamePlaceholder);
+        var fromRoot = await sourceDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var banner = service.GetFileBanner(fromRoot);
 
-        return bannerText;
+        banner = UpdateEmbeddedFileNames(
+            sourceDocument, destinationDocument, banner, service.CreateTrivia);
+
+        var destinationRoot = await destinationDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var newRoot = destinationRoot.WithPrependedLeadingTrivia(banner);
+        return destinationDocument.WithSyntaxRoot(newRoot);
     }
 
-    public static ImmutableArray<SyntaxTrivia> GetBannerTriviaWithFileName(string bannerText, Document document, string? fileName)
+    /// <summary>
+    /// Looks at <paramref name="banner"/> to see if it contains the name of <paramref name="sourceDocument"/>
+    /// in it.  If so, those names will be replaced with <paramref name="destinationDocument"/>'s name.
+    /// </summary>
+    private static ImmutableArray<SyntaxTrivia> UpdateEmbeddedFileNames(
+        Document sourceDocument,
+        Document destinationDocument,
+        ImmutableArray<SyntaxTrivia> banner,
+        Func<SyntaxTrivia, string, SyntaxTrivia> createTrivia)
     {
-        if (!string.IsNullOrEmpty(fileName))
-            bannerText = bannerText.Replace(BannerFileNamePlaceholder, fileName);
+        var sourceName = IOUtilities.PerformIO(() => Path.GetFileName(sourceDocument.FilePath));
+        var destinationName = IOUtilities.PerformIO(() => Path.GetFileName(destinationDocument.FilePath));
+        if (string.IsNullOrEmpty(sourceName) || string.IsNullOrEmpty(destinationName))
+            return banner;
 
-        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-        var token = syntaxFacts.ParseToken(bannerText);
+        var result = new FixedSizeArrayBuilder<SyntaxTrivia>(banner.Length);
+        foreach (var trivia in banner)
+        {
+            var updated = createTrivia(trivia, trivia.ToFullString().Replace(sourceName, destinationName));
+            result.Add(updated);
+        }
 
-        var bannerService = document.GetRequiredLanguageService<IFileBannerFactsService>();
-        return bannerService.GetFileBanner(token);
+        return result.MoveToImmutable();
     }
 }

--- a/src/Features/Core/Portable/AddFileBanner/AddFileBannerHelpers.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AddFileBannerHelpers.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Roslyn.Utilities;
+
+
+namespace Microsoft.CodeAnalysis.AddFileBanner;
+
+internal static class AddFileBannerHelpers
+{
+    private const string BannerFileNamePlaceholder = "{filename}";
+
+    public static string GetBannerTextWithoutFileName(Document document, ImmutableArray<SyntaxTrivia> banner)
+    {
+        var bannerText = banner.Select(trivia => trivia.ToFullString()).Join(string.Empty);
+
+        var fileName = IOUtilities.PerformIO(() => Path.GetFileName(document.FilePath));
+        if (!string.IsNullOrEmpty(fileName))
+            bannerText = bannerText.Replace(fileName, BannerFileNamePlaceholder);
+
+        return bannerText;
+    }
+
+    public static ImmutableArray<SyntaxTrivia> GetBannerTriviaWithFileName(string bannerText, Document document, string? fileName)
+    {
+        if (!string.IsNullOrEmpty(fileName))
+            bannerText = bannerText.Replace(BannerFileNamePlaceholder, fileName);
+
+        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+        var token = syntaxFacts.ParseToken(bannerText);
+
+        var bannerService = document.GetRequiredLanguageService<IFileBannerFactsService>();
+        return bannerService.GetFileBanner(token);
+    }
+}

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -146,7 +146,7 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
             // inside it needs.
             var newDocument = solutionWithNewDocument.GetRequiredDocument(newDocumentId);
             var newDocumentWithUpdatedBanner = await AddFileBannerHelpers.CopyBannerAsync(
-                newDocument, document, this.CancellationToken).ConfigureAwait(false);
+                newDocument, FileName, document, this.CancellationToken).ConfigureAwait(false);
 
             return newDocumentWithUpdatedBanner;
         }
@@ -196,6 +196,7 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
             documentEditor.RemoveNode(State.TypeNode, SyntaxRemoveOptions.KeepUnbalancedDirectives);
 
             var updatedDocument = documentEditor.GetChangedDocument();
+            updatedDocument = await AddFileBannerHelpers.CopyBannerAsync(updatedDocument, sourceDocument.FilePath, sourceDocument, this.CancellationToken).ConfigureAwait(false);
 
             return updatedDocument.Project.Solution;
         }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -135,16 +135,6 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
             var modifiedRoot = documentEditor.GetChangedRoot();
             modifiedRoot = await AddFinalNewLineIfDesiredAsync(document, modifiedRoot).ConfigureAwait(false);
 
-            var bannerService = document.GetRequiredLanguageService<IFileBannerFactsService>();
-            var oldBanner = bannerService.GetFileBanner(root);
-            var newBanner = AddFileBannerHelpers.GetBannerTriviaWithFileName(
-                AddFileBannerHelpers.GetBannerTextWithoutFileName(document, oldBanner),
-                document,
-                this.FileName);
-
-
-            bannerService.GetFileBanner
-
             // add an empty document to solution, so that we'll have options from the right context.
             var solutionWithNewDocument = projectToBeUpdated.Solution.AddDocument(
                 newDocumentId, FileName, text: string.Empty, folders: document.Folders);
@@ -155,7 +145,10 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
             // get the updated document, give it the minimal set of imports that the type
             // inside it needs.
             var newDocument = solutionWithNewDocument.GetRequiredDocument(newDocumentId);
-            return newDocument;
+            var newDocumentWithUpdatedBanner = await AddFileBannerHelpers.CopyBannerAsync(
+                newDocument, document, this.CancellationToken).ConfigureAwait(false);
+
+            return newDocumentWithUpdatedBanner;
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/MoveTypeCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/MoveTypeCodeRefactoringProvider.cs
@@ -11,14 +11,10 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic,
     Name = PredefinedCodeRefactoringProviderNames.MoveTypeToFile), Shared]
-internal sealed class MoveTypeCodeRefactoringProvider : CodeRefactoringProvider
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class MoveTypeCodeRefactoringProvider() : CodeRefactoringProvider
 {
-    [ImportingConstructor]
-    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-    public MoveTypeCodeRefactoringProvider()
-    {
-    }
-
     public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
     {
         var (document, textSpan, cancellationToken) = context;

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.CodeRefactorings
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
     <ExportCodeRefactoringProvider(LanguageNames.VisualBasic,
         Name:=PredefinedCodeRefactoringProviderNames.AddFileBanner), [Shared]>
-    Friend Class VisualBasicAddFileBannerCodeRefactoringProvider
+    Friend NotInheritable Class VisualBasicAddFileBannerCodeRefactoringProvider
         Inherits AbstractAddFileBannerCodeRefactoringProvider
 
         <ImportingConstructor>

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
@@ -21,11 +21,5 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
         Protected Overrides Function IsCommentStartCharacter(ch As Char) As Boolean
             Return ch = "'"c
         End Function
-
-        Protected Overrides Function CreateTrivia(trivia As SyntaxTrivia, text As String) As SyntaxTrivia
-            Return If(trivia.Kind() = SyntaxKind.CommentTrivia OrElse trivia.Kind() = SyntaxKind.DocumentationCommentTrivia,
-                      SyntaxFactory.CommentTrivia(text),
-                      trivia)
-        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpFileBannerFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpFileBannerFacts.cs
@@ -17,4 +17,9 @@ internal class CSharpFileBannerFacts : AbstractFileBannerFacts
     protected override ISyntaxFacts SyntaxFacts => CSharpSyntaxFacts.Instance;
 
     protected override IDocumentationCommentService DocumentationCommentService => CSharpDocumentationCommentService.Instance;
+
+    public override SyntaxTrivia CreateTrivia(SyntaxTrivia trivia, string text)
+        => trivia.Kind() is SyntaxKind.SingleLineCommentTrivia or SyntaxKind.MultiLineCommentTrivia or SyntaxKind.SingleLineDocumentationCommentTrivia or SyntaxKind.MultiLineDocumentationCommentTrivia
+            ? SyntaxFactory.Comment(text)
+            : trivia;
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/FileBannerFacts/AbstractFileBannerFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/FileBannerFacts/AbstractFileBannerFacts.cs
@@ -58,6 +58,8 @@ internal abstract class AbstractFileBannerFacts : IFileBannerFacts
     protected abstract ISyntaxFacts SyntaxFacts { get; }
     protected abstract IDocumentationCommentService DocumentationCommentService { get; }
 
+    public abstract SyntaxTrivia CreateTrivia(SyntaxTrivia trivia, string text);
+
     public string GetBannerText(SyntaxNode? documentationCommentTriviaSyntax, int bannerLength, CancellationToken cancellationToken)
         => DocumentationCommentService.GetBannerText(documentationCommentTriviaSyntax, bannerLength, cancellationToken);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/FileBannerFacts/AbstractFileBannerFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/FileBannerFacts/AbstractFileBannerFacts.cs
@@ -173,7 +173,7 @@ internal abstract class AbstractFileBannerFacts : IFileBannerFacts
 
         var leadingTrivia = firstToken.LeadingTrivia;
         var index = 0;
-        _fileBannerMatcher.TryMatch(leadingTrivia.ToList(), ref index);
+        _fileBannerMatcher.TryMatch([.. leadingTrivia], ref index);
 
         return ImmutableArray.CreateRange(leadingTrivia.Take(index));
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/FileBannerFacts/IFileBannerFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/FileBannerFacts/IFileBannerFacts.cs
@@ -9,6 +9,8 @@ namespace Microsoft.CodeAnalysis.LanguageService;
 
 internal interface IFileBannerFacts
 {
+    SyntaxTrivia CreateTrivia(SyntaxTrivia trivia, string text);
+
     ImmutableArray<SyntaxTrivia> GetFileBanner(SyntaxNode root);
     ImmutableArray<SyntaxTrivia> GetFileBanner(SyntaxToken firstToken);
     string GetBannerText(SyntaxNode? documentationCommentTriviaSyntax, int maxBannerLength, CancellationToken cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicFileBannerFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicFileBannerFacts.vb
@@ -24,5 +24,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
                 Return VisualBasicDocumentationCommentService.Instance
             End Get
         End Property
+
+        Public Overrides Function CreateTrivia(trivia As SyntaxTrivia, text As String) As SyntaxTrivia
+            Return If(trivia.Kind() = SyntaxKind.CommentTrivia OrElse trivia.Kind() = SyntaxKind.DocumentationCommentTrivia,
+                      SyntaxFactory.CommentTrivia(text),
+                      trivia)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpFileBannerFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpFileBannerFactsService.cs
@@ -11,11 +11,6 @@ using Microsoft.CodeAnalysis.LanguageService;
 namespace Microsoft.CodeAnalysis.CSharp;
 
 [ExportLanguageService(typeof(IFileBannerFactsService), LanguageNames.CSharp), Shared]
-internal class CSharpFileBannerFactsService : CSharpFileBannerFacts, IFileBannerFactsService
-{
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpFileBannerFactsService()
-    {
-    }
-}
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpFileBannerFactsService() : CSharpFileBannerFacts, IFileBannerFactsService;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicFileBannerFactsService.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicFileBannerFactsService.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.LanguageService
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
     <ExportLanguageService(GetType(IFileBannerFactsService), LanguageNames.VisualBasic), [Shared]>
-    Friend Class VisualBasicFileBannerFactsService
+    Friend NotInheritable Class VisualBasicFileBannerFactsService
         Inherits VisualBasicFileBannerFacts
         Implements IFileBannerFactsService
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74703