### PR TITLE
Honor abstract required during state initialization in nullable

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -910,13 +910,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 => ImmutableArray<Symbol>.Empty,
 
                             (includeAllMembers: false, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: false)
-                                => containingType.GetMembersUnordered().SelectManyAsArray(predicate: SymbolExtensions.IsRequired, selector: getAllMembersToBeDefaulted),
+                                => containingType.GetMembersUnordered().SelectManyAsArray(
+                                    predicate: SymbolExtensions.IsRequired,
+                                    selector: symbol => getAllMembersToBeDefaulted(symbol, filterOverridingProperties: true)),
 
                             (includeAllMembers: false, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: true)
-                                => containingType.AllRequiredMembers.SelectManyAsArray(static kvp => getAllMembersToBeDefaulted(kvp.Value)),
+                                => containingType.AllRequiredMembers.SelectManyAsArray(static kvp => getAllMembersToBeDefaulted(kvp.Value, filterOverridingProperties: true)),
 
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: _, includeBaseRequiredMembers: false)
-                                => containingType.GetMembersUnordered().SelectAsArray(getFieldSymbolToBeInitialized),
+                                => containingType.GetMembersUnordered().SelectManyAsArray(
+                                    selector: symbol =>
+                                    {
+                                        var symbolToInitialize = getFieldSymbolToBeInitialized(symbol);
+                                        var prop = symbolToInitialize as PropertySymbol ?? (symbolToInitialize as FieldSymbol)?.AssociatedSymbol as PropertySymbol;
+                                        if (prop is not null && isFilterableOverrideOfAbstractProperty(prop))
+                                        {
+                                            return OneOrMany<Symbol>.Empty;
+                                        }
+                                        else
+                                        {
+                                            return OneOrMany.Create(symbolToInitialize);
+                                        }
+                                    }),
 
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: true)
                                 => getAllTypeAndRequiredMembers(containingType),
@@ -928,50 +943,94 @@ namespace Microsoft.CodeAnalysis.CSharp
                         static ImmutableArray<Symbol> getAllTypeAndRequiredMembers(TypeSymbol containingType)
                         {
                             var members = containingType.GetMembersUnordered();
-                            var requiredMembers = containingType.BaseTypeNoUseSiteDiagnostics?.AllRequiredMembers ?? ImmutableSegmentedDictionary<string, Symbol>.Empty;
+                            var baseRequiredMembers = containingType.BaseTypeNoUseSiteDiagnostics?.AllRequiredMembers ?? ImmutableSegmentedDictionary<string, Symbol>.Empty;
 
-                            if (requiredMembers.IsEmpty)
+                            if (baseRequiredMembers.IsEmpty)
                             {
                                 return members;
                             }
 
-                            var builder = ArrayBuilder<Symbol>.GetInstance(members.Length + requiredMembers.Count);
+                            var builder = ArrayBuilder<Symbol>.GetInstance(members.Length + baseRequiredMembers.Count);
                             builder.AddRange(members);
-                            foreach (var (_, requiredMember) in requiredMembers)
+                            foreach (var (_, requiredMember) in baseRequiredMembers)
                             {
                                 // We want to assume that all required members were _not_ set by the chained constructor
-                                builder.AddRange(getAllMembersToBeDefaulted(requiredMember));
+
+                                // We exclude any members that are abstract and have an implementation in the current type, when that implementation passes the same heuristics
+                                // we use in the other other cases (annotations match up across overrides)
+                                if (requiredMember is PropertySymbol { IsAbstract: true } abstractProperty)
+                                {
+                                    if (members.FirstOrDefault(static (thisMember, baseMember) => thisMember.IsOverride && (object)thisMember.GetOverriddenMember() == baseMember, requiredMember) is { } overridingMember
+                                        && isFilterableOverrideOfAbstractProperty((PropertySymbol)overridingMember))
+                                    {
+                                        continue;
+                                    }
+                                }
+
+                                builder.AddRange(getAllMembersToBeDefaulted(requiredMember, filterOverridingProperties: false));
                             }
 
                             return builder.ToImmutableAndFree();
                         }
 
-                        static IEnumerable<Symbol> getAllMembersToBeDefaulted(Symbol requiredMember)
+                        static OneOrMany<Symbol> getAllMembersToBeDefaulted(Symbol requiredMember, bool filterOverridingProperties)
                         {
                             Debug.Assert(requiredMember.IsRequired());
 
                             if (requiredMember is FieldSymbol)
                             {
-                                yield return requiredMember;
+                                return OneOrMany.Create(requiredMember);
                             }
                             else
                             {
                                 var property = (PropertySymbol)requiredMember;
-                                yield return getFieldSymbolToBeInitialized(property);
+
+                                if (filterOverridingProperties && isFilterableOverrideOfAbstractProperty(property))
+                                {
+                                    return OneOrMany<Symbol>.Empty;
+                                }
+
+                                var @return = OneOrMany.Create(getFieldSymbolToBeInitialized(property));
 
                                 // If the set method is null (ie missing), that's an error, but we'll recover as best we can
                                 foreach (var notNullMemberName in (property.SetMethod?.NotNullMembers ?? property.NotNullMembers))
                                 {
                                     foreach (var member in property.ContainingType.GetMembers(notNullMemberName))
                                     {
-                                        yield return getFieldSymbolToBeInitialized(member);
+                                        @return = @return.Add(getFieldSymbolToBeInitialized(member));
                                     }
                                 }
+
+                                return @return;
                             }
                         }
 
                         static Symbol getFieldSymbolToBeInitialized(Symbol requiredMember)
                             => requiredMember is SourcePropertySymbolBase { BackingField: { } backingField } ? backingField : requiredMember;
+
+                        static bool isFilterableOverrideOfAbstractProperty(PropertySymbol property)
+                        {
+                            // If this is an override of an abstract property, and the overridden property has the same nullable
+                            // annotation as us, we can skip default-initializing the property because the chained constructor
+                            // will have done so
+                            if (property.OverriddenProperty is not { IsAbstract: true } overriddenProperty)
+                            {
+                                return false;
+                            }
+
+                            var symbolAnnotations = property is SourcePropertySymbolBase { UsesFieldKeyword: true, BackingField: { } field }
+                                ? field!.FlowAnalysisAnnotations
+                                : property.GetFlowAnalysisAnnotations();
+                            var symbolType = ApplyUnconditionalAnnotations(property.TypeWithAnnotations, symbolAnnotations);
+                            if (!symbolType.NullableAnnotation.IsNotAnnotated())
+                            {
+                                return false;
+                            }
+
+                            var overriddenAnnotations = overriddenProperty.GetFlowAnalysisAnnotations();
+                            var overriddenType = ApplyUnconditionalAnnotations(overriddenProperty.TypeWithAnnotations, overriddenAnnotations);
+                            return overriddenType.NullableAnnotation == symbolType.NullableAnnotation;
+                        }
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -957,7 +957,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // We want to assume that all required members were _not_ set by the chained constructor
 
                                 // We exclude any members that are abstract and have an implementation in the current type, when that implementation passes the same heuristics
-                                // we use in the other other cases (annotations match up across overrides)
+                                // we use in the other other cases (annotations match up across overrides). This is because the chained constructor, which as SetsRequiredMembers as well,
+                                // will have already set the abstract member to non-null, and there isn't a separate slot for that abstract member.
                                 if (requiredMember is PropertySymbol { IsAbstract: true } abstractProperty)
                                 {
                                     if (members.FirstOrDefault(static (thisMember, baseMember) => thisMember.IsOverride && (object)thisMember.GetOverriddenMember() == baseMember, requiredMember) is { } overridingMember

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -6276,6 +6276,212 @@ public class Derived : Base
         );
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_13()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public required virtual string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (12,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(12, 12),
+            // (12,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(12, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_14()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public virtual string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (6,27): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public virtual string Str { get; set; }
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Str").WithArguments("property", "Str").WithLocation(6, 27),
+            // (12,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(12, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_15()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (12,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(12, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_16()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                }
+
+                public virtual string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (7,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Base(string str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Base").WithArguments("property", "Str").WithLocation(7, 12),
+            // (17,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str) : base(str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(17, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_17()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                }
+
+                public abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_18()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                    this.Str = str;
+                }
+    
+                public required abstract string? Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                [AllowNull]
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers([code, AllowNullAttributeDefinition]);
+        comp.VerifyDiagnostics(
+        );
+    }
+
     [Fact]
     public void SetsRequiredMembersAppliedToRecordCopyConstructor_DeclaredInType()
     {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -5820,6 +5820,462 @@ public class Derived : Base
         );
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_01()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                    this.Str = str;
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_02()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                }
+
+                public required virtual string Str { get; set; } = "";
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (17,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str) : base(str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(17, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_03()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (7,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Base(string str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Base").WithArguments("property", "Str").WithLocation(7, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_04()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public Base(string str)
+                {
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (16,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str) : base(str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(16, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_05()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public Base()
+                {
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base()
+                {
+                    this.Str = str;
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_06()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public Base()
+                {
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                public Derived() : base()
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+
+            public class DerivedDerived : Derived
+            {
+                [SetsRequiredMembers]
+                public DerivedDerived(string str) : base()
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (25,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public DerivedDerived(string str) : base()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "DerivedDerived").WithArguments("property", "Str").WithLocation(25, 12),
+            // (25,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public DerivedDerived(string str) : base()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "DerivedDerived").WithArguments("property", "Str").WithLocation(25, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_07()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public Base()
+                {
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                public Derived() : base()
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+
+            public class DerivedDerived : Derived
+            {
+                [SetsRequiredMembers]
+                public DerivedDerived(string str) : base()
+                {
+                }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (25,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public DerivedDerived(string str) : base()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "DerivedDerived").WithArguments("property", "Str").WithLocation(25, 12)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_08()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                    this.Str = str;
+                }
+    
+                public required abstract string? Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers([code, NotNullAttributeDefinition, DisallowNullAttributeDefinition]);
+        comp.VerifyDiagnostics(
+            // (18,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str) : base(str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(18, 12),
+            // (22,48): warning CS8765: Nullability of type of parameter 'value' doesn't match overridden member (possibly because of nullability attributes).
+            //     public override required string Str { get; set; }
+            Diagnostic(ErrorCode.WRN_TopLevelNullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(22, 48)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_09()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                    this.Str = str;
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                public override required string? Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers([code, MaybeNullAttributeDefinition, AllowNullAttributeDefinition]);
+        comp.VerifyDiagnostics(
+            // (22,44): warning CS8764: Nullability of return type doesn't match overridden member (possibly because of nullability attributes).
+            //     public override required string Str { get; set; }
+            Diagnostic(ErrorCode.WRN_TopLevelNullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(22, 44)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_10()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                    this.Str = str;
+                }
+    
+                public required abstract string? Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                [NotNull, DisallowNull]
+                public override required string? Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers([code, NotNullAttributeDefinition, DisallowNullAttributeDefinition]);
+        comp.VerifyDiagnostics(
+            // (18,12): warning CS8618: Non-nullable property 'Str' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived(string str) : base(str)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Str").WithLocation(18, 12),
+            // (23,49): warning CS8765: Nullability of type of parameter 'value' doesn't match overridden member (possibly because of nullability attributes).
+            //     public override required string? Str { get; set; }
+            Diagnostic(ErrorCode.WRN_TopLevelNullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(23, 49)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_11()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                [SetsRequiredMembers]
+                public Base(string str)
+                {
+                    this.Str = str;
+                }
+    
+                public required abstract string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str) : base(str)
+                {
+                }
+
+                [MaybeNull, AllowNull]
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers([code, MaybeNullAttributeDefinition, AllowNullAttributeDefinition]);
+        comp.VerifyDiagnostics(
+            // (23,43): warning CS8764: Nullability of return type doesn't match overridden member (possibly because of nullability attributes).
+            //     public override required string Str { get; set; }
+            Diagnostic(ErrorCode.WRN_TopLevelNullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(23, 43)
+        );
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_12()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public required abstract string Str { get; set; }
+            }
+
+            public abstract class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str)
+                {
+                    Str = str;
+                }
+
+                public abstract override required string Str { get; set; }
+            }
+
+            public class DerivedDerived : Derived
+            {
+                [SetsRequiredMembers]
+                public DerivedDerived(string str) : base(str)
+                {
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers([code, MaybeNullAttributeDefinition, AllowNullAttributeDefinition]);
+        comp.VerifyDiagnostics(
+        );
+    }
+
     [Fact]
     public void SetsRequiredMembersAppliedToRecordCopyConstructor_DeclaredInType()
     {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -6311,6 +6311,35 @@ public class Derived : Base
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
+    public void SetsRequiredMembersHonoredForPropertyOverride_13A()
+    {
+        var code = """
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            public abstract class Base
+            {
+                public required virtual string Str { get; set; }
+            }
+
+            public class Derived : Base
+            {
+                [SetsRequiredMembers]
+                public Derived(string str)
+                {
+                    Str = str;
+                    base.Str = str;
+                }
+
+                public override required string Str { get; set; }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74423")]
     public void SetsRequiredMembersHonoredForPropertyOverride_14()
     {
         var code = """

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -302,6 +302,28 @@ namespace Microsoft.CodeAnalysis
         /// <typeparam name="TItem">Type of the source array items</typeparam>
         /// <typeparam name="TResult">Type of the transformed array items</typeparam>
         /// <param name="array">The array to transform</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TResult>(this ImmutableArray<TItem> array, Func<TItem, OneOrMany<TResult>> selector)
+        {
+            if (array.Length == 0)
+                return ImmutableArray<TResult>.Empty;
+
+            var builder = ArrayBuilder<TResult>.GetInstance();
+            foreach (var item in array)
+            {
+                selector(item).AddRangeTo(builder);
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+        /// <summary>
+        /// Maps and flattens a subset of immutable array to another immutable array.
+        /// </summary>
+        /// <typeparam name="TItem">Type of the source array items</typeparam>
+        /// <typeparam name="TResult">Type of the transformed array items</typeparam>
+        /// <param name="array">The array to transform</param>
         /// <param name="predicate">The condition to use for filtering the array content.</param>
         /// <param name="selector">A transform function to apply to each element that is not filtered out by <paramref name="predicate"/>.</param>
         /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
@@ -339,6 +361,55 @@ namespace Microsoft.CodeAnalysis
             {
                 if (predicate(item))
                     builder.AddRange(selector(item));
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+        /// <summary>
+        /// Maps and flattens a subset of immutable array to another immutable array.
+        /// </summary>
+        /// <typeparam name="TItem">Type of the source array items</typeparam>
+        /// <typeparam name="TResult">Type of the transformed array items</typeparam>
+        /// <param name="array">The array to transform</param>
+        /// <param name="predicate">The condition to use for filtering the array content.</param>
+        /// <param name="selector">A transform function to apply to each element that is not filtered out by <paramref name="predicate"/>.</param>
+        /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TResult>(this ImmutableArray<TItem> array, Func<TItem, bool> predicate, Func<TItem, OneOrMany<TResult>> selector)
+        {
+            if (array.Length == 0)
+                return ImmutableArray<TResult>.Empty;
+
+            var builder = ArrayBuilder<TResult>.GetInstance();
+            foreach (var item in array)
+            {
+                if (predicate(item))
+                    selector(item).AddRangeTo(builder);
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+        /// <summary>
+        /// Maps and flattens a subset of immutable array to another immutable array.
+        /// </summary>
+        /// <typeparam name="TItem">Type of the source array items</typeparam>
+        /// <typeparam name="TArg">Type of the argument to pass to the predicate and selector</typeparam>
+        /// <typeparam name="TResult">Type of the transformed array items</typeparam>
+        /// <param name="array">The array to transform</param>
+        /// <param name="predicate">The condition to use for filtering the array content.</param>
+        /// <param name="selector">A transform function to apply to each element that is not filtered out by <paramref name="predicate"/>.</param>
+        /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> array, Func<TItem, TArg, bool> predicate, Func<TItem, TArg, OneOrMany<TResult>> selector, TArg arg)
+        {
+            if (array.Length == 0)
+                return ImmutableArray<TResult>.Empty;
+
+            var builder = ArrayBuilder<TResult>.GetInstance();
+            foreach (var item in array)
+            {
+                if (predicate(item, arg))
+                    selector(item, arg).AddRangeTo(builder);
             }
 
             return builder.ToImmutableAndFree();

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -447,6 +447,18 @@ namespace Roslyn.Utilities
             return builder.ToImmutableAndFree();
         }
 
+        public static ImmutableArray<TResult> SelectManyAsArray<TSource, TResult>(this IEnumerable<TSource>? source, Func<TSource, OneOrMany<TResult>> selector)
+        {
+            if (source == null)
+                return ImmutableArray<TResult>.Empty;
+
+            var builder = ArrayBuilder<TResult>.GetInstance();
+            foreach (var item in source)
+                selector(item).AddRangeTo(builder);
+
+            return builder.ToImmutableAndFree();
+        }
+
         /// <summary>
         /// Maps an immutable array through a function that returns ValueTask, returning the new ImmutableArray.
         /// </summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74423. When we're enforcing that all members of a type must have non-null values for `SetsRequiredMembers`, we don't want to include any members of the current type that are overrides of a base type. Instead, those members should be enforced when we check the chained constructor call, since the chained constructor may itself have `SetsRequiredMembers`, and therefore already enforced that overridden properties have a valid state.
