### PR TITLE
Fix multiple updates for dynamic file

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.TextChangesTextLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.TextChangesTextLoader.cs
@@ -14,12 +14,19 @@ internal partial class RazorDynamicFileInfoProvider
 {
     private sealed class TextChangesTextLoader(
         TextDocument? document,
-        IEnumerable<TextChange> changes,
+        IEnumerable<RazorDynamicFileUpdate> updates,
         byte[] checksum,
         SourceHashAlgorithm checksumAlgorithm,
         int? codePage,
         Uri razorUri) : TextLoader
     {
+        private readonly TextDocument? _document = document;
+        private readonly IEnumerable<RazorDynamicFileUpdate> _updates = updates;
+        private readonly byte[] _checksum = checksum;
+        private readonly SourceHashAlgorithm _checksumAlgorithm = checksumAlgorithm;
+        private readonly int? _codePage = codePage;
+        private readonly Uri _razorUri = razorUri;
+
         private readonly Lazy<SourceText> _emptySourceText = new Lazy<SourceText>(() =>
         {
             var encoding = codePage is null ? null : Encoding.GetEncoding(codePage.Value);
@@ -28,38 +35,38 @@ internal partial class RazorDynamicFileInfoProvider
 
         public override async Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
         {
-            if (document is null)
+            if (_document is null)
             {
-                var text = _emptySourceText.Value.WithChanges(changes);
+                var text = UpdateSourceTextWithEdits(_emptySourceText.Value, _updates);
                 return TextAndVersion.Create(text, VersionStamp.Default.GetNewerVersion());
             }
 
-            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var sourceText = await _document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             // Validate the checksum information so the edits are known to be correct
             if (IsSourceTextMatching(sourceText))
             {
-                var version = await document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
-                var newText = sourceText.WithChanges(changes);
+                var version = await _document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
+                var newText = UpdateSourceTextWithEdits(sourceText, _updates);
                 return TextAndVersion.Create(newText, version.GetNewerVersion());
             }
 
-            return await GetFullDocumentFromServerAsync(razorUri, cancellationToken).ConfigureAwait(false);
+            return await GetFullDocumentFromServerAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private bool IsSourceTextMatching(SourceText sourceText)
         {
-            if (sourceText.ChecksumAlgorithm != checksumAlgorithm)
+            if (sourceText.ChecksumAlgorithm != _checksumAlgorithm)
             {
                 return false;
             }
 
-            if (sourceText.Encoding?.CodePage != codePage)
+            if (sourceText.Encoding?.CodePage != _codePage)
             {
                 return false;
             }
 
-            if (!sourceText.GetChecksum().SequenceEqual(checksum))
+            if (!sourceText.GetChecksum().SequenceEqual(_checksum))
             {
                 return false;
             }
@@ -67,7 +74,7 @@ internal partial class RazorDynamicFileInfoProvider
             return true;
         }
 
-        private async Task<TextAndVersion> GetFullDocumentFromServerAsync(Uri razorUri, CancellationToken cancellationToken)
+        private async Task<TextAndVersion> GetFullDocumentFromServerAsync(CancellationToken cancellationToken)
         {
             Contract.ThrowIfNull(LanguageServerHost.Instance, "We don't have an LSP channel yet to send this request through.");
             var clientLanguageServerManager = LanguageServerHost.Instance.GetRequiredLspService<IClientLanguageServerManager>();
@@ -78,18 +85,28 @@ internal partial class RazorDynamicFileInfoProvider
                 {
                     RazorDocument = new()
                     {
-                        Uri = razorUri,
+                        Uri = _razorUri,
                     },
                     FullText = true
                 },
                 cancellationToken);
 
-            RoslynDebug.AssertNotNull(response.Edits);
-            RoslynDebug.Assert(response.Edits.IsSingle());
+            RoslynDebug.AssertNotNull(response.Updates);
+            RoslynDebug.Assert(response.Updates.IsSingle());
 
-            var textChanges = response.Edits.Select(e => new TextChange(e.Span.ToTextSpan(), e.NewText));
-            var text = _emptySourceText.Value.WithChanges(textChanges);
+            var text = UpdateSourceTextWithEdits(_emptySourceText.Value, response.Updates);
             return TextAndVersion.Create(text, VersionStamp.Default.GetNewerVersion());
+        }
+
+        private static SourceText UpdateSourceTextWithEdits(SourceText sourceText, IEnumerable<RazorDynamicFileUpdate> updates) 
+        {
+            foreach (var update in updates)
+            {
+                var changes = update.Edits.Select(e => new TextChange(e.Span.ToTextSpan(), e.NewText));
+                sourceText = sourceText.WithChanges(changes);
+            }
+
+            return sourceText;
         }
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.cs
@@ -79,14 +79,13 @@ internal partial class RazorDynamicFileInfoProvider : IDynamicFileInfoProvider
         var responseUri = response.CSharpDocument.Uri;
         var dynamicFileInfoFilePath = ProtocolConversions.GetDocumentFilePathFromUri(responseUri);
 
-        if (response.Edits is not null)
+        if (response.Updates is not null)
         {
             var textDocument = await _workspaceFactory.Workspace.CurrentSolution.GetTextDocumentAsync(response.CSharpDocument, cancellationToken).ConfigureAwait(false);
-            var textChanges = response.Edits.Select(e => new TextChange(e.Span.ToTextSpan(), e.NewText));
             var checksum = Convert.FromBase64String(response.Checksum);
             var textLoader = new TextChangesTextLoader(
                 textDocument,
-                textChanges,
+                response.Updates,
                 checksum,
                 response.ChecksumAlgorithm,
                 response.SourceEncodingCodePage,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileUpdate.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileUpdate.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.Razor;
+
+class RazorDynamicFileUpdate
+{
+    [JsonPropertyName("edits")]
+    public required ServerTextChange[] Edits { get; set; }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorProvideDynamicFileResponse.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorProvideDynamicFileResponse.cs
@@ -13,8 +13,8 @@ internal class RazorProvideDynamicFileResponse
     [JsonPropertyName("csharpDocument")]
     public required TextDocumentIdentifier CSharpDocument { get; set; }
 
-    [JsonPropertyName("edits")]
-    public ServerTextChange[]? Edits { get; set; }
+    [JsonPropertyName("updates")]
+    public RazorDynamicFileUpdate[]? Updates { get; set; }
 
     [JsonPropertyName("checksum")]
     public required string Checksum { get; set; }


### PR DESCRIPTION
Dynamic file updates can come in multiples before Roslyn asks for them. They are also not guaranteed to not overlap. Rather than trying to reason about a minimum set of updates, this just modifies the response to receive those updates directly. Each update is guaranteed to have no overlapping edits, but across updates that is not guaranteed
