### PR TITLE
Do not bail generating base type initializer in the presence of use site warnings

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7197,7 +7197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return succeededConsideringAccessibility;
         }
 
-        internal static bool ReportConstructorUseSiteDiagnostics(Location errorLocation, BindingDiagnosticBag diagnostics, bool suppressUnsupportedRequiredMembersError, in CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        internal static void ReportConstructorUseSiteDiagnostics(Location errorLocation, BindingDiagnosticBag diagnostics, bool suppressUnsupportedRequiredMembersError, in CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (suppressUnsupportedRequiredMembersError && useSiteInfo.AccumulatesDiagnostics && useSiteInfo.Diagnostics is { Count: not 0 })
             {
@@ -7213,12 +7213,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     diagnostics.ReportUseSiteDiagnostic(diagnostic, errorLocation);
                 }
-
-                return true;
             }
             else
             {
-                return diagnostics.Add(errorLocation, useSiteInfo);
+                diagnostics.Add(errorLocation, useSiteInfo);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3988,10 +3988,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var constructorUseSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, constructor.ContainingAssembly);
             constructorUseSiteInfo.Add(baseConstructor.GetUseSiteInfo());
-            if (Binder.ReportConstructorUseSiteDiagnostics(diagnosticsLocation, diagnostics, suppressUnsupportedRequiredMembersError: constructor.HasSetsRequiredMembers, constructorUseSiteInfo))
-            {
-                return null;
-            }
+            Binder.ReportConstructorUseSiteDiagnostics(diagnosticsLocation, diagnostics, suppressUnsupportedRequiredMembersError: constructor.HasSetsRequiredMembers, constructorUseSiteInfo);
 
             diagnostics.Add(diagnosticsLocation, useSiteInfo);
 

--- a/src/Compilers/CSharp/Test/Emit3/Microsoft.CodeAnalysis.CSharp.Emit3.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/Emit3/Microsoft.CodeAnalysis.CSharp.Emit3.UnitTests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.DiaSymReader" />
     <PackageReference Include="Basic.Reference.Assemblies.Net50" />
     <PackageReference Include="Basic.Reference.Assemblies.Net60" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net70" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" />
     <PackageReference Include="Basic.Reference.Assemblies.Net90" />
   </ItemGroup>

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
@@ -14097,7 +14097,7 @@ record A(int X)
                 public record DerivedRecord : BaseRecord;
                 """, assemblyName: "Derived", references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80);
 
-            var verifier = CompileAndVerify(comp2, expectedOutput: "False", verify: Verification.FailsPEVerify);
+            var verifier = CompileAndVerify(comp2, expectedOutput: ExecutionConditionUtil.IsCoreClr ? "False" : null, verify: Verification.FailsPEVerify);
 
             // Historical note: These warnings were the cause of the bug, so they are not being suppressed
             var expectedDiagnostic =

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
@@ -14073,6 +14073,51 @@ record A(int X)
             CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "123").VerifyDiagnostics();
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72357")]
+        public void CopyCtor_AssemblyWarnings()
+        {
+            var comp1 = CreateCompilation("""
+                public record BaseRecord
+                {
+                    public required object Object1 { get; init; }
+                    public required object Object2 { get; init; }
+                }
+                """, assemblyName: "Base", targetFramework: TargetFramework.Net70);
+
+            var comp2 = CreateCompilation("""
+                var sut = new DerivedRecord
+                {
+                    Object1 = new object(),
+                    Object2 = new object()
+                };
+
+                var broken = sut with { Object2 = new object()};
+                System.Console.Write(broken.Object1 is null);
+
+                public record DerivedRecord : BaseRecord;
+                """, assemblyName: "Derived", references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80);
+
+            var verifier = CompileAndVerify(comp2, expectedOutput: "False");
+
+            // Historical note: These warnings were the cause of the bug, so they are not being suppressed
+            var expectedDiagnostic =
+                // warning CS1701: Assuming assembly reference 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by 'Base' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin).WithArguments("System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "Base", "System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Runtime").WithLocation(1, 1);
+
+            verifier.VerifyDiagnostics(Enumerable.Repeat(expectedDiagnostic, 21).ToArray());
+
+            verifier.VerifyIL("DerivedRecord..ctor(DerivedRecord)", """
+                {
+                  // Code size        8 (0x8)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldarg.1
+                  IL_0002:  call       "BaseRecord..ctor(BaseRecord)"
+                  IL_0007:  ret
+                }
+                """);
+        }
+
         [Fact]
         public void Deconstruct_Simple()
         {

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
@@ -14097,7 +14097,7 @@ record A(int X)
                 public record DerivedRecord : BaseRecord;
                 """, assemblyName: "Derived", references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80);
 
-            var verifier = CompileAndVerify(comp2, expectedOutput: "False");
+            var verifier = CompileAndVerify(comp2, expectedOutput: "False", verify: Verification.FailsPEVerify);
 
             // Historical note: These warnings were the cause of the bug, so they are not being suppressed
             var expectedDiagnostic =


### PR DESCRIPTION
We were returning early from generating a call to the base record copy constructor initializer if use site diagnostics reported any kind of diagnostic, including warnings. This isn't good in general, but is particularly bad for warnings like CS1701, which are typically suppressed by the SDK and results in what seems like a completely clean csc invocation skipping calling the base constructor. Fixes https://github.com/dotnet/roslyn/issues/72357.
