### PR TITLE
Implement editorconfig serializer for naming style preferences

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
@@ -2,27 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.NamingStyles;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.SymbolSpecification;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyles;
 
-public static class EditorConfigNamingStyleParserTests
+public class EditorConfigNamingStyleParserTests
 {
     private static NamingStylePreferences ParseDictionary(Dictionary<string, string> options)
         => EditorConfigNamingStyleParser.ParseDictionary(new DictionaryAnalyzerConfigOptions(options.ToImmutableDictionary()));
 
     [Fact]
-    public static void TestPascalCaseRule()
+    public void TestPascalCaseRule()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -70,7 +69,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40705")]
-    public static void TestPascalCaseRuleWithKeyCapitalization()
+    public void TestPascalCaseRuleWithKeyCapitalization()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -91,7 +90,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestAsyncMethodsAndLocalFunctionsRule()
+    public void TestAsyncMethodsAndLocalFunctionsRule()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -133,7 +132,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestRuleWithoutCapitalization()
+    public void TestRuleWithoutCapitalization()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -150,7 +149,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestPublicMembersCapitalizedRule()
+    public void TestPublicMembersCapitalizedRule()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -198,7 +197,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestNonPublicMembersLowerCaseRule()
+    public void TestNonPublicMembersLowerCaseRule()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -240,7 +239,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestParametersAndLocalsAreCamelCaseRule()
+    public void TestParametersAndLocalsAreCamelCaseRule()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -283,7 +282,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestLocalFunctionsAreCamelCaseRule()
+    public void TestLocalFunctionsAreCamelCaseRule()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -322,7 +321,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestNoRulesAreReturned()
+    public void TestNoRulesAreReturned()
     {
         var dictionary = new Dictionary<string, string>()
         {
@@ -347,7 +346,7 @@ public static class EditorConfigNamingStyleParserTests
     [InlineData("invalid", new object[] { })]
     [InlineData("", new object[] { })]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20907")]
-    public static void TestApplicableKindsParse(string specification, object[] typeOrSymbolKinds)
+    public void TestApplicableKindsParse(string specification, object[] typeOrSymbolKinds)
     {
         var rule = new Dictionary<string, string>()
         {
@@ -378,7 +377,7 @@ public static class EditorConfigNamingStyleParserTests
     [InlineData("invalid", new Accessibility[] { })]
     [InlineData("", new Accessibility[] { })]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20907")]
-    public static void TestApplicableAccessibilitiesParse(string specification, Accessibility[] accessibilities)
+    public void TestApplicableAccessibilitiesParse(string specification, Accessibility[] accessibilities)
     {
         var rule = new Dictionary<string, string>()
         {
@@ -398,7 +397,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestRequiredModifiersParse()
+    public void TestRequiredModifiersParse()
     {
         var charpRule = new Dictionary<string, string>()
         {
@@ -427,7 +426,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38513")]
-    public static void TestPrefixParse()
+    public void TestPrefixParse()
     {
         var rule = new Dictionary<string, string>()
         {
@@ -461,7 +460,7 @@ public static class EditorConfigNamingStyleParserTests
     }
 
     [Fact]
-    public static void TestEditorConfigParseForApplicableSymbolKinds()
+    public void TestEditorConfigParseForApplicableSymbolKinds()
     {
         var symbolSpecifications = CreateDefaultSymbolSpecification();
         foreach (var applicableSymbolKind in symbolSpecifications.ApplicableSymbolKindList)
@@ -484,7 +483,7 @@ public static class EditorConfigNamingStyleParserTests
     [InlineData("B", "a", "a", "*", "*")]
     [InlineData("A", "B", "A", "*", "*")]
     [InlineData("B", "A", "A", "*", "*")]
-    public static void TestOrderedByAccessibilityBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstAccessibility, string secondAccessibility)
+    public void TestOrderedByAccessibilityBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstAccessibility, string secondAccessibility)
     {
         var namingStylePreferences = ParseDictionary(new Dictionary<string, string>()
         {
@@ -520,7 +519,7 @@ public static class EditorConfigNamingStyleParserTests
     [InlineData("B", "a", "a", "", "")]
     [InlineData("A", "B", "A", "", "")]
     [InlineData("B", "A", "A", "", "")]
-    public static void TestOrderedByModifiersBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstModifiers, string secondModifiers)
+    public void TestOrderedByModifiersBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstModifiers, string secondModifiers)
     {
         var namingStylePreferences = ParseDictionary(new Dictionary<string, string>()
         {
@@ -556,7 +555,7 @@ public static class EditorConfigNamingStyleParserTests
     [InlineData("B", "a", "a", "*", "*")]
     [InlineData("A", "B", "A", "*", "*")]
     [InlineData("B", "A", "A", "*", "*")]
-    public static void TestOrderedBySymbolsBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstSymbols, string secondSymbols)
+    public void TestOrderedBySymbolsBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstSymbols, string secondSymbols)
     {
         var namingStylePreferences = ParseDictionary(new Dictionary<string, string>()
         {
@@ -575,5 +574,122 @@ public static class EditorConfigNamingStyleParserTests
         var secondNameAfterOrdering = firstNameAfterOrdering == firstName ? secondName : firstName;
         Assert.Equal($"{firstNameAfterOrdering}_style", namingStylePreferences.Rules.NamingRules[0].NamingStyle.Name);
         Assert.Equal($"{secondNameAfterOrdering}_style", namingStylePreferences.Rules.NamingRules[1].NamingStyle.Name);
+    }
+
+    /// <summary>
+    /// Two rules with different names but same specification.
+    /// </summary>
+    [Fact]
+    public void DuplicateRuleKeys()
+    {
+        var dictionary = new Dictionary<string, string>()
+        {
+            ["dotnet_naming_rule.R1.severity"] = "warning",
+            ["dotnet_naming_rule.R1.symbols"] = "SYMBOLS",
+            ["dotnet_naming_rule.R1.style"] = "STYLE",
+
+            ["dotnet_naming_rule.R2.severity"] = "warning",
+            ["dotnet_naming_rule.R2.symbols"] = "SYMBOLS",
+            ["dotnet_naming_rule.R2.style"] = "STYLE",
+
+            ["dotnet_naming_symbols.SYMBOLS.applicable_kinds"] = "method",
+            ["dotnet_naming_symbols.SYMBOLS.applicable_accessibilities"] = "*",
+            ["dotnet_naming_style.STYLE.capitalization"] = "pascal_case",
+        };
+
+        var result = ParseDictionary(dictionary);
+
+        AssertEx.AssertEqualToleratingWhitespaceDifferences("""
+            <NamingPreferencesInfo SerializationVersion="5">
+              <SymbolSpecifications>
+                <SymbolSpecification ID="0" Name="SYMBOLS">
+                  <ApplicableSymbolKindList>
+                    <MethodKind>Ordinary</MethodKind>
+                  </ApplicableSymbolKindList>
+                  <ApplicableAccessibilityList>
+                    <AccessibilityKind>NotApplicable</AccessibilityKind>
+                    <AccessibilityKind>Public</AccessibilityKind>
+                    <AccessibilityKind>Internal</AccessibilityKind>
+                    <AccessibilityKind>Private</AccessibilityKind>
+                    <AccessibilityKind>Protected</AccessibilityKind>
+                    <AccessibilityKind>ProtectedAndInternal</AccessibilityKind>
+                    <AccessibilityKind>ProtectedOrInternal</AccessibilityKind>
+                  </ApplicableAccessibilityList>
+                  <RequiredModifierList />
+                </SymbolSpecification>
+                <SymbolSpecification ID="1" Name="SYMBOLS">
+                  <ApplicableSymbolKindList>
+                    <MethodKind>Ordinary</MethodKind>
+                  </ApplicableSymbolKindList>
+                  <ApplicableAccessibilityList>
+                    <AccessibilityKind>NotApplicable</AccessibilityKind>
+                    <AccessibilityKind>Public</AccessibilityKind>
+                    <AccessibilityKind>Internal</AccessibilityKind>
+                    <AccessibilityKind>Private</AccessibilityKind>
+                    <AccessibilityKind>Protected</AccessibilityKind>
+                    <AccessibilityKind>ProtectedAndInternal</AccessibilityKind>
+                    <AccessibilityKind>ProtectedOrInternal</AccessibilityKind>
+                  </ApplicableAccessibilityList>
+                  <RequiredModifierList />
+                </SymbolSpecification>
+              </SymbolSpecifications>
+              <NamingStyles>
+                <NamingStyle ID="2" Name="STYLE" Prefix="" Suffix="" WordSeparator="" CapitalizationScheme="PascalCase" />
+                <NamingStyle ID="3" Name="STYLE" Prefix="" Suffix="" WordSeparator="" CapitalizationScheme="PascalCase" />
+              </NamingStyles>
+              <NamingRules>
+                <SerializableNamingRule SymbolSpecificationID="4" NamingStyleID="5" EnforcementLevel="Warning" />
+                <SerializableNamingRule SymbolSpecificationID="6" NamingStyleID="7" EnforcementLevel="Warning" />
+              </NamingRules>
+            </NamingPreferencesInfo>
+            """,
+            result.Inspect());
+    }
+
+    [Fact]
+    public void Priorities()
+    {
+        var dictionary = new Dictionary<string, string>()
+        {
+            ["dotnet_naming_rule.R1.severity"] = "warning",
+            ["dotnet_naming_rule.R1.symbols"] = "SYMBOLS1",
+            ["dotnet_naming_rule.R1.style"] = "STYLE1",
+
+            ["dotnet_naming_rule.R2.severity"] = "error",
+            ["dotnet_naming_rule.R2.symbols"] = "SYMBOLS2",
+            ["dotnet_naming_rule.R2.style"] = "STYLE2",
+
+            ["dotnet_naming_symbols.SYMBOLS1.applicable_kinds"] = "method",
+            ["dotnet_naming_symbols.SYMBOLS1.applicable_accessibilities"] = "*",
+            ["dotnet_naming_style.STYLE1.capitalization"] = "pascal_case",
+
+            ["dotnet_naming_symbols.SYMBOLS2.applicable_kinds"] = "method, field",
+            ["dotnet_naming_symbols.SYMBOLS2.applicable_accessibilities"] = "*",
+            ["dotnet_naming_style.STYLE2.capitalization"] = "pascal_case",
+        };
+
+        AssertEx.AssertEqualToleratingWhitespaceDifferences("""
+            <NamingPreferencesInfo SerializationVersion="5">
+              <NamingRules>
+                <SerializableNamingRule SymbolSpecificationID="0" NamingStyleID="1" EnforcementLevel="Warning" />
+                <SerializableNamingRule SymbolSpecificationID="2" NamingStyleID="3" EnforcementLevel="Error" />
+              </NamingRules>
+            </NamingPreferencesInfo>
+            """,
+            ParseDictionary(dictionary).Inspect(excludeNodes: ["SymbolSpecifications", "NamingStyles"]));
+
+        // adding priorities reverses the order:
+        dictionary.Add("dotnet_naming_rule.R1.priority", "0");
+        dictionary.Add("dotnet_naming_rule.R2.priority", "1");
+
+        AssertEx.AssertEqualToleratingWhitespaceDifferences("""
+            <NamingPreferencesInfo SerializationVersion="5">
+              <NamingRules>
+                <SerializableNamingRule SymbolSpecificationID="0" NamingStyleID="1" EnforcementLevel="Error" />
+                <SerializableNamingRule SymbolSpecificationID="2" NamingStyleID="3" EnforcementLevel="Warning" />
+              </NamingRules>
+            </NamingPreferencesInfo>
+            """,
+            ParseDictionary(dictionary).Inspect(excludeNodes: ["SymbolSpecifications", "NamingStyles"]));
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.NamingStyles;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.UnitTests;
 using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.SymbolSpecification;
@@ -17,9 +18,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
 
 public class EditorConfigNamingStyleParserTests
 {
-    private static NamingStylePreferences ParseDictionary(Dictionary<string, string> options)
-        => EditorConfigNamingStyleParser.ParseDictionary(new DictionaryAnalyzerConfigOptions(options.ToImmutableDictionary()));
-
     [Fact]
     public void TestPascalCaseRule()
     {
@@ -32,7 +30,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities"] = "*",
             ["dotnet_naming_style.pascal_case_style.capitalization"] = "pascal_case"
         };
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Single(result.NamingRules);
         var namingRule = result.NamingRules.Single();
         Assert.Single(result.NamingStyles);
@@ -80,7 +78,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities"] = "*",
             ["dotnet_naming_style.pascal_case_style.capitalization"] = "pascal_case"
         };
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         var namingRule = Assert.Single(result.NamingRules);
         var namingStyle = Assert.Single(result.NamingStyles);
         var symbolSpec = Assert.Single(result.SymbolSpecifications);
@@ -102,7 +100,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_style.end_in_async_style.capitalization "] = "pascal_case",
             ["dotnet_naming_style.end_in_async_style.required_suffix"] = "Async",
         };
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Single(result.NamingRules);
         var namingRule = result.NamingRules.Single();
         Assert.Single(result.NamingStyles);
@@ -144,7 +142,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_symbols.any_async_methods.required_modifiers"] = "async",
             ["dotnet_naming_style.end_in_async.required_suffix"] = "Async",
         };
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Empty(result.NamingStyles);
     }
 
@@ -160,7 +158,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_symbols.public_symbols.applicable_accessibilities"] = "public,internal,protected,protected_internal",
             ["dotnet_naming_style.first_word_upper_case_style.capitalization"] = "first_word_upper",
         };
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Single(result.NamingRules);
         var namingRule = result.NamingRules.Single();
         Assert.Single(result.NamingStyles);
@@ -208,7 +206,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_symbols.non_public_symbols.applicable_accessibilities"] = "private",
             ["dotnet_naming_style.all_lower_case_style.capitalization"] = "all_lower",
         };
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Single(result.NamingRules);
         var namingRule = result.NamingRules.Single();
         Assert.Single(result.NamingStyles);
@@ -250,7 +248,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_style.camel_case_style.capitalization"] = "camel_case",
         };
 
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Single(result.NamingRules);
         var namingRule = result.NamingRules.Single();
         Assert.Single(result.NamingStyles);
@@ -293,7 +291,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_style.camel_case_style.capitalization"] = "camel_case",
         };
 
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Single(result.NamingRules);
         var namingRule = result.NamingRules.Single();
         Assert.Single(result.NamingStyles);
@@ -329,7 +327,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_symbols.non_public_symbols.applicable_accessibilities"] = "private",
             ["dotnet_naming_style.all_lower_case_style.capitalization"] = "all_lower",
         };
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
         Assert.Empty(result.NamingRules);
         Assert.Empty(result.NamingStyles);
         Assert.Empty(result.SymbolSpecifications);
@@ -362,7 +360,7 @@ public class EditorConfigNamingStyleParserTests
         }
 
         var kinds = typeOrSymbolKinds.Select(NamingStylesTestOptionSets.ToSymbolKindOrTypeKind).ToArray();
-        var result = ParseDictionary(rule);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(rule);
         Assert.Equal(kinds, result.SymbolSpecifications.SelectMany(x => x.ApplicableSymbolKindList));
     }
 
@@ -392,7 +390,7 @@ public class EditorConfigNamingStyleParserTests
             rule["dotnet_naming_symbols.accessibilities.applicable_accessibilities"] = specification;
         }
 
-        var result = ParseDictionary(rule);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(rule);
         Assert.Equal(accessibilities, result.SymbolSpecifications.SelectMany(x => x.ApplicableAccessibilityList));
     }
 
@@ -416,8 +414,8 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_style.pascal_case.capitalization "] = "pascal_case",
         };
 
-        var csharpResult = ParseDictionary(charpRule);
-        var vbResult = ParseDictionary(vbRule);
+        var csharpResult = OptionsTestHelpers.ParseNamingStylePreferences(charpRule);
+        var vbResult = OptionsTestHelpers.ParseNamingStylePreferences(vbRule);
 
         Assert.Equal(csharpResult.SymbolSpecifications.SelectMany(x => x.RequiredModifierList.Select(y => y.Modifier)),
                      vbResult.SymbolSpecifications.SelectMany(x => x.RequiredModifierList.Select(y => y.Modifier)));
@@ -439,7 +437,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_rule.must_be_pascal_cased_and_prefixed.severity"] = "warning",
         };
 
-        var result = ParseDictionary(rule);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(rule);
         Assert.Single(result.NamingRules);
         var namingRule = result.NamingRules.Single();
         Assert.Single(result.NamingStyles);
@@ -485,7 +483,7 @@ public class EditorConfigNamingStyleParserTests
     [InlineData("B", "A", "A", "*", "*")]
     public void TestOrderedByAccessibilityBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstAccessibility, string secondAccessibility)
     {
-        var namingStylePreferences = ParseDictionary(new Dictionary<string, string>()
+        var namingStylePreferences = OptionsTestHelpers.ParseNamingStylePreferences(new Dictionary<string, string>()
         {
             [$"dotnet_naming_rule.{firstName}.severity"] = "error",
             [$"dotnet_naming_rule.{firstName}.symbols"] = "first_symbols",
@@ -521,7 +519,7 @@ public class EditorConfigNamingStyleParserTests
     [InlineData("B", "A", "A", "", "")]
     public void TestOrderedByModifiersBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstModifiers, string secondModifiers)
     {
-        var namingStylePreferences = ParseDictionary(new Dictionary<string, string>()
+        var namingStylePreferences = OptionsTestHelpers.ParseNamingStylePreferences(new Dictionary<string, string>()
         {
             [$"dotnet_naming_rule.{firstName}.severity"] = "error",
             [$"dotnet_naming_rule.{firstName}.symbols"] = "first_symbols",
@@ -557,7 +555,7 @@ public class EditorConfigNamingStyleParserTests
     [InlineData("B", "A", "A", "*", "*")]
     public void TestOrderedBySymbolsBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstSymbols, string secondSymbols)
     {
-        var namingStylePreferences = ParseDictionary(new Dictionary<string, string>()
+        var namingStylePreferences = OptionsTestHelpers.ParseNamingStylePreferences(new Dictionary<string, string>()
         {
             [$"dotnet_naming_rule.{firstName}.severity"] = "error",
             [$"dotnet_naming_rule.{firstName}.symbols"] = "first_symbols",
@@ -597,7 +595,7 @@ public class EditorConfigNamingStyleParserTests
             ["dotnet_naming_style.STYLE.capitalization"] = "pascal_case",
         };
 
-        var result = ParseDictionary(dictionary);
+        var result = OptionsTestHelpers.ParseNamingStylePreferences(dictionary);
 
         AssertEx.AssertEqualToleratingWhitespaceDifferences("""
             <NamingPreferencesInfo SerializationVersion="5">
@@ -638,8 +636,8 @@ public class EditorConfigNamingStyleParserTests
                 <NamingStyle ID="3" Name="STYLE" Prefix="" Suffix="" WordSeparator="" CapitalizationScheme="PascalCase" />
               </NamingStyles>
               <NamingRules>
-                <SerializableNamingRule SymbolSpecificationID="4" NamingStyleID="5" EnforcementLevel="Warning" />
-                <SerializableNamingRule SymbolSpecificationID="6" NamingStyleID="7" EnforcementLevel="Warning" />
+                <SerializableNamingRule SymbolSpecificationID="1" NamingStyleID="3" EnforcementLevel="Warning" />
+                <SerializableNamingRule SymbolSpecificationID="0" NamingStyleID="2" EnforcementLevel="Warning" />
               </NamingRules>
             </NamingPreferencesInfo>
             """,
@@ -676,11 +674,11 @@ public class EditorConfigNamingStyleParserTests
               </NamingRules>
             </NamingPreferencesInfo>
             """,
-            ParseDictionary(dictionary).Inspect(excludeNodes: ["SymbolSpecifications", "NamingStyles"]));
+            OptionsTestHelpers.ParseNamingStylePreferences(dictionary).Inspect(excludeNodes: ["SymbolSpecifications", "NamingStyles"]));
 
-        // adding priorities reverses the order:
-        dictionary.Add("dotnet_naming_rule.R1.priority", "0");
-        dictionary.Add("dotnet_naming_rule.R2.priority", "1");
+        // adding priorities reverses the order - R2 (P0) is now ordered before R1 (P1):
+        dictionary.Add("dotnet_naming_rule.R2.priority", "0");
+        dictionary.Add("dotnet_naming_rule.R1.priority", "1");
 
         AssertEx.AssertEqualToleratingWhitespaceDifferences("""
             <NamingPreferencesInfo SerializationVersion="5">
@@ -690,6 +688,6 @@ public class EditorConfigNamingStyleParserTests
               </NamingRules>
             </NamingPreferencesInfo>
             """,
-            ParseDictionary(dictionary).Inspect(excludeNodes: ["SymbolSpecifications", "NamingStyles"]));
+            OptionsTestHelpers.ParseNamingStylePreferences(dictionary).Inspect(excludeNodes: ["SymbolSpecifications", "NamingStyles"]));
     }
 }

--- a/src/Features/TestUtilities/Options/NamingStyleTestUtilities.cs
+++ b/src/Features/TestUtilities/Options/NamingStyleTestUtilities.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities;
+
+internal static class NamingStyleTestUtilities
+{
+    public static string Inspect(this NamingStylePreferences preferences, string[]? excludeNodes = null)
+    {
+        var xml = preferences.CreateXElement();
+
+        // filter out insignificant elements:
+        var elementsToRemove = new List<XElement>();
+        foreach (var element in xml.DescendantsAndSelf())
+        {
+            if (excludeNodes != null && excludeNodes.Contains(element.Name.LocalName))
+            {
+                elementsToRemove.Add(element);
+            }
+        }
+
+        foreach (var element in elementsToRemove)
+        {
+            element.Remove();
+        }
+
+        // replaces GUIDs with unique deterministic numbers:
+        var ordinal = 0;
+        var guidMap = new Dictionary<Guid, int>();
+        foreach (var element in xml.DescendantsAndSelf())
+        {
+            foreach (var attribute in element.Attributes())
+            {
+                if (Guid.TryParse(attribute.Value, out var guid))
+                {
+                    if (!guidMap.TryGetValue(guid, out var existingOrdinal))
+                    {
+                        existingOrdinal = ordinal++;
+                    }
+
+                    attribute.Value = existingOrdinal.ToString();
+                }
+            }
+        }
+
+        return xml.ToString();
+    }
+}

--- a/src/Features/TestUtilities/Options/NamingStyleTestUtilities.cs
+++ b/src/Features/TestUtilities/Options/NamingStyleTestUtilities.cs
@@ -4,14 +4,28 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.NamingStyles;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities;
 
 internal static class NamingStyleTestUtilities
 {
+    public static string Inspect(this NamingRule rule)
+        => $"{rule.NamingStyle.Inspect()} {rule.SymbolSpecification.Inspect()} {rule.EnforcementLevel}";
+
+    public static string Inspect(this NamingStyle style)
+        => $"{style.Name} prefix='{style.Prefix}' suffix='{style.Suffix}' separator='{style.WordSeparator}'";
+
+    public static string Inspect(this SymbolSpecification symbol)
+        => $"{symbol.Name} {Inspect(symbol.ApplicableSymbolKindList)} {Inspect(symbol.ApplicableAccessibilityList)} {Inspect(symbol.RequiredModifierList)}";
+
+    public static string Inspect<T>(ImmutableArray<T> items) where T : notnull
+        => string.Join(",", items.Select(item => item.ToString()));
+
     public static string Inspect(this NamingStylePreferences preferences, string[]? excludeNodes = null)
     {
         var xml = preferences.CreateXElement();
@@ -43,6 +57,7 @@ internal static class NamingStyleTestUtilities
                     if (!guidMap.TryGetValue(guid, out var existingOrdinal))
                     {
                         existingOrdinal = ordinal++;
+                        guidMap.Add(guid, existingOrdinal);
                     }
 
                     attribute.Value = existingOrdinal.ToString();

--- a/src/LanguageServer/Protocol/Features/Options/SolutionAnalyzerConfigOptionsUpdater.cs
+++ b/src/LanguageServer/Protocol/Features/Options/SolutionAnalyzerConfigOptionsUpdater.cs
@@ -95,8 +95,7 @@ internal sealed class SolutionAnalyzerConfigOptionsUpdater(IGlobalOptionService 
                                 language,
                                 entryWriter: (name, value) => lazyBuilder[name] = value,
                                 triviaWriter: null,
-                                // lower priority than any that would be specified explicitly in editorconfig:
-                                priority: int.MaxValue - preferences.NamingRules.Length);
+                                setPrioritiesToPreserveOrder: true);
                         }
                         else
                         {

--- a/src/LanguageServer/Protocol/Features/Options/SolutionAnalyzerConfigOptionsUpdater.cs
+++ b/src/LanguageServer/Protocol/Features/Options/SolutionAnalyzerConfigOptionsUpdater.cs
@@ -8,9 +8,9 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -86,8 +86,22 @@ internal sealed class SolutionAnalyzerConfigOptionsUpdater(IGlobalOptionService 
 
                         // update changed values:
                         var configName = key.Option.Definition.ConfigName;
-                        var configValue = key.Option.Definition.Serializer.Serialize(value);
-                        lazyBuilder[configName] = configValue;
+                        if (value is NamingStylePreferences preferences)
+                        {
+                            NamingStylePreferencesEditorConfigSerializer.WriteNamingStylePreferencesToEditorConfig(
+                                preferences.SymbolSpecifications,
+                                preferences.NamingStyles,
+                                preferences.NamingRules,
+                                language,
+                                entryWriter: (name, value) => lazyBuilder[name] = value,
+                                triviaWriter: null,
+                                // lower priority than any that would be specified explicitly in editorconfig:
+                                priority: int.MaxValue - preferences.NamingRules.Length);
+                        }
+                        else
+                        {
+                            lazyBuilder[configName] = key.Option.Definition.Serializer.Serialize(value);
+                        }
                     }
 
                     if (lazyBuilder != null)

--- a/src/LanguageServer/ProtocolUnitTests/Options/SolutionAnalyzerConfigOptionsUpdaterTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Options/SolutionAnalyzerConfigOptionsUpdaterTests.cs
@@ -3,10 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.UnitTests;
 using Roslyn.Test.Utilities;
@@ -98,24 +102,151 @@ public class SolutionAnalyzerConfigOptionsUpdaterTests
     }
 
     [Fact]
+    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2297536")]
     public void FlowsNamingStylePreferencesToWorkspace()
     {
         using var workspace = CreateWorkspace();
 
+        var testProjectWithoutConfig = new TestHostProject(workspace, "proj_without_config", LanguageNames.CSharp);
+
+        testProjectWithoutConfig.AddDocument(new TestHostDocument("""
+            class MyClass1;
+            """,
+            filePath: Path.Combine(TempRoot.Root, "proj_without_config", "test.cs")));
+
+        var testProjectWithConfig = new TestHostProject(workspace, "proj_with_config", LanguageNames.CSharp);
+
+        // explicitly specified style should override style specified in the fallback:
+        testProjectWithConfig.AddAnalyzerConfigDocument(new TestHostDocument(
+            """
+            [*.cs]
+            dotnet_naming_rule.rule1.severity = warning
+            dotnet_naming_rule.rule1.symbols = symbols1
+            dotnet_naming_rule.rule1.style = style1
+
+            dotnet_naming_symbols.symbols1.applicable_kinds = class
+            dotnet_naming_symbols.symbols1.applicable_accessibilities = *
+            dotnet_naming_style.style1.capitalization = camel_case
+            """,
+            filePath: Path.Combine(TempRoot.Root, "proj_with_config", ".editorconfig")));
+
+        testProjectWithConfig.AddDocument(new TestHostDocument("""
+            class MyClass2;
+            """,
+            filePath: Path.Combine(TempRoot.Root, "proj_with_config", "test.cs")));
+
+        workspace.AddTestProject(testProjectWithoutConfig);
+        workspace.AddTestProject(testProjectWithConfig);
+
         var globalOptions = workspace.GetService<IGlobalOptionService>();
 
-        // C# project hasn't been loaded to the workspace yet:
-        Assert.Empty(workspace.CurrentSolution.FallbackAnalyzerOptions);
+        var hostPeferences = OptionsTestHelpers.CreateNamingStylePreferences(
+            ([MethodKind.Ordinary], Capitalization.PascalCase, ReportDiagnostic.Error),
+            ([MethodKind.Ordinary, SymbolKind.Field], Capitalization.PascalCase, ReportDiagnostic.Error));
 
-        var project = new TestHostProject(workspace, "proj1", LanguageNames.CSharp);
-        workspace.AddTestProject(project);
-
-        var preferences = OptionsTestHelpers.GetNonDefaultNamingStylePreference();
-
-        globalOptions.SetGlobalOption(NamingStyleOptions.NamingPreferences, LanguageNames.CSharp, preferences);
+        globalOptions.SetGlobalOption(NamingStyleOptions.NamingPreferences, LanguageNames.CSharp, hostPeferences);
 
         Assert.True(workspace.CurrentSolution.FallbackAnalyzerOptions.TryGetValue(LanguageNames.CSharp, out var fallbackOptions));
-        AssertEx.EqualOrDiff(preferences.Inspect(), fallbackOptions.GetNamingStylePreferences().Inspect());
+
+        // Note: rules are ordered but symbol and naming style specifications are not.
+        AssertEx.Equal(
+            hostPeferences.Rules.NamingRules.Select(r => r.Inspect()),
+            fallbackOptions.GetNamingStylePreferences().Rules.NamingRules.Select(r => r.Inspect()));
+
+        var projectWithConfig = workspace.CurrentSolution.GetRequiredProject(testProjectWithConfig.Id);
+        var treeWithConfig = projectWithConfig.Documents.Single().GetSyntaxTreeSynchronously(CancellationToken.None);
+        Assert.NotNull(treeWithConfig);
+        var documentOptions = projectWithConfig.HostAnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(treeWithConfig);
+
+        Assert.True(documentOptions.TryGetEditorConfigOption<NamingStylePreferences>(NamingStyleOptions.NamingPreferences, out var documentPreferences));
+        Assert.NotNull(documentPreferences);
+
+        // Only naming styles specified in the editorconfig are present.
+        // Host preferences are ignored. This behavior is consistent with VS 16.11.
+        AssertEx.EqualOrDiff("""
+            <NamingPreferencesInfo SerializationVersion="5">
+              <SymbolSpecifications>
+                <SymbolSpecification ID="0" Name="symbols1">
+                  <ApplicableSymbolKindList>
+                    <TypeKind>Class</TypeKind>
+                  </ApplicableSymbolKindList>
+                  <ApplicableAccessibilityList>
+                    <AccessibilityKind>NotApplicable</AccessibilityKind>
+                    <AccessibilityKind>Public</AccessibilityKind>
+                    <AccessibilityKind>Internal</AccessibilityKind>
+                    <AccessibilityKind>Private</AccessibilityKind>
+                    <AccessibilityKind>Protected</AccessibilityKind>
+                    <AccessibilityKind>ProtectedAndInternal</AccessibilityKind>
+                    <AccessibilityKind>ProtectedOrInternal</AccessibilityKind>
+                  </ApplicableAccessibilityList>
+                  <RequiredModifierList />
+                </SymbolSpecification>
+              </SymbolSpecifications>
+              <NamingStyles>
+                <NamingStyle ID="1" Name="style1" Prefix="" Suffix="" WordSeparator="" CapitalizationScheme="CamelCase" />
+              </NamingStyles>
+              <NamingRules>
+                <SerializableNamingRule SymbolSpecificationID="0" NamingStyleID="1" EnforcementLevel="Warning" />
+              </NamingRules>
+            </NamingPreferencesInfo>
+            """,
+            documentPreferences.Inspect());
+
+        var projectWithoutConfig = workspace.CurrentSolution.GetRequiredProject(testProjectWithoutConfig.Id);
+        var treeWithoutConfig = projectWithoutConfig.Documents.Single().GetSyntaxTreeSynchronously(CancellationToken.None);
+        Assert.NotNull(treeWithoutConfig);
+        documentOptions = projectWithoutConfig.HostAnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(treeWithoutConfig);
+
+        Assert.True(documentOptions.TryGetEditorConfigOption(NamingStyleOptions.NamingPreferences, out documentPreferences));
+        Assert.NotNull(documentPreferences);
+
+        // Host preferences:
+        AssertEx.EqualOrDiff("""
+            <NamingPreferencesInfo SerializationVersion="5">
+              <SymbolSpecifications>
+                <SymbolSpecification ID="0" Name="symbols1">
+                  <ApplicableSymbolKindList>
+                    <MethodKind>Ordinary</MethodKind>
+                    <SymbolKind>Field</SymbolKind>
+                  </ApplicableSymbolKindList>
+                  <ApplicableAccessibilityList>
+                    <AccessibilityKind>NotApplicable</AccessibilityKind>
+                    <AccessibilityKind>Public</AccessibilityKind>
+                    <AccessibilityKind>Internal</AccessibilityKind>
+                    <AccessibilityKind>Private</AccessibilityKind>
+                    <AccessibilityKind>Protected</AccessibilityKind>
+                    <AccessibilityKind>ProtectedAndInternal</AccessibilityKind>
+                    <AccessibilityKind>ProtectedOrInternal</AccessibilityKind>
+                  </ApplicableAccessibilityList>
+                  <RequiredModifierList />
+                </SymbolSpecification>
+                <SymbolSpecification ID="1" Name="symbols0">
+                  <ApplicableSymbolKindList>
+                    <MethodKind>Ordinary</MethodKind>
+                  </ApplicableSymbolKindList>
+                  <ApplicableAccessibilityList>
+                    <AccessibilityKind>NotApplicable</AccessibilityKind>
+                    <AccessibilityKind>Public</AccessibilityKind>
+                    <AccessibilityKind>Internal</AccessibilityKind>
+                    <AccessibilityKind>Private</AccessibilityKind>
+                    <AccessibilityKind>Protected</AccessibilityKind>
+                    <AccessibilityKind>ProtectedAndInternal</AccessibilityKind>
+                    <AccessibilityKind>ProtectedOrInternal</AccessibilityKind>
+                  </ApplicableAccessibilityList>
+                  <RequiredModifierList />
+                </SymbolSpecification>
+              </SymbolSpecifications>
+              <NamingStyles>
+                <NamingStyle ID="2" Name="style1" Prefix="" Suffix="" WordSeparator="" CapitalizationScheme="PascalCase" />
+                <NamingStyle ID="3" Name="style0" Prefix="" Suffix="" WordSeparator="" CapitalizationScheme="PascalCase" />
+              </NamingStyles>
+              <NamingRules>
+                <SerializableNamingRule SymbolSpecificationID="1" NamingStyleID="3" EnforcementLevel="Error" />
+                <SerializableNamingRule SymbolSpecificationID="0" NamingStyleID="2" EnforcementLevel="Error" />
+              </NamingRules>
+            </NamingPreferencesInfo>
+            """,
+            documentPreferences.Inspect());
     }
 
     [Fact]

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -107,9 +107,18 @@ public class VisualStudioOptionStorageTests
             return;
         }
 
-        if (!info.Option.Definition.IsEditorConfigOption)
+        // TODO: https://github.com/dotnet/roslyn/issues/65787
+        if (info.Option.Name is
+            "csharp_format_on_return" or
+            "csharp_format_on_typing" or
+            "csharp_format_on_semicolon" or
+            "csharp_format_on_close_brace" or
+            "csharp_enable_inlay_hints_for_types" or
+            "csharp_enable_inlay_hints_for_implicit_variable_types" or
+            "csharp_enable_inlay_hints_for_lambda_parameter_types" or
+            "csharp_enable_inlay_hints_for_implicit_object_creation" or
+            "csharp_enable_inlay_hints_for_collection_expressions")
         {
-            // TODO: remove condition once all options have config name https://github.com/dotnet/roslyn/issues/65787
             return;
         }
 

--- a/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
+++ b/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var symbolSpecification = new SymbolSpecification(
                 Guid.NewGuid(),
-                "Name",
+                "name",
                 ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(TypeKind.Class)),
                 accessibilityList: default,
                 modifiers: default);
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var namingStyle = new NamingStyle(
                 Guid.NewGuid(),
                 capitalizationScheme: Capitalization.PascalCase,
-                name: "Name",
+                name: "name",
                 prefix: "",
                 suffix: "",
                 wordSeparator: "");

--- a/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
+++ b/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.NamingStyles;
@@ -147,33 +148,53 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         public static NamingStylePreferences GetNonDefaultNamingStylePreference()
+            => CreateNamingStylePreferences(([TypeKind.Class], Capitalization.PascalCase, ReportDiagnostic.Error));
+
+        public static NamingStylePreferences CreateNamingStylePreferences(
+            params (SymbolSpecification.SymbolKindOrTypeKind[], Capitalization capitalization, ReportDiagnostic severity)[] rules)
         {
-            var symbolSpecification = new SymbolSpecification(
-                Guid.NewGuid(),
-                "name",
-                ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(TypeKind.Class)),
-                accessibilityList: default,
-                modifiers: default);
+            var symbolSpecifications = new List<SymbolSpecification>();
+            var namingStyles = new List<NamingStyle>();
+            var namingRules = new List<SerializableNamingRule>();
 
-            var namingStyle = new NamingStyle(
-                Guid.NewGuid(),
-                capitalizationScheme: Capitalization.PascalCase,
-                name: "name",
-                prefix: "",
-                suffix: "",
-                wordSeparator: "");
-
-            var namingRule = new SerializableNamingRule()
+            foreach (var (kinds, capitalization, severity) in rules)
             {
-                SymbolSpecificationID = symbolSpecification.ID,
-                NamingStyleID = namingStyle.ID,
-                EnforcementLevel = ReportDiagnostic.Error
-            };
+                var id = namingRules.Count;
+
+                var symbolSpecification = new SymbolSpecification(
+                    Guid.NewGuid(),
+                    name: $"symbols{id}",
+                    [.. kinds],
+                    accessibilityList: default,
+                    modifiers: default);
+
+                symbolSpecifications.Add(symbolSpecification);
+
+                var namingStyle = new NamingStyle(
+                    Guid.NewGuid(),
+                    capitalizationScheme: capitalization,
+                    name: $"style{id}",
+                    prefix: "",
+                    suffix: "",
+                    wordSeparator: "");
+
+                namingStyles.Add(namingStyle);
+
+                namingRules.Add(new SerializableNamingRule()
+                {
+                    SymbolSpecificationID = symbolSpecification.ID,
+                    NamingStyleID = namingStyle.ID,
+                    EnforcementLevel = severity
+                });
+            }
 
             return new NamingStylePreferences(
-                ImmutableArray.Create(symbolSpecification),
-                ImmutableArray.Create(namingStyle),
-                ImmutableArray.Create(namingRule));
+                [.. symbolSpecifications],
+                [.. namingStyles],
+                [.. namingRules]);
         }
+
+        public static NamingStylePreferences ParseNamingStylePreferences(Dictionary<string, string> options)
+            => EditorConfigNamingStyleParser.ParseDictionary(new DictionaryAnalyzerConfigOptions(options.ToImmutableDictionary()));
     }
 }

--- a/src/Workspaces/CoreTestUtilities/OptionsCollection.cs
+++ b/src/Workspaces/CoreTestUtilities/OptionsCollection.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                         LanguageName,
                         entryWriter: builder.Add,
                         triviaWriter: null,
-                        priority: null);
+                        setPrioritiesToPreserveOrder: false);
                 }
                 else
                 {

--- a/src/Workspaces/CoreTestUtilities/OptionsCollection.cs
+++ b/src/Workspaces/CoreTestUtilities/OptionsCollection.cs
@@ -109,7 +109,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                         namingPreferences.NamingRules,
                         LanguageName,
                         entryWriter: builder.Add,
-                        triviaWriter: null);
+                        triviaWriter: null,
+                        priority: null);
                 }
                 else
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -62,7 +62,8 @@ internal sealed partial class FormattingOptions2
     public static PerLanguageOption2<IndentStyle> SmartIndent = new PerLanguageOption2<IndentStyle>(
         "smart_indent",
         defaultValue: IndentationOptions.DefaultIndentStyle,
-        group: FormattingOptionGroups.IndentationAndSpacing)
+        group: FormattingOptionGroups.IndentationAndSpacing,
+        serializer: EditorConfigValueSerializer.CreateSerializerForEnum<IndentStyle>())
         .WithPublicOption(PublicFeatureName, "SmartIndent", static value => (PublicIndentStyle)value, static value => (IndentStyle)value);
 
     /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -66,7 +66,7 @@ internal static partial class EditorConfigNamingStyleParser
         // which a user has trouble ordering, the intersection of the two rules can be broken out into a new rule
         // will always match earlier than the broader rules it was derived from.
         var orderedRules = preferences.Rules.NamingRules
-            .OrderByDescending(rule => ruleNamesAndPriorities[(rule.SymbolSpecification.ID, rule.NamingStyle.ID, rule.EnforcementLevel)].priority)
+            .OrderBy(rule => ruleNamesAndPriorities[(rule.SymbolSpecification.ID, rule.NamingStyle.ID, rule.EnforcementLevel)].priority)
             .ThenBy(rule => rule, NamingRuleModifierListComparer.Instance)
             .ThenBy(rule => rule, NamingRuleAccessibilityListComparer.Instance)
             .ThenBy(rule => rule, NamingRuleSymbolListComparer.Instance)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.NamingStyles;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -22,38 +20,22 @@ internal static partial class EditorConfigNamingStyleParser
         var symbolSpecifications = ArrayBuilder<SymbolSpecification>.GetInstance();
         var namingStyles = ArrayBuilder<NamingStyle>.GetInstance();
         var namingRules = ArrayBuilder<SerializableNamingRule>.GetInstance();
-        var ruleNames = new Dictionary<(Guid symbolSpecificationID, Guid namingStyleID, ReportDiagnostic enforcementLevel), string>();
+        var ruleNamesAndPriorities = new Dictionary<(Guid symbolSpecificationID, Guid namingStyleID, ReportDiagnostic enforcementLevel), (string title, int priority)>();
 
         foreach (var namingRuleTitle in GetRuleTitles(trimmedDictionary))
         {
             if (TryGetSymbolSpec(namingRuleTitle, trimmedDictionary, out var symbolSpec) &&
                 TryGetNamingStyleData(namingRuleTitle, trimmedDictionary, out var namingStyle) &&
-                TryGetSerializableNamingRule(namingRuleTitle, symbolSpec, namingStyle, trimmedDictionary, out var serializableNamingRule))
+                TryGetSerializableNamingRule(namingRuleTitle, symbolSpec, namingStyle, trimmedDictionary, out var serializableNamingRule, out var priority))
             {
                 symbolSpecifications.Add(symbolSpec);
                 namingStyles.Add(namingStyle);
                 namingRules.Add(serializableNamingRule);
 
-                var ruleKey = (serializableNamingRule.SymbolSpecificationID, serializableNamingRule.NamingStyleID, serializableNamingRule.EnforcementLevel);
-                if (ruleNames.TryGetValue(ruleKey, out var existingName))
-                {
-                    // For duplicated rules, only preserve the one with a name that would sort first
-                    var ordinalIgnoreCaseOrdering = StringComparer.OrdinalIgnoreCase.Compare(namingRuleTitle, existingName);
-                    if (ordinalIgnoreCaseOrdering > 0)
-                    {
-                        continue;
-                    }
-                    else if (ordinalIgnoreCaseOrdering == 0)
-                    {
-                        var ordinalOrdering = StringComparer.Ordinal.Compare(namingRuleTitle, existingName);
-                        if (ordinalOrdering > 0)
-                        {
-                            continue;
-                        }
-                    }
-                }
-
-                ruleNames[ruleKey] = namingRuleTitle;
+                // the key comprises of newly generated guids and is thus unique:
+                ruleNamesAndPriorities.Add(
+                    (serializableNamingRule.SymbolSpecificationID, serializableNamingRule.NamingStyleID, serializableNamingRule.EnforcementLevel),
+                    (namingRuleTitle, priority));
             }
         }
 
@@ -62,7 +44,9 @@ internal static partial class EditorConfigNamingStyleParser
             namingStyles.ToImmutableAndFree(),
             namingRules.ToImmutableAndFree());
 
-        // Deterministically order the naming style rules according to the symbols matched by the rule. The rules
+        // Deterministically order the naming style rules.
+        // 
+        // Rules of the same priority are ordered according to the symbols matched by the rule. The rules
         // are applied in order; later rules are only relevant if earlier rules fail to specify an order.
         //
         // 1. If the modifiers required by rule 'x' are a strict superset of the modifiers required by rule 'y',
@@ -82,11 +66,12 @@ internal static partial class EditorConfigNamingStyleParser
         // which a user has trouble ordering, the intersection of the two rules can be broken out into a new rule
         // will always match earlier than the broader rules it was derived from.
         var orderedRules = preferences.Rules.NamingRules
-            .OrderBy(rule => rule, NamingRuleModifierListComparer.Instance)
+            .OrderByDescending(rule => ruleNamesAndPriorities[(rule.SymbolSpecification.ID, rule.NamingStyle.ID, rule.EnforcementLevel)].priority)
+            .ThenBy(rule => rule, NamingRuleModifierListComparer.Instance)
             .ThenBy(rule => rule, NamingRuleAccessibilityListComparer.Instance)
             .ThenBy(rule => rule, NamingRuleSymbolListComparer.Instance)
-            .ThenBy(rule => ruleNames[(rule.SymbolSpecification.ID, rule.NamingStyle.ID, rule.EnforcementLevel)], StringComparer.OrdinalIgnoreCase)
-            .ThenBy(rule => ruleNames[(rule.SymbolSpecification.ID, rule.NamingStyle.ID, rule.EnforcementLevel)], StringComparer.Ordinal);
+            .ThenBy(rule => ruleNamesAndPriorities[(rule.SymbolSpecification.ID, rule.NamingStyle.ID, rule.EnforcementLevel)].title, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(rule => ruleNamesAndPriorities[(rule.SymbolSpecification.ID, rule.NamingStyle.ID, rule.EnforcementLevel)].title, StringComparer.Ordinal);
 
         return new NamingStylePreferences(
             preferences.SymbolSpecifications,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_NamingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_NamingRule.cs
@@ -17,8 +17,11 @@ internal static partial class EditorConfigNamingStyleParser
         SymbolSpecification symbolSpec,
         NamingStyle namingStyle,
         IReadOnlyDictionary<string, string> conventionsDictionary,
-        [NotNullWhen(true)] out SerializableNamingRule? serializableNamingRule)
+        [NotNullWhen(true)] out SerializableNamingRule? serializableNamingRule,
+        out int priority)
     {
+        priority = GetRulePriority(namingRuleTitle, conventionsDictionary);
+
         if (!TryGetRuleSeverity(namingRuleTitle, conventionsDictionary, out var severity))
         {
             serializableNamingRule = null;
@@ -34,6 +37,12 @@ internal static partial class EditorConfigNamingStyleParser
 
         return true;
     }
+
+    private static int GetRulePriority(string namingRuleName, IReadOnlyDictionary<string, string> conventionsDictionary)
+        => conventionsDictionary.TryGetValue($"dotnet_naming_rule.{namingRuleName}.priority", out var value) &&
+           int.TryParse(value, out var result)
+            ? result
+            : 0;
 
     internal static bool TryGetRuleSeverity(
         string namingRuleName,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingRule.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.NamingStyles;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 
-internal readonly struct NamingRule(SymbolSpecification symbolSpecification, NamingStyle namingStyle, ReportDiagnostic enforcementLevel)
+internal readonly struct NamingRule(
+    SymbolSpecification symbolSpecification,
+    NamingStyle namingStyle,
+    ReportDiagnostic enforcementLevel)
 {
     public readonly SymbolSpecification SymbolSpecification = symbolSpecification;
     public readonly NamingStyle NamingStyle = namingStyle;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyleOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyleOptions.cs
@@ -24,7 +24,8 @@ internal static class NamingStyleOptions
     internal static PerLanguageOption2<NamingStylePreferences> NamingPreferences { get; } = new(
         NamingPreferencesOptionName,
         defaultValue: NamingStylePreferences.Default,
-        isEditorConfigOption: true);
+        isEditorConfigOption: true,
+        serializer: EditorConfigValueSerializer<NamingStylePreferences>.Unsupported);
 }
 
 internal interface NamingStylePreferencesProvider

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/NamingStylePreferencesEditorConfigSerializer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/NamingStylePreferencesEditorConfigSerializer.cs
@@ -40,7 +40,7 @@ internal static partial class NamingStylePreferencesEditorConfigSerializer
             language,
             entryWriter: (name, value) => builder.AppendLine($"{name} = {value}"),
             triviaWriter: trivia => builder.AppendLine(trivia),
-            priority: null);
+            setPrioritiesToPreserveOrder: false);
     }
 
     public static void WriteNamingStylePreferencesToEditorConfig(
@@ -50,7 +50,7 @@ internal static partial class NamingStylePreferencesEditorConfigSerializer
         string language,
         Action<string, string> entryWriter,
         Action<string>? triviaWriter,
-        int? priority)
+        bool setPrioritiesToPreserveOrder)
     {
         triviaWriter?.Invoke($"#### {CompilerExtensionsResources.Naming_styles} ####");
 
@@ -61,7 +61,7 @@ internal static partial class NamingStylePreferencesEditorConfigSerializer
         triviaWriter?.Invoke("");
         triviaWriter?.Invoke($"# {CompilerExtensionsResources.Naming_rules}");
 
-        var ruleIndex = 0;
+        var priority = 0;
         foreach (var namingRule in rules)
         {
             referencedElements.Add(namingRule.SymbolSpecificationID);
@@ -70,16 +70,16 @@ internal static partial class NamingStylePreferencesEditorConfigSerializer
             triviaWriter?.Invoke("");
             var ruleName = ruleNameMap[namingRule];
 
-            if (priority.HasValue)
+            if (setPrioritiesToPreserveOrder)
             {
-                entryWriter($"dotnet_naming_rule.{ruleName}.priority", $"{priority.Value + ruleIndex}");
+                entryWriter($"dotnet_naming_rule.{ruleName}.priority", priority.ToString());
             }
 
             entryWriter($"dotnet_naming_rule.{ruleName}.severity", namingRule.EnforcementLevel.ToNotificationOption(defaultSeverity: DiagnosticSeverity.Hidden).ToEditorConfigString());
             entryWriter($"dotnet_naming_rule.{ruleName}.symbols", serializedNameMap[namingRule.SymbolSpecificationID]);
             entryWriter($"dotnet_naming_rule.{ruleName}.style", serializedNameMap[namingRule.NamingStyleID]);
 
-            ruleIndex++;
+            priority++;
         }
 
         triviaWriter?.Invoke("");

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SerializableNamingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SerializableNamingRule.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 using System.Xml.Linq;
@@ -45,9 +43,9 @@ internal sealed record class SerializableNamingRule
     {
         return new SerializableNamingRule()
         {
-            EnforcementLevel = ((DiagnosticSeverity)Enum.Parse(typeof(DiagnosticSeverity), namingRuleElement.Attribute(nameof(EnforcementLevel)).Value)).ToReportDiagnostic(),
-            NamingStyleID = Guid.Parse(namingRuleElement.Attribute(nameof(NamingStyleID)).Value),
-            SymbolSpecificationID = Guid.Parse(namingRuleElement.Attribute(nameof(SymbolSpecificationID)).Value)
+            EnforcementLevel = ((DiagnosticSeverity)Enum.Parse(typeof(DiagnosticSeverity), namingRuleElement.Attribute(nameof(EnforcementLevel))!.Value)).ToReportDiagnostic(),
+            NamingStyleID = Guid.Parse(namingRuleElement.Attribute(nameof(NamingStyleID))!.Value),
+            SymbolSpecificationID = Guid.Parse(namingRuleElement.Attribute(nameof(SymbolSpecificationID))!.Value)
         };
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
@@ -439,6 +439,15 @@ internal sealed class SymbolSpecification(
 
         internal static SymbolKindOrTypeKind AddMethodKindFromXElement(XElement methodKindElement)
             => new((MethodKind)Enum.Parse(typeof(MethodKind), methodKindElement.Value));
+
+        public static implicit operator SymbolKindOrTypeKind(SymbolKind symbolKind)
+            => new(symbolKind);
+
+        public static implicit operator SymbolKindOrTypeKind(TypeKind symbolKind)
+            => new(symbolKind);
+
+        public static implicit operator SymbolKindOrTypeKind(MethodKind symbolKind)
+            => new(symbolKind);
     }
 
     [DataContract]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfigValueSerializer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfigValueSerializer.cs
@@ -52,7 +52,7 @@ internal static class EditorConfigValueSerializer
         return optionalBool.HasValue ? new Optional<bool?>(optionalBool.Value) : new Optional<bool?>();
     }
 
-    public static EditorConfigValueSerializer<T> Default<T>()
+    public static EditorConfigValueSerializer<T> GetDefault<T>(bool isEditorConfigOption)
     {
         if (typeof(T) == typeof(bool))
             return (EditorConfigValueSerializer<T>)(object)s_bool;
@@ -66,9 +66,10 @@ internal static class EditorConfigValueSerializer
         if (typeof(T) == typeof(bool?))
             return (EditorConfigValueSerializer<T>)(object)s_nullableBoolean;
 
-        // TODO: https://github.com/dotnet/roslyn/issues/65787
-        // Once all global options define a serializer this should be changed to:
-        // throw ExceptionUtilities.UnexpectedValue(typeof(T));
+        // editorconfig options must have a serializer:
+        if (isEditorConfigOption)
+            throw ExceptionUtilities.UnexpectedValue(typeof(T));
+
         return EditorConfigValueSerializer<T>.Unsupported;
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/OptionDefinition.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/OptionDefinition.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Options;
 
@@ -116,7 +117,7 @@ internal sealed class OptionDefinition<T>(
     bool isEditorConfigOption) : OptionDefinition(group, configName, defaultValue, storageMapping, isEditorConfigOption)
 {
     public new T DefaultValue { get; } = defaultValue;
-    public new EditorConfigValueSerializer<T> Serializer { get; } = serializer ?? EditorConfigValueSerializer.Default<T>();
+    public new EditorConfigValueSerializer<T> Serializer { get; } = serializer ?? EditorConfigValueSerializer.GetDefault<T>(isEditorConfigOption);
 
     public override Type Type
         => typeof(T);


### PR DESCRIPTION
The serializer is required when saving naming style preferences specified in Tools > Options to solution fallback options. The option was throwing NotSupportedException, which was reported via NFW but for some reason does not appear in telemetry  data (TBD why).

In order to preserve ordering of the naming style rules as specified in Tools > Options settings we introduce a new editor option `dotnet_naming_rule.{rule-name}.priority`. The highest priority is 0, which is the default. When saving VS options we generate priorities 0..N-1 where N is the number of rules. This causes VS option order to be preserved when the preferences are deserialized from fallback options.

Note that if any naming style is set in .editorconfig file, all naming style settings in VS options are ignored. This behavior is consistent with VS 2019.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2297536