### PR TITLE
Preserve comment inside class body when switching to primary constructor

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -23,6 +23,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UsePrimaryConstructor;
@@ -36,6 +37,12 @@ using static SyntaxFactory;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed partial class CSharpUsePrimaryConstructorCodeFixProvider() : CodeFixProvider
 {
+    private static Matcher<SyntaxTrivia> s_commentFollowedByBlankLine = Matcher.Sequence(
+        Matcher.Single<SyntaxTrivia>(t => t.IsSingleOrMultiLineComment(), "comment"),
+        Matcher.Single<SyntaxTrivia>(t => t.Kind() == SyntaxKind.EndOfLineTrivia, "first end of line"),
+        Matcher.Repeat(Matcher.Single<SyntaxTrivia>(t => t.Kind() == SyntaxKind.WhitespaceTrivia, "whitespace")),
+        Matcher.Single<SyntaxTrivia>(t => t.IsKind(SyntaxKind.EndOfLineTrivia), "second end of line"));
+
     public override ImmutableArray<string> FixableDiagnosticIds
         => [IDEDiagnosticIds.UsePrimaryConstructorDiagnosticId];
 
@@ -157,7 +164,7 @@ internal sealed partial class CSharpUsePrimaryConstructorCodeFixProvider() : Cod
                 var finalTrivia = CreateFinalTypeDeclarationLeadingTrivia(
                     currentTypeDeclaration, constructorDeclaration, constructor, properties, removedMembers);
 
-                return currentTypeDeclaration
+                var finalTypeDeclaration = currentTypeDeclaration
                     .WithAttributeLists(finalAttributeLists)
                     .WithLeadingTrivia(finalTrivia)
                     .WithIdentifier(typeParameterList != null ? currentTypeDeclaration.Identifier : currentTypeDeclaration.Identifier.WithoutTrailingTrivia())
@@ -166,9 +173,45 @@ internal sealed partial class CSharpUsePrimaryConstructorCodeFixProvider() : Cod
                         .WithoutLeadingTrivia()
                         .WithTrailingTrivia(triviaAfterName)
                         .WithAdditionalAnnotations(Formatter.Annotation));
+
+                return WithCommentMoved(finalTypeDeclaration);
             });
 
         return;
+
+        TypeDeclarationSyntax WithCommentMoved(TypeDeclarationSyntax finalTypeDeclaration)
+        {
+            var firstMember = typeDeclaration.Members.First();
+            if (firstMember == constructorDeclaration || removedMembers.Any(kvp => kvp.Value.memberNode == firstMember))
+            {
+                // We're removing the first member in the type.  If this member had comments above it (with a blank line
+                // between it and the member) then keep those comments around.
+                var triviaToMove = GetLeadingCommentTrivia(firstMember);
+                if (triviaToMove.Length > 0)
+                {
+                    var nextToken = finalTypeDeclaration.OpenBraceToken.GetNextToken();
+                    return finalTypeDeclaration.ReplaceToken(
+                        nextToken,
+                        nextToken.WithPrependedLeadingTrivia(triviaToMove));
+                }
+            }
+
+            return finalTypeDeclaration;
+        }
+
+        ImmutableArray<SyntaxTrivia> GetLeadingCommentTrivia(MemberDeclarationSyntax firstMember)
+        {
+            var leadingTrivia = firstMember.GetLeadingTrivia().ToImmutableArray();
+
+            for (var i = leadingTrivia.Length - 1; i >= 0; i--)
+            {
+                var currentIndex = i;
+                if (s_commentFollowedByBlankLine.TryMatch(leadingTrivia, ref currentIndex))
+                    return leadingTrivia.Take(currentIndex).ToImmutableArray();
+            }
+
+            return [];
+        }
 
         SyntaxRemoveOptions GetConstructorRemovalOptions()
         {

--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -37,7 +37,7 @@ using static SyntaxFactory;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed partial class CSharpUsePrimaryConstructorCodeFixProvider() : CodeFixProvider
 {
-    private static Matcher<SyntaxTrivia> s_commentFollowedByBlankLine = Matcher.Sequence(
+    private static readonly Matcher<SyntaxTrivia> s_commentFollowedByBlankLine = Matcher.Sequence(
         Matcher.Single<SyntaxTrivia>(t => t.IsSingleOrMultiLineComment(), "comment"),
         Matcher.Single<SyntaxTrivia>(t => t.Kind() == SyntaxKind.EndOfLineTrivia, "first end of line"),
         Matcher.Repeat(Matcher.Single<SyntaxTrivia>(t => t.Kind() == SyntaxKind.WhitespaceTrivia, "whitespace")),

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -4383,7 +4383,7 @@ public sealed class UsePrimaryConstructorTests
                     // This should stay
 
                     /// <summary/>
-                    private int i, j;
+                    private int i;
                     int k;
 
                     public [|C|](int i, int j)
@@ -4394,7 +4394,6 @@ public sealed class UsePrimaryConstructorTests
                 }
                 """,
             FixedCode = """
-                /// <summary/>
                 /// <summary/>
                 class C(int i, int j)
                 {
@@ -4418,7 +4417,7 @@ public sealed class UsePrimaryConstructorTests
                 {
                     // This should be removed
                     /// <summary/>
-                    private int i, j;
+                    private int i;
                     int k;
 
                     public [|C|](int i, int j)
@@ -4429,7 +4428,6 @@ public sealed class UsePrimaryConstructorTests
                 }
                 """,
             FixedCode = """
-                /// <summary/>
                 /// <summary/>
                 class C(int i, int j)
                 {

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -17,7 +17,7 @@ using VerifyCS = CSharpCodeFixVerifier<
     CSharpUsePrimaryConstructorCodeFixProvider>;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsUsePrimaryConstructor)]
-public partial class UsePrimaryConstructorTests
+public sealed class UsePrimaryConstructorTests
 {
     [Fact]
     public async Task TestInCSharp12()
@@ -4125,6 +4125,386 @@ public partial class UsePrimaryConstructorTests
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should stay
+
+                    private int i;
+                    private int j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    // This should stay
+
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should be removed
+                    private int i;
+                    private int j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should stay
+                
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+
+                    private int i;
+                    private int j;
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    // This should stay
+
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should be removed
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+
+                    private int i;
+                    private int j;
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should stay
+
+                    private int i, j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    // This should stay
+
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should be removed
+                    private int i, j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment7()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should stay
+
+                    private int i, j;
+                    int k;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    // This should stay
+
+                    int k;
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment8()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should be removed
+                    private int i, j;
+                    int k;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    int k;
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment9()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should stay
+
+                    /// <summary/>
+                    private int i, j;
+                    int k;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                /// <summary/>
+                /// <summary/>
+                class C(int i, int j)
+                {
+                    // This should stay
+
+                    int k;
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment10()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should be removed
+                    /// <summary/>
+                    private int i, j;
+                    int k;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                /// <summary/>
+                /// <summary/>
+                class C(int i, int j)
+                {
+                    int k;
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment11()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should stay
+
+                    // This should be removed
+                    private int i, j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    // This should stay
+
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69012")]
+    public async Task TestLeadingComment12()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // This should stay 1
+
+                    // This should stay 2
+
+                    private int i, j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    // This should stay 1
+
+                    // This should stay 2
+
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
 }

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -4386,16 +4386,15 @@ public sealed class UsePrimaryConstructorTests
                     private int i;
                     int k;
 
-                    public [|C|](int i, int j)
+                    public [|C|](int i)
                     {
                         this.i = i;
-                        this.j = j;
                     }
                 }
                 """,
             FixedCode = """
                 /// <summary/>
-                class C(int i, int j)
+                class C(int i)
                 {
                     // This should stay
 
@@ -4420,16 +4419,15 @@ public sealed class UsePrimaryConstructorTests
                     private int i;
                     int k;
 
-                    public [|C|](int i, int j)
+                    public [|C|](int i)
                     {
                         this.i = i;
-                        this.j = j;
                     }
                 }
                 """,
             FixedCode = """
                 /// <summary/>
-                class C(int i, int j)
+                class C(int i)
                 {
                     int k;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69012