### PR TITLE
Use TotalMilliseconds instead of TimeSpan in delay telemetry

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
                     m["smartRenameCorrelationId"] = _smartRenameSession.CorrelationId;
                     m["smartRenameSemanticContextUsed"] = _semanticContextUsed;
-                    m["smartRenameSemanticContextDelay"] = _semanticContextDelay;
+                    m["smartRenameSemanticContextDelay"] = _semanticContextDelay.TotalMilliseconds;
                     m["smartRenameSemanticContextError"] = _semanticContextError;
                 }));
             }
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
                     m["smartRenameCorrelationId"] = _smartRenameSession.CorrelationId;
                     m["smartRenameSemanticContextUsed"] = _semanticContextUsed;
-                    m["smartRenameSemanticContextDelay"] = _semanticContextDelay;
+                    m["smartRenameSemanticContextDelay"] = _semanticContextDelay.TotalMilliseconds;
                     m["smartRenameSemanticContextError"] = _semanticContextError;
                 }));
             }


### PR DESCRIPTION
Just noticed that recent telemetry change #76045 uses Timestamp to report delay, e.g. `00:00:00.0006369`. Processing timestamp is expensive. I'm updating telemetry to use `double TotalMillseconds`, e.g. `68.9512` (sic, this example is pasted from a different measurement)