### PR TITLE
Use variable instead of value for parameter completion items

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             { WellKnownTags.Method, ImmutableArray.Create(LSP.CompletionItemKind.Method) },
             { WellKnownTags.Module, ImmutableArray.Create(LSP.CompletionItemKind.Module) },
             { WellKnownTags.Operator, ImmutableArray.Create(LSP.CompletionItemKind.Operator) },
-            { WellKnownTags.Parameter, ImmutableArray.Create(LSP.CompletionItemKind.Value) },
+            { WellKnownTags.Parameter, ImmutableArray.Create(LSP.CompletionItemKind.Variable) },
             { WellKnownTags.Property, ImmutableArray.Create(LSP.CompletionItemKind.Property) },
             { WellKnownTags.RangeVariable, ImmutableArray.Create(LSP.CompletionItemKind.Variable) },
             { WellKnownTags.Reference, ImmutableArray.Create(LSP.CompletionItemKind.Reference) },


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/50324

Now:
![image](https://github.com/user-attachments/assets/e656f521-0a3f-432a-a6d1-3f3c41ed4b7e)
