### PR TITLE
Attempt to reuse 'nameof' expressions in attributes when converting from a local function to a method

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -207,7 +207,7 @@ internal sealed partial class CSharpUsePrimaryConstructorCodeFixProvider() : Cod
             {
                 var currentIndex = i;
                 if (s_commentFollowedByBlankLine.TryMatch(leadingTrivia, ref currentIndex))
-                    return leadingTrivia.Take(currentIndex).ToImmutableArray();
+                    return leadingTrivia[..currentIndex];
             }
 
             return [];

--- a/src/Features/CSharpTest/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
+++ b/src/Features/CSharpTest/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertLocalFunctionToMethod;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsConvertLocalFunctionToMethod)]
-public class ConvertLocalFunctionToMethodTests : AbstractCSharpCodeActionTest_NoEditor
+public sealed class ConvertLocalFunctionToMethodTests : AbstractCSharpCodeActionTest_NoEditor
 {
     protected override CodeRefactoringProvider CreateCodeRefactoringProvider(TestWorkspace workspace, TestParameters parameters)
         => new CSharpConvertLocalFunctionToMethodCodeRefactoringProvider();
@@ -1113,6 +1113,53 @@ class C
             {
                 public int Value;
             }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/64904")]
+    public async Task TestNameofReferenceInParameterInitializer()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            using System;
+
+            sealed class A : Attribute
+            {
+                public A(string _) { }
+                public string P { get; set; }
+            }
+
+            class C
+            {
+                void M()
+                {
+                    void [||]M2([A(nameof(b), P = nameof(b))] string b)
+                    {
+                    }
+                }
+            }
+            
+            """,
+            """
+            using System;
+
+            sealed class A : Attribute
+            {
+                public A(string _) { }
+                public string P { get; set; }
+            }
+
+            class C
+            {
+                void M()
+                {
+                }
+
+                private static void M2([A(nameof(b), P = nameof(b))] string b)
+                {
+                }
+            }
+            
             """);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/AttributeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/AttributeGenerator.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 using static Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationHelpers;
@@ -63,38 +64,60 @@ internal static class AttributeGenerator
         if (IsCompilerInternalAttribute(attribute))
             return null;
 
-        if (!info.Context.MergeAttributes)
-        {
-            var reusableSyntax = GetReuseableSyntaxNodeForAttribute<AttributeSyntax>(attribute, info);
-            if (reusableSyntax != null)
-            {
-                return reusableSyntax;
-            }
-        }
+        var reusableSyntax = GetReuseableSyntaxNodeForAttribute<AttributeSyntax>(attribute);
+        if (info.Context.ReuseSyntax && reusableSyntax != null)
+            return reusableSyntax;
 
         if (attribute.AttributeClass == null)
             return null;
 
-        var attributeArguments = GenerateAttributeArgumentList(info.Generator, attribute);
+        var attributeArguments = GenerateAttributeArgumentList(
+            info.Generator, attribute, reusableSyntax);
         return attribute.AttributeClass.GenerateTypeSyntax() is NameSyntax nameSyntax
             ? Attribute(nameSyntax, attributeArguments)
             : null;
     }
 
-    private static AttributeArgumentListSyntax? GenerateAttributeArgumentList(SyntaxGenerator generator, AttributeData attribute)
+    private static AttributeArgumentListSyntax? GenerateAttributeArgumentList(
+        SyntaxGenerator generator, AttributeData attribute, AttributeSyntax? existingSyntax)
     {
         if (attribute.ConstructorArguments.Length == 0 && attribute.NamedArguments.Length == 0)
             return null;
 
-        var arguments = new List<AttributeArgumentSyntax>();
-        arguments.AddRange(attribute.ConstructorArguments.Select(c =>
-            AttributeArgument(ExpressionGenerator.GenerateExpression(generator, c))));
+        using var _ = ArrayBuilder<AttributeArgumentSyntax>.GetInstance(out var arguments);
 
-        arguments.AddRange(attribute.NamedArguments.Select(kvp =>
-            AttributeArgument(
-                NameEquals(IdentifierName(kvp.Key)), null,
-                ExpressionGenerator.GenerateExpression(generator, kvp.Value))));
+        foreach (var argument in attribute.ConstructorArguments)
+            arguments.Add(AttributeArgument(GenerateAttributeSyntax(argument)));
 
-        return AttributeArgumentList([.. arguments]);
+        foreach (var argument in attribute.NamedArguments)
+        {
+            arguments.Add(AttributeArgument(
+                NameEquals(IdentifierName(argument.Key)),
+                nameColon: null,
+                GenerateAttributeSyntax(argument.Value)));
+        }
+
+        return AttributeArgumentList(SeparatedList(arguments));
+
+        ExpressionSyntax GenerateAttributeSyntax(TypedConstant constant)
+        {
+            // In the case of a string constant with value "x", see if the originating syntax was a `nameof(x)`
+            // expression and attempt to preserve that.
+            if (existingSyntax?.ArgumentList != null && constant.Value is string stringValue)
+            {
+                foreach (var existingArgument in existingSyntax.ArgumentList.Arguments)
+                {
+                    if (existingArgument.Expression is InvocationExpressionSyntax { ArgumentList.Arguments: [{ Expression: var nameofArgument }] } invocation &&
+                        invocation.IsNameOfInvocation())
+                    {
+                        var inferredName = nameofArgument.TryGetInferredMemberName();
+                        if (inferredName == stringValue)
+                            return existingArgument.Expression.WithoutTrivia();
+                    }
+                }
+            }
+
+            return ExpressionGenerator.GenerateExpression(generator, constant);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationHelpers.cs
@@ -175,12 +175,12 @@ internal static class CodeGenerationHelpers
         return node.WithLeadingTrivia(leadingTrivia);
     }
 
-    public static T? GetReuseableSyntaxNodeForAttribute<T>(AttributeData attribute, CodeGenerationContextInfo info)
+    public static T? GetReuseableSyntaxNodeForAttribute<T>(AttributeData attribute)
         where T : SyntaxNode
     {
         Contract.ThrowIfNull(attribute);
 
-        return info.Context.ReuseSyntax && attribute.ApplicationSyntaxReference != null
+        return attribute.ApplicationSyntaxReference != null
             ? attribute.ApplicationSyntaxReference.GetSyntax() as T
             : null;
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/CodeGeneration/AttributeGenerator.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/CodeGeneration/AttributeGenerator.vb
@@ -28,14 +28,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function GenerateAttribute(attribute As AttributeData, options As CodeGenerationContextInfo, target As SyntaxToken?) As AttributeSyntax
-            Dim reusableSyntax = GetReuseableSyntaxNodeForAttribute(Of AttributeSyntax)(attribute, options)
+            Dim reusableSyntax = If(options.Context.ReuseSyntax,
+                GetReuseableSyntaxNodeForAttribute(Of AttributeSyntax)(attribute),
+                Nothing)
             If reusableSyntax IsNot Nothing Then
                 Return reusableSyntax
             End If
 
-            Return SyntaxFactory.Attribute(If(target.HasValue, SyntaxFactory.AttributeTarget(target.Value), Nothing),
-                                           attribute.AttributeClass.GenerateTypeSyntax(),
-                                           GenerateArgumentList(options.Generator, attribute))
+            Return SyntaxFactory.Attribute(
+                If(target.HasValue, SyntaxFactory.AttributeTarget(target.Value), Nothing),
+                attribute.AttributeClass.GenerateTypeSyntax(),
+                GenerateArgumentList(options.Generator, attribute))
         End Function
 
         Private Function GenerateArgumentList(generator As SyntaxGenerator, attribute As AttributeData) As ArgumentListSyntax


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76188?issue=dotnet%7Croslyn%7C64904
