### PR TITLE
Update add/remove accessibility modifiers for interfaces

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
@@ -21,53 +21,6 @@ internal class CSharpAddAccessibilityModifiers : AbstractAddAccessibilityModifie
     {
     }
 
-    ///// <summary>
-    ///// Returns if this is a classic bodyless interface member, that would be considered public by default if it had no
-    ///// accessibility modifiers on it.
-    ///// </summary>
-    //private bool IsClassicPublicInterfaceMethod(MemberDeclarationSyntax member)
-    //{
-    //    // Type are newly allowed in interfaces and are not public by default.
-    //    if (member is BaseTypeDeclarationSyntax)
-    //        return false;
-
-    //    // Member has to actually be in an interface.
-    //    if (member.Parent is not InterfaceDeclarationSyntax)
-    //        return false;
-
-    //    // Static members are new and are are not public by default.
-    //    if (member.Modifiers.Any(SyntaxKind.StaticKeyword))
-    //        return false;
-
-    //    // If it's explicitly marked as something other than public (or no accessibility) it's not a classic method.
-    //    if (member.Modifiers.Any(SyntaxKind.InternalKeyword) ||
-    //        member.Modifiers.Any(SyntaxKind.PrivateKeyword) ||
-    //        member.Modifiers.Any(SyntaxKind.ProtectedKeyword))
-    //    {
-    //        return false;
-    //    }
-
-    //    if (member.Modifiers.Any(SyntaxKind.PartialKeyword))
-    //        return false;
-
-    //    // void M();   is a classic public interface method.
-    //    if (member is MethodDeclarationSyntax { SemicolonToken.IsMissing: false })
-    //        return true;
-
-    //    // int P { get; }   is a classic public interface property.
-    //    if (member is PropertyDeclarationSyntax { AccessorList: not null } property &&
-    //        property.AccessorList.Accessors.All(a => !a.SemicolonToken.IsMissing))
-    //    {
-    //        return true;
-    //    }
-
-    //    // event E E;   is a classic public interface event.
-    //    if (member is EventFieldDeclarationSyntax)
-    //        return true;
-
-    //    return false;
-    //}
-
     public override bool ShouldUpdateAccessibilityModifier(
         IAccessibilityFacts accessibilityFacts,
         MemberDeclarationSyntax member,

--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
@@ -90,13 +90,18 @@ internal class CSharpAddAccessibilityModifiers : AbstractAddAccessibilityModifie
         // member itself.  Not any sort of computed accessibility based on the containing type.
         var accessibility = accessibilityFacts.GetAccessibility(member);
 
-        // If we have a member in an interface, we want to remove the accessibility if it's explicitly declared public.
         if (option == AccessibilityModifiersRequired.ForNonInterfaceMembers &&
-            accessibility == Accessibility.Public &&
             member.Parent is InterfaceDeclarationSyntax)
         {
-            modifierAdded = false;
-            return true;
+            // A member in an interface explicitly declared as 'public'.  Remove this modifier as it's the default for
+            // interfaces, and the user only wants explicit default accessibility modifiers for things *outside* of interfaces.
+            if (accessibility == Accessibility.Public)
+            {
+                modifierAdded = false;
+                return true;
+            }
+
+            return false;
         }
 
         if (option != AccessibilityModifiersRequired.OmitIfDefault)

--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
@@ -60,7 +60,7 @@ internal class CSharpAddAccessibilityModifiers : AbstractAddAccessibilityModifie
             {
                 // We want to have require accessibility modifiers on non-interface-members, *excluding* only public
                 // interface members due to the long history of this being the only way to declare interface members.
-                // So remove an explciti `public` from an interface member if present.
+                // So remove an explicit `public` from an interface member if present.
                 modifierAdded = false;
                 return accessibility == Accessibility.Public;
             }

--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
 using Microsoft.CodeAnalysis.AddAccessibilityModifiers;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;

--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Linq;
 using Microsoft.CodeAnalysis.AddAccessibilityModifiers;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -18,6 +20,53 @@ internal class CSharpAddAccessibilityModifiers : AbstractAddAccessibilityModifie
     protected CSharpAddAccessibilityModifiers()
     {
     }
+
+    ///// <summary>
+    ///// Returns if this is a classic bodyless interface member, that would be considered public by default if it had no
+    ///// accessibility modifiers on it.
+    ///// </summary>
+    //private bool IsClassicPublicInterfaceMethod(MemberDeclarationSyntax member)
+    //{
+    //    // Type are newly allowed in interfaces and are not public by default.
+    //    if (member is BaseTypeDeclarationSyntax)
+    //        return false;
+
+    //    // Member has to actually be in an interface.
+    //    if (member.Parent is not InterfaceDeclarationSyntax)
+    //        return false;
+
+    //    // Static members are new and are are not public by default.
+    //    if (member.Modifiers.Any(SyntaxKind.StaticKeyword))
+    //        return false;
+
+    //    // If it's explicitly marked as something other than public (or no accessibility) it's not a classic method.
+    //    if (member.Modifiers.Any(SyntaxKind.InternalKeyword) ||
+    //        member.Modifiers.Any(SyntaxKind.PrivateKeyword) ||
+    //        member.Modifiers.Any(SyntaxKind.ProtectedKeyword))
+    //    {
+    //        return false;
+    //    }
+
+    //    if (member.Modifiers.Any(SyntaxKind.PartialKeyword))
+    //        return false;
+
+    //    // void M();   is a classic public interface method.
+    //    if (member is MethodDeclarationSyntax { SemicolonToken.IsMissing: false })
+    //        return true;
+
+    //    // int P { get; }   is a classic public interface property.
+    //    if (member is PropertyDeclarationSyntax { AccessorList: not null } property &&
+    //        property.AccessorList.Accessors.All(a => !a.SemicolonToken.IsMissing))
+    //    {
+    //        return true;
+    //    }
+
+    //    // event E E;   is a classic public interface event.
+    //    if (member is EventFieldDeclarationSyntax)
+    //        return true;
+
+    //    return false;
+    //}
 
     public override bool ShouldUpdateAccessibilityModifier(
         IAccessibilityFacts accessibilityFacts,
@@ -37,57 +86,75 @@ internal class CSharpAddAccessibilityModifiers : AbstractAddAccessibilityModifie
         if (!accessibilityFacts.CanHaveAccessibility(member))
             return false;
 
-        // This analyzer bases all of its decisions on the accessibility
+        // Find what accessibility the member was *directly* declared with.  This only considers the modifiers on the
+        // member itself.  Not any sort of computed accessibility based on the containing type.
         var accessibility = accessibilityFacts.GetAccessibility(member);
 
-        // Omit will flag any accessibility values that exist and are default
-        // The other options will remove or ignore accessibility
-        var isOmit = option == AccessibilityModifiersRequired.OmitIfDefault;
-        modifierAdded = !isOmit;
-
-        if (isOmit)
+        // If we have a member in an interface, we want to remove the accessibility if it's explicitly declared public.
+        if (option == AccessibilityModifiersRequired.ForNonInterfaceMembers &&
+            accessibility == Accessibility.Public &&
+            member.Parent is InterfaceDeclarationSyntax)
         {
-            if (accessibility == Accessibility.NotApplicable)
-                return false;
-
-            var parentKind = member.GetRequiredParent().Kind();
-            switch (parentKind)
-            {
-                // Check for default modifiers in namespace and outside of namespace
-                case SyntaxKind.CompilationUnit:
-                case SyntaxKind.FileScopedNamespaceDeclaration:
-                case SyntaxKind.NamespaceDeclaration:
-                    {
-                        // Default is internal
-                        if (accessibility != Accessibility.Internal)
-                            return false;
-                    }
-
-                    break;
-
-                case SyntaxKind.ClassDeclaration:
-                case SyntaxKind.RecordDeclaration:
-                case SyntaxKind.StructDeclaration:
-                case SyntaxKind.RecordStructDeclaration:
-                    {
-                        // Inside a type, default is private
-                        if (accessibility != Accessibility.Private)
-                            return false;
-                    }
-
-                    break;
-
-                default:
-                    return false; // Unknown parent kind, don't do anything
-            }
-        }
-        else
-        {
-            // Mode is always, so we have to flag missing modifiers
-            if (accessibility != Accessibility.NotApplicable)
-                return false;
+            modifierAdded = false;
+            return true;
         }
 
+        if (option != AccessibilityModifiersRequired.OmitIfDefault)
+        {
+            // We want to have explicit accessibility modifiers.  So add if the member doesn't have any accessibility
+            // modifiers currently.
+            modifierAdded = true;
+            return accessibility == Accessibility.NotApplicable;
+        }
+
+        // We want to omit redundant accessibility modifiers. If the member already doesn't have any accessibility
+        // modifiers, then there's nothing to remove.
+        if (accessibility == Accessibility.NotApplicable)
+            return false;
+
+        var parentKind = member.GetRequiredParent().Kind();
+        switch (parentKind)
+        {
+            // Check for default modifiers in namespace and outside of namespace
+            case SyntaxKind.CompilationUnit:
+            case SyntaxKind.FileScopedNamespaceDeclaration:
+            case SyntaxKind.NamespaceDeclaration:
+                {
+                    // Default is internal
+                    if (accessibility != Accessibility.Internal)
+                        return false;
+                }
+
+                break;
+
+            case SyntaxKind.ClassDeclaration:
+            case SyntaxKind.RecordDeclaration:
+            case SyntaxKind.StructDeclaration:
+            case SyntaxKind.RecordStructDeclaration:
+                {
+                    // Inside a type, default is private
+                    if (accessibility != Accessibility.Private)
+                        return false;
+                }
+
+                break;
+
+            case SyntaxKind.InterfaceDeclaration:
+                {
+                    // Inside an interface, default is public
+                    if (accessibility != Accessibility.Public)
+                        return false;
+                }
+
+                break;
+
+            default:
+                return false; // Unknown parent kind, don't do anything
+        }
+
+        // Looks like a member whose declared accessibility matches the default accessibility for its parent.
+        // We can remove this modifier.
+        modifierAdded = false;
         return true;
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
@@ -44,25 +44,8 @@ internal class CSharpAddAccessibilityModifiersDiagnosticAnalyzer
             ProcessMembers(context, option, namespaceDeclaration.Members);
 
         // If we have a class or struct, recurse inwards.
-        if (member is TypeDeclarationSyntax(
-                SyntaxKind.ClassDeclaration or
-                SyntaxKind.StructDeclaration or
-                SyntaxKind.RecordDeclaration or
-                SyntaxKind.RecordStructDeclaration) typeDeclaration)
-        {
+        if (member is TypeDeclarationSyntax typeDeclaration)
             ProcessMembers(context, option, typeDeclaration.Members);
-        }
-
-#if false
-        // Add this once we have the language version for C# that supports accessibility
-        // modifiers on interface methods.
-        if (option.Value == AccessibilityModifiersRequired.Always &&
-            member.IsKind(SyntaxKind.InterfaceDeclaration, out typeDeclaration))
-        {
-            // Only recurse into an interface if the user wants accessibility modifiers on 
-            ProcessTypeDeclaration(context, generator, option, typeDeclaration);
-        }
-#endif
 
         if (!CSharpAddAccessibilityModifiers.Instance.ShouldUpdateAccessibilityModifier(
                 CSharpAccessibilityFacts.Instance, member, option.Value, out var name, out var modifiersAdded))

--- a/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers;
-using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -734,7 +733,7 @@ public sealed class AddAccessibilityModifiersTests
             }
             """;
 
-        var test = new VerifyCS.Test
+        await new VerifyCS.Test
         {
             TestCode = source,
             FixedCode = fixedSource,
@@ -744,8 +743,151 @@ public sealed class AddAccessibilityModifiersTests
             {
                 { CodeStyleOptions2.AccessibilityModifiersRequired,AccessibilityModifiersRequired.OmitIfDefault }
             }
-        };
+        }.RunAsync();
+    }
 
-        await test.RunAsync();
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74244")]
+    public async Task TestAlwaysForInterfaceMembers()
+    {
+
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                interface [|I|]
+                {
+                    void [|M|]();
+                    int [|P|] { get; }
+                    event Action [|E|];
+
+                    class [|Nested|]
+                    {
+                        void [|M|]() { }
+                        int [|P|] { get; }
+                        event Action [|E|];
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                internal interface I
+                {
+                    public void M();
+                    public int P { get; }
+                    public event Action E;
+                
+                    public class Nested
+                    {
+                        private void M() { }
+                        private int P { get; }
+                        private event Action E;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            CodeActionEquivalenceKey = nameof(AnalyzersResources.Add_accessibility_modifiers),
+            Options =
+            {
+                { CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.Always }
+            }
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74244")]
+    public async Task TestOmitIfDefaultForInterfaceMembers()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                
+                interface I
+                {
+                    public void [|M|]();
+                    public int [|P|] { get; }
+                    public event Action [|E|];
+                
+                    public class [|Nested|]
+                    {
+                        private void [|M|]() { }
+                        private int [|P|] { get; }
+                        private event Action [|E|];
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                interface I
+                {
+                    void M();
+                    int P { get; }
+                    event Action E;
+                
+                    class Nested
+                    {
+                        void M() { }
+                        int P { get; }
+                        event Action E;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            CodeActionEquivalenceKey = nameof(AnalyzersResources.Remove_accessibility_modifiers),
+            Options =
+            {
+                { CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.OmitIfDefault }
+            }
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74244")]
+    public async Task TestForNonInterfaceMembers()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                
+                internal interface I
+                {
+                    public void [|M|]();
+                    public int [|P|] { get; }
+                    public event Action [|E|];
+                
+                    public class [|Nested|]
+                    {
+                        private void M() { }
+                        private int P { get; }
+                        private event Action E;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                internal interface I
+                {
+                    void M();
+                    int P { get; }
+                    event Action E;
+                
+                    class Nested
+                    {
+                        private void M() { }
+                        private int P { get; }
+                        private event Action E;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            CodeActionEquivalenceKey = nameof(AnalyzersResources.Remove_accessibility_modifiers),
+            Options =
+            {
+                { CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.ForNonInterfaceMembers }
+            }
+        }.RunAsync();
     }
 }

--- a/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
@@ -19,7 +19,7 @@ using VerifyCS = CSharpCodeFixVerifier<
     CSharpAddAccessibilityModifiersCodeFixProvider>;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)]
-public class AddAccessibilityModifiersTests
+public sealed class AddAccessibilityModifiersTests
 {
     [Theory, CombinatorialData]
     public void TestStandardProperty(AnalyzerProperty property)

--- a/src/Analyzers/Core/Analyzers/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersDiagnosticAnalyzer.cs
@@ -8,21 +8,17 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.AddAccessibilityModifiers;
 
-internal abstract class AbstractAddAccessibilityModifiersDiagnosticAnalyzer<TCompilationUnitSyntax>
-    : AbstractBuiltInCodeStyleDiagnosticAnalyzer
+internal abstract class AbstractAddAccessibilityModifiersDiagnosticAnalyzer<TCompilationUnitSyntax>()
+    : AbstractBuiltInCodeStyleDiagnosticAnalyzer(
+        IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId,
+        EnforceOnBuildValues.AddAccessibilityModifiers,
+        CodeStyleOptions2.AccessibilityModifiersRequired,
+        new LocalizableResourceString(nameof(AnalyzersResources.Add_accessibility_modifiers), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+        new LocalizableResourceString(nameof(AnalyzersResources.Accessibility_modifiers_required), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
     where TCompilationUnitSyntax : SyntaxNode
 {
     protected static readonly ImmutableDictionary<string, string?> ModifiersAddedProperties = ImmutableDictionary<string, string?>.Empty.Add(
         AddAccessibilityModifiersConstants.ModifiersAdded, AddAccessibilityModifiersConstants.ModifiersAdded);
-
-    protected AbstractAddAccessibilityModifiersDiagnosticAnalyzer()
-        : base(IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId,
-               EnforceOnBuildValues.AddAccessibilityModifiers,
-               CodeStyleOptions2.AccessibilityModifiersRequired,
-               new LocalizableResourceString(nameof(AnalyzersResources.Add_accessibility_modifiers), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
-               new LocalizableResourceString(nameof(AnalyzersResources.Accessibility_modifiers_required), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
-    {
-    }
 
     public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory()
         => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;

--- a/src/Analyzers/Core/CodeFixes/AddAccessibilityModifiers/AddAccessibilityModifiersHelpers.cs
+++ b/src/Analyzers/Core/CodeFixes/AddAccessibilityModifiers/AddAccessibilityModifiersHelpers.cs
@@ -49,6 +49,9 @@ internal static partial class AddAccessibilityModifiersHelpers
         // that's not legal.  And these are reasonable default values for them.
         if (symbol is IMethodSymbol or IPropertySymbol or IEventSymbol)
         {
+            if (symbol.ContainingType?.TypeKind == TypeKind.Interface)
+                return Accessibility.Public;
+
             if (symbol.IsAbstract)
                 return Accessibility.Protected;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74244
Fixes https://github.com/dotnet/roslyn/issues/74245
Fixes https://github.com/dotnet/roslyn/issues/47448

Prior to DIMs (and later language changes to effectively allow any sort of members in an interface), interface members were *always* public, without the ability to even specify accessibility for this.

This made the default coding for 100% of .net code that interface members did not accessibility listed (users couldn't add it even if they wanted to).  This meant that defacto style for interfaces is: no accessibility modifiers listed for public members.

When we added teh 'require accessibility modifiers' feature, we recognized this, and carved out an exception for interfaces so that users would not be in the position where they would say: i want accessibility modifiers and then were forced to add accessibility modifiers to all their interfaces once the language allowed them. 

To achieve this we had the following options:

1. Never.  No requirements.  User can have (or not have) whatever modifiers they want on a member, and we do not complain.
2. Always.  Modifiers are *always* required, even if they're the default.  This applies to interface members as well.
3. ForNonInterfaceMembers.  This was the default we picked knowing where the language was going.  Which this option, we require modifiers on non-interface members, but we ignore interface members since the majority of .net doesn't want to have modifiers on interfaces.
4. OmitIfDefault.  Remove modifiers that match the default for the language.  This is for people who do not like writing redundant modifiers, and would prefer to just exclude in that case.

To accomplish the above, we just said: we will not even look at interface members, excluding them (and their children entirely).  This meant users didn't get false positives.  But it also meant they did not get true positives. 

This PR does final work on supporting 'Always/ForNonInterfaceMembers/Omit' even inside an interface.   If the user has set 'always', then modifiers like 'public' are required inside an interface, even though they are redundant.

If the user has set `ForNonInterfaceMembers` then we do remove 'public' from interface members as that's the default, and the user has said they only want to write the default on non-interface members.

If the user has set `OmitIfDefault` then we remove `public` from interface members as that is the default.