### PR TITLE
Reduce allocations in WithUsingNamespacesAndTypesBinder.GetForwardedToAssemblyInUsingNamespaces

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -2630,9 +2630,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Next?.GetForwardedToAssemblyInUsingNamespaces(metadataName, ref qualifierOpt, diagnostics, location);
         }
 
-        protected AssemblySymbol GetForwardedToAssembly(string fullName, BindingDiagnosticBag diagnostics, Location location)
+        protected AssemblySymbol GetForwardedToAssembly(MetadataTypeName metadataName, BindingDiagnosticBag diagnostics, Location location)
         {
-            var metadataName = MetadataTypeName.FromFullName(fullName);
             foreach (var referencedAssembly in
                 Compilation.Assembly.Modules[0].GetReferencedAssemblySymbols())
             {
@@ -2647,7 +2646,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (diagInfo.Code == (int)ErrorCode.ERR_CycleInTypeForwarder)
                         {
                             Debug.Assert((object)forwardedType.ContainingAssembly != null, "How did we find a cycle if there was no forwarding?");
-                            diagnostics.Add(ErrorCode.ERR_CycleInTypeForwarder, location, fullName, forwardedType.ContainingAssembly.Name);
+                            diagnostics.Add(ErrorCode.ERR_CycleInTypeForwarder, location, metadataName.FullName, forwardedType.ContainingAssembly.Name);
                         }
                         else if (diagInfo.Code == (int)ErrorCode.ERR_TypeForwardedToMultipleAssemblies)
                         {
@@ -2717,7 +2716,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // File types can't be forwarded, so we won't attempt to determine a file identifier to attach to the metadata name.
             var metadataName = MetadataHelpers.ComposeAritySuffixedMetadataName(name, arity, associatedFileIdentifier: null);
             var fullMetadataName = MetadataHelpers.BuildQualifiedName(qualifierOpt?.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat), metadataName);
-            var result = GetForwardedToAssembly(fullMetadataName, diagnostics, location);
+            var result = GetForwardedToAssembly(
+                MetadataTypeName.FromFullName(fullMetadataName),
+                diagnostics,
+                location);
             if ((object)result != null)
             {
                 return result;

--- a/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
@@ -52,8 +52,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var typeOrNamespace in GetUsings(basesBeingResolved: null))
             {
-                var fullName = typeOrNamespace.NamespaceOrType + "." + name;
-                var result = GetForwardedToAssembly(fullName, diagnostics, location);
+                var result = GetForwardedToAssembly(
+                    MetadataTypeName.FromNamespaceAndTypeName(typeOrNamespace.NamespaceOrType.ToString(), name),
+                    diagnostics,
+                    location);
                 if (result != null)
                 {
                     qualifierOpt = typeOrNamespace.NamespaceOrType;


### PR DESCRIPTION
This method shows up as 1.1% of allocations in the typing scenario in the csharp editing speedometer test. Of that, 0.6% is in the string.Concat call merging the Namespace, '.', and type name.

Instead of creating and passing this merged string to GetForwardedToAssembly, we can instead construct a MetadataTypeName to pass to that method. That struct can either be constructed using a fullname or a namespace/typename combination.  In the caller where we are trying to get rid of the string concat, we can pass in the namespace/typename and avoid the concat operation completely.

The other caller to GetForwardedToAssembly also now passes in a MetadataTypeName, but it's constructed from the fullname as that method used to do itself before taking in the MetadataTypeName.

![image](https://github.com/user-attachments/assets/89d5dc7b-1093-4533-a515-8c8d1a706f71)