### PR TITLE
Prefer ReadOnlySpan over Span as better conversion target

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2980,19 +2980,6 @@ outerDefault:
             switch ((conv1.Kind, conv2.Kind))
             {
                 case (ConversionKind.ImplicitSpan, ConversionKind.ImplicitSpan):
-                    // If the expression is of an array type, prefer ReadOnlySpan over Span (to avoid ArrayTypeMismatchExceptions).
-                    if (node.Type is ArrayTypeSymbol)
-                    {
-                        if (t1.IsReadOnlySpan() && t2.IsSpan())
-                        {
-                            return BetterResult.Left;
-                        }
-
-                        if (t1.IsSpan() && t2.IsReadOnlySpan())
-                        {
-                            return BetterResult.Right;
-                        }
-                    }
                     break;
                 case (_, ConversionKind.ImplicitSpan):
                     return BetterResult.Right;
@@ -3454,6 +3441,19 @@ outerDefault:
                 return BetterResult.Neither;
             }
 
+            // SPEC: T₁ is System.ReadOnlySpan<E₁>, T₂ is System.Span<E₂>, and an identity conversion from E₁ to E₂ exists
+            if (Compilation.IsFeatureEnabled(MessageID.IDS_FeatureFirstClassSpan))
+            {
+                if (isBetterSpanConversionTarget(type1, type2))
+                {
+                    return BetterResult.Left;
+                }
+                else if (isBetterSpanConversionTarget(type2, type1))
+                {
+                    return BetterResult.Right;
+                }
+            }
+
             // Given two different types T1 and T2, T1 is a better conversion target than T2 if no implicit conversion from T2 to T1 exists,
             // and at least one of the following holds:
             bool type1ToType2 = Conversions.ClassifyImplicitConversionFromType(type1, type2, ref useSiteInfo).IsImplicit;
@@ -3592,6 +3592,22 @@ outerDefault:
             }
 
             return BetterResult.Neither;
+
+            static bool isBetterSpanConversionTarget(TypeSymbol type1, TypeSymbol type2)
+            {
+                // SPEC: T₁ is System.ReadOnlySpan<E₁>, T₂ is System.Span<E₂>, and an identity conversion from E₁ to E₂ exists
+                if (type1.IsReadOnlySpan() && type2.IsSpan())
+                {
+                    var type1Element = ((NamedTypeSymbol)type1).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0].Type;
+                    var type2Element = ((NamedTypeSymbol)type2).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0].Type;
+                    if (Conversions.HasIdentityConversion(type1Element, type2Element))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
         }
 
         private bool IsMethodGroupConversionIncompatibleWithDelegate(BoundMethodGroup node, NamedTypeSymbol delegateType, Conversion conv)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3452,6 +3452,12 @@ outerDefault:
                 {
                     return BetterResult.Right;
                 }
+                // The next case (a type is a better target if an implicit conversion from it to the other type exists)
+                // does not apply to span conversions except the covariant ReadOnlySpan->ReadOnlySpan conversion.
+                else if (type1.IsSpan() || type2.IsSpan())
+                {
+                    return BetterResult.Neither;
+                }
             }
 
             // Given two different types T1 and T2, T1 is a better conversion target than T2 if no implicit conversion from T2 to T1 exists,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3454,7 +3454,9 @@ outerDefault:
                 }
                 // The next case (a type is a better target if an implicit conversion from it to the other type exists)
                 // does not apply to span conversions except the covariant ReadOnlySpan->ReadOnlySpan conversion.
-                else if (type1.IsSpan() || type2.IsSpan())
+                else if ((type1.IsSpan() || type1.IsReadOnlySpan()) &&
+                    (type2.IsSpan() || type2.IsReadOnlySpan()) &&
+                    !(type1.IsReadOnlySpan() && type2.IsReadOnlySpan()))
                 {
                     return BetterResult.Neither;
                 }

--- a/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
@@ -8043,15 +8043,8 @@ public class FirstClassSpanTests : CSharpTestBase
     [Fact]
     public void OverloadResolution_SpanVsReadOnlySpan_04()
     {
-        var source = """
+        var source1 = """
             using System;
-
-            C.M1(new object[0]);
-            C.M1(new string[0]);
-
-            C.M2(new object[0]);
-            C.M2(new string[0]);
-
             static class C
             {
                 public static void M1(Span<string> arg) => Console.Write(1);
@@ -8061,8 +8054,63 @@ public class FirstClassSpanTests : CSharpTestBase
                 public static void M2(ReadOnlySpan<string> arg) => Console.Write(2);
             }
             """;
-        var comp = CreateCompilationWithSpanAndMemoryExtensions(source);
-        CompileAndVerify(comp, expectedOutput: "2112").VerifyDiagnostics();
+
+        {
+            var source2 = """
+                C.M1(new object[0]);
+                C.M2(new object[0]);
+                """;
+
+            var expectedOutput = "21";
+
+            var comp = CreateCompilationWithSpanAndMemoryExtensions([source1, source2], parseOptions: TestOptions.Regular13);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            comp = CreateCompilationWithSpanAndMemoryExtensions([source1, source2], parseOptions: TestOptions.RegularNext);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            comp = CreateCompilationWithSpanAndMemoryExtensions([source1, source2]);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
+
+        {
+            var source3 = """
+                C.M1(new string[0]);
+                """;
+
+            var expectedDiagnostics = new[]
+            {
+                // (1,3): error CS0121: The call is ambiguous between the following methods or properties: 'C.M1(Span<string>)' and 'C.M1(ReadOnlySpan<object>)'
+                // C.M1(new string[0]);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M1").WithArguments("C.M1(System.Span<string>)", "C.M1(System.ReadOnlySpan<object>)").WithLocation(1, 3)
+            };
+
+            CreateCompilationWithSpanAndMemoryExtensions([source1, source3],
+                parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilationWithSpanAndMemoryExtensions([source1, source3],
+                parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilationWithSpanAndMemoryExtensions([source1, source3]).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        {
+            var source4 = """
+                C.M2(new string[0]);
+                """;
+
+            CreateCompilationWithSpanAndMemoryExtensions([source1, source4],
+               parseOptions: TestOptions.Regular13).VerifyDiagnostics(
+               // (1,3): error CS0121: The call is ambiguous between the following methods or properties: 'C.M2(Span<object>)' and 'C.M2(ReadOnlySpan<string>)'
+               // C.M2(new string[0]);
+               Diagnostic(ErrorCode.ERR_AmbigCall, "M2").WithArguments("C.M2(System.Span<object>)", "C.M2(System.ReadOnlySpan<string>)").WithLocation(1, 3));
+
+            var expectedOutput = "2";
+
+            var comp = CreateCompilationWithSpanAndMemoryExtensions([source1, source4], parseOptions: TestOptions.RegularNext);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            comp = CreateCompilationWithSpanAndMemoryExtensions([source1, source4]);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
     }
 
     [Fact]
@@ -8141,13 +8189,12 @@ public class FirstClassSpanTests : CSharpTestBase
         CreateCompilationWithSpanAndMemoryExtensions(source).VerifyDiagnostics(expectedDiagnostics);
     }
 
-    [Fact]
-    public void OverloadResolution_SpanVsReadOnlySpan_07()
+    [Theory, MemberData(nameof(LangVersions))]
+    public void OverloadResolution_SpanVsReadOnlySpan_07(LanguageVersion langVersion)
     {
         var source = """
             using System;
             
-            C.M(new D());
             C.M(new D());
             
             static class C
@@ -8162,21 +8209,10 @@ public class FirstClassSpanTests : CSharpTestBase
                 public static implicit operator ReadOnlySpan<object>(D d) => default;
             }
             """;
-        CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.Regular13).VerifyDiagnostics(
+        CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.Regular.WithLanguageVersion(langVersion)).VerifyDiagnostics(
             // (3,3): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(Span<string>)' and 'C.M(ReadOnlySpan<object>)'
             // C.M(new D());
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(System.Span<string>)", "C.M(System.ReadOnlySpan<object>)").WithLocation(3, 3),
-            // (4,3): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(Span<string>)' and 'C.M(ReadOnlySpan<object>)'
-            // C.M(new D());
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(System.Span<string>)", "C.M(System.ReadOnlySpan<object>)").WithLocation(4, 3));
-
-        var expectedOutput = "11";
-
-        var comp = CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.RegularNext);
-        CompileAndVerify(comp, expectedOutput: expectedOutput, verify: Verification.FailsILVerify).VerifyDiagnostics();
-
-        comp = CreateCompilationWithSpanAndMemoryExtensions(source);
-        CompileAndVerify(comp, expectedOutput: expectedOutput, verify: Verification.FailsILVerify).VerifyDiagnostics();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(System.Span<string>)", "C.M(System.ReadOnlySpan<object>)").WithLocation(3, 3));
     }
 
     [Fact]
@@ -8363,15 +8399,8 @@ public class FirstClassSpanTests : CSharpTestBase
     [Fact]
     public void OverloadResolution_SpanVsReadOnlySpan_ExtensionMethodReceiver_05()
     {
-        var source = """
+        var source1 = """
             using System;
-
-            (new object[0]).M1();
-            (new string[0]).M1();
-
-            (new object[0]).M2();
-            (new string[0]).M2();
-
             static class E
             {
                 public static void M1(this Span<string> arg) => Console.Write(1);
@@ -8381,8 +8410,22 @@ public class FirstClassSpanTests : CSharpTestBase
                 public static void M2(this ReadOnlySpan<string> arg) => Console.Write(2);
             }
             """;
-        var comp = CreateCompilationWithSpanAndMemoryExtensions(source);
-        CompileAndVerify(comp, expectedOutput: "2112").VerifyDiagnostics();
+
+        var source2 = """
+            (new object[0]).M1();
+            (new object[0]).M2();
+            (new string[0]).M2();
+            """;
+        var comp = CreateCompilationWithSpanAndMemoryExtensions([source1, source2]);
+        CompileAndVerify(comp, expectedOutput: "212").VerifyDiagnostics();
+
+        var source3 = """
+            (new string[0]).M1();
+            """;
+        CreateCompilationWithSpanAndMemoryExtensions([source1, source3]).VerifyDiagnostics(
+            // (1,17): error CS0121: The call is ambiguous between the following methods or properties: 'E.M1(Span<string>)' and 'E.M1(ReadOnlySpan<object>)'
+            // (new string[0]).M1();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M1").WithArguments("E.M1(System.Span<string>)", "E.M1(System.ReadOnlySpan<object>)").WithLocation(1, 17));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
@@ -8630,6 +8630,31 @@ public class FirstClassSpanTests : CSharpTestBase
         CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
     }
 
+    [Theory, MemberData(nameof(LangVersions))]
+    public void OverloadResolution_SpanVsUserDefined_03(LanguageVersion langVersion)
+    {
+        var source = """
+            using System;
+
+            C.M(new E());
+
+            static class C
+            {
+                public static void M(Span<object> arg) => Console.Write(1);
+                public static void M(D arg) => Console.Write(2);
+            }
+
+            class D
+            {
+                public static implicit operator Span<object>(D d) => default;
+            }
+
+            class E : D;
+            """;
+        var comp = CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.Regular.WithLanguageVersion(langVersion));
+        CompileAndVerify(comp, expectedOutput: "2", verify: Verification.FailsILVerify).VerifyDiagnostics();
+    }
+
     [Fact]
     public void OverloadResolution_ReadOnlySpanVsArrayVsSpan()
     {

--- a/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
@@ -8180,6 +8180,76 @@ public class FirstClassSpanTests : CSharpTestBase
     }
 
     [Fact]
+    public void OverloadResolution_SpanVsReadOnlySpan_08()
+    {
+        var source = """
+            using System;
+
+            (int, int)[] t = [(1, 2)];
+
+            C.M1(t);
+            C.M1(t);
+
+            C.M2(t);
+            C.M2(t);
+
+            static class C
+            {
+                public static void M1(Span<(int X, int Y)> arg) => Console.Write(1);
+                public static void M1(ReadOnlySpan<(int, int)> arg) => Console.Write(2);
+
+                public static void M2(Span<(int X, int Y)> arg) => Console.Write(1);
+                public static void M2(ReadOnlySpan<(int A, int B)> arg) => Console.Write(2);
+            }
+            """;
+        var comp = CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.Regular13);
+        CompileAndVerify(comp, expectedOutput: "1111").VerifyDiagnostics();
+
+        var expectedOutput = "2222";
+
+        comp = CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.RegularNext);
+        CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+        comp = CreateCompilationWithSpanAndMemoryExtensions(source);
+        CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void OverloadResolution_SpanVsReadOnlySpan_09()
+    {
+        var source = """
+            using System;
+
+            object[] a = [];
+
+            C.M1(a);
+            C.M1(a);
+
+            C.M2(a);
+            C.M2(a);
+
+            static class C
+            {
+                public static void M1(Span<object> arg) => Console.Write(1);
+                public static void M1(ReadOnlySpan<dynamic> arg) => Console.Write(2);
+
+                public static void M2(Span<dynamic> arg) => Console.Write(1);
+                public static void M2(ReadOnlySpan<object> arg) => Console.Write(2);
+            }
+            """;
+        var comp = CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.Regular13);
+        CompileAndVerify(comp, expectedOutput: "1111").VerifyDiagnostics();
+
+        var expectedOutput = "2222";
+
+        comp = CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.RegularNext);
+        CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+        comp = CreateCompilationWithSpanAndMemoryExtensions(source);
+        CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+    }
+
+    [Fact]
     public void OverloadResolution_SpanVsReadOnlySpan_ExtensionMethodReceiver_01()
     {
         var source = """


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/73445
Follow up on https://github.com/dotnet/roslyn/pull/75853 from LDM 2024-12-04.
Speclet change: https://github.com/dotnet/csharplang/pull/8779