### PR TITLE
Internally identify interceptions by content hash

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2427,16 +2427,35 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal bool InterceptorsDiscoveryComplete;
 
-        // NB: the 'Many' case for these dictionary values means there are duplicates. An error is reported for this after binding.
-        private ConcurrentDictionary<(string FilePath, int Position), OneOrMany<(Location AttributeLocation, MethodSymbol Interceptor)>>? _interceptions;
+        private sealed class InterceptorKeyComparer : IEqualityComparer<(ImmutableArray<byte> ContentHash, int Position)>
+        {
+            private InterceptorKeyComparer() { }
+            public static InterceptorKeyComparer Instance { get; } = new InterceptorKeyComparer();
 
-        internal void AddInterception(string filePath, int position, Location attributeLocation, MethodSymbol interceptor)
+            public bool Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)
+            {
+                return x.ContentHash.SequenceEqual(y.ContentHash) && x.Position == y.Position;
+            }
+
+            public int GetHashCode((ImmutableArray<byte> ContentHash, int Position) obj)
+            {
+                return Hash.Combine(
+                    BinaryPrimitives.ReadInt32LittleEndian(obj.ContentHash.AsSpan()),
+                    obj.Position);
+            }
+        }
+
+        // NB: the 'Many' case for these dictionary values means there are duplicates. An error is reported for this after binding.
+        private ConcurrentDictionary<(ImmutableArray<byte> ContentHash, int Position), OneOrMany<(Location AttributeLocation, MethodSymbol Interceptor)>>? _interceptions;
+
+        internal void AddInterception(ImmutableArray<byte> contentHash, int position, Location attributeLocation, MethodSymbol interceptor)
         {
             Debug.Assert(!_declarationDiagnosticsFrozen);
             Debug.Assert(!InterceptorsDiscoveryComplete);
 
-            var dictionary = LazyInitializer.EnsureInitialized(ref _interceptions);
-            dictionary.AddOrUpdate((filePath, position),
+            var dictionary = LazyInitializer.EnsureInitialized(ref _interceptions,
+                () => new ConcurrentDictionary<(ImmutableArray<byte> ContentHash, int Position), OneOrMany<(Location AttributeLocation, MethodSymbol Interceptor)>>(comparer: InterceptorKeyComparer.Instance));
+            dictionary.AddOrUpdate((contentHash, position),
                 addValueFactory: static (key, newValue) => OneOrMany.Create(newValue),
                 updateValueFactory: static (key, existingValues, newValue) =>
                 {
@@ -2469,7 +2488,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            var key = (node.SyntaxTree.FilePath, node.Position);
+            var key = (node.SyntaxTree.GetText().GetContentHash(), node.Position);
             if (_interceptions.TryGetValue(key, out var interceptionsAtAGivenLocation) && interceptionsAtAGivenLocation is [var oneInterception])
             {
                 return oneInterception;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2427,10 +2427,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal bool InterceptorsDiscoveryComplete;
 
+        /// <remarks>Equals and GetHashCode on this type intentionally resemble corresponding methods on <see cref="InterceptableLocation1"/>.</remarks>
         private sealed class InterceptorKeyComparer : IEqualityComparer<(ImmutableArray<byte> ContentHash, int Position)>
         {
             private InterceptorKeyComparer() { }
-            public static InterceptorKeyComparer Instance { get; } = new InterceptorKeyComparer();
+            public static readonly InterceptorKeyComparer Instance = new InterceptorKeyComparer();
 
             public bool Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -1103,7 +1103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            DeclaringCompilation.AddInterception(matchingTree.FilePath, position, attributeLocation, this);
+            DeclaringCompilation.AddInterception(matchingTree.GetText().GetContentHash(), position, attributeLocation, this);
 
             // Caller must free the returned builder.
             static ArrayBuilder<string> getNamespaceNames(SourceMethodSymbol @this)
@@ -1316,7 +1316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            DeclaringCompilation.AddInterception(matchingTree.FilePath, referencedToken.Position, attributeLocation, this);
+            DeclaringCompilation.AddInterception(matchingTree.GetText().GetContentHash(), referencedToken.Position, attributeLocation, this);
 
             // Caller must free the returned builder.
             ArrayBuilder<string> getNamespaceNames()


### PR DESCRIPTION
Closes #76341 

Tests that would be impacted by this change are indicated by https://github.com/dotnet/roslyn/commit/ddc9b84e126b20a054e40434f24f5b3ec7ad7e8f (i.e. the workaround of specifying path in that commit would no longer be necessary.)