### PR TITLE
Razor synchronize loader

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1729,7 +1729,7 @@ class C
             // - update the "UpgradeProject" codefixer
             // - update all the tests that call this canary
             // - update _MaxAvailableLangVersion (a relevant test should break when new version is introduced)
-            // - email release management to add to the release notes (see old example: https://github.com/dotnet/core/pull/1454)
+            // - email release management to add to the release notes (see csharp-version in release.json in previous example: https://github.com/dotnet/core/pull/9493)
             AssertEx.SetEqual(new[] { "default", "1", "2", "3", "4", "5", "6", "7.0", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "latest", "latestmajor", "preview" },
                 Enum.GetValues(typeof(LanguageVersion)).Cast<LanguageVersion>().Select(v => v.ToDisplayString()));
             // For minor versions and new major versions, the format should be "x.y", such as "7.1"

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -45,12 +45,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         public Assembly? ResolveAssembly(AssemblyName assemblyName)
         {
+            Func<AssemblyName, Assembly?>? resolver = null;
             lock (s_resolverLock)
             {
                 s_assembliesRequested.Add(assemblyName);
+                resolver = s_assemblyResolver;
             }
 
-            return s_assemblyResolver?.Invoke(assemblyName);
+            return resolver?.Invoke(assemblyName);
         }
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -3,49 +3,53 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     [Export(typeof(IAnalyzerAssemblyResolver)), Shared]
-    internal class RazorAnalyzerAssemblyResolver : IAnalyzerAssemblyResolver
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal class RazorAnalyzerAssemblyResolver() : IAnalyzerAssemblyResolver
     {
         private static Func<AssemblyName, Assembly?>? s_assemblyResolver;
 
+        private static readonly List<AssemblyName>? s_assembliesRequested = [];
+
+        private static readonly object s_resolverLock = new();
+
         /// <summary>
-        /// We use this as a heuristic to catch a case where we set the resolver too 
-        /// late and the resolver has already been asked to resolve a razor assembly.
-        /// 
-        /// Note this isn't perfectly accurate but is only used to trigger an assert
-        /// in debug builds. 
+        /// Attempts to set the assembly resolver. Will only succeed if the <paramref name="canaryAssembly"/> has not already been requested to load.
         /// </summary>
-        private static bool s_razorRequested = false;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public RazorAnalyzerAssemblyResolver()
+        /// <param name="resolver">The resolver function to set.</param>
+        /// <param name="canaryAssembly">The name of an assembly that is checked to see if it has been requested to load. Setting the resolver will fail if this has already been requested.</param>
+        /// <returns><c>true</c> when the resolver was successfully set.</returns>
+        internal static bool TrySetAssemblyResolver(Func<AssemblyName, Assembly?> resolver, AssemblyName canaryAssembly)
         {
-        }
-
-        internal static Func<AssemblyName, Assembly?>? AssemblyResolver
-        {
-            get => s_assemblyResolver;
-            set
+            lock (s_resolverLock)
             {
-                Debug.Assert(s_assemblyResolver == null, "Assembly resolver should not be set multiple times.");
-                Debug.Assert(!s_razorRequested, "A razor assembly has already been requested before setting the resolver.");
-                s_assemblyResolver = value;
+                if (s_assemblyResolver is not null && s_assembliesRequested is not null && !s_assembliesRequested.Contains(canaryAssembly))
+                {
+                    s_assemblyResolver = resolver;
+                    return true;
+                }
+                return false;
             }
         }
 
         public Assembly? ResolveAssembly(AssemblyName assemblyName)
         {
-            s_razorRequested |= assemblyName.FullName.Contains("Razor");
-            return s_assemblyResolver?.Invoke(assemblyName);
+            lock (s_resolverLock)
+            {
+                s_assembliesRequested?.Add(assemblyName);
+                return s_assemblyResolver?.Invoke(assemblyName);
+            }
         }
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             lock (s_resolverLock)
             {
-                if (s_assemblyResolver is not null && !s_assembliesRequested.Contains(canaryAssembly))
+                if (s_assemblyResolver is null && !s_assembliesRequested.Contains(canaryAssembly))
                 {
                     s_assemblyResolver = resolver;
                     return true;

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     {
         private static Func<AssemblyName, Assembly?>? s_assemblyResolver;
 
-        private static readonly List<AssemblyName> s_assembliesRequested = [];
+        private static readonly HashSet<AssemblyName> s_assembliesRequested = [];
 
         private static readonly object s_resolverLock = new();
 

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     {
         private static Func<AssemblyName, Assembly?>? s_assemblyResolver;
 
-        private static readonly List<AssemblyName>? s_assembliesRequested = [];
+        private static readonly List<AssemblyName> s_assembliesRequested = [];
 
         private static readonly object s_resolverLock = new();
 
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             lock (s_resolverLock)
             {
-                if (s_assemblyResolver is not null && s_assembliesRequested is not null && !s_assembliesRequested.Contains(canaryAssembly))
+                if (s_assemblyResolver is not null && !s_assembliesRequested.Contains(canaryAssembly))
                 {
                     s_assemblyResolver = resolver;
                     return true;
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             lock (s_resolverLock)
             {
-                s_assembliesRequested?.Add(assemblyName);
+                s_assembliesRequested.Add(assemblyName);
                 return s_assemblyResolver?.Invoke(assemblyName);
             }
         }

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -48,8 +48,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             lock (s_resolverLock)
             {
                 s_assembliesRequested.Add(assemblyName);
-                return s_assemblyResolver?.Invoke(assemblyName);
             }
+
+            return s_assemblyResolver?.Invoke(assemblyName);
         }
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorProjectExtensions.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorProjectExtensions.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
             var generatorIdentity = new SourceGeneratorIdentity(assemblyName, assemblyPath, assemblyVersion, typeName);
             return results.Where(s => s.Identity.Generator == generatorIdentity);
-
         }
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorProjectExtensions.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorProjectExtensions.cs
@@ -17,5 +17,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             return project.GetSourceGeneratorRunResultAsync(cancellationToken);
         }
+
+        internal static async ValueTask<IEnumerable<SourceGeneratedDocument>> GetSourceGeneratedDocumentsForGeneratorAsync(this Project project, string assemblyName, string assemblyPath, Version assemblyVersion, string typeName, CancellationToken cancellationToken)
+        {
+            var results = await project.GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false);
+
+            var generatorIdentity = new SourceGeneratorIdentity(assemblyName, assemblyPath, assemblyVersion, typeName);
+            return results.Where(s => s.Identity.Generator == generatorIdentity);
+
+        }
     }
 }


### PR DESCRIPTION
This updates the way the razor assembly loader installs its handler to ensure we can synchronize correctly between Razor and Roslyn. The approach is to track which assemblies have been loaded and only install the filter if the requested assembly has not yet been loaded. 

 Most of the work is on the Razor side, the Roslyn side is deliberately simple with nothing hard coded so we aren't baking in any Razor specific logic or dependencies. A WIP doc explaining the process from both sides is available at https://gist.github.com/chsienki/f3b3b19bf6cf6d1f8e047e59242db648.

Also adds a method to retrieve only the documents from a specific source generator. Again, we don't bake in the razor generator, so that we can change that without needing to change roslyn. 