### PR TITLE
Fix broken strings in Unified Setting page

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             => ServicesVSResources.Never_add_new_line_on_enter;
 
         public static string Option_Only_add_new_line_on_enter_with_whole_word
-            => ServicesVSResources.Only_add_new_line_on_enter_after_end_of_fully_typed_word;
+            => ServicesVSResources._Only_add_new_line_on_enter_after_end_of_fully_typed_word;
 
         public static string Option_Always_add_new_line_on_enter
             => ServicesVSResources.Always_add_new_line_on_enter;

--- a/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
@@ -198,4 +198,4 @@
 [$RootKey$\SettingsManifests\{13c3bbb4-f18f-4111-9f54-a0fb010d9194}]
 @="Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\csharpSettings.registration.json"
-"CacheTag"=qword:CE76341698AB8CD7
+"CacheTag"=qword:3AEFDB0DA1308654

--- a/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
@@ -198,4 +198,4 @@
 [$RootKey$\SettingsManifests\{13c3bbb4-f18f-4111-9f54-a0fb010d9194}]
 @="Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\csharpSettings.registration.json"
-"CacheTag"=qword:CE76341698AB8CD3
+"CacheTag"=qword:CE76341698AB8CD7

--- a/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
+++ b/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
@@ -6,7 +6,7 @@
   "properties": {
     // CompletionOptionsStorage.TriggerOnTypingLetters
     "textEditor.csharp.intellisense.triggerCompletionOnTypingLetters": {
-      "title": "@Show_completion_list_after_a_character_is_typed;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+      "title": "@Show_completion_list_after_a_character_is_typed;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 0,
@@ -21,7 +21,7 @@
     },
     // CompletionOptionsStorage.TriggerOnDeletion
     "textEditor.csharp.intellisense.triggerCompletionOnDeletion": {
-      "title": "@Show_completion_list_after_a_character_is_deleted;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+      "title": "@Show_completion_list_after_a_character_is_deleted;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": false,
       "order": 1,
@@ -52,7 +52,7 @@
     },
     // CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems
     "textEditor.csharp.intellisense.highlightMatchingPortionsOfCompletionListItems": {
-      "title": "@Highlight_matching_portions_of_completion_list_items;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+      "title": "@Highlight_matching_portions_of_completion_list_items;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 20,
@@ -67,7 +67,7 @@
     },
     // CompletionViewOptionsStorage.ShowCompletionItemFilters
     "textEditor.csharp.intellisense.showCompletionItemFilters": {
-      "title": "@Show_completion_item_filters;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+      "title": "@Show_completion_item_filters;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 30,
@@ -97,7 +97,7 @@
     },
     // CompletionOptionsStorage.SnippetsBehavior
     "textEditor.csharp.intellisense.snippetsBehavior": {
-      "title": "@Snippets_behavior;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+      "title": "@Snippets_behavior;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "neverInclude", "alwaysInclude", "includeAfterTypingIdentifierQuestionTab" ],
       "enumItemLabels": [ "@Never_include_snippets;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}", "@Always_include_snippets;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}", "@Include_snippets_when_Tab_is_typed_after_an_identifier;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}" ],
@@ -136,10 +136,10 @@
     },
     // CompletionOptionsStorage.EnterKeyBehavior
     "textEditor.csharp.intellisense.returnKeyCompletionBehavior": {
-      "title": "@Enter_key_behavior_colon;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+      "title": "@Enter_key_behavior_colon;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "never", "afterFullyTypedWord", "always" ],
-      "enumItemLabels": [ "@Never_add_new_line_on_enter;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}", "@Only_add_new_line_on_enter_after_end_of_fully_typed_word;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}", "@Always_add_new_line_on_enter;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}" ],
+      "enumItemLabels": [ "@Never_add_new_line_on_enter;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}", "@Only_add_new_line_on_enter_after_end_of_fully_typed_word;..\\Microsoft.VisualStudio.LanguageServices.dll", "@Always_add_new_line_on_enter;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}" ],
       "default": "never",
       "order": 60,
       "migration": {
@@ -190,7 +190,7 @@
     },
     // CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces
     "textEditor.csharp.intellisense.showCompletionItemsFromUnimportedNamespaces": {
-      "title": "@Show_items_from_unimported_namespaces;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+      "title": "@Show_items_from_unimported_namespaces;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 80,

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1883,9 +1883,6 @@ Additional information: {1}</value>
   <data name="Show_completion_item_filters" xml:space="preserve">
     <value>Show completion item _filters</value>
   </data>
-  <data name="Only_add_new_line_on_enter_after_end_of_fully_typed_word" xml:space="preserve">
-    <value>_Only add new line on enter after end of fully typed word</value>
-  </data>
   <data name="Snippets_behavior" xml:space="preserve">
     <value>Snippets behavior</value>
   </data>
@@ -1918,5 +1915,11 @@ Additional information: {1}</value>
   </data>
   <data name="Show_preview_for_rename_tracking" xml:space="preserve">
     <value>Show preview for rename _tracking</value>
+  </data>
+  <data name="_Only_add_new_line_on_enter_after_end_of_fully_typed_word" xml:space="preserve">
+    <value>_Only add new line on enter after end of fully typed word</value>
+  </data>
+  <data name="Only_add_new_line_on_enter_after_end_of_fully_typed_word" xml:space="preserve">
+    <value>Only add new line on enter after end of fully typed word</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">{0} se změní na veřejný.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">"{0}" wird in öffentlichen Wert geändert.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">"{0}" se cambiará a público.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">'{0}' va être changé en valeur publique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">'{0}' verrà modificato in pubblico.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">'{0}' はパブリックに変更されます。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">'{0}'이(가) 공용으로 변경됩니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">Element „{0}” zostanie zmieniony na publiczny.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">'{0}' será alterado para público.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">Элемент "{0}" будет изменен на открытый.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">'{0}' ortak olacak şekilde değiştirildi.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">“{0}”将更改为“公共”。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -963,8 +963,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Only_add_new_line_on_enter_after_end_of_fully_typed_word">
-        <source>_Only add new line on enter after end of fully typed word</source>
-        <target state="new">_Only add new line on enter after end of fully typed word</target>
+        <source>Only add new line on enter after end of fully typed word</source>
+        <target state="new">Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="Open_documents">
@@ -1850,6 +1850,11 @@
       <trans-unit id="_0_will_be_changed_to_public">
         <source>'{0}' will be changed to public.</source>
         <target state="translated">'{0}' 會變更為公用。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_Only_add_new_line_on_enter_after_end_of_fully_typed_word">
+        <source>_Only add new line on enter after end of fully typed word</source>
+        <target state="new">_Only add new line on enter after end of fully typed word</target>
         <note />
       </trans-unit>
       <trans-unit id="at_the_end_of_the_line_of_code">

--- a/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
@@ -195,4 +195,4 @@
 [$RootKey$\SettingsManifests\{574fc912-f74f-4b4e-92c3-f695c208a2bb}]
 @="Microsoft.VisualStudio.LanguageServices.VisualBasic.VisualBasicPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\visualBasicSettings.registration.json"
-"CacheTag"=qword:5DE8496A8900B809
+"CacheTag"=qword:5DE8496A8900B800

--- a/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
@@ -195,4 +195,4 @@
 [$RootKey$\SettingsManifests\{574fc912-f74f-4b4e-92c3-f695c208a2bb}]
 @="Microsoft.VisualStudio.LanguageServices.VisualBasic.VisualBasicPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\visualBasicSettings.registration.json"
-"CacheTag"=qword:5DE8496A8900B800
+"CacheTag"=qword:1F15ACF7AC28A65C

--- a/src/VisualStudio/VisualBasic/Impl/UnifiedSettings/visualBasicSettings.registration.json
+++ b/src/VisualStudio/VisualBasic/Impl/UnifiedSettings/visualBasicSettings.registration.json
@@ -6,7 +6,7 @@
   "properties": {
     // CompletionOptionsStorage.TriggerOnTypingLetters
     "textEditor.basic.intellisense.triggerCompletionOnTypingLetters": {
-      "title": "@Show_completion_list_after_a_character_is_typed;..\\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
+      "title": "@Show_completion_list_after_a_character_is_typed;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 0,
@@ -21,7 +21,7 @@
     },
     // CompletionOptionsStorage.TriggerOnDeletion
     "textEditor.basic.intellisense.triggerCompletionOnDeletion": {
-      "title": "@Show_completion_list_after_a_character_is_deleted;..\\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
+      "title": "@Show_completion_list_after_a_character_is_deleted;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 1,
@@ -36,7 +36,7 @@
     },
     // CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems
     "textEditor.basic.intellisense.highlightMatchingPortionsOfCompletionListItems": {
-      "title": "@Highlight_matching_portions_of_completion_list_items;..\\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
+      "title": "@Highlight_matching_portions_of_completion_list_items;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 10,
@@ -51,7 +51,7 @@
     },
     // CompletionViewOptionsStorage.ShowCompletionItemFilters
     "textEditor.basic.intellisense.showCompletionItemFilters": {
-      "title": "@Show_completion_item_filters;..\\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
+      "title": "@Show_completion_item_filters;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 20,
@@ -66,7 +66,7 @@
     },
     // CompletionOptionsStorage.SnippetsBehavior
     "textEditor.basic.intellisense.snippetsBehavior": {
-      "title": "@Snippets_behavior;..\\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
+      "title": "@Snippets_behavior;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "neverInclude", "alwaysInclude", "includeAfterTypingIdentifierQuestionTab" ],
       "enumItemLabels": [ "@Never_include_snippets;{574fc912-f74f-4b4e-92c3-f695c208a2bb}", "@Always_include_snippets;{574fc912-f74f-4b4e-92c3-f695c208a2bb}", "@Include_snippets_when_Tab_is_typed_after_an_identifier;{574fc912-f74f-4b4e-92c3-f695c208a2bb}" ],
@@ -105,7 +105,7 @@
     },
     // CompletionOptionsStorage.EnterKeyBehavior
     "textEditor.basic.intellisense.returnKeyCompletionBehavior": {
-      "title": "@Enter_key_behavior_colon;..\\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
+      "title": "@Enter_key_behavior_colon;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "never", "afterFullyTypedWord", "always" ],
       "enumItemLabels": [ "@Never_add_new_line_on_enter;{574fc912-f74f-4b4e-92c3-f695c208a2bb}", "@Only_add_new_line_on_enter_after_end_of_fully_typed_word;{574fc912-f74f-4b4e-92c3-f695c208a2bb}", "@Always_add_new_line_on_enter;{574fc912-f74f-4b4e-92c3-f695c208a2bb}" ],
@@ -144,7 +144,7 @@
     },
     // CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces
     "textEditor.basic.intellisense.showCompletionItemsFromUnimportedNamespaces": {
-      "title": "@Show_items_from_unimported_namespaces;..\\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
+      "title": "@Show_items_from_unimported_namespaces;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
       "order": 50,


### PR DESCRIPTION
Clearly strings are going to be broken if this is merged.

https://github.com/dotnet/roslyn/commit/dfc660c23aecaf5aae4ad2249d8eead228db43d5#diff-a16de2a58a10f14a7fc8512f47bbd467869339a6135046bb0274d2fce1151f93R1901

This PR brings back to track.

Current: 
![image](https://github.com/user-attachments/assets/8a89b863-2e48-49c4-992a-1c06fd358fde)
After:
![image](https://github.com/user-attachments/assets/d244aedb-6ec3-4183-81d8-b61ef9e69445)


This should be covered by unit test. I am preparing it in https://github.com/Cosifne/roslyn/tree/dev/shech/UnifiedSettingsAdvPage, will cover these strings will that is ready