### PR TITLE
Cache the MEF composition in the Roslyn LSP.

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ExportProviderBuilderTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ExportProviderBuilderTests.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
+{
+    public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelper)
+        : AbstractLanguageServerHostTests(testOutputHelper)
+    {
+        [Fact]
+        public async Task MefCompositionIsCached()
+        {
+            await using var testServer = await CreateLanguageServerAsync(includeDevKitComponents: false);
+
+            var mefCompositions = Directory.EnumerateFiles(MefCacheDirectory.Path, "*.mef-composition", SearchOption.AllDirectories);
+
+            Assert.Single(mefCompositions);
+        }
+
+        [Fact]
+        public async Task MefCompositionIsReused()
+        {
+            await using var testServer = await CreateLanguageServerAsync(includeDevKitComponents: false);
+
+            // Second test server with the same set of assemblies.
+            await using var testServer2 = await CreateLanguageServerAsync(includeDevKitComponents: false);
+
+            var mefCompositions = Directory.EnumerateFiles(MefCacheDirectory.Path, "*.mef-composition", SearchOption.AllDirectories);
+
+            Assert.Single(mefCompositions);
+        }
+
+        [Fact]
+        public async Task MultipleMefCompositionsAreCached()
+        {
+            await using var testServer = await CreateLanguageServerAsync(includeDevKitComponents: false);
+
+            // Second test server with a different set of assemblies.
+            await using var testServer2 = await CreateLanguageServerAsync(includeDevKitComponents: true);
+
+            var mefCompositions = Directory.EnumerateFiles(MefCacheDirectory.Path, "*.mef-composition", SearchOption.AllDirectories);
+
+            Assert.Equal(2, mefCompositions.Count());
+        }
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
@@ -14,7 +14,8 @@ using FileSystemWatcher = Roslyn.LanguageServer.Protocol.FileSystemWatcher;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
-public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
+public class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper)
+    : AbstractLanguageServerHostTests(testOutputHelper)
 {
     private readonly ClientCapabilities _clientCapabilitiesWithFileWatcherSupport = new ClientCapabilities
     {
@@ -24,14 +25,10 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
         }
     };
 
-    public LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
-    {
-    }
-
     [Fact]
     public async Task LspFileWatcherNotSupportedWithoutClientSupport()
     {
-        await using var testLspServer = await TestLspServer.CreateAsync(new ClientCapabilities(), TestOutputLogger);
+        await using var testLspServer = await TestLspServer.CreateAsync(new ClientCapabilities(), TestOutputLogger, MefCacheDirectory.Path);
 
         Assert.False(LspFileChangeWatcher.SupportsLanguageServerHost(testLspServer.LanguageServerHost));
     }
@@ -39,7 +36,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
     [Fact]
     public async Task LspFileWatcherSupportedWithClientSupport()
     {
-        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, TestOutputLogger);
+        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, TestOutputLogger, MefCacheDirectory.Path);
 
         Assert.True(LspFileChangeWatcher.SupportsLanguageServerHost(testLspServer.LanguageServerHost));
     }
@@ -49,7 +46,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
 
-        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, TestOutputLogger);
+        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, TestOutputLogger, MefCacheDirectory.Path);
         var lspFileChangeWatcher = new LspFileChangeWatcher(
             testLspServer.LanguageServerHost,
             testLspServer.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>());
@@ -57,8 +54,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
         var dynamicCapabilitiesRpcTarget = new DynamicCapabilitiesRpcTarget();
         testLspServer.AddClientLocalRpcTarget(dynamicCapabilitiesRpcTarget);
 
-        using var tempRoot = new TempRoot();
-        var tempDirectory = tempRoot.CreateDirectory();
+        var tempDirectory = TempRoot.CreateDirectory();
 
         // Try creating a context and ensure we created the registration
         var context = lspFileChangeWatcher.CreateContext([new ProjectSystem.WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
@@ -80,7 +76,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
 
-        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, TestOutputLogger);
+        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, TestOutputLogger, MefCacheDirectory.Path);
         var lspFileChangeWatcher = new LspFileChangeWatcher(
             testLspServer.LanguageServerHost,
             testLspServer.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>());
@@ -88,8 +84,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
         var dynamicCapabilitiesRpcTarget = new DynamicCapabilitiesRpcTarget();
         testLspServer.AddClientLocalRpcTarget(dynamicCapabilitiesRpcTarget);
 
-        using var tempRoot = new TempRoot();
-        var tempDirectory = tempRoot.CreateDirectory();
+        var tempDirectory = TempRoot.CreateDirectory();
 
         // Try creating a single file watch and ensure we created the registration
         var context = lspFileChangeWatcher.CreateContext([]);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
@@ -9,16 +9,17 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
-public sealed class TelemetryReporterTests : AbstractLanguageServerHostTests
+public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper)
+    : AbstractLanguageServerHostTests(testOutputHelper)
 {
-    public TelemetryReporterTests(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
-
     private async Task<ITelemetryReporter> CreateReporterAsync()
     {
-        var exportProvider = await LanguageServerTestComposition.CreateExportProviderAsync(TestOutputLogger.Factory, includeDevKitComponents: true, out var _, out var _);
+        var exportProvider = await LanguageServerTestComposition.CreateExportProviderAsync(
+            TestOutputLogger.Factory,
+            includeDevKitComponents: true,
+            MefCacheDirectory.Path,
+            out var _,
+            out var _);
 
         // VS Telemetry requires this environment variable to be set.
         Environment.SetEnvironmentVariable("CommonPropertyBagPath", Path.GetTempFileName());

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -39,6 +39,6 @@ internal sealed class LanguageServerTestComposition
             ExtensionLogDirectory: string.Empty);
         var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
         assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
-        return ExportProviderBuilder.CreateExportProviderAsync(extensionManager, assemblyLoader, devKitDependencyPath, loggerFactory);
+        return ExportProviderBuilder.CreateExportProviderAsync(extensionManager, assemblyLoader, devKitDependencyPath, cacheDirectory: null, loggerFactory);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -23,6 +23,7 @@ internal sealed class LanguageServerTestComposition
     public static Task<ExportProvider> CreateExportProviderAsync(
         ILoggerFactory loggerFactory,
         bool includeDevKitComponents,
+        string cacheDirectory,
         out ServerConfiguration serverConfiguration,
         out IAssemblyLoader assemblyLoader)
     {
@@ -39,6 +40,6 @@ internal sealed class LanguageServerTestComposition
             ExtensionLogDirectory: string.Empty);
         var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
         assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
-        return ExportProviderBuilder.CreateExportProviderAsync(extensionManager, assemblyLoader, devKitDependencyPath, cacheDirectory: null, loggerFactory);
+        return ExportProviderBuilder.CreateExportProviderAsync(extensionManager, assemblyLoader, devKitDependencyPath, cacheDirectory, loggerFactory);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -7,17 +7,19 @@ using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
-public class WorkspaceProjectFactoryServiceTests
+public class WorkspaceProjectFactoryServiceTests(ITestOutputHelper testOutputHelper)
+    : AbstractLanguageServerHostTests(testOutputHelper)
 {
     [Fact]
     public async Task CreateProjectAndBatch()
     {
         var loggerFactory = new LoggerFactory();
         using var exportProvider = await LanguageServerTestComposition.CreateExportProviderAsync(
-            loggerFactory, includeDevKitComponents: false, out var serverConfiguration, out var _);
+            loggerFactory, includeDevKitComponents: false, MefCacheDirectory.Path, out var serverConfiguration, out var _);
 
         exportProvider.GetExportedValue<ServerConfigurationFactory>()
             .InitializeConfiguration(serverConfiguration);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
@@ -120,9 +120,12 @@ internal sealed class ExportProviderBuilder
 
     private static string GetCompositionCacheFilePath(string cacheDirectory, ImmutableArray<string> assemblyPaths)
     {
-        // Include the .NET runtime version in the cache path so that running on a newer
-        // runtime causes the cache to be rebuilt.
+        // This should vary based on .NET runtime major version so that as some of our processes switch between our target
+        // .NET version and the user's selected SDK runtime version (which may be newer), the MEF cache is kept isolated.
+        // This can be important when the MEF catalog records full assembly names such as "System.Runtime, 8.0.0.0" yet
+        // we might be running on .NET 7 or .NET 8, depending on the particular session and user settings.
         var cacheSubdirectory = $".NET {Environment.Version.Major}";
+
         return Path.Combine(cacheDirectory, cacheSubdirectory, $"c#-languageserver.{ComputeAssemblyHash(assemblyPaths)}.mef-composition");
 
         static string ComputeAssemblyHash(ImmutableArray<string> assemblyPaths)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
@@ -106,7 +106,7 @@ internal sealed class ExportProviderBuilder
         ThrowOnUnexpectedErrors(config, catalog, logger);
 
         // Try to cache the composition.
-        _ = WriteCompositionCacheAsync(compositionCacheFile, config, logger);
+        _ = WriteCompositionCacheAsync(compositionCacheFile, config, logger).ReportNonFatalErrorAsync();
 
         // Prepare an ExportProvider factory based on this graph.
         return config.CreateExportProviderFactory();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
@@ -20,7 +20,7 @@ internal sealed class ExportProviderBuilder
         ExtensionAssemblyManager extensionManager,
         IAssemblyLoader assemblyLoader,
         string? devKitDependencyPath,
-        string? cacheDirectory,
+        string cacheDirectory,
         ILoggerFactory loggerFactory)
     {
         var logger = loggerFactory.CreateLogger<ExportProviderBuilder>();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.CodeAnalysis.LanguageServer.Logging;
 using Microsoft.CodeAnalysis.LanguageServer.Services;
 using Microsoft.CodeAnalysis.Shared.Collections;
@@ -18,6 +20,7 @@ internal sealed class ExportProviderBuilder
         ExtensionAssemblyManager extensionManager,
         IAssemblyLoader assemblyLoader,
         string? devKitDependencyPath,
+        string? cacheDirectory,
         ILoggerFactory loggerFactory)
     {
         var logger = loggerFactory.CreateLogger<ExportProviderBuilder>();
@@ -38,29 +41,8 @@ internal sealed class ExportProviderBuilder
         // Add the extension assemblies to the MEF catalog.
         assemblyPaths = assemblyPaths.Concat(extensionManager.ExtensionAssemblyPaths);
 
-        logger.LogTrace($"Composing MEF catalog using:{Environment.NewLine}{string.Join($"    {Environment.NewLine}", assemblyPaths)}.");
-
-        // Create a MEF resolver that can resolve assemblies in the extension contexts.
-        var resolver = new Resolver(assemblyLoader);
-
-        var discovery = PartDiscovery.Combine(
-            resolver,
-            new AttributedPartDiscovery(resolver, isNonPublicSupported: true), // "NuGet MEF" attributes (Microsoft.Composition)
-            new AttributedPartDiscoveryV1(resolver));
-
-        // TODO - we should likely cache the catalog so we don't have to rebuild it every time.
-        var catalog = ComposableCatalog.Create(resolver)
-            .AddParts(await discovery.CreatePartsAsync(assemblyPaths))
-            .WithCompositionService(); // Makes an ICompositionService export available to MEF parts to import
-
-        // Assemble the parts into a valid graph.
-        var config = CompositionConfiguration.Create(catalog);
-
-        // Verify we only have expected errors.
-        ThrowOnUnexpectedErrors(config, catalog, logger);
-
-        // Prepare an ExportProvider factory based on this graph.
-        var exportProviderFactory = config.CreateExportProviderFactory();
+        // Get the cached MEF composition or create a new one.
+        var exportProviderFactory = await GetCompositionConfigurationAsync(assemblyPaths.ToImmutableArray(), assemblyLoader, cacheDirectory, logger);
 
         // Create an export provider, which represents a unique container of values.
         // You can create as many of these as you want, but typically an app needs just one.
@@ -73,6 +55,102 @@ internal sealed class ExportProviderBuilder
         exportProvider.GetExportedValue<ExtensionAssemblyManagerMefProvider>().SetMefExtensionAssemblyManager(extensionManager);
 
         return exportProvider;
+    }
+
+    private static async Task<IExportProviderFactory> GetCompositionConfigurationAsync(
+        ImmutableArray<string> assemblyPaths,
+        IAssemblyLoader assemblyLoader,
+        string? cacheDirectory,
+        ILogger logger)
+    {
+        // Create a MEF resolver that can resolve assemblies in the extension contexts.
+        var resolver = new Resolver(assemblyLoader);
+
+        string? compositionCacheFile = cacheDirectory is not null
+            ? GetCompositionCacheFilePath(cacheDirectory, assemblyPaths)
+            : null;
+
+        // Try to load a cached composition.
+        try
+        {
+            if (compositionCacheFile is not null && File.Exists(compositionCacheFile))
+            {
+                logger.LogTrace($"Loading cached MEF catalog: {compositionCacheFile}");
+
+                CachedComposition cachedComposition = new();
+                using FileStream cacheStream = new(compositionCacheFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
+                return await cachedComposition.LoadExportProviderFactoryAsync(cacheStream, resolver);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Log the error, and move on to recover by recreating the MEF composition.
+            logger.LogError($"Loading cached MEF composition failed: {ex}");
+        }
+
+        logger.LogTrace($"Composing MEF catalog using:{Environment.NewLine}{string.Join($"    {Environment.NewLine}", assemblyPaths)}.");
+
+        var discovery = PartDiscovery.Combine(
+            resolver,
+            new AttributedPartDiscovery(resolver, isNonPublicSupported: true), // "NuGet MEF" attributes (Microsoft.Composition)
+            new AttributedPartDiscoveryV1(resolver));
+
+        var catalog = ComposableCatalog.Create(resolver)
+            .AddParts(await discovery.CreatePartsAsync(assemblyPaths))
+            .WithCompositionService(); // Makes an ICompositionService export available to MEF parts to import
+
+        // Assemble the parts into a valid graph.
+        var config = CompositionConfiguration.Create(catalog);
+
+        // Verify we only have expected errors.
+        ThrowOnUnexpectedErrors(config, catalog, logger);
+
+        // Try to cache the composition.
+        if (compositionCacheFile is not null)
+        {
+            if (Path.GetDirectoryName(compositionCacheFile) is string directory)
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            CachedComposition cachedComposition = new();
+            var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            using (FileStream cacheStream = new(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true))
+            {
+                await cachedComposition.SaveAsync(config, cacheStream);
+            }
+
+            File.Move(tempFilePath, compositionCacheFile, overwrite: true);
+        }
+
+        // Prepare an ExportProvider factory based on this graph.
+        return config.CreateExportProviderFactory();
+    }
+
+    private static string GetCompositionCacheFilePath(string cacheDirectory, ImmutableArray<string> assemblyPaths)
+    {
+        // Include the .NET runtime version in the cache path so that running on a newer
+        // runtime causes the cache to be rebuilt.
+        var cacheSubdirectory = $".NET {Environment.Version.Major}";
+        return Path.Combine(cacheDirectory, cacheSubdirectory, $"c#-languageserver.{ComputeAssemblyHash(assemblyPaths)}.mef-composition");
+
+        static string ComputeAssemblyHash(ImmutableArray<string> assemblyPaths)
+        {
+            var assemblies = new StringBuilder();
+            foreach (var assemblyPath in assemblyPaths)
+            {
+                // Include assembly path in the hash so that changes to the set of included
+                // assemblies cause the composition to be rebuilt.
+                assemblies.Append(assemblyPath);
+                // Include the last write time in the hash so that newer assemblies written
+                // to the same location cause the composition to be rebuilt.
+                assemblies.Append(File.GetLastWriteTimeUtc(assemblyPath).ToString("F"));
+            }
+
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(assemblies.ToString()));
+            // Convert to filename safe base64 string.
+            return Convert.ToBase64String(hash).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        }
     }
 
     private static void ThrowOnUnexpectedErrors(CompositionConfiguration configuration, ComposableCatalog catalog, ILogger logger)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -86,7 +86,9 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     var assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
     var typeRefResolver = new ExtensionTypeRefResolver(assemblyLoader, loggerFactory);
 
-    using var exportProvider = await ExportProviderBuilder.CreateExportProviderAsync(extensionManager, assemblyLoader, serverConfiguration.DevKitDependencyPath, loggerFactory);
+    var cacheDirectory = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location)!, "cache");
+
+    using var exportProvider = await ExportProviderBuilder.CreateExportProviderAsync(extensionManager, assemblyLoader, serverConfiguration.DevKitDependencyPath, cacheDirectory, loggerFactory);
 
     // LSP server doesn't have the pieces yet to support 'balanced' mode for source-generators.  Hardcode us to
     // 'automatic' for now.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -639,4 +639,8 @@ internal enum FunctionId
     VSCode_LanguageServer_Started = 860,
     VSCode_Project_Load_Started = 861,
     VSCode_Projects_Load_Completed = 862,
+
+    LSP_MEF_Cache_Load_Success = 865,
+    LSP_MEF_Cache_Load_Failure = 866,
+    LSP_MEF_Cache_Built = 867
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -639,8 +639,4 @@ internal enum FunctionId
     VSCode_LanguageServer_Started = 860,
     VSCode_Project_Load_Started = 861,
     VSCode_Projects_Load_Completed = 862,
-
-    LSP_MEF_Cache_Load_Success = 865,
-    LSP_MEF_Cache_Load_Failure = 866,
-    LSP_MEF_Cache_Built = 867
 }


### PR DESCRIPTION
To improve startup time of the LSP we can cache the MEF composition and load it from file instead of building up a new composition.

The cache is invalidated when:
1. The location of the Microsoft.CodeAnalysis.LanguageServer changes (such as installing an updated C# extension or `dotnet.server.path` is updated).
2. Changing major .NET runtime version.
3. The set of assembly paths that make up the composition changes.
4. The last write time of any assembly that is part of the composition changes.

Resolves #68568