### PR TITLE
Reduce allocations in CompletionItem.GetEntireDisplayText

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -543,7 +543,14 @@ public sealed class CompletionItem : IComparable<CompletionItem>
     }
 
     internal string GetEntireDisplayText()
-        => _lazyEntireDisplayText ??= DisplayTextPrefix + DisplayText + DisplayTextSuffix;
+    {
+        // Avoid allocating in common case where prefix and suffix are empty
+        _lazyEntireDisplayText ??= (DisplayTextPrefix.Length > 0 || DisplayTextSuffix.Length > 0)
+            ? DisplayTextPrefix + DisplayText + DisplayTextSuffix
+            : DisplayText;
+
+        return _lazyEntireDisplayText;
+    }
 
     public override string ToString() => GetEntireDisplayText();
 }


### PR DESCRIPTION
This method's call to string.Concat shows up as about 0.4% of allocations during the typing scenario in the csharp editing speedometer test.

Manual local testing was showing over 90% of calls to this method are done with both prefix and suffix strings empty. Unfortunately, netfx's string.Concat implementation still allocates in this case. Instead, we'll check for this case, and either do the string.Concat if necessary or just use DisplayText directly.

*** allocations of interest from the csharp editing speedometer test ***
![image](https://github.com/user-attachments/assets/8210d9c8-5cc4-4a1d-84d7-0616ec6cf56c)