### PR TITLE
Change PR Val builds to be unsigned

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -33,6 +33,8 @@ variables:
     value: false
   - name: Codeql.SkipTaskAutoInjection
     value: true
+  - name: SignType
+    value: test
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # If the pipeline is running in DevDiv, the account has access to the VS drop storage.
@@ -338,6 +340,7 @@ extends:
         publishingInfraVersion: 3
         # Symbol validation is not entirely reliable as of yet, so should be turned off until
         # https://github.com/dotnet/arcade/issues/2871 is resolved.
+        enableSigningValidation: false
         enableSymbolValidation: false
         enableSourceLinkValidation: false
         SDLValidationParameters: false

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -34,7 +34,7 @@ variables:
   - name: Codeql.SkipTaskAutoInjection
     value: true
   - name: SignType
-    value: test
+    value: ''
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # If the pipeline is running in DevDiv, the account has access to the VS drop storage.

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -340,7 +340,7 @@ extends:
         publishingInfraVersion: 3
         # Symbol validation is not entirely reliable as of yet, so should be turned off until
         # https://github.com/dotnet/arcade/issues/2871 is resolved.
-        enableSigningValidation: false
         enableSymbolValidation: false
+        enableSigningValidation: false
         enableSourceLinkValidation: false
         SDLValidationParameters: false

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -61,4 +61,8 @@
     <FileSignInfo Include="Microsoft.VisualStudio.Threading.dll" CertificateName="MicrosoftSHA2" />
     <FileSignInfo Include="StreamJsonRpc.dll" CertificateName="MicrosoftSHA2" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(PreReleaseVersionLabel)' == 'pr-validation' And '$(SignType)' == 'test'">
+    <FileExtensionSignInfo Update=".nupkg" CertificateName="None" />
+  </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -66,7 +66,7 @@
     We do not intend to ship the artifacts produced for PR validation buildm so we can skip signing the artifacts.
    -->
   <Choose>
-    <When Condition="'$(PreReleaseVersionLabel)' == 'pr-validation' And '$(SignType)' == 'test'">
+    <When Condition="'$(PreReleaseVersionLabel)' == 'pr-validation' And '$(SignType)' == ''">
       <ItemGroup>
         <ItemsToSign Remove="@(ItemsToSign)" />
       </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <!--
-    We do not intend to ship the artifacts produced for PR validation buildm so we can skip signing the artifacts.
+    We do not intend to ship the artifacts produced for PR validation build so we can skip signing the artifacts.
    -->
   <Choose>
     <When Condition="'$(PreReleaseVersionLabel)' == 'pr-validation' And '$(SignType)' == ''">

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -62,7 +62,18 @@
     <FileSignInfo Include="StreamJsonRpc.dll" CertificateName="MicrosoftSHA2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(PreReleaseVersionLabel)' == 'pr-validation' And '$(SignType)' == 'test'">
-    <FileExtensionSignInfo Update=".nupkg" CertificateName="None" />
-  </ItemGroup>
+  <!--
+    We do not intend to ship the artifacts produced for PR validation buildm so we can skip signing the artifacts.
+   -->
+  <Choose>
+    <When Condition="'$(PreReleaseVersionLabel)' == 'pr-validation' And '$(SignType)' == 'test'">
+      <ItemGroup>
+        <ItemsToSign Remove="@(ItemsToSign)" />
+      </ItemGroup>
+
+      <PropertyGroup>
+        <AllowEmptySignList>true</AllowEmptySignList>
+      </PropertyGroup>
+    </When>
+  </Choose>
 </Project>


### PR DESCRIPTION
Disables signing for build artifacts to improve the turn around time for getting results back from a validation run.

Measuring from `SignToolTask starting` to `SignToolTask execution finished`.
- Real signing: varies but is a whole lotta time (could be over an hour)
- Test signing: ~7min
- No signing: <1sec

Test Run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10705817&view=results (microsoft)