### PR TITLE
Fix formatting of accessor blocks in 'use block body'

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForAccessorsHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForAccessorsHelper.cs
@@ -3,15 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 
-internal class UseExpressionBodyForAccessorsHelper :
+using static SyntaxFactory;
+
+internal sealed class UseExpressionBodyForAccessorsHelper :
     UseExpressionBodyHelper<AccessorDeclarationSyntax>
 {
     public static readonly UseExpressionBodyForAccessorsHelper Instance = new();
@@ -51,7 +55,15 @@ internal class UseExpressionBodyForAccessorsHelper :
         => declaration.WithExpressionBody(expressionBody);
 
     protected override AccessorDeclarationSyntax WithBody(AccessorDeclarationSyntax declaration, BlockSyntax? body)
-        => declaration.WithBody(body);
+    {
+        // If the accessor was on the same line as its parent, add an elastic marker so we can place it properly now
+        // that it will have a multi-line block body.  If it's already on its own line, do nothing as we want to just
+        // keep it there and not move it.
+        var result = declaration.WithBody(body);
+        return !declaration.GetLeadingTrivia().Any(t => t.Kind() == SyntaxKind.EndOfLineTrivia)
+            ? result.WithPrependedLeadingTrivia(ElasticMarker)
+            : result;
+    }
 
     protected override bool CreateReturnStatementForExpression(SemanticModel semanticModel, AccessorDeclarationSyntax declaration)
         => declaration.IsKind(SyntaxKind.GetAccessorDeclaration);

--- a/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForAccessorsAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForAccessorsAnalyzerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
@@ -20,11 +21,11 @@ using VerifyCS = CSharpCodeFixVerifier<
     UseExpressionBodyCodeFixProvider>;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
-public class UseExpressionBodyForAccessorsTests
+public sealed class UseExpressionBodyForAccessorsTests
 {
     private static async Task TestWithUseExpressionBody(
-        string code,
-        string fixedCode,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string fixedCode,
         LanguageVersion version = LanguageVersion.CSharp8)
     {
         var test = new VerifyCS.Test
@@ -44,7 +45,10 @@ public class UseExpressionBodyForAccessorsTests
         await test.RunAsync();
     }
 
-    private static async Task TestWithUseExpressionBodyIncludingPropertiesAndIndexers(string code, string fixedCode, LanguageVersion version = LanguageVersion.CSharp8)
+    private static async Task TestWithUseExpressionBodyIncludingPropertiesAndIndexers(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string fixedCode,
+        LanguageVersion version = LanguageVersion.CSharp8)
     {
         await new VerifyCS.Test
         {
@@ -61,7 +65,10 @@ public class UseExpressionBodyForAccessorsTests
         }.RunAsync();
     }
 
-    private static async Task TestWithUseBlockBodyIncludingPropertiesAndIndexers(string code, string fixedCode, LanguageVersion version = LanguageVersion.CSharp8)
+    private static async Task TestWithUseBlockBodyIncludingPropertiesAndIndexers(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string fixedCode,
+        LanguageVersion version = LanguageVersion.CSharp8)
     {
         await new VerifyCS.Test
         {
@@ -650,7 +657,7 @@ public class UseExpressionBodyForAccessorsTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
-    public async Task TestAccessorListFormatting_FixAll()
+    public async Task TestAccessorListFormatting_FixAll1()
     {
         var code = """
             class C
@@ -667,7 +674,120 @@ public class UseExpressionBodyForAccessorsTests
 
                 int Goo
                 {
-                    get { return Bar(); }
+                    get
+                    {
+                        return Bar();
+                    }
+
+                    set
+                    {
+                        Bar();
+                    }
+                }
+            }
+            """;
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            BatchFixedCode = fixedCode,
+            Options =
+            {
+                { CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, ExpressionBodyPreference.Never  },
+                { CSharpCodeStyleOptions.PreferExpressionBodiedProperties, ExpressionBodyPreference.Never },
+                { CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, ExpressionBodyPreference.Never },
+            },
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    public async Task TestAccessorListFormatting_FixAll2()
+    {
+        var code = """
+            class C
+            {
+                int Bar() { return 0; }
+
+                int Goo { {|IDE0027:get => Bar();|} {|IDE0027:set => Bar();|} }
+            }
+            """;
+        var fixedCode = """
+            class C
+            {
+                int Bar() { return 0; }
+
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                    set => Bar();
+                }
+            }
+            """;
+        var batchFixedCode = """
+            class C
+            {
+                int Bar() { return 0; }
+
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+
+                    set
+                    {
+                        Bar();
+                    }
+                }
+            }
+            """;
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            BatchFixedCode = batchFixedCode,
+            DiagnosticSelector = diagnostics => diagnostics[0],
+            CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
+            Options =
+            {
+                { CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, ExpressionBodyPreference.Never  },
+                { CSharpCodeStyleOptions.PreferExpressionBodiedProperties, ExpressionBodyPreference.Never },
+                { CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, ExpressionBodyPreference.Never },
+            },
+            FixedState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(7,9): hidden IDE0027: Use block body for accessor
+                    VerifyCS.Diagnostic("IDE0027").WithMessage(CSharpAnalyzersResources.Use_block_body_for_accessor).WithSpan(11, 9, 11, 22).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations),
+                }
+            },
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    public async Task TestAccessorListFormatting_FixAll3()
+    {
+        var code = """
+            class C
+            {
+                int Bar() { return 0; }
+
+                int Goo { {|IDE0027:get => Bar();|} {|IDE0027:set => Bar();|} }
+            }
+            """;
+        var fixedCode = """
+            class C
+            {
+                int Bar() { return 0; }
+
+                int Goo
+                {
+                    get => Bar();
                     set
                     {
                         Bar();
@@ -699,17 +819,27 @@ public class UseExpressionBodyForAccessorsTests
             TestCode = code,
             FixedCode = fixedCode,
             BatchFixedCode = batchFixedCode,
+            DiagnosticSelector = diagnostics => diagnostics[1],
+            CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
             Options =
             {
                 { CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, ExpressionBodyPreference.Never  },
                 { CSharpCodeStyleOptions.PreferExpressionBodiedProperties, ExpressionBodyPreference.Never },
                 { CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, ExpressionBodyPreference.Never },
             },
+            FixedState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(7,9): hidden IDE0027: Use block body for accessor
+                    VerifyCS.Diagnostic("IDE0027").WithMessage(CSharpAnalyzersResources.Use_block_body_for_accessor).WithSpan(7, 9, 7, 22).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations),
+                }
+            },
         }.RunAsync();
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
-    public async Task TestAccessorListFormatting_FixAll2()
+    public async Task TestAccessorListFormatting_FixAll4()
     {
         var code =
             """
@@ -721,22 +851,6 @@ public class UseExpressionBodyForAccessorsTests
             }
             """;
         var fixedCode =
-            """
-            class C
-            {
-                int Goo
-                {
-                    get { return Bar(); }
-                    init
-                    {
-                        Bar();
-                    }
-                }
-
-                int Bar() { return 0; }
-            }
-            """;
-        var batchFixedCode =
             """
             class C
             {
@@ -762,7 +876,7 @@ public class UseExpressionBodyForAccessorsTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             TestCode = code,
             FixedCode = fixedCode,
-            BatchFixedCode = batchFixedCode,
+            BatchFixedCode = fixedCode,
             LanguageVersion = LanguageVersion.CSharp9,
             Options =
             {

--- a/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForAccessorsAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForAccessorsAnalyzerTests.cs
@@ -656,7 +656,9 @@ public sealed class UseExpressionBodyForAccessorsTests
         await TestWithUseBlockBodyIncludingPropertiesAndIndexers(code, fixedCode);
     }
 
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/61279")]
     public async Task TestAccessorListFormatting_FixAll1()
     {
         var code = """
@@ -700,7 +702,9 @@ public sealed class UseExpressionBodyForAccessorsTests
         }.RunAsync();
     }
 
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/61279")]
     public async Task TestAccessorListFormatting_FixAll2()
     {
         var code = """
@@ -769,7 +773,9 @@ public sealed class UseExpressionBodyForAccessorsTests
         }.RunAsync();
     }
 
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/61279")]
     public async Task TestAccessorListFormatting_FixAll3()
     {
         var code = """
@@ -838,7 +844,9 @@ public sealed class UseExpressionBodyForAccessorsTests
         }.RunAsync();
     }
 
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/61279")]
     public async Task TestAccessorListFormatting_FixAll4()
     {
         var code =


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61279
Fixes https://github.com/dotnet/roslyn/issues/23251