### PR TITLE
Support adding package and reference assemblies from an import

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
@@ -61,10 +61,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(Task.FromResult(true));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -98,10 +98,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(Task.FromResult(true));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            "nuget.org", "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+            "nuget.org", new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -133,10 +133,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -168,10 +168,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         await TestInRegularAndScriptAsync(
@@ -201,10 +201,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
             .Returns(true);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         await TestMissingInRegularAndScriptAsync(
@@ -229,10 +229,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
             .Returns(ImmutableArray.Create("1.0", "2.0"));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         var data = new FixProviderData(installerServiceMock.Object, packageServiceMock.Object);
@@ -279,10 +279,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -317,9 +317,9 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -354,9 +354,9 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(SpecializedTasks.False);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync(new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, new TypeQuery("NuGetType", 0), It.IsAny<NamespaceQuery>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
@@ -243,8 +243,8 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                 [|NuGetType|] n;
             }
             """,
-string.Format(FeaturesResources.Use_local_version_0, "1.0"),
-parameters: new TestParameters(fixProviderData: data));
+            string.Format(FeaturesResources.Use_local_version_0, "1.0"),
+            parameters: new TestParameters(fixProviderData: data));
 
         await TestSmartTagTextAsync(
             """
@@ -253,8 +253,8 @@ parameters: new TestParameters(fixProviderData: data));
                 [|NuGetType|] n;
             }
             """,
-string.Format(FeaturesResources.Use_local_version_0, "2.0"),
-parameters: new TestParameters(index: 1, fixProviderData: data));
+            string.Format(FeaturesResources.Use_local_version_0, "2.0"),
+            parameters: new TestParameters(index: 1, fixProviderData: data));
 
         await TestSmartTagTextAsync(
             """
@@ -263,8 +263,8 @@ parameters: new TestParameters(index: 1, fixProviderData: data));
                 [|NuGetType|] n;
             }
             """,
-FeaturesResources.Find_and_install_latest_version,
-parameters: new TestParameters(index: 2, fixProviderData: data));
+            FeaturesResources.Find_and_install_latest_version,
+            parameters: new TestParameters(index: 2, fixProviderData: data));
     }
 
     [Fact]

--- a/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
@@ -61,23 +61,27 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(Task.FromResult(true));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
-@"using NuGetNamespace;
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
+            """
+            using NuGetNamespace;
 
-class C
-{
-    NuGetType n;
-}", fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
+            class C
+            {
+                NuGetType n;
+            }
+            """, fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
     }
 
     [Fact]
@@ -94,23 +98,27 @@ class C
                             .Returns(Task.FromResult(true));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            "nuget.org", "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            "nuget.org", "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
-@"using NuGetNamespace;
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
+            """
+            using NuGetNamespace;
 
-class C
-{
-    NuGetType n;
-}", fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
+            class C
+            {
+                NuGetType n;
+            }
+            """, fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
     }
 
     [Fact]
@@ -125,23 +133,27 @@ class C
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
-@"using NuGetNamespace;
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
+            """
+            using NuGetNamespace;
 
-class C
-{
-    NuGetType n;
-}", fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
+            class C
+            {
+                NuGetType n;
+            }
+            """, fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
     }
 
     [Fact]
@@ -156,23 +168,27 @@ class C
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
-@"using NS1.NS2;
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
+            """
+            using NS1.NS2;
 
-class C
-{
-    NuGetType n;
-}", fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
+            class C
+            {
+                NuGetType n;
+            }
+            """, fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
     }
 
     [Fact]
@@ -185,17 +201,19 @@ class C
             .Returns(true);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         await TestMissingInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}", new TestParameters(fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object)));
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """, new TestParameters(fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object)));
     }
 
     [Fact]
@@ -211,34 +229,40 @@ class C
             .Returns(ImmutableArray.Create("1.0", "2.0"));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         var data = new FixProviderData(installerServiceMock.Object, packageServiceMock.Object);
         await TestSmartTagTextAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
 string.Format(FeaturesResources.Use_local_version_0, "1.0"),
 parameters: new TestParameters(fixProviderData: data));
 
         await TestSmartTagTextAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
 string.Format(FeaturesResources.Use_local_version_0, "2.0"),
 parameters: new TestParameters(index: 1, fixProviderData: data));
 
         await TestSmartTagTextAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
 FeaturesResources.Find_and_install_latest_version,
 parameters: new TestParameters(index: 2, fixProviderData: data));
     }
@@ -255,23 +279,27 @@ parameters: new TestParameters(index: 2, fixProviderData: data));
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
         packageServiceMock.Setup(s => s.FindPackagesAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
-@"using NuGetNamespace;
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
+            """
+            using NuGetNamespace;
 
-class C
-{
-    NuGetType n;
-}", fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
+            class C
+            {
+                NuGetType n;
+            }
+            """, fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
         installerServiceMock.Verify();
     }
 
@@ -289,22 +317,26 @@ class C
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
-@"using NuGetNamespace;
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
+            """
+            using NuGetNamespace;
 
-class C
-{
-    NuGetType n;
-}", fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
+            class C
+            {
+                NuGetType n;
+            }
+            """, fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
         installerServiceMock.Verify();
     }
 
@@ -322,20 +354,24 @@ class C
                             .Returns(SpecializedTasks.False);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<ImmutableArray<string>>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|NuGetType|] n;
-}",
-@"class C
-{
-    NuGetType n;
-}", fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
+            """
+            class C
+            {
+                [|NuGetType|] n;
+            }
+            """,
+            """
+            class C
+            {
+                NuGetType n;
+            }
+            """, fixProviderData: new FixProviderData(installerServiceMock.Object, packageServiceMock.Object));
         installerServiceMock.Verify();
     }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
@@ -61,10 +61,10 @@ public class AddUsingNuGetTests : AbstractAddUsingTests
                             .Returns(Task.FromResult(true));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -94,10 +94,10 @@ class C
                             .Returns(Task.FromResult(true));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-            "nuget.org", "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(
+            "nuget.org", "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -125,10 +125,10 @@ class C
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -156,10 +156,10 @@ class C
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         await TestInRegularAndScriptAsync(
@@ -185,10 +185,10 @@ class C
             .Returns(true);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         await TestMissingInRegularAndScriptAsync(
@@ -211,10 +211,10 @@ class C
             .Returns(ImmutableArray.Create("1.0", "2.0"));
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
         var data = new FixProviderData(installerServiceMock.Object, packageServiceMock.Object);
@@ -255,10 +255,10 @@ parameters: new TestParameters(index: 2, fixProviderData: data));
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(
+            PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -289,9 +289,9 @@ class C
                             .Returns(SpecializedTasks.True);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -322,9 +322,9 @@ class C
                             .Returns(SpecializedTasks.False);
 
         var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
-        packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
-            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty));
-        packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+        packageServiceMock.Setup(s => s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty));
+        packageServiceMock.Setup(s => s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(() => CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
         await TestInRegularAndScriptAsync(
@@ -339,15 +339,15 @@ class C
         installerServiceMock.Verify();
     }
 
-    private static ValueTask<ImmutableArray<PackageWithTypeResult>> CreateSearchResult(
+    private static ValueTask<ImmutableArray<PackageResult>> CreateSearchResult(
         string packageName, string typeName, ImmutableArray<string> containingNamespaceNames)
     {
-        return CreateSearchResult(new PackageWithTypeResult(
+        return CreateSearchResult(new PackageResult(
             packageName: packageName, rank: 0, typeName: typeName,
             version: null, containingNamespaceNames: containingNamespaceNames));
     }
 
-    private static ValueTask<ImmutableArray<PackageWithTypeResult>> CreateSearchResult(params PackageWithTypeResult[] results)
+    private static ValueTask<ImmutableArray<PackageResult>> CreateSearchResult(params PackageResult[] results)
         => new(ImmutableArray.Create(results));
 
     private static ImmutableArray<string> CreateNameParts(params string[] parts)

--- a/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddUsing/AddUsingNuGetTests.cs
@@ -29,7 +29,7 @@ using FixProviderData = Tuple<IPackageInstallerService, ISymbolSearchService>;
 public class AddUsingNuGetTests : AbstractAddUsingTests
 {
     private static readonly ImmutableArray<PackageSource> NugetPackageSources =
-        ImmutableArray.Create(new PackageSource(PackageSourceHelper.NugetOrgSourceName, "http://nuget.org/"));
+        [new PackageSource(PackageSourceHelper.NugetOrgSourceName, "http://nuget.org/")];
 
     protected override void InitializeWorkspace(EditorTestWorkspace workspace, TestParameters parameters)
     {

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
@@ -56,9 +56,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(
@@ -85,9 +85,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestInRegularAndScriptAsync(
@@ -114,9 +114,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.False)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestInRegularAndScriptAsync(
@@ -139,9 +139,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 Returns(True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestMissingInRegularAndScriptAsync(
@@ -164,9 +164,9 @@ New TestParameters(fixProviderData:=New ProviderData(installerServiceMock.Object
                 Returns(ImmutableArray.Create("1.0", "2.0"))
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Dim data = New ProviderData(installerServiceMock.Object, packageServiceMock.Object)
@@ -206,9 +206,9 @@ parameters:=New TestParameters(index:=2, fixProviderData:=data))
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(
@@ -238,9 +238,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny(Of CancellationToken))).
-                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyWithTypeResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesWithTypeAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+                Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(
@@ -257,8 +257,8 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
             installerServiceMock.Verify()
         End Function
 
-        Private Shared Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As ValueTask(Of ImmutableArray(Of PackageWithTypeResult))
-            Return CreateSearchResult(New PackageWithTypeResult(
+        Private Shared Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As ValueTask(Of ImmutableArray(Of PackageResult))
+            Return CreateSearchResult(New PackageResult(
                 packageName:=packageName,
                 rank:=0,
                 typeName:=typeName,
@@ -266,7 +266,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 containingNamespaceNames:=nameParts))
         End Function
 
-        Private Shared Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As ValueTask(Of ImmutableArray(Of PackageWithTypeResult))
+        Private Shared Function CreateSearchResult(ParamArray results As PackageResult()) As ValueTask(Of ImmutableArray(Of PackageResult))
             Return ValueTaskFactory.FromResult(ImmutableArray.Create(results))
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
@@ -56,9 +56,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync(New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(
@@ -85,9 +85,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync(New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestInRegularAndScriptAsync(
@@ -114,9 +114,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.False)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync(New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestInRegularAndScriptAsync(
@@ -139,9 +139,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 Returns(True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync(New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestMissingInRegularAndScriptAsync(
@@ -164,9 +164,9 @@ New TestParameters(fixProviderData:=New ProviderData(installerServiceMock.Object
                 Returns(ImmutableArray.Create("1.0", "2.0"))
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync(New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Dim data = New ProviderData(installerServiceMock.Object, packageServiceMock.Object)
@@ -206,9 +206,9 @@ parameters:=New TestParameters(index:=2, fixProviderData:=data))
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync(New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(
@@ -238,9 +238,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync(New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, New TypeQuery("NuGetType", 0), It.IsAny(Of NamespaceQuery), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
@@ -8,10 +8,7 @@ Imports Microsoft.CodeAnalysis.AddImport
 Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Packaging
-Imports Microsoft.CodeAnalysis.Shared.Utilities
 Imports Microsoft.CodeAnalysis.SymbolSearch
 Imports Microsoft.CodeAnalysis.VisualBasic.AddImport
 Imports Moq

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/AddImport/AddImportTests_NuGet.vb
@@ -56,9 +56,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(
@@ -85,9 +85,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestInRegularAndScriptAsync(
@@ -114,9 +114,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.False)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestInRegularAndScriptAsync(
@@ -139,9 +139,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 Returns(True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Await TestMissingInRegularAndScriptAsync(
@@ -164,9 +164,9 @@ New TestParameters(fixProviderData:=New ProviderData(installerServiceMock.Object
                 Returns(ImmutableArray.Create("1.0", "2.0"))
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")))
 
             Dim data = New ProviderData(installerServiceMock.Object, packageServiceMock.Object)
@@ -206,9 +206,9 @@ parameters:=New TestParameters(index:=2, fixProviderData:=data))
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(
@@ -238,9 +238,9 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                                  Returns(SpecializedTasks.True)
 
             Dim packageServiceMock = New Mock(Of ISymbolSearchService)(MockBehavior.Strict)
-            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
+            packageServiceMock.Setup(Function(s) s.FindReferenceAssembliesAsync("NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken))).
                 Returns(Function() ValueTaskFactory.FromResult(ImmutableArray(Of ReferenceAssemblyResult).Empty))
-            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken)())).
+            packageServiceMock.Setup(Function(s) s.FindPackagesAsync(PackageSourceHelper.NugetOrgSourceName, "NuGetType", 0, It.IsAny(Of ImmutableArray(Of String)), It.IsAny(Of CancellationToken)())).
                 Returns(Function() CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")))
 
             Await TestInRegularAndScriptAsync(

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -21,6 +19,11 @@ internal static class AddImportDiagnosticIds
     /// name does not exist in context
     /// </summary>
     public const string CS0103 = nameof(CS0103);
+
+    /// <summary>
+    /// The type or namespace name 'X' does not exist in the namespace 'Y' (are you missing an assembly reference?)
+    /// </summary>
+    public const string CS0234 = nameof(CS0234);
 
     /// <summary>
     /// type or namespace could not be found
@@ -149,10 +152,10 @@ internal static class AddImportDiagnosticIds
     public const string CS8415 = nameof(CS8415);
 
     public static ImmutableArray<string> FixableTypeIds =
-        [CS0103, CS0246, CS0305, CS0308, CS0122, CS0307, CS0616, CS1580, CS1581, CS8129, IDEDiagnosticIds.UnboundIdentifierId];
+        [CS0103, CS0234, CS0246, CS0305, CS0308, CS0122, CS0307, CS0616, CS1580, CS1581, CS8129, IDEDiagnosticIds.UnboundIdentifierId];
 
     public static ImmutableArray<string> FixableDiagnosticIds =
-        FixableTypeIds.Concat(ImmutableArray.Create(
+        FixableTypeIds.Concat([
                 CS1061,
                 CS1935,
                 CS1501,
@@ -168,11 +171,11 @@ internal static class AddImportDiagnosticIds
                 CS1579,
                 CS8414,
                 CS8411,
-                CS8415));
+                CS8415]);
 }
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.AddImport), Shared]
-internal class CSharpAddImportCodeFixProvider : AbstractAddImportCodeFixProvider
+internal sealed class CSharpAddImportCodeFixProvider : AbstractAddImportCodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => AddImportDiagnosticIds.FixableDiagnosticIds;
 

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -32,19 +32,15 @@ using static CSharpSyntaxTokens;
 using static SyntaxFactory;
 
 [ExportLanguageService(typeof(IAddImportFeatureService), LanguageNames.CSharp), Shared]
-internal class CSharpAddImportFeatureService : AbstractAddImportFeatureService<SimpleNameSyntax>
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpAddImportFeatureService() : AbstractAddImportFeatureService<SimpleNameSyntax>
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpAddImportFeatureService()
-    {
-    }
+    protected override bool IsWithinImport(SyntaxNode node)
+        => node.GetAncestor<UsingDirectiveSyntax>()?.Parent is CompilationUnitSyntax;
 
     protected override bool CanAddImport(SyntaxNode node, bool allowInHiddenRegions, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return node.CanAddUsingDirectives(allowInHiddenRegions, cancellationToken);
-    }
+        => node.CanAddUsingDirectives(allowInHiddenRegions, cancellationToken);
 
     protected override bool CanAddImportForMethod(
         string diagnosticId, ISyntaxFacts syntaxFacts, SyntaxNode node, out SimpleNameSyntax nameNode)

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -175,6 +175,7 @@ internal sealed class CSharpAddImportFeatureService() : AbstractAddImportFeature
             case CS1581:
             case CS1955:
             case CS0281:
+            case CS0234:
                 break;
 
             case CS1574:

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -191,7 +191,7 @@ internal sealed class CSharpAddImportFeatureService() : AbstractAddImportFeature
                 // The type or namespace name 'X' does not exist in the namespace 'Y'.
                 //
                 // We support this within a using, on any part of the using name that doesn't bind.
-                if (!this.IsWithinImport(nameNode))
+                if (!this.IsWithinImport(node))
                     return false;
 
                 nameNode = node as SimpleNameSyntax;

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -46,7 +46,7 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
     protected abstract bool CanAddImportForGetEnumerator(string diagnosticId, ISyntaxFacts syntaxFactsService, SyntaxNode node);
     protected abstract bool CanAddImportForGetAsyncEnumerator(string diagnosticId, ISyntaxFacts syntaxFactsService, SyntaxNode node);
     protected abstract bool CanAddImportForQuery(string diagnosticId, SyntaxNode node);
-    protected abstract bool CanAddImportForType(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
+    protected abstract bool CanAddImportForTypeOrNamespace(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
 
     protected abstract ISet<INamespaceSymbol> GetImportNamespacesInScope(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
     protected abstract ITypeSymbol GetDeconstructInfo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -37,6 +37,7 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
     /// </summary>
     private static readonly ConditionalWeakTable<PortableExecutableReference, StrongBox<bool>> s_isInPackagesDirectory = new();
 
+    protected abstract bool IsWithinImport(SyntaxNode node);
     protected abstract bool CanAddImport(SyntaxNode node, bool allowInHiddenRegions, CancellationToken cancellationToken);
     protected abstract bool CanAddImportForMethod(string diagnosticId, ISyntaxFacts syntaxFacts, SyntaxNode node, out TSimpleNameSyntax nameNode);
     protected abstract bool CanAddImportForNamespace(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
@@ -117,6 +118,8 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
                             if (result.Count > maxResults)
                                 break;
                         }
+
+                        GC.KeepAlive(semanticModel);
                     }
                 }
             }
@@ -126,8 +129,15 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
     }
 
     private async Task<ImmutableArray<Reference>> FindResultsAsync(
-        Document document, SemanticModel semanticModel, string diagnosticId, SyntaxNode node, int maxResults, ISymbolSearchService symbolSearchService,
-        AddImportOptions options, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
+        Document document,
+        SemanticModel semanticModel,
+        string diagnosticId,
+        SyntaxNode node,
+        int maxResults,
+        ISymbolSearchService symbolSearchService,
+        AddImportOptions options,
+        ImmutableArray<PackageSource> packageSources,
+        CancellationToken cancellationToken)
     {
         // Caches so we don't produce the same data multiple times while searching 
         // all over the solution.
@@ -136,25 +146,20 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         var referenceToCompilation = new ConcurrentDictionary<PortableExecutableReference, Compilation>(concurrencyLevel: 2, capacity: project.Solution.Projects.Sum(p => p.MetadataReferences.Count));
 
         var finder = new SymbolReferenceFinder(
-            this, document, semanticModel, diagnosticId, node, symbolSearchService,
-            options, packageSources, cancellationToken);
+            this, document, semanticModel, diagnosticId, node, symbolSearchService, options, packageSources, cancellationToken);
 
         // Look for exact matches first:
-        var exactReferences = await FindResultsAsync(projectToAssembly, referenceToCompilation, project, maxResults, finder, exact: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var exactReferences = await FindResultsAsync(projectToAssembly, referenceToCompilation, project, maxResults, finder, exact: true, cancellationToken).ConfigureAwait(false);
         if (exactReferences.Length > 0)
             return exactReferences;
 
-        // No exact matches found.  Fall back to fuzzy searching.
-        // Only bother doing this for host workspaces.  We don't want this for 
-        // things like the Interactive workspace as this will cause us to 
-        // create expensive bk-trees which we won't even be able to save for 
-        // future use.
+        // No exact matches found.  Fall back to fuzzy searching. Only bother doing this for host workspaces.  We don't
+        // want this for things like the Interactive workspace as this will cause us to create expensive bk-trees which
+        // we won't even be able to save for future use.
         if (!IsHostOrRemoteWorkspace(project))
-        {
             return [];
-        }
 
-        var fuzzyReferences = await FindResultsAsync(projectToAssembly, referenceToCompilation, project, maxResults, finder, exact: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var fuzzyReferences = await FindResultsAsync(projectToAssembly, referenceToCompilation, project, maxResults, finder, exact: false, cancellationToken).ConfigureAwait(false);
         return fuzzyReferences;
     }
 
@@ -164,7 +169,11 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
     private async Task<ImmutableArray<Reference>> FindResultsAsync(
         ConcurrentDictionary<Project, AsyncLazy<IAssemblySymbol>> projectToAssembly,
         ConcurrentDictionary<PortableExecutableReference, Compilation> referenceToCompilation,
-        Project project, int maxResults, SymbolReferenceFinder finder, bool exact, CancellationToken cancellationToken)
+        Project project,
+        int maxResults,
+        SymbolReferenceFinder finder,
+        bool exact,
+        CancellationToken cancellationToken)
     {
         var allReferences = new ConcurrentQueue<Reference>();
 
@@ -188,9 +197,7 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
 
             // We only support searching NuGet in an exact manner currently. 
             if (exact)
-            {
                 await finder.FindNugetOrReferenceAssemblyReferencesAsync(allReferences, cancellationToken).ConfigureAwait(false);
-            }
         }
 
         return [.. allReferences];

--- a/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
@@ -17,10 +17,10 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
     private sealed partial class AssemblyReference(
         AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
         SearchResult searchResult,
-        ReferenceAssemblyWithTypeResult referenceAssemblyWithType,
+        ReferenceAssemblyResult referenceAssemblyWithType,
         bool isWithinImport) : Reference(provider, searchResult, isWithinImport)
     {
-        private readonly ReferenceAssemblyWithTypeResult _referenceAssemblyWithType = referenceAssemblyWithType;
+        private readonly ReferenceAssemblyResult _referenceAssemblyWithType = referenceAssemblyWithType;
 
         public override async Task<AddImportFixData> TryGetFixDataAsync(
             Document document, SyntaxNode node, CodeCleanupOptions options, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
@@ -17,7 +17,8 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
     private sealed partial class AssemblyReference(
         AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
         SearchResult searchResult,
-        ReferenceAssemblyWithTypeResult referenceAssemblyWithType) : Reference(provider, searchResult)
+        ReferenceAssemblyWithTypeResult referenceAssemblyWithType,
+        bool isWithinImport) : Reference(provider, searchResult, isWithinImport)
     {
         private readonly ReferenceAssemblyWithTypeResult _referenceAssemblyWithType = referenceAssemblyWithType;
 

--- a/src/Features/Core/Portable/AddImport/References/PackageReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/PackageReference.cs
@@ -18,7 +18,8 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         SearchResult searchResult,
         string source,
         string packageName,
-        string versionOpt) : Reference(provider, searchResult)
+        string versionOpt,
+        bool isWithinImport) : Reference(provider, searchResult, isWithinImport)
     {
         private readonly string _source = source;
         private readonly string _packageName = packageName;

--- a/src/Features/Core/Portable/AddImport/References/Reference.cs
+++ b/src/Features/Core/Portable/AddImport/References/Reference.cs
@@ -103,7 +103,8 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         protected async Task<ImmutableArray<TextChange>> GetTextChangesAsync(
             Document document, SyntaxNode node, CodeCleanupOptions options, CancellationToken cancellationToken)
         {
-            // Within an import, we're only adding a package/nuget reference.  So no need for text changes.
+            // Within an import, we're only adding a package/nuget reference (and we're not going to add another
+            // using/import as we're already in one).  So no need for text changes.
             if (_isWithinImport)
                 return [];
 

--- a/src/Features/Core/Portable/AddImport/References/Reference.cs
+++ b/src/Features/Core/Portable/AddImport/References/Reference.cs
@@ -20,18 +20,15 @@ namespace Microsoft.CodeAnalysis.AddImport;
 
 internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
 {
-    private abstract class Reference : IEquatable<Reference>
+    private abstract class Reference(
+        AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+        SearchResult searchResult,
+        bool isWithinImport) : IEquatable<Reference>
     {
-        protected readonly AbstractAddImportFeatureService<TSimpleNameSyntax> provider;
-        public readonly SearchResult SearchResult;
+        protected readonly AbstractAddImportFeatureService<TSimpleNameSyntax> provider = provider;
+        public readonly SearchResult SearchResult = searchResult;
 
-        protected Reference(
-            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-            SearchResult searchResult)
-        {
-            this.provider = provider;
-            SearchResult = searchResult;
-        }
+        private readonly bool _isWithinImport = isWithinImport;
 
         public int CompareTo(Document document, Reference other)
         {
@@ -106,6 +103,10 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         protected async Task<ImmutableArray<TextChange>> GetTextChangesAsync(
             Document document, SyntaxNode node, CodeCleanupOptions options, CancellationToken cancellationToken)
         {
+            // Within an import, we're only adding a package/nuget reference.  So no need for text changes.
+            if (_isWithinImport)
+                return [];
+
             var originalDocument = document;
 
             (node, document) = await ReplaceNameNodeAsync(

--- a/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
@@ -20,7 +20,8 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
 {
     private abstract partial class SymbolReference(
         AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-        SymbolResult<INamespaceOrTypeSymbol> symbolResult) : Reference(provider, new SearchResult(symbolResult))
+        SymbolResult<INamespaceOrTypeSymbol> symbolResult)
+        : Reference(provider, new SearchResult(symbolResult), isWithinImport: false)
     {
         public readonly SymbolResult<INamespaceOrTypeSymbol> SymbolResult = symbolResult;
 

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -32,12 +32,12 @@ internal sealed class RemoteMissingImportDiscoveryServiceCallbackDispatcher()
     private ISymbolSearchService GetService(RemoteServiceCallbackId callbackId)
         => (ISymbolSearchService)GetCallback(callbackId);
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => GetService(callbackId).FindPackagesAsync(source, name, arity, isNamespace, cancellationToken);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken)
         => GetService(callbackId).FindPackagesWithAssemblyAsync(source, name, cancellationToken);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => GetService(callbackId).FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken);
 }

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -32,12 +32,12 @@ internal sealed class RemoteMissingImportDiscoveryServiceCallbackDispatcher()
     private ISymbolSearchService GetService(RemoteServiceCallbackId callbackId)
         => (ISymbolSearchService)GetCallback(callbackId);
 
-    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-        => GetService(callbackId).FindPackagesAsync(source, name, arity, isNamespace, cancellationToken);
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+        => GetService(callbackId).FindPackagesAsync(source, typeName, arity, namespaceNames, cancellationToken);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken)
         => GetService(callbackId).FindPackagesWithAssemblyAsync(source, name, cancellationToken);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-        => GetService(callbackId).FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken);
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+        => GetService(callbackId).FindReferenceAssembliesAsync(typeName, arity, namespaceNames, cancellationToken);
 }

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -24,23 +24,20 @@ namespace Microsoft.CodeAnalysis.AddImport;
 /// portion of the search.  Ideally we could keep this all OOP.
 /// </summary>
 [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteMissingImportDiscoveryService)), Shared]
-internal sealed class RemoteMissingImportDiscoveryServiceCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteMissingImportDiscoveryService.ICallback
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class RemoteMissingImportDiscoveryServiceCallbackDispatcher()
+    : RemoteServiceCallbackDispatcher, IRemoteMissingImportDiscoveryService.ICallback
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public RemoteMissingImportDiscoveryServiceCallbackDispatcher()
-    {
-    }
-
     private ISymbolSearchService GetService(RemoteServiceCallbackId callbackId)
         => (ISymbolSearchService)GetCallback(callbackId);
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, CancellationToken cancellationToken)
-        => GetService(callbackId).FindPackagesWithTypeAsync(source, name, arity, cancellationToken);
+    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        => GetService(callbackId).FindPackagesAsync(source, name, arity, isNamespace, cancellationToken);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken)
         => GetService(callbackId).FindPackagesWithAssemblyAsync(source, name, cancellationToken);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(RemoteServiceCallbackId callbackId, string name, int arity, CancellationToken cancellationToken)
-        => GetService(callbackId).FindReferenceAssembliesWithTypeAsync(name, arity, cancellationToken);
+    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        => GetService(callbackId).FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken);
 }

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -32,12 +32,12 @@ internal sealed class RemoteMissingImportDiscoveryServiceCallbackDispatcher()
     private ISymbolSearchService GetService(RemoteServiceCallbackId callbackId)
         => (ISymbolSearchService)GetCallback(callbackId);
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => GetService(callbackId).FindPackagesAsync(source, name, arity, isNamespace, cancellationToken);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken)
         => GetService(callbackId).FindPackagesWithAssemblyAsync(source, name, cancellationToken);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => GetService(callbackId).FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken);
 }

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -32,12 +32,12 @@ internal sealed class RemoteMissingImportDiscoveryServiceCallbackDispatcher()
     private ISymbolSearchService GetService(RemoteServiceCallbackId callbackId)
         => (ISymbolSearchService)GetCallback(callbackId);
 
-    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
-        => GetService(callbackId).FindPackagesAsync(source, typeName, arity, namespaceNames, cancellationToken);
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
+        => GetService(callbackId).FindPackagesAsync(source, typeQuery, namespaceQuery, cancellationToken);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken)
         => GetService(callbackId).FindPackagesWithAssemblyAsync(source, name, cancellationToken);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
-        => GetService(callbackId).FindReferenceAssembliesAsync(typeName, arity, namespaceNames, cancellationToken);
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
+        => GetService(callbackId).FindReferenceAssembliesAsync(typeQuery, namespaceQuery, cancellationToken);
 }

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -18,9 +18,9 @@ internal interface IRemoteMissingImportDiscoveryService
 {
     internal interface ICallback
     {
-        ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
     }
 
     ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -18,9 +18,9 @@ internal interface IRemoteMissingImportDiscoveryService
 {
     internal interface ICallback
     {
-        ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
     }
 
     ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -18,9 +18,9 @@ internal interface IRemoteMissingImportDiscoveryService
 {
     internal interface ICallback
     {
-        ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
     }
 
     ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -18,9 +18,9 @@ internal interface IRemoteMissingImportDiscoveryService
 {
     internal interface ICallback
     {
-        ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(RemoteServiceCallbackId callbackId, string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(RemoteServiceCallbackId callbackId, string name, int arity, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(RemoteServiceCallbackId callbackId, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
     }
 
     ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -18,9 +18,9 @@ internal interface IRemoteMissingImportDiscoveryService
 {
     internal interface ICallback
     {
-        ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(RemoteServiceCallbackId callbackId, string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(RemoteServiceCallbackId callbackId, string source, string name, CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(RemoteServiceCallbackId callbackId, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken);
     }
 
     ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/RemoteMissingImportDiscoveryServiceCallbackDispatcher.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/RemoteMissingImportDiscoveryServiceCallbackDispatcher.cs
@@ -14,14 +14,13 @@ using Microsoft.CodeAnalysis.SymbolSearch;
 namespace Microsoft.CodeAnalysis.AddImport;
 
 /// <summary>
-/// Used to supply the OOP server a callback that it can use to search for ReferenceAssemblies or
-/// nuget packages.  We can't necessarily do that search directly in the OOP server as our 
-/// 'SymbolSearchEngine' may actually be running in a *different* process (there is no guarantee
-/// that all remote work happens in the same process).  
+/// Used to supply the OOP server a callback that it can use to search for ReferenceAssemblies or nuget packages.  We
+/// can't necessarily do that search directly in the OOP server as our 'SymbolSearchEngine' may actually be running in a
+/// *different* process (there is no guarantee that all remote work happens in the same process).  
 /// 
-/// This does mean, currently, that when we call over to OOP to do a search, it will bounce
-/// back to VS, which will then bounce back out to OOP to perform the Nuget/ReferenceAssembly
-/// portion of the search.  Ideally we could keep this all OOP.
+/// This does mean, currently, that when we call over to OOP to do a search, it will bounce back to VS, which will then
+/// bounce back out to OOP to perform the Nuget/ReferenceAssembly portion of the search.  Ideally we could keep this all
+/// OOP.
 /// </summary>
 [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteMissingImportDiscoveryService)), Shared]
 [method: ImportingConstructor]

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -103,7 +103,8 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
             cancellationToken.ThrowIfCancellationRequested();
 
             // Within a using/import directive, we don't want to offer to add other imports.  We only want to offer to
-            // add nuget packages.
+            // add nuget packages.  So bail out immediately on all symbolic searches.  The only searches we aactually
+            // perform are done in FindNugetOrReferenceAssemblyReferencesAsync.
             if (_isWithinImport)
                 return [];
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -41,6 +41,9 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         private readonly AddImportOptions _options;
         private readonly ImmutableArray<PackageSource> _packageSources;
 
+        /// <summary>
+        /// If the search is being conducted inside of a `using/import` directive.
+        /// </summary>
         private readonly bool _isWithinImport;
 
         public SymbolReferenceFinder(

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -177,10 +177,8 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
             SearchScope searchScope, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!_owner.CanAddImportForType(_diagnosticId, _node, out var nameNode))
-            {
+            if (!_owner.CanAddImportForTypeOrNamespace(_diagnosticId, _node, out var nameNode))
                 return [];
-            }
 
             CalculateContext(
                 nameNode, _syntaxFacts,

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -71,20 +71,16 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         {
             if (_isWithinImport)
             {
+                // Inside of a using/import we do a search on the part of the using that doesn't bind (like 'Json' in `using
+                // Newtonsoft.Json;`).  But this may find results in other potential namespaces (like `Goobar.Json`).  So we
+                // need to make sure the namespace the index found matches the full name in the using/import.
                 var current = (SyntaxNode)nameNode;
                 while (_syntaxFacts.IsQualifiedName(current.Parent))
                     current = current.Parent;
 
                 using var _1 = ArrayBuilder<string>.GetInstance(out var result);
 
-                // Inside of a using/import we do a search on the part of the using that doesn't bind (like 'Json' in `using
-                // Newtonsoft.Json;`).  But this may find results in other potential namespaces (like `Goobar.Json`).  So we
-                // need to make sure the namespace the index found matches the full name in the using/import.
-                var rootNode = _syntaxFacts.IsRightOfQualifiedName(nameNode)
-                    ? nameNode.GetRequiredParent()
-                    : nameNode;
-
-                if (!TryAddNames(result, rootNode))
+                if (!TryAddNames(result, current))
                     return default;
 
                 return (TypeQuery.Default, result.ToImmutableAndClear(), inAttributeContext: false);

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -49,38 +49,31 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
                 out _, out _);
 
             if (arity == 0 && inAttributeContext)
-            {
-                await FindNugetOrReferenceAssemblyReferencesWorkerAsync(
-                    allReferences, nameNode, name + AttributeSuffix, arity,
-                    isAttributeSearch: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
+                await FindWorkerAsync(name + AttributeSuffix, arity, isAttributeSearch: true).ConfigureAwait(false);
 
-            await FindNugetOrReferenceAssemblyReferencesWorkerAsync(
-                allReferences, nameNode, name, arity,
-                isAttributeSearch: false, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
+            await FindWorkerAsync(name, arity, isAttributeSearch: false).ConfigureAwait(false);
 
-        private async Task FindNugetOrReferenceAssemblyReferencesWorkerAsync(
-            ConcurrentQueue<Reference> allReferences,
-            TSimpleNameSyntax nameNode,
-            string name,
-            int arity,
-            bool isAttributeSearch,
-            CancellationToken cancellationToken)
-        {
-            if (_options.SearchOptions.SearchReferenceAssemblies)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                await FindReferenceAssemblyReferencesAsync(
-                    allReferences, nameNode, name, arity, isAttributeSearch, cancellationToken).ConfigureAwait(false);
-            }
+            return;
 
-            var packageSources = PackageSourceHelper.GetPackageSources(_packageSources);
-            foreach (var (sourceName, sourceUrl) in packageSources)
+            async Task FindWorkerAsync(
+                string name,
+                int arity,
+                bool isAttributeSearch)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                await FindNugetReferencesAsync(
-                    sourceName, sourceUrl, allReferences, nameNode, name, arity, isAttributeSearch, cancellationToken).ConfigureAwait(false);
+                if (_options.SearchOptions.SearchReferenceAssemblies)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await FindReferenceAssemblyReferencesAsync(
+                        allReferences, nameNode, name, arity, isAttributeSearch, cancellationToken).ConfigureAwait(false);
+                }
+
+                var packageSources = PackageSourceHelper.GetPackageSources(_packageSources);
+                foreach (var (sourceName, sourceUrl) in packageSources)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await FindNugetReferencesAsync(
+                        sourceName, sourceUrl, allReferences, nameNode, name, arity, isAttributeSearch, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
+using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SymbolSearch;
 using Microsoft.CodeAnalysis.Utilities;
@@ -20,13 +22,22 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         internal async Task FindNugetOrReferenceAssemblyReferencesAsync(
             ConcurrentQueue<Reference> allReferences, CancellationToken cancellationToken)
         {
-            // Only do this if none of the project or metadata searches produced 
-            // any results. We always consider source and local metadata to be 
-            // better than any NuGet/assembly-reference results.
+            // Only do this if none of the project or metadata searches produced any results. We always consider source
+            // and local metadata to be better than any NuGet/assembly-reference results.
             if (!allReferences.IsEmpty)
                 return;
 
-            if (!_owner.CanAddImportForType(_diagnosticId, _node, out var nameNode))
+            TSimpleNameSyntax? nameNode;
+            if (_isWithinImport)
+            {
+                nameNode = _node as TSimpleNameSyntax;
+            }
+            else if (!_owner.CanAddImportForType(_diagnosticId, _node, out nameNode))
+            {
+                return;
+            }
+
+            if (nameNode is null)
                 return;
 
             if (ExpressionBinds(nameNode, checkForExtensionMethods: false, cancellationToken))
@@ -37,15 +48,6 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
                 out var name, out var arity, out var inAttributeContext,
                 out _, out _);
 
-            await FindNugetOrReferenceAssemblyReferencesAsync(
-                allReferences, nameNode, name, arity, inAttributeContext, cancellationToken).ConfigureAwait(false);
-        }
-
-        private async Task FindNugetOrReferenceAssemblyReferencesAsync(
-            ConcurrentQueue<Reference> allReferences, TSimpleNameSyntax nameNode,
-            string name, int arity, bool inAttributeContext,
-            CancellationToken cancellationToken)
-        {
             if (arity == 0 && inAttributeContext)
             {
                 await FindNugetOrReferenceAssemblyReferencesWorkerAsync(
@@ -99,10 +101,59 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
             foreach (var result in results)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                if (!IncludeResult(nameNode, result.ContainingNamespaceNames))
+                    continue;
+
                 await HandleReferenceAssemblyReferenceAsync(
                     allReferences, nameNode, project,
                     isAttributeSearch, result, weight: allReferences.Count,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private bool IncludeResult(TSimpleNameSyntax nameNode, ImmutableArray<string> namespaceNames)
+        {
+            // Outside of a using/import we did a search based on a simple leftmost name.  The index only provides
+            // results for namespaces that contain that name.  So we don't need to do anything special here and we can
+            // include that result.
+            if (!_isWithinImport)
+                return true;
+
+            // Inside of a using/import we do a search on the part of the using that doesn't bind (like 'Json' in `using
+            // Newtonsoft.Json;`).  But this may find results in other potential namespaces (like `Goobar.Json`).  So we
+            // need to make sure the namespace the index found matches the full name in the using/import.
+            var syntaxFacts = this._document.GetRequiredLanguageService<ISyntaxFactsService>();
+            var rootNode = syntaxFacts.IsRightOfQualifiedName(nameNode)
+                ? nameNode.GetRequiredParent()
+                : nameNode;
+
+            return NamespaceMatches(rootNode, namespaceNames.AsSpan());
+
+            bool NamespaceMatches(SyntaxNode rootNode, ReadOnlySpan<string> namespaceNames)
+            {
+                // We have a part of the name tree, but no more namespace names to match.  This is definitely not a match.
+                if (namespaceNames.Length == 0)
+                    return false;
+
+                if (syntaxFacts.IsIdentifierName(rootNode))
+                {
+                    // If we're on a single identifier, then we have to have a single namespace name that matches it.
+                    return namespaceNames is [var name] && name == syntaxFacts.GetIdentifierOfIdentifierName(rootNode).ValueText;
+                }
+                else if (syntaxFacts.IsQualifiedName(rootNode))
+                {
+                    // If we have a qualified name (like A.B.C) then we recurse down the left side (A.B) and the right (C),
+                    // passing in the corresponding parts of the namespace-name to match against.
+
+                    syntaxFacts.GetPartsOfQualifiedName(rootNode, out var left, out _, out var right);
+                    return NamespaceMatches(left, namespaceNames[0..^1]) &&
+                           NamespaceMatches(right, namespaceNames[^1..]);
+                }
+                else
+                {
+                    // Anything else is a mismatch.
+                    return false;
+                }
             }
         }
 
@@ -123,8 +174,16 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
             foreach (var result in results)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                HandleNugetReference(
-                    sourceUrl, allReferences, nameNode, isAttributeSearch, result, weight: allReferences.Count);
+                if (!IncludeResult(nameNode, result.ContainingNamespaceNames))
+                    continue;
+
+                allReferences.Enqueue(new PackageReference(
+                    _owner,
+                    new SearchResult(
+                        desiredName: GetDesiredName(_isWithinImport, isAttributeSearch, result.TypeName),
+                        nameNode,
+                        result.ContainingNamespaceNames.ToReadOnlyList(), weight: allReferences.Count),
+                    sourceUrl, result.PackageName, result.Version, _isWithinImport));
             }
         }
 
@@ -133,7 +192,7 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
             TSimpleNameSyntax nameNode,
             Project project,
             bool isAttributeSearch,
-            ReferenceAssemblyWithTypeResult result,
+            ReferenceAssemblyResult result,
             int weight,
             CancellationToken cancellationToken)
         {
@@ -156,21 +215,6 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
                 new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames.ToReadOnlyList(), weight),
                 result,
                 _isWithinImport));
-        }
-
-        private void HandleNugetReference(
-            string source,
-            ConcurrentQueue<Reference> allReferences,
-            TSimpleNameSyntax nameNode,
-            bool isAttributeSearch,
-            PackageWithTypeResult result,
-            int weight)
-        {
-            var desiredName = GetDesiredName(_isWithinImport, isAttributeSearch, result.TypeName);
-            allReferences.Enqueue(new PackageReference(
-                _owner,
-                new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames.ToReadOnlyList(), weight),
-                source, result.PackageName, result.Version, _isWithinImport));
         }
 
         private static string? GetDesiredName(bool isWithinImport, bool isAttributeSearch, string typeName)

--- a/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
@@ -21,11 +21,11 @@ internal sealed class SymbolSearchUpdateNoOpEngine : ISymbolSearchUpdateEngine
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-        => ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        => ValueTaskFactory.FromResult(ImmutableArray<PackageResult>.Empty);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-        => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty);
 
     public ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken)
         => default;

--- a/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
@@ -21,10 +21,10 @@ internal sealed class SymbolSearchUpdateNoOpEngine : ISymbolSearchUpdateEngine
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
 
     public ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
@@ -21,10 +21,10 @@ internal sealed class SymbolSearchUpdateNoOpEngine : ISymbolSearchUpdateEngine
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
-    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageResult>.Empty);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty);
 
     public ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
@@ -21,10 +21,10 @@ internal sealed class SymbolSearchUpdateNoOpEngine : ISymbolSearchUpdateEngine
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
-    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageResult>.Empty);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty);
 
     public ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
@@ -70,8 +70,8 @@ internal sealed partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngi
         // Nothing to do for the core symbol search engine.
     }
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-        string source, string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(
+        string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         if (!_sourceToDatabase.TryGetValue(source, out var databaseWrapper))
         {
@@ -150,8 +150,8 @@ internal sealed partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngi
         return ValueTaskFactory.FromResult(result.ToImmutableAndFree());
     }
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-        string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+        string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         // Our reference assembly data is stored in the nuget.org DB.
         if (!_sourceToDatabase.TryGetValue(PackageSourceHelper.NugetOrgSourceName, out var databaseWrapper))

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
@@ -76,6 +76,7 @@ internal sealed partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngi
     {
         return FindPackageOrReferenceAssembliesAsync(
             source, typeQuery, namespaceQuery,
+            // Ignore any reference assembly results.
             packageNameMatches: packageName => packageName != MicrosoftAssemblyReferencesName,
             createResult: (database, symbol) =>
             {

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
@@ -225,11 +225,6 @@ internal sealed partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngi
         }
     }
 
-    private static bool NameMatches(Path8 fullName, ImmutableArray<string> namespaceNames)
-    {
-        throw new NotImplementedException();
-    }
-
     private static int GetRank(Symbol symbol)
     {
         if (!TryGetRankingSymbol(symbol, out var rankingSymbol) ||

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
@@ -72,7 +72,7 @@ internal sealed partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngi
     }
 
     public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
-        string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+        string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         if (!_sourceToDatabase.TryGetValue(source, out var databaseWrapper))
         {
@@ -159,7 +159,7 @@ internal sealed partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngi
     }
 
     public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+        TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         // Our reference assembly data is stored in the nuget.org DB.
         if (!_sourceToDatabase.TryGetValue(PackageSourceHelper.NugetOrgSourceName, out var databaseWrapper))

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
@@ -16,10 +16,10 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
     public void Dispose()
         => _connection.Dispose();
 
-    public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
     {
         var result = await _connection.TryInvokeAsync(
-            (service, cancellationToken) => service.FindPackagesAsync(source, name, arity, isNamespace, cancellationToken),
+            (service, cancellationToken) => service.FindPackagesAsync(source, typeName, arity, namespaceNames, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         return result.HasValue ? result.Value : [];
@@ -36,10 +36,10 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
     }
 
     public async ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
     {
         var result = await _connection.TryInvokeAsync(
-            (service, cancellationToken) => service.FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken),
+            (service, cancellationToken) => service.FindReferenceAssembliesAsync(typeName, arity, namespaceNames, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         return result.HasValue ? result.Value : [];

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
@@ -16,10 +16,10 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
     public void Dispose()
         => _connection.Dispose();
 
-    public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         var result = await _connection.TryInvokeAsync(
-            (service, cancellationToken) => service.FindPackagesAsync(source, typeName, arity, namespaceNames, cancellationToken),
+            (service, cancellationToken) => service.FindPackagesAsync(source, typeQuery, namespaceQuery, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         return result.HasValue ? result.Value : [];
@@ -36,10 +36,10 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
     }
 
     public async ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+        TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         var result = await _connection.TryInvokeAsync(
-            (service, cancellationToken) => service.FindReferenceAssembliesAsync(typeName, arity, namespaceNames, cancellationToken),
+            (service, cancellationToken) => service.FindReferenceAssembliesAsync(typeQuery, namespaceQuery, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         return result.HasValue ? result.Value : [];

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
@@ -16,10 +16,10 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
     public void Dispose()
         => _connection.Dispose();
 
-    public async ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
-        var result = await _connection.TryInvokeAsync<ImmutableArray<PackageWithTypeResult>>(
-            (service, cancellationToken) => service.FindPackagesWithTypeAsync(source, name, arity, cancellationToken),
+        var result = await _connection.TryInvokeAsync(
+            (service, cancellationToken) => service.FindPackagesAsync(source, name, arity, isNamespace, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         return result.HasValue ? result.Value : [];
@@ -28,18 +28,18 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
     public async ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
         string source, string assemblyName, CancellationToken cancellationToken)
     {
-        var result = await _connection.TryInvokeAsync<ImmutableArray<PackageWithAssemblyResult>>(
+        var result = await _connection.TryInvokeAsync(
             (service, cancellationToken) => service.FindPackagesWithAssemblyAsync(source, assemblyName, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         return result.HasValue ? result.Value : [];
     }
 
-    public async ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-        string name, int arity, CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+        string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
-        var result = await _connection.TryInvokeAsync<ImmutableArray<ReferenceAssemblyWithTypeResult>>(
-            (service, cancellationToken) => service.FindReferenceAssembliesWithTypeAsync(name, arity, cancellationToken),
+        var result = await _connection.TryInvokeAsync(
+            (service, cancellationToken) => service.FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         return result.HasValue ? result.Value : [];

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
@@ -16,7 +16,7 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
     public void Dispose()
         => _connection.Dispose();
 
-    public async ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         var result = await _connection.TryInvokeAsync(
             (service, cancellationToken) => service.FindPackagesAsync(source, name, arity, isNamespace, cancellationToken),
@@ -35,7 +35,7 @@ internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : I
         return result.HasValue ? result.Value : [];
     }
 
-    public async ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+    public async ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
         string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         var result = await _connection.TryInvokeAsync(

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -131,7 +131,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
                 node.GetAncestor(Of QueryExpressionSyntax)() IsNot Nothing
         End Function
 
-        Protected Overrides Function CanAddImportForType(
+        Protected Overrides Function CanAddImportForTypeOrNamespace(
                 diagnosticId As String, node As SyntaxNode, ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnosticId
                 Case AddImportDiagnosticIds.BC30002,

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -6,7 +6,6 @@ Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.AddImport
 Imports Microsoft.CodeAnalysis.CaseCorrection
-Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Formatting
@@ -17,7 +16,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
     <ExportLanguageService(GetType(IAddImportFeatureService), LanguageNames.VisualBasic), [Shared]>
-    Friend Class VisualBasicAddImportFeatureService
+    Friend NotInheritable Class VisualBasicAddImportFeatureService
         Inherits AbstractAddImportFeatureService(Of SimpleNameSyntax)
 
         <ImportingConstructor>
@@ -25,8 +24,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
         Public Sub New()
         End Sub
 
+        Protected Overrides Function IsWithinImport(node As SyntaxNode) As Boolean
+            Return node.GetAncestor(Of ImportsStatementSyntax)() IsNot Nothing
+        End Function
+
         Protected Overrides Function CanAddImport(node As SyntaxNode, allowInHiddenRegions As Boolean, cancellationToken As CancellationToken) As Boolean
-            cancellationToken.ThrowIfCancellationRequested()
             Return node.CanAddImportsStatements(allowInHiddenRegions, cancellationToken)
         End Function
 

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -25,7 +25,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Settings;
 using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
-using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch;
 
@@ -44,7 +43,7 @@ internal partial class VisualStudioSymbolSearchService(
     IAsynchronousOperationListenerProvider listenerProvider,
     VisualStudioWorkspaceImpl workspace,
     IGlobalOptionService globalOptions,
-    VSShell.SVsServiceProvider serviceProvider)
+    SVsServiceProvider serviceProvider)
     : AbstractDelayStartedService(threadingContext,
         globalOptions,
         workspace,

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -132,11 +132,11 @@ internal partial class VisualStudioSymbolSearchService(
     }
 
     public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
-        string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+        string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);
         var allPackagesWithType = await engine.FindPackagesAsync(
-            source, typeName, arity, namespaceNames, cancellationToken).ConfigureAwait(false);
+            source, typeQuery, namespaceQuery, cancellationToken).ConfigureAwait(false);
 
         return FilterAndOrderPackages(allPackagesWithType);
     }
@@ -203,10 +203,10 @@ internal partial class VisualStudioSymbolSearchService(
     }
 
     public async ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+        TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);
         return await engine.FindReferenceAssembliesAsync(
-            typeName, arity, namespaceNames, cancellationToken).ConfigureAwait(false);
+            typeQuery, namespaceQuery, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -131,12 +131,12 @@ internal partial class VisualStudioSymbolSearchService(
         await engine.UpdateContinuouslyAsync(sourceName, _localSettingsDirectory, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-        string source, string name, int arity, CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(
+        string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);
-        var allPackagesWithType = await engine.FindPackagesWithTypeAsync(
-            source, name, arity, cancellationToken).ConfigureAwait(false);
+        var allPackagesWithType = await engine.FindPackagesAsync(
+            source, name, arity, isNamespace, cancellationToken).ConfigureAwait(false);
 
         return FilterAndOrderPackages(allPackagesWithType);
     }
@@ -202,11 +202,11 @@ internal partial class VisualStudioSymbolSearchService(
         return result.ToImmutableAndFree();
     }
 
-    public async ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-        string name, int arity, CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+        string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);
-        return await engine.FindReferenceAssembliesWithTypeAsync(
-            name, arity, cancellationToken).ConfigureAwait(false);
+        return await engine.FindReferenceAssembliesAsync(
+            name, arity, isNamespace, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -131,7 +131,7 @@ internal partial class VisualStudioSymbolSearchService(
         await engine.UpdateContinuouslyAsync(sourceName, _localSettingsDirectory, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(
+    public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
         string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);
@@ -152,7 +152,7 @@ internal partial class VisualStudioSymbolSearchService(
     }
 
     private ImmutableArray<TPackageResult> FilterAndOrderPackages<TPackageResult>(
-        ImmutableArray<TPackageResult> allPackages) where TPackageResult : PackageResult
+        ImmutableArray<TPackageResult> allPackages) where TPackageResult : AbstractPackageResult
     {
         // The ranking threshold under while we start aggressively filtering out packages if they don't have a high
         // enough rank.  Above this and we will always include the item as it's shown more than enough usage to
@@ -202,7 +202,7 @@ internal partial class VisualStudioSymbolSearchService(
         return result.ToImmutableAndFree();
     }
 
-    public async ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+    public async ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
         string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -132,11 +132,11 @@ internal partial class VisualStudioSymbolSearchService(
     }
 
     public async ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
-        string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);
         var allPackagesWithType = await engine.FindPackagesAsync(
-            source, name, arity, isNamespace, cancellationToken).ConfigureAwait(false);
+            source, typeName, arity, namespaceNames, cancellationToken).ConfigureAwait(false);
 
         return FilterAndOrderPackages(allPackagesWithType);
     }
@@ -203,10 +203,10 @@ internal partial class VisualStudioSymbolSearchService(
     }
 
     public async ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
     {
         var engine = await GetEngineAsync(cancellationToken).ConfigureAwait(false);
         return await engine.FindReferenceAssembliesAsync(
-            name, arity, isNamespace, cancellationToken).ConfigureAwait(false);
+            typeName, arity, namespaceNames, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 internal interface IRemoteSymbolSearchUpdateService
 {
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 internal interface IRemoteSymbolSearchUpdateService
 {
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 internal interface IRemoteSymbolSearchUpdateService
 {
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 internal interface IRemoteSymbolSearchUpdateService
 {
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -21,7 +21,12 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 [DataContract]
 internal readonly record struct TypeQuery(
     [property: DataMember(Order = 0)] string Name,
-    [property: DataMember(Order = 1)] int Arity);
+    [property: DataMember(Order = 1)] int Arity)
+{
+    public static readonly TypeQuery Default = default;
+
+    public bool IsDefault => string.IsNullOrEmpty(Name);
+}
 
 /// <param name="Names">The names comprising the namespace being searched for.  For example <c>["System", "Collections",
 /// "Immutable"]</c>.</param>
@@ -29,6 +34,8 @@ internal readonly record struct TypeQuery(
 internal readonly record struct NamespaceQuery(
     [property: DataMember(Order = 0)] ImmutableArray<string> Names)
 {
+    public static readonly NamespaceQuery Default = default;
+
     public static implicit operator NamespaceQuery(ImmutableArray<string> names)
         => new(names);
 

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -24,7 +24,7 @@ internal interface ISymbolSearchService : IWorkspaceService
     /// Implementations should return results in order from best to worst (from their perspective).
     /// </summary>
     ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
-        string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
 
     /// <summary>
     /// Searches for packages that contain an assembly with the provided name. Note: Implementations are free to return
@@ -45,7 +45,7 @@ internal interface ISymbolSearchService : IWorkspaceService
     /// perspective).
     /// </summary>
     ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
 }
 
 [DataContract]
@@ -127,12 +127,12 @@ internal sealed class ReferenceAssemblyResult(
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class DefaultSymbolSearchService() : ISymbolSearchService
 {
-    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageResult>.Empty);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -23,7 +23,7 @@ internal interface ISymbolSearchService : IWorkspaceService
     /// 
     /// Implementations should return results in order from best to worst (from their perspective).
     /// </summary>
-    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(
+    ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
         string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 
     /// <summary>
@@ -44,33 +44,27 @@ internal interface ISymbolSearchService : IWorkspaceService
     /// Implementations should return results in order from best to worst (from their
     /// perspective).
     /// </summary>
-    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+    ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
         string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 }
 
 [DataContract]
-internal abstract class PackageResult
+internal abstract class AbstractPackageResult(string packageName, int rank)
 {
     [DataMember(Order = 0)]
-    public readonly string PackageName;
+    public readonly string PackageName = packageName;
 
     [DataMember(Order = 1)]
-    public readonly int Rank;
-
-    protected PackageResult(string packageName, int rank)
-    {
-        PackageName = packageName;
-        Rank = rank;
-    }
+    public readonly int Rank = rank;
 }
 
 [DataContract]
-internal sealed class PackageWithTypeResult(
+internal sealed class PackageResult(
     string packageName,
     int rank,
     string typeName,
     string? version,
-    ImmutableArray<string> containingNamespaceNames) : PackageResult(packageName, rank)
+    ImmutableArray<string> containingNamespaceNames) : AbstractPackageResult(packageName, rank)
 {
     [DataMember(Order = 2)]
     public readonly string TypeName = typeName;
@@ -86,7 +80,7 @@ internal sealed class PackageWithTypeResult(
 internal sealed class PackageWithAssemblyResult(
     string packageName,
     int rank,
-    string version) : PackageResult(packageName, rank), IEquatable<PackageWithAssemblyResult?>, IComparable<PackageWithAssemblyResult?>
+    string version) : AbstractPackageResult(packageName, rank), IEquatable<PackageWithAssemblyResult?>, IComparable<PackageWithAssemblyResult?>
 {
     [DataMember(Order = 2)]
     public readonly string? Version = version;
@@ -113,7 +107,7 @@ internal sealed class PackageWithAssemblyResult(
 }
 
 [DataContract]
-internal sealed class ReferenceAssemblyWithTypeResult(
+internal sealed class ReferenceAssemblyResult(
     string assemblyName,
     string typeName,
     ImmutableArray<string> containingNamespaceNames)
@@ -133,12 +127,12 @@ internal sealed class ReferenceAssemblyWithTypeResult(
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class DefaultSymbolSearchService() : ISymbolSearchService
 {
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-        => ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        => ValueTaskFactory.FromResult(ImmutableArray<PackageResult>.Empty);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-        => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyResult>.Empty);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -17,24 +17,20 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 internal interface ISymbolSearchService : IWorkspaceService
 {
     /// <summary>
-    /// Searches for packages that contain a type with the provided name and arity.
-    /// Note: Implementations are free to return the results they feel best for the
-    /// given data.  Specifically, they can do exact or fuzzy matching on the name.
-    /// They can use or ignore the arity depending on their capabilities. 
+    /// Searches for packages that contain a type with the provided name and arity. Note: Implementations are free to
+    /// return the results they feel best for the given data.  Specifically, they can do exact or fuzzy matching on the
+    /// name. They can use or ignore the arity depending on their capabilities. 
     /// 
-    /// Implementations should return results in order from best to worst (from their
-    /// perspective).
+    /// Implementations should return results in order from best to worst (from their perspective).
     /// </summary>
-    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-        string source, string name, int arity, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(
+        string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Searches for packages that contain an assembly with the provided name.
-    /// Note: Implementations are free to return the results they feel best for the
-    /// given data.  Specifically, they can do exact or fuzzy matching on the name.
+    /// Searches for packages that contain an assembly with the provided name. Note: Implementations are free to return
+    /// the results they feel best for the given data.  Specifically, they can do exact or fuzzy matching on the name.
     /// 
-    /// Implementations should return results in order from best to worst (from their
-    /// perspective).
+    /// Implementations should return results in order from best to worst (from their perspective).
     /// </summary>
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
         string source, string assemblyName, CancellationToken cancellationToken);
@@ -48,8 +44,8 @@ internal interface ISymbolSearchService : IWorkspaceService
     /// Implementations should return results in order from best to worst (from their
     /// perspective).
     /// </summary>
-    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-        string name, int arity, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+        string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 }
 
 [DataContract]
@@ -133,20 +129,16 @@ internal sealed class ReferenceAssemblyWithTypeResult(
 }
 
 [ExportWorkspaceService(typeof(ISymbolSearchService)), Shared]
-internal sealed class DefaultSymbolSearchService : ISymbolSearchService
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class DefaultSymbolSearchService() : ISymbolSearchService
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public DefaultSymbolSearchService()
-    {
-    }
-
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithTypeResult>.Empty);
 
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -18,11 +18,16 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 /// would have the name <c>ImmutableArray</c></param>
 /// <param name="Arity">The arity of the type.  For example <see cref="ImmutableArray{T}"/> would have arity
 /// <c>1</c></param>.
-internal readonly record struct TypeQuery(string Name, int Arity);
+[DataContract]
+internal readonly record struct TypeQuery(
+    [property: DataMember(Order = 0)] string Name,
+    [property: DataMember(Order = 1)] int Arity);
 
 /// <param name="Names">The names comprising the namespace being searched for.  For example <c>["System", "Collections",
 /// "Immutable"]</c>.</param>
-internal readonly record struct NamespaceQuery(ImmutableArray<string> Names)
+[DataContract]
+internal readonly record struct NamespaceQuery(
+    [property: DataMember(Order = 0)] ImmutableArray<string> Names)
 {
     public static implicit operator NamespaceQuery(ImmutableArray<string> names)
         => new(names);

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -26,6 +26,8 @@ internal readonly record struct NamespaceQuery(ImmutableArray<string> Names)
 {
     public static implicit operator NamespaceQuery(ImmutableArray<string> names)
         => new(names);
+
+    public bool IsDefault => Names.IsDefaultOrEmpty;
 }
 
 internal interface ISymbolSearchService : IWorkspaceService

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
@@ -18,9 +18,9 @@ internal interface ISymbolSearchUpdateEngine : IDisposable
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
 
     ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
-        string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
+        string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
         string source, string assemblyName, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
+        TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
@@ -19,10 +19,10 @@ internal interface ISymbolSearchUpdateEngine : IDisposable
 {
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
 
-    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(
+    ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
         string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
         string source, string assemblyName, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+    ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
         string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading;
@@ -20,9 +18,9 @@ internal interface ISymbolSearchUpdateEngine : IDisposable
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
 
     ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(
-        string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
         string source, string assemblyName, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(
-        string name, int arity, bool isNamespace, CancellationToken cancellationToken);
+        string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
@@ -19,10 +19,10 @@ internal interface ISymbolSearchUpdateEngine : IDisposable
 {
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
 
-    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-        string source, string name, int arity, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(
+        string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
         string source, string assemblyName, CancellationToken cancellationToken);
-    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-        string name, int arity, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(
+        string name, int arity, bool isNamespace, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -103,13 +103,13 @@ internal sealed class RemoteMissingImportDiscoveryService(
         private readonly RemoteCallback<IRemoteMissingImportDiscoveryService.ICallback> _callback = callback;
         private readonly RemoteServiceCallbackId _callbackId = callbackId;
 
-        public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesAsync(_callbackId, source, name, arity, isNamespace, cancellationToken), cancellationToken);
+        public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesAsync(_callbackId, source, typeName, arity, namespaceNames, cancellationToken), cancellationToken);
 
         public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
             => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesWithAssemblyAsync(_callbackId, source, assemblyName, cancellationToken), cancellationToken);
 
-        public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
-            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindReferenceAssembliesAsync(_callbackId, name, arity, isNamespace, cancellationToken), cancellationToken);
+        public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindReferenceAssembliesAsync(_callbackId, typeName, arity, namespaceNames, cancellationToken), cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -103,13 +103,13 @@ internal sealed class RemoteMissingImportDiscoveryService(
         private readonly RemoteCallback<IRemoteMissingImportDiscoveryService.ICallback> _callback = callback;
         private readonly RemoteServiceCallbackId _callbackId = callbackId;
 
-        public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
-            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesAsync(_callbackId, source, typeName, arity, namespaceNames, cancellationToken), cancellationToken);
+        public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
+            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesAsync(_callbackId, source, typeQuery, namespaceQuery, cancellationToken), cancellationToken);
 
         public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
             => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesWithAssemblyAsync(_callbackId, source, assemblyName, cancellationToken), cancellationToken);
 
-        public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
-            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindReferenceAssembliesAsync(_callbackId, typeName, arity, namespaceNames, cancellationToken), cancellationToken);
+        public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
+            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindReferenceAssembliesAsync(_callbackId, typeQuery, namespaceQuery, cancellationToken), cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -103,13 +103,13 @@ internal sealed class RemoteMissingImportDiscoveryService(
         private readonly RemoteCallback<IRemoteMissingImportDiscoveryService.ICallback> _callback = callback;
         private readonly RemoteServiceCallbackId _callbackId = callbackId;
 
-        public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
-            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesWithTypeAsync(_callbackId, source, name, arity, cancellationToken), cancellationToken);
+        public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesAsync(_callbackId, source, name, arity, isNamespace, cancellationToken), cancellationToken);
 
         public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
             => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesWithAssemblyAsync(_callbackId, source, assemblyName, cancellationToken), cancellationToken);
 
-        public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
-            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindReferenceAssembliesWithTypeAsync(_callbackId, name, arity, cancellationToken), cancellationToken);
+        public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+            => _callback.InvokeAsync((callback, cancellationToken) => callback.FindReferenceAssembliesAsync(_callbackId, name, arity, isNamespace, cancellationToken), cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -103,13 +103,13 @@ internal sealed class RemoteMissingImportDiscoveryService(
         private readonly RemoteCallback<IRemoteMissingImportDiscoveryService.ICallback> _callback = callback;
         private readonly RemoteServiceCallbackId _callbackId = callbackId;
 
-        public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
             => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesAsync(_callbackId, source, name, arity, isNamespace, cancellationToken), cancellationToken);
 
         public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
             => _callback.InvokeAsync((callback, cancellationToken) => callback.FindPackagesWithAssemblyAsync(_callbackId, source, assemblyName, cancellationToken), cancellationToken);
 
-        public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+        public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
             => _callback.InvokeAsync((callback, cancellationToken) => callback.FindReferenceAssembliesAsync(_callbackId, name, arity, isNamespace, cancellationToken), cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
@@ -33,7 +33,7 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
             _updateEngine.FindPackagesAsync(source, name, arity, isNamespace, cancellationToken),
@@ -47,7 +47,7 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
             _updateEngine.FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken),

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
@@ -33,10 +33,10 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
-            _updateEngine.FindPackagesWithTypeAsync(source, name, arity, cancellationToken),
+            _updateEngine.FindPackagesAsync(source, name, arity, isNamespace, cancellationToken),
             cancellationToken);
     }
 
@@ -47,10 +47,10 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
-            _updateEngine.FindReferenceAssembliesWithTypeAsync(name, arity, cancellationToken),
+            _updateEngine.FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken),
             cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
@@ -33,10 +33,10 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
-            _updateEngine.FindPackagesAsync(source, name, arity, isNamespace, cancellationToken),
+            _updateEngine.FindPackagesAsync(source, typeName, arity, namespaceNames, cancellationToken),
             cancellationToken);
     }
 
@@ -47,10 +47,10 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string name, int arity, bool isNamespace, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
-            _updateEngine.FindReferenceAssembliesAsync(name, arity, isNamespace, cancellationToken),
+            _updateEngine.FindReferenceAssembliesAsync(typeName, arity, namespaceNames, cancellationToken),
             cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolSearchUpdate/RemoteSymbolSearchUpdateService.cs
@@ -33,10 +33,10 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<PackageResult>> FindPackagesAsync(string source, TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
-            _updateEngine.FindPackagesAsync(source, typeName, arity, namespaceNames, cancellationToken),
+            _updateEngine.FindPackagesAsync(source, typeQuery, namespaceQuery, cancellationToken),
             cancellationToken);
     }
 
@@ -47,10 +47,10 @@ internal sealed class RemoteSymbolSearchUpdateService : BrokeredServiceBase, IRe
             cancellationToken);
     }
 
-    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(string typeName, int arity, ImmutableArray<string> namespaceNames, CancellationToken cancellationToken)
+    public ValueTask<ImmutableArray<ReferenceAssemblyResult>> FindReferenceAssembliesAsync(TypeQuery typeQuery, NamespaceQuery namespaceQuery, CancellationToken cancellationToken)
     {
         return RunServiceAsync(cancellationToken =>
-            _updateEngine.FindReferenceAssembliesAsync(typeName, arity, namespaceNames, cancellationToken),
+            _updateEngine.FindReferenceAssembliesAsync(typeQuery, namespaceQuery, cancellationToken),
             cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/CompilationUnitSyntaxExtensions.cs
@@ -18,15 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions;
 
 internal static partial class CompilationUnitSyntaxExtensions
 {
-    public static bool CanAddUsingDirectives(this SyntaxNode contextNode, bool allowInHiddenRegions, CancellationToken cancellationToken)
+    public static bool CanAddUsingDirectives(
+        this SyntaxNode contextNode, bool allowInHiddenRegions, CancellationToken cancellationToken)
     {
-        var usingDirectiveAncestor = contextNode.GetAncestor<UsingDirectiveSyntax>();
-        if (usingDirectiveAncestor?.Parent is CompilationUnitSyntax)
-        {
-            // We are inside a top level using directive (i.e. one that's directly in the compilation unit).
-            return false;
-        }
-
         if (!allowInHiddenRegions && contextNode.SyntaxTree.HasHiddenRegions())
         {
             var namespaceDeclaration = contextNode.GetInnermostNamespaceDeclarationWithUsings();
@@ -34,14 +28,7 @@ internal static partial class CompilationUnitSyntaxExtensions
             var span = GetUsingsSpan(root, namespaceDeclaration);
 
             if (contextNode.SyntaxTree.OverlapsHiddenPosition(span, cancellationToken))
-            {
                 return false;
-            }
-        }
-
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return false;
         }
 
         return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpAddImportsService.cs
@@ -21,15 +21,11 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp.AddImport;
 
 [ExportLanguageService(typeof(IAddImportsService), LanguageNames.CSharp), Shared]
-internal sealed class CSharpAddImportsService : AbstractAddImportsService<
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpAddImportsService() : AbstractAddImportsService<
     CompilationUnitSyntax, BaseNamespaceDeclarationSyntax, UsingDirectiveSyntax, ExternAliasDirectiveSyntax>
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpAddImportsService()
-    {
-    }
-
     protected override string Language
         => LanguageNames.CSharp;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
@@ -16,11 +16,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
     Friend Module CompilationUnitSyntaxExtensions
         <Extension>
-        Public Function CanAddImportsStatements(contextNode As SyntaxNode, allowInHiddenRegions As Boolean, cancellationToken As CancellationToken) As Boolean
-            If contextNode.GetAncestor(Of ImportsStatementSyntax)() IsNot Nothing Then
-                Return False
-            End If
-
+        Public Function CanAddImportsStatements(
+                contextNode As SyntaxNode,
+                allowInHiddenRegions As Boolean,
+                cancellationToken As CancellationToken) As Boolean
             If allowInHiddenRegions Then
                 Return True
             End If


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/8788.

Looks like this:

![image](https://github.com/user-attachments/assets/1be1bedb-a2ff-4a28-b584-851970dcb47d)

The basic idea was simple.  remove the restriction that disabled the feature within a using/import.  But also made it so we only search for packages/references in that context, using the same indices we already have.