### PR TITLE
Make it clearer when 'move declaration' might change semantics

### DIFF
--- a/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceCodeRefactoringProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -14,11 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MoveDeclarationNearReference;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.MoveDeclarationNearReference), Shared]
 [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.InlineTemporary)]
-internal class CSharpMoveDeclarationNearReferenceCodeRefactoringProvider : AbstractMoveDeclarationNearReferenceCodeRefactoringProvider<LocalDeclarationStatementSyntax>
-{
-    [ImportingConstructor]
-    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-    public CSharpMoveDeclarationNearReferenceCodeRefactoringProvider()
-    {
-    }
-}
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class CSharpMoveDeclarationNearReferenceCodeRefactoringProvider()
+    : AbstractMoveDeclarationNearReferenceCodeRefactoringProvider<LocalDeclarationStatementSyntax>;

--- a/src/Features/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/Features/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -653,7 +653,8 @@ public class MoveDeclarationNearReferenceTests : AbstractCSharpCodeActionTest_No
                     });
                 }
             }
-            """);
+            """,
+            title: FeaturesResources.Move_declaration_near_reference_may_change_semantics);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545435")]

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -965,6 +965,9 @@ This version used in: {2}</value>
   <data name="Move_declaration_near_reference" xml:space="preserve">
     <value>Move declaration near reference</value>
   </data>
+  <data name="Move_declaration_near_reference_may_change_semantics" xml:space="preserve">
+    <value>Move declaration near reference (may change semantics)</value>
+  </data>
   <data name="Convert_to_full_property" xml:space="preserve">
     <value>Convert to full property</value>
   </data>

--- a/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceCodeRefactoringProvider.cs
@@ -14,38 +14,32 @@ namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference;
 
 internal abstract class AbstractMoveDeclarationNearReferenceCodeRefactoringProvider<TLocalDeclaration> : CodeRefactoringProvider where TLocalDeclaration : SyntaxNode
 {
-    [ImportingConstructor]
-    public AbstractMoveDeclarationNearReferenceCodeRefactoringProvider()
-    {
-    }
-
     public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
     {
         var (document, _, cancellationToken) = context;
         var declaration = await context.TryGetRelevantNodeAsync<TLocalDeclaration>().ConfigureAwait(false);
         if (declaration == null)
-        {
             return;
-        }
 
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
         var variables = syntaxFacts.GetVariablesOfLocalDeclarationStatement(declaration);
         if (variables.Count != 1)
-        {
             return;
-        }
 
         var service = document.GetRequiredLanguageService<IMoveDeclarationNearReferenceService>();
-        if (!await service.CanMoveDeclarationNearReferenceAsync(document, declaration, cancellationToken).ConfigureAwait(false))
-        {
+        var (canMove, mayChangeSemantics) = await service.CanMoveDeclarationNearReferenceAsync(document, declaration, cancellationToken).ConfigureAwait(false);
+        if (!canMove)
             return;
-        }
+
+        var (title, equivalenceKey) = mayChangeSemantics
+            ? (FeaturesResources.Move_declaration_near_reference_may_change_semantics, nameof(FeaturesResources.Move_declaration_near_reference_may_change_semantics))
+            : (FeaturesResources.Move_declaration_near_reference, nameof(FeaturesResources.Move_declaration_near_reference));
 
         context.RegisterRefactoring(
             CodeAction.Create(
-                FeaturesResources.Move_declaration_near_reference,
-                c => MoveDeclarationNearReferenceAsync(document, declaration, c),
-                nameof(FeaturesResources.Move_declaration_near_reference),
+                title,
+                cancellationToken => MoveDeclarationNearReferenceAsync(document, declaration, cancellationToken),
+                equivalenceKey,
                 CodeActionPriority.Low),
             declaration.Span);
     }

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -1180,6 +1180,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Přesunout obsah do oboru názvů...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Přesunout soubor do: {0}</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -1180,6 +1180,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Inhalt in Namespace verschieben...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Datei in "{0}" verschieben</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -1180,6 +1180,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Mover contenido al espacio de nombres...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Mover el archivo a "{0}"</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -1180,6 +1180,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Déplacer le contenu vers un espace de noms...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Déplacer le fichier vers '{0}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -1180,6 +1180,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Sposta contenuto nello spazio dei nomi...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Sposta il file in '{0}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -1180,6 +1180,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">名前空間へのコンテンツの移動...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">ファイルを '{0}' に移動します</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -1180,6 +1180,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">네임스페이스로 콘텐츠 이동...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">파일을 '{0}'(으)로 이동</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -1180,6 +1180,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Przenieś zawartość do przestrzeni nazw...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Przenieś plik do lokalizacji „{0}”</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -1180,6 +1180,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Mover conteúdo para o namespace...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Mover o arquivo para '{0}'</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -1180,6 +1180,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Переместить содержимое в пространство имен...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Переместить файл в "{0}"</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -1180,6 +1180,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">İçerikleri ad alanına taşı...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">Dosyayı '{0}' konumuna taşı</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -1180,6 +1180,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">将内容移动到命名空间...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">将文件移至“{0}”</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -1180,6 +1180,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">將內容移到命名空間...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Move_declaration_near_reference_may_change_semantics">
+        <source>Move declaration near reference (may change semantics)</source>
+        <target state="new">Move declaration near reference (may change semantics)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_file_to_0">
         <source>Move file to '{0}'</source>
         <target state="translated">將檔案移至 ‘{0}'</target>

--- a/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearRefactoringProvider.vb
@@ -11,7 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.MoveDeclarationNearReference
     <ExportCodeRefactoringProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeRefactoringProviderNames.MoveDeclarationNearReference), [Shared]>
     <ExtensionOrder(After:=PredefinedCodeRefactoringProviderNames.InlineTemporary)>
-    Friend Class VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider
+    Friend NotInheritable Class VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider
         Inherits AbstractMoveDeclarationNearReferenceCodeRefactoringProvider(Of LocalDeclarationStatementSyntax)
 
         <ImportingConstructor>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/MoveDeclarationNearReference/IMoveDeclarationNearReferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/MoveDeclarationNearReference/IMoveDeclarationNearReferenceService.cs
@@ -13,10 +13,10 @@ namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference;
 internal interface IMoveDeclarationNearReferenceService : ILanguageService
 {
     /// <summary>
-    /// Returns true if <paramref name="localDeclarationStatement"/> is local declaration statement
-    /// that can be moved forward to be closer to its first reference.
+    /// Returns <see langword="true"/> for <c>canMove</c> if <paramref name="localDeclarationStatement"/> is local
+    /// declaration statement that can be moved forward to be closer to its first reference.
     /// </summary>
-    Task<bool> CanMoveDeclarationNearReferenceAsync(Document document, SyntaxNode localDeclarationStatement, CancellationToken cancellationToken);
+    Task<(bool canMove, bool mayChangeSemantics)> CanMoveDeclarationNearReferenceAsync(Document document, SyntaxNode localDeclarationStatement, CancellationToken cancellationToken);
 
     /// <summary>
     /// Moves <paramref name="localDeclarationStatement"/> closer to its first reference. Only


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/25741