### PR TITLE
Disable signing validation for the PR Val pipeline.

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -338,6 +338,7 @@ extends:
         publishingInfraVersion: 3
         # Symbol validation is not entirely reliable as of yet, so should be turned off until
         # https://github.com/dotnet/arcade/issues/2871 is resolved.
+        enableSigningValidation: false
         enableSymbolValidation: false
         enableSourceLinkValidation: false
         SDLValidationParameters: false

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -338,7 +338,7 @@ extends:
         publishingInfraVersion: 3
         # Symbol validation is not entirely reliable as of yet, so should be turned off until
         # https://github.com/dotnet/arcade/issues/2871 is resolved.
-        enableSigningValidation: false
         enableSymbolValidation: false
+        enableSigningValidation: false
         enableSourceLinkValidation: false
         SDLValidationParameters: false


### PR DESCRIPTION
This will allow us to use test signed builds for PR validation.