### PR TITLE
Reduce allocations in AbstractRecommendationServiceBasedCompletionProvider.GetSymbolsAsync

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -60,7 +60,7 @@ internal abstract class AbstractRecommendationServiceBasedCompletionProvider<TSy
             if (!shouldPreselectInferredTypes)
                 return recommendedSymbols.NamedSymbols.SelectAsArray(s => new SymbolAndSelectionInfo(Symbol: s, Preselect: false));
 
-            var inferredTypes = context.InferredTypes.Where(t => t.SpecialType != SpecialType.System_Void).ToSet();
+            var inferredTypes = context.InferredTypes.Where(t => t.SpecialType != SpecialType.System_Void).ToSet(SymbolEqualityComparer.Default);
 
             return recommendedSymbols.NamedSymbols.SelectAsArray(
                 static (symbol, args) =>
@@ -68,7 +68,8 @@ internal abstract class AbstractRecommendationServiceBasedCompletionProvider<TSy
                     // Don't preselect intrinsic type symbols so we can preselect their keywords instead. We will also
                     // ignore nullability for purposes of preselection -- if a method is returning a string? but we've
                     // inferred we're assigning to a string or vice versa we'll still count those as the same.
-                    var preselect = args.inferredTypes.Contains(GetSymbolType(symbol), SymbolEqualityComparer.Default) && !args.self.IsInstrinsic(symbol);
+
+                    var preselect = !args.self.IsInstrinsic(symbol) && args.inferredTypes.Count > 0 && args.inferredTypes.Contains(GetSymbolType(symbol));
                     return new SymbolAndSelectionInfo(symbol, preselect);
                 },
                 (inferredTypes, self: this));


### PR DESCRIPTION
This method accounts for about 3% of VS allocations during the typing scenario in the csharp editing scrolling speedometer test.

1) Move the comparer from the Contains call to the Set creation. By having this on the Contains call, the code was actually invoking the Linq overload of contains, fully walking the collection (and creating an enumerator to do so) instead of treating it like a set.

2) Moved the IsIntrinsic call before the InferredTypes check as it is cheap

3) Don't invoke the GetSymbolType method if the inferredTypes array is empty.

It's unclear exactly how much gain this will get, but I saw the inferredTypes collection empty often enough that I am expecting somewhere between a 1% and 2% reduction from this.

*** Relevant allocations from speedometer test without this change ***
![image](https://github.com/user-attachments/assets/e7f5257b-780d-4deb-8881-fdbd6f732f74)