### PR TITLE
Emit multiple deltas for a project with multiple baselines

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -12,12 +12,13 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
+using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -34,14 +35,6 @@ internal sealed class DebuggingSession : IDisposable
     private readonly CancellationTokenSource _cancellationSource = new();
 
     /// <summary>
-    /// MVIDs read from the assembly built for given project id.
-    /// Only contains ids for projects that support EnC.
-    /// </summary>
-    private readonly Dictionary<ProjectId, (Guid Mvid, Diagnostic Error)> _projectModuleIds = [];
-    private readonly Dictionary<Guid, ProjectId> _moduleIds = [];
-    private readonly object _projectModuleIdsGuard = new();
-
-    /// <summary>
     /// The current baseline for given project id.
     /// The baseline is updated when changes are committed at the end of edit session.
     /// The backing module readers of initial baselines need to be kept alive -- store them in
@@ -52,8 +45,8 @@ internal sealed class DebuggingSession : IDisposable
     /// Therefore once an initial baseline is created it needs to be kept alive till the end of the debugging session,
     /// even when it's replaced in <see cref="_projectBaselines"/> by a newer baseline.
     /// </remarks>
-    private readonly Dictionary<ProjectId, ProjectBaseline> _projectBaselines = [];
-    private readonly Dictionary<ProjectId, (IDisposable metadata, IDisposable pdb)> _initialBaselineModuleReaders = [];
+    private readonly Dictionary<ProjectId, ImmutableList<ProjectBaseline>> _projectBaselines = [];
+    private readonly Dictionary<Guid, (IDisposable metadata, IDisposable pdb)> _initialBaselineModuleReaders = [];
     private readonly object _projectEmitBaselinesGuard = new();
 
     /// <summary>
@@ -239,23 +232,17 @@ internal sealed class DebuggingSession : IDisposable
     }
 
     /// <summary>
-    /// Reads the MVID of a compiled project.
+    /// Reads the latest MVID of the assembly compiled from given project.
     /// </summary>
     /// <returns>
     /// An MVID and an error message to report, in case an IO exception occurred while reading the binary.
     /// The MVID is <see cref="Guid.Empty"/> if either the project is not built, or the MVID can't be read from the module binary.
     /// </returns>
-    internal async Task<(Guid Mvid, Diagnostic? Error)> GetProjectModuleIdAsync(Project project, CancellationToken cancellationToken)
+    internal Task<(Guid Mvid, Diagnostic? Error)> GetProjectModuleIdAsync(Project project, CancellationToken cancellationToken)
     {
         Debug.Assert(project.SupportsEditAndContinue());
-
-        lock (_projectModuleIdsGuard)
-        {
-            if (_projectModuleIds.TryGetValue(project.Id, out var id))
-            {
-                return id;
-            }
-        }
+        // Note: Does not cache the result as the project may be rebuilt at any point in time.
+        return Task.Run(ReadMvid, cancellationToken);
 
         (Guid Mvid, Diagnostic? Error) ReadMvid()
         {
@@ -275,91 +262,70 @@ internal sealed class DebuggingSession : IDisposable
                 return (Mvid: Guid.Empty, Error: Diagnostic.Create(descriptor, Location.None, [outputs.AssemblyDisplayPath, e.Message]));
             }
         }
-
-        var newId = await Task.Run(ReadMvid, cancellationToken).ConfigureAwait(false);
-
-        lock (_projectModuleIdsGuard)
-        {
-            if (_projectModuleIds.TryGetValue(project.Id, out var id))
-            {
-                return id;
-            }
-
-            // Do not cache failures. The error might be intermittent and might be corrected next time we attempt to read the MVID.
-            if (newId.Mvid != Guid.Empty)
-            {
-                _moduleIds[newId.Mvid] = project.Id;
-                _projectModuleIds[project.Id] = newId;
-            }
-
-            return newId;
-        }
-    }
-
-    internal bool TryGetProjectId(Guid moduleId, [NotNullWhen(true)] out ProjectId? projectId)
-    {
-        lock (_projectModuleIdsGuard)
-        {
-            return _moduleIds.TryGetValue(moduleId, out projectId);
-        }
     }
 
     /// <summary>
     /// Get <see cref="EmitBaseline"/> for given project.
     /// </summary>
+    /// <param name="moduleId">The current MVID of the project compilation output.</param>
     /// <param name="baselineProject">Project used to create the initial baseline, if the baseline does not exist yet.</param>
     /// <param name="baselineCompilation">Compilation used to create the initial baseline, if the baseline does not exist yet.</param>
     /// <returns>True unless the project outputs can't be read.</returns>
-    internal bool TryGetOrCreateEmitBaseline(
+    internal ImmutableList<ProjectBaseline> GetOrCreateEmitBaselines(
+        Guid moduleId,
         Project baselineProject,
         Compilation baselineCompilation,
-        out ImmutableArray<Diagnostic> diagnostics,
-        [NotNullWhen(true)] out ProjectBaseline? baseline,
-        [NotNullWhen(true)] out ReaderWriterLockSlim? baselineAccessLock)
+        out ImmutableArray<Diagnostic> errors,
+        out ReaderWriterLockSlim baselineAccessLock)
     {
         baselineAccessLock = _baselineAccessLock;
 
+        ImmutableList<ProjectBaseline>? existingBaselines;
         lock (_projectEmitBaselinesGuard)
         {
-            if (_projectBaselines.TryGetValue(baselineProject.Id, out baseline))
+            if (TryGetBaselinesContainingModuleVersion(moduleId, out existingBaselines))
             {
-                diagnostics = [];
-                return true;
+                errors = [];
+                return existingBaselines;
             }
         }
 
         var outputs = GetCompilationOutputs(baselineProject);
-        if (!TryCreateInitialBaseline(baselineCompilation, outputs, baselineProject.Id, out diagnostics, out var initialBaseline, out var debugInfoReaderProvider, out var metadataReaderProvider))
+        if (!TryCreateInitialBaseline(baselineCompilation, outputs, baselineProject.Id, out errors, out var initialBaseline, out var debugInfoReaderProvider, out var metadataReaderProvider))
         {
             // Unable to read the DLL/PDB at this point (it might be open by another process).
             // Don't cache the failure so that the user can attempt to apply changes again.
-            baseline = null;
-            return false;
+            return existingBaselines ?? [];
         }
 
         lock (_projectEmitBaselinesGuard)
         {
-            if (_projectBaselines.TryGetValue(baselineProject.Id, out baseline))
+            if (TryGetBaselinesContainingModuleVersion(moduleId, out existingBaselines))
             {
                 metadataReaderProvider.Dispose();
                 debugInfoReaderProvider.Dispose();
-                return true;
+                return existingBaselines;
             }
 
-            baseline = new ProjectBaseline(baselineProject.Id, initialBaseline, generation: 0);
+            var newBaseline = new ProjectBaseline(moduleId, baselineProject.Id, initialBaseline, generation: 0);
+            var baselines = (existingBaselines ?? []).Add(newBaseline);
 
-            _projectBaselines.Add(baselineProject.Id, baseline);
-            _initialBaselineModuleReaders.Add(baselineProject.Id, (metadataReaderProvider, debugInfoReaderProvider));
+            _projectBaselines[baselineProject.Id] = baselines;
+            _initialBaselineModuleReaders.Add(moduleId, (metadataReaderProvider, debugInfoReaderProvider));
+
+            return baselines;
         }
 
-        return true;
+        bool TryGetBaselinesContainingModuleVersion(Guid moduleId, [NotNullWhen(true)] out ImmutableList<ProjectBaseline>? baselines)
+            => _projectBaselines.TryGetValue(baselineProject.Id, out baselines) &&
+               baselines.Any(static (b, moduleId) => b.ModuleId == moduleId, moduleId);
     }
 
     private static unsafe bool TryCreateInitialBaseline(
         Compilation compilation,
         CompilationOutputs compilationOutputs,
         ProjectId projectId,
-        out ImmutableArray<Diagnostic> diagnostics,
+        out ImmutableArray<Diagnostic> errors,
         [NotNullWhen(true)] out EmitBaseline? baseline,
         [NotNullWhen(true)] out DebugInformationReaderProvider? debugInfoReaderProvider,
         [NotNullWhen(true)] out MetadataReaderProvider? metadataReaderProvider)
@@ -370,7 +336,7 @@ internal sealed class DebuggingSession : IDisposable
         // Alternatively, we could drop the data once we are done with emitting the delta and re-emit the baseline again 
         // when we need it next time and the module is loaded.
 
-        diagnostics = default;
+        errors = [];
         baseline = null;
         debugInfoReaderProvider = null;
         metadataReaderProvider = null;
@@ -413,7 +379,7 @@ internal sealed class DebuggingSession : IDisposable
             EditAndContinueService.Log.Write("Failed to create baseline for '{0}': {1}", projectId, e.Message);
 
             var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.ErrorReadingFile);
-            diagnostics = [Diagnostic.Create(descriptor, Location.None, [fileBeingRead, e.Message])];
+            errors = [Diagnostic.Create(descriptor, Location.None, [fileBeingRead, e.Message])];
         }
         finally
         {
@@ -596,9 +562,11 @@ internal sealed class DebuggingSession : IDisposable
         // update baselines:
         lock (_projectEmitBaselinesGuard)
         {
-            foreach (var baseline in pendingUpdate.ProjectBaselines)
+            foreach (var updatedBaseline in pendingUpdate.ProjectBaselines)
             {
-                _projectBaselines[baseline.ProjectId] = baseline;
+                _projectBaselines[updatedBaseline.ProjectId] = _projectBaselines[updatedBaseline.ProjectId]
+                    .Select(existingBaseline => existingBaseline.ModuleId == updatedBaseline.ModuleId ? updatedBaseline : existingBaseline)
+                    .ToImmutableList();
             }
         }
 
@@ -623,20 +591,31 @@ internal sealed class DebuggingSession : IDisposable
 
         LastCommittedSolution.CommitSolution(solution);
 
+        // Wait for all operations on baseline to finish before we dispose the readers.
+        _baselineAccessLock.EnterWriteLock();
+
         lock (_projectEmitBaselinesGuard)
         {
             foreach (var projectId in rebuiltProjects)
             {
-                if (_projectBaselines.Remove(projectId))
+                if (_projectBaselines.TryGetValue(projectId, out var projectBaselines))
                 {
-                    var (metadata, pdb) = _initialBaselineModuleReaders[projectId];
-                    metadata.Dispose();
-                    pdb.Dispose();
+                    // remove all versions of modules associated with the project:
+                    _projectBaselines.Remove(projectId);
 
-                    _initialBaselineModuleReaders.Remove(projectId);
+                    foreach (var projectBaseline in projectBaselines)
+                    {
+                        var (metadata, pdb) = _initialBaselineModuleReaders[projectBaseline.ModuleId];
+                        metadata.Dispose();
+                        pdb.Dispose();
+
+                        _initialBaselineModuleReaders.Remove(projectBaseline.ModuleId);
+                    }
                 }
             }
         }
+
+        _baselineAccessLock.ExitWriteLock();
 
         foreach (var projectId in rebuiltProjects)
         {
@@ -898,19 +877,19 @@ internal sealed class DebuggingSession : IDisposable
             }
         }
 
-        public EmitBaseline GetProjectEmitBaseline(ProjectId id)
+        public ImmutableList<ProjectBaseline> GetProjectBaselines(ProjectId projectId)
         {
             lock (instance._projectEmitBaselinesGuard)
             {
-                return instance._projectBaselines[id].EmitBaseline;
+                return instance._projectBaselines[projectId];
             }
         }
 
-        public bool HasProjectEmitBaseline(ProjectId id)
+        public bool HasProjectEmitBaseline(ProjectId projectId)
         {
             lock (instance._projectEmitBaselinesGuard)
             {
-                return instance._projectBaselines.ContainsKey(id);
+                return instance._projectBaselines.ContainsKey(projectId);
             }
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -957,21 +957,149 @@ internal sealed class EditSession
                 var oldCompilation = await oldProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfNull(oldCompilation);
 
-                if (!DebuggingSession.TryGetOrCreateEmitBaseline(oldProject, oldCompilation, out var createBaselineDiagnostics, out var projectBaseline, out var baselineAccessLock))
+                var projectBaselines = DebuggingSession.GetOrCreateEmitBaselines(mvid, oldProject, oldCompilation, out var createBaselineErrors, out var baselineAccessLock);
+                if (!createBaselineErrors.IsEmpty)
                 {
-                    Debug.Assert(!createBaselineDiagnostics.IsEmpty);
-
                     // Report diagnosics even when the module is never going to be loaded (e.g. in multi-targeting scenario, where only one framework being debugged).
                     // This is consistent with reporting compilation errors - the IDE reports them for all TFMs regardless of what framework the app is running on.
-                    diagnostics.Add(new(newProject.Id, createBaselineDiagnostics));
-                    Telemetry.LogProjectAnalysisSummary(projectSummary, newProject.State.ProjectInfo.Attributes.TelemetryId, createBaselineDiagnostics);
-                    isBlocked = true;
+                    diagnostics.Add(new(newProject.Id, createBaselineErrors));
+                    Telemetry.LogProjectAnalysisSummary(projectSummary, newProject.State.ProjectInfo.Attributes.TelemetryId, createBaselineErrors);
 
+                    isBlocked = true;
                     await LogDocumentChangesAsync(generation: null, cancellationToken).ConfigureAwait(false);
                     continue;
                 }
 
-                await LogDocumentChangesAsync(projectBaseline.Generation + 1, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfTrue(projectBaselines.IsEmpty);
+
+                log.Write("Emitting update of '{0}' {1}", newProject.Name, newProject.FilePath);
+
+                var newCompilation = await newProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+                // project must support compilations since it supports EnC
+                Contract.ThrowIfNull(newCompilation);
+
+                var oldActiveStatementsMap = await BaseActiveStatements.GetValueAsync(cancellationToken).ConfigureAwait(false);
+                var projectChanges = await GetProjectChangesAsync(oldActiveStatementsMap, oldCompilation, newCompilation, oldProject, newProject, changedDocumentAnalyses, cancellationToken).ConfigureAwait(false);
+
+                // The compiler only uses this predicate to determine if CS7101: "Member 'X' added during the current debug session
+                // can only be accessed from within its declaring assembly 'Lib'" should be reported. 
+                // Prior to .NET 8 Preview 4 the runtime failed to apply such edits.
+                // This was fixed in Preview 4 along with support for generics. If we see a generic capability we can disable reporting
+                // this compiler error. Otherwise, we leave the check as is in order to detect at least some runtime failures on .NET Framework.
+                // Note that the analysis in the compiler detecting the circumstances under which the runtime fails
+                // to apply the change has both false positives (flagged generic updates that shouldn't be flagged) and negatives
+                // (didn't flag cases like https://github.com/dotnet/roslyn/issues/68293).
+                var capabilities = await Capabilities.GetValueAsync(cancellationToken).ConfigureAwait(false);
+                var requiredCapabilities = projectChanges.RequiredCapabilities.ToStringArray();
+
+                var isAddedSymbolPredicate = capabilities.HasFlag(EditAndContinueCapabilities.GenericAddMethodToExistingType) ?
+                    static _ => false : (Func<ISymbol, bool>)projectChanges.AddedSymbols.Contains;
+
+                var emitDiagnostics = ImmutableArray<Diagnostic>.Empty;
+
+                foreach (var projectBaseline in projectBaselines)
+                {
+                    await LogDocumentChangesAsync(projectBaseline.Generation + 1, cancellationToken).ConfigureAwait(false);
+
+                    using var pdbStream = SerializableBytes.CreateWritableStream();
+                    using var metadataStream = SerializableBytes.CreateWritableStream();
+                    using var ilStream = SerializableBytes.CreateWritableStream();
+
+                    EmitDifferenceResult emitResult;
+
+                    // The lock protects underlying baseline readers from being disposed while emitting delta.
+                    // If the lock is disposed at this point the session has been incorrectly disposed while operations on it are in progress.
+                    using (baselineAccessLock.DisposableRead())
+                    {
+                        DebuggingSession.ThrowIfDisposed();
+
+                        var emitDifferenceTimer = SharedStopwatch.StartNew();
+
+                        emitResult = newCompilation.EmitDifference(
+                            projectBaseline.EmitBaseline,
+                            projectChanges.SemanticEdits,
+                            isAddedSymbolPredicate,
+                            metadataStream,
+                            ilStream,
+                            pdbStream,
+                            cancellationToken);
+
+                        Telemetry.LogEmitDifferenceTime(emitDifferenceTimer.Elapsed);
+                    }
+
+                    // TODO: https://github.com/dotnet/roslyn/issues/36061
+                    // We should only report diagnostics from emit phase.
+                    // Syntax and semantic diagnostics are already reported by the diagnostic analyzer.
+                    // Currently we do not have means to distinguish between diagnostics reported from compilation and emit phases.
+                    // Querying diagnostics of the entire compilation or just the updated files migth be slow.
+                    // In fact, it is desirable to allow emitting deltas for symbols affected by the change while allowing untouched
+                    // method bodies to have errors.
+                    if (!emitResult.Diagnostics.IsEmpty)
+                    {
+                        diagnostics.Add(new(newProject.Id, emitResult.Diagnostics));
+                    }
+
+                    if (!emitResult.Success)
+                    {
+                        // error
+                        isBlocked = hasEmitErrors = true;
+                        emitDiagnostics = emitResult.Diagnostics;
+                        break;
+                    }
+
+                    Contract.ThrowIfNull(emitResult.Baseline);
+
+                    var unsupportedChangesDiagnostic = await GetUnsupportedChangesDiagnosticAsync(emitResult, cancellationToken).ConfigureAwait(false);
+                    if (unsupportedChangesDiagnostic is not null)
+                    {
+                        emitDiagnostics = [unsupportedChangesDiagnostic];
+                        diagnostics.Add(new(newProject.Id, emitDiagnostics));
+                        isBlocked = true;
+                        break;
+                    }
+
+                    var updatedMethodTokens = emitResult.UpdatedMethods.SelectAsArray(h => MetadataTokens.GetToken(h));
+                    var changedTypeTokens = emitResult.ChangedTypes.SelectAsArray(h => MetadataTokens.GetToken(h));
+
+                    // Determine all active statements whose span changed and exception region span deltas.
+                    GetActiveStatementAndExceptionRegionSpans(
+                        projectBaseline.ModuleId,
+                        oldActiveStatementsMap,
+                        updatedMethodTokens,
+                        NonRemappableRegions,
+                        projectChanges.ActiveStatementChanges,
+                        out var activeStatementsInUpdatedMethods,
+                        out var moduleNonRemappableRegions,
+                        out var exceptionRegionUpdates);
+
+                    var delta = new ManagedHotReloadUpdate(
+                        projectBaseline.ModuleId,
+                        newCompilation.AssemblyName ?? newProject.Name, // used for display in debugger diagnostics
+                        newProject.Id,
+                        ilStream.ToImmutableArray(),
+                        metadataStream.ToImmutableArray(),
+                        pdbStream.ToImmutableArray(),
+                        changedTypeTokens,
+                        requiredCapabilities,
+                        updatedMethodTokens,
+                        projectChanges.LineChanges,
+                        activeStatementsInUpdatedMethods,
+                        exceptionRegionUpdates);
+
+                    deltas.Add(delta);
+
+                    nonRemappableRegions.Add((mvid, moduleNonRemappableRegions));
+                    newProjectBaselines.Add(new ProjectBaseline(mvid, projectBaseline.ProjectId, emitResult.Baseline, projectBaseline.Generation + 1));
+
+                    var fileLog = log.FileLog;
+                    if (fileLog != null)
+                    {
+                        await LogDeltaFilesAsync(fileLog, delta, projectBaseline.Generation, oldProject, newProject, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                Telemetry.LogProjectAnalysisSummary(projectSummary, newProject.State.ProjectInfo.Attributes.TelemetryId, emitDiagnostics);
 
                 async ValueTask LogDocumentChangesAsync(int? generation, CancellationToken cancellationToken)
                 {
@@ -989,127 +1117,6 @@ internal sealed class EditSession
                         }
                     }
                 }
-
-                log.Write("Emitting update of '{0}' {1}", newProject.Name, newProject.FilePath);
-
-                var newCompilation = await newProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                Contract.ThrowIfNull(newCompilation);
-
-                var oldActiveStatementsMap = await BaseActiveStatements.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                var projectChanges = await GetProjectChangesAsync(oldActiveStatementsMap, oldCompilation, newCompilation, oldProject, newProject, changedDocumentAnalyses, cancellationToken).ConfigureAwait(false);
-
-                using var pdbStream = SerializableBytes.CreateWritableStream();
-                using var metadataStream = SerializableBytes.CreateWritableStream();
-                using var ilStream = SerializableBytes.CreateWritableStream();
-
-                // project must support compilations since it supports EnC
-                Contract.ThrowIfNull(newCompilation);
-
-                // The compiler only uses this predicate to determine if CS7101: "Member 'X' added during the current debug session
-                // can only be accessed from within its declaring assembly 'Lib'" should be reported. 
-                // Prior to .NET 8 Preview 4 the runtime failed to apply such edits.
-                // This was fixed in Preview 4 along with support for generics. If we see a generic capability we can disable reporting
-                // this compiler error. Otherwise, we leave the check as is in order to detect at least some runtime failures on .NET Framework.
-                // Note that the analysis in the compiler detecting the circumstances under which the runtime fails
-                // to apply the change has both false positives (flagged generic updates that shouldn't be flagged) and negatives
-                // (didn't flag cases like https://github.com/dotnet/roslyn/issues/68293).
-                var capabilities = await Capabilities.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                var isAddedSymbolPredicate = capabilities.HasFlag(EditAndContinueCapabilities.GenericAddMethodToExistingType) ?
-                    static _ => false : (Func<ISymbol, bool>)projectChanges.AddedSymbols.Contains;
-
-                EmitDifferenceResult emitResult;
-
-                // The lock protects underlying baseline readers from being disposed while emitting delta.
-                // If the lock is disposed at this point the session has been incorrectly disposed while operations on it are in progress.
-                using (baselineAccessLock.DisposableRead())
-                {
-                    DebuggingSession.ThrowIfDisposed();
-
-                    var emitDifferenceTimer = SharedStopwatch.StartNew();
-
-                    emitResult = newCompilation.EmitDifference(
-                        projectBaseline.EmitBaseline,
-                        projectChanges.SemanticEdits,
-                        isAddedSymbolPredicate,
-                        metadataStream,
-                        ilStream,
-                        pdbStream,
-                        cancellationToken);
-
-                    Telemetry.LogEmitDifferenceTime(emitDifferenceTimer.Elapsed);
-                }
-
-                if (emitResult.Success)
-                {
-                    Contract.ThrowIfNull(emitResult.Baseline);
-
-                    var unsupportedChangesDiagnostic = await GetUnsupportedChangesDiagnosticAsync(emitResult, cancellationToken).ConfigureAwait(false);
-                    if (unsupportedChangesDiagnostic is not null)
-                    {
-                        diagnostics.Add(new(newProject.Id, [unsupportedChangesDiagnostic]));
-                        isBlocked = true;
-                    }
-                    else
-                    {
-                        var updatedMethodTokens = emitResult.UpdatedMethods.SelectAsArray(h => MetadataTokens.GetToken(h));
-                        var changedTypeTokens = emitResult.ChangedTypes.SelectAsArray(h => MetadataTokens.GetToken(h));
-
-                        // Determine all active statements whose span changed and exception region span deltas.
-                        GetActiveStatementAndExceptionRegionSpans(
-                            mvid,
-                            oldActiveStatementsMap,
-                            updatedMethodTokens,
-                            NonRemappableRegions,
-                            projectChanges.ActiveStatementChanges,
-                            out var activeStatementsInUpdatedMethods,
-                            out var moduleNonRemappableRegions,
-                            out var exceptionRegionUpdates);
-
-                        var delta = new ManagedHotReloadUpdate(
-                            mvid,
-                            newCompilation.AssemblyName ?? newProject.Name, // used for display in debugger diagnostics
-                            newProject.Id,
-                            ilStream.ToImmutableArray(),
-                            metadataStream.ToImmutableArray(),
-                            pdbStream.ToImmutableArray(),
-                            changedTypeTokens,
-                            projectChanges.RequiredCapabilities.ToStringArray(),
-                            updatedMethodTokens,
-                            projectChanges.LineChanges,
-                            activeStatementsInUpdatedMethods,
-                            exceptionRegionUpdates);
-
-                        deltas.Add(delta);
-
-                        nonRemappableRegions.Add((mvid, moduleNonRemappableRegions));
-                        newProjectBaselines.Add(new ProjectBaseline(projectBaseline.ProjectId, emitResult.Baseline, projectBaseline.Generation + 1));
-
-                        var fileLog = log.FileLog;
-                        if (fileLog != null)
-                        {
-                            await LogDeltaFilesAsync(fileLog, delta, projectBaseline.Generation, oldProject, newProject, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                }
-                else
-                {
-                    // error
-                    isBlocked = hasEmitErrors = true;
-                }
-
-                // TODO: https://github.com/dotnet/roslyn/issues/36061
-                // We should only report diagnostics from emit phase.
-                // Syntax and semantic diagnostics are already reported by the diagnostic analyzer.
-                // Currently we do not have means to distinguish between diagnostics reported from compilation and emit phases.
-                // Querying diagnostics of the entire compilation or just the updated files migth be slow.
-                // In fact, it is desirable to allow emitting deltas for symbols affected by the change while allowing untouched
-                // method bodies to have errors.
-                if (!emitResult.Diagnostics.IsEmpty)
-                {
-                    diagnostics.Add(new(newProject.Id, emitResult.Diagnostics));
-                }
-
-                Telemetry.LogProjectAnalysisSummary(projectSummary, newProject.State.ProjectInfo.Attributes.TelemetryId, emitResult.Diagnostics);
             }
 
             // log capabilities for edit sessions with changes or reported errors:

--- a/src/Features/Core/Portable/EditAndContinue/ProjectBaseline.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ProjectBaseline.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
-internal sealed class ProjectBaseline(ProjectId projectId, EmitBaseline emitBaseline, int generation)
+internal sealed class ProjectBaseline(Guid moduleId, ProjectId projectId, EmitBaseline emitBaseline, int generation)
 {
+    public Guid ModuleId { get; } = moduleId;
     public ProjectId ProjectId { get; } = projectId;
     public EmitBaseline EmitBaseline { get; } = emitBaseline;
     public int Generation { get; } = generation;


### PR DESCRIPTION
Enables scenario where a shared library Lib is references by multiple executable projects A and B and Lib.dll is copied to their respective output directories and the following events occur:

1) A is launched, modules A.exe and Lib.dll [1] are loaded.
2) Change is made to Lib.cs and applied.
3) B is launched, which builds new version of Lib.dll [2], and modules B.exe and Lib.dll [2] are loaded.
4) Another change is made to Lib.cs and applied.

At this point we have two baselines for Lib: Lib.dll [1] and Lib.dll [2], each have different MVID.
We need to emit 2 deltas for the change in step 4: 
- one that chains to the first delta applied to Lib.dll, which itself chains to the baseline of Lib.dll [1].
- one that chains to the baseline Lib.dll [2]

Both of these deltas are sent to the debugger, which applies them to all processes.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2308982
