### PR TITLE
Do not remove parentheses when it would cause a parsing change in a 'when clause'

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -3478,6 +3477,55 @@ compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLib
                 void M(bool b)
                 {
                     int[] a = b ? [1] : []; 
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75203")]
+    public async Task TestConditionalExpressionInWhenClauseAmbiguity1()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                public void M(object o, object?[] c)
+                {
+                    switch(o)
+                    {
+                        case { } when $$(c?[0] is { }):
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75203")]
+    public async Task TestConditionalExpressionInWhenClauseAmbiguity2()
+    {
+        await TestInRegularAndScript1Async("""
+            class C
+            {
+                public void M(object o, object?[] c)
+                {
+                    switch(o)
+                    {
+                        case { } when $$(c ? [0] : [1]):
+                            break;
+                    }
+                }
+            }
+            """, """
+            class C
+            {
+                public void M(object o, object?[] c)
+                {
+                    switch(o)
+                    {
+                        case { } when c ? [0] : [1]:
+                            break;
+                    }
                 }
             }
             """);

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryPatternParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryPatternParenthesesTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryParentheses;
@@ -18,13 +16,9 @@ using Xunit.Abstractions;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParentheses;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
-public partial class RemoveUnnecessaryPatternParenthesesTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor
+public sealed class RemoveUnnecessaryPatternParenthesesTests(ITestOutputHelper logger)
+    : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor(logger)
 {
-    public RemoveUnnecessaryPatternParenthesesTests(ITestOutputHelper logger)
-      : base(logger)
-    {
-    }
-
     internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
         => (new CSharpRemoveUnnecessaryPatternParenthesesDiagnosticAnalyzer(), new CSharpRemoveUnnecessaryParenthesesCodeFixProvider());
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -259,7 +259,17 @@ internal static class ParenthesizedExpressionSyntaxExtensions
 
         // case x when (y): -> case x when y:
         if (nodeParent.IsKind(SyntaxKind.WhenClause))
+        {
+            // Subtle case, `when (x?[] ...):`.  Can't remove the parentheses here as it can the conditional access
+            // become a conditional expression.
+            for (var current = expression; current != null; current = current.ChildNodes().FirstOrDefault() as ExpressionSyntax)
+            {
+                if (current is ConditionalAccessExpressionSyntax)
+                    return false;
+            }
+
             return true;
+        }
 
         // #if (x)   ->   #if x
         if (nodeParent is DirectiveTriviaSyntax)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/75203