### PR TITLE
Remove an enumerator allocation in SymbolCompletionItem.CreateWorker

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
@@ -189,7 +189,7 @@ internal class AttributeNamedParameterCompletionProvider : LSPCompletionProvider
                    displayText: p.Name.ToIdentifierToken().ToString(),
                    displayTextSuffix: displayTextSuffix,
                    insertionText: null,
-                   symbols: ImmutableArray.Create(p),
+                   symbols: [p],
                    contextPosition: token.SpanStart,
                    sortText: p.Name,
                    rules: CompletionItemRules.Default);

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/FunctionPointerUnmanagedCallingConventionCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/FunctionPointerUnmanagedCallingConventionCompletionProvider.cs
@@ -112,7 +112,7 @@ internal sealed partial class FunctionPointerUnmanagedCallingConventionCompletio
                 completionItems.Add(
                     SymbolCompletionItem.CreateWithSymbolId(
                         displayName,
-                        ImmutableArray.Create(type),
+                        [type],
                         rules: CompletionItemRules.Default,
                         contextPosition));
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -117,7 +117,7 @@ internal sealed partial class NamedParameterCompletionProvider : LSPCompletionPr
                 context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
                     displayText: escapedName,
                     displayTextSuffix: ColonString,
-                    symbols: ImmutableArray.Create(parameter),
+                    symbols: [parameter],
                     rules: s_rules.WithMatchPriority(SymbolMatchPriority.PreferNamedArgument),
                     contextPosition: token.SpanStart,
                     filterText: escapedName));

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
@@ -106,7 +106,7 @@ internal class TupleNameCompletionProvider : LSPCompletionProvider
             context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
               displayText: field.Name,
               displayTextSuffix: ColonString,
-              symbols: ImmutableArray.Create(field),
+              symbols: [field],
               rules: CompletionItemRules.Default,
               contextPosition: spanStart,
               filterText: field.Name));

--- a/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
@@ -82,28 +82,6 @@ internal static class CommonCompletionUtilities
         return true;
     }
 
-    public static Func<CancellationToken, Task<CompletionDescription>> CreateDescriptionFactory(
-        SolutionServices workspaceServices,
-        SemanticModel semanticModel,
-        int position,
-        ISymbol symbol,
-        SymbolDescriptionOptions options)
-    {
-        return CreateDescriptionFactory(workspaceServices, semanticModel, position, options, [symbol]);
-    }
-
-    public static Func<CancellationToken, Task<CompletionDescription>> CreateDescriptionFactory(
-        SolutionServices workspaceServices, SemanticModel semanticModel, int position, SymbolDescriptionOptions options, IReadOnlyList<ISymbol> symbols)
-    {
-        return c => CreateDescriptionAsync(workspaceServices, semanticModel, position, symbols, options, supportedPlatforms: null, cancellationToken: c);
-    }
-
-    public static Func<CancellationToken, Task<CompletionDescription>> CreateDescriptionFactory(
-        SolutionServices workspaceServices, SemanticModel semanticModel, int position, IReadOnlyList<ISymbol> symbols, SymbolDescriptionOptions options, SupportedPlatformData supportedPlatforms)
-    {
-        return c => CreateDescriptionAsync(workspaceServices, semanticModel, position, symbols, options, supportedPlatforms: supportedPlatforms, cancellationToken: c);
-    }
-
     public static async Task<CompletionDescription> CreateDescriptionAsync(
         SolutionServices workspaceServices, SemanticModel semanticModel, int position, ISymbol symbol, int overloadCount, SymbolDescriptionOptions options, SupportedPlatformData? supportedPlatforms, CancellationToken cancellationToken)
     {
@@ -170,13 +148,13 @@ internal static class CommonCompletionUtilities
     }
 
     public static Task<CompletionDescription> CreateDescriptionAsync(
-        SolutionServices workspaceServices, SemanticModel semanticModel, int position, IReadOnlyList<ISymbol> symbols, SymbolDescriptionOptions options, SupportedPlatformData? supportedPlatforms, CancellationToken cancellationToken)
+        SolutionServices workspaceServices, SemanticModel semanticModel, int position, ImmutableArray<ISymbol> symbols, SymbolDescriptionOptions options, SupportedPlatformData? supportedPlatforms, CancellationToken cancellationToken)
     {
         // Lets try to find the first non-obsolete symbol (overload) and fall-back
         // to the first symbol if all are obsolete.
         var symbol = symbols.FirstOrDefault(s => !s.IsObsolete()) ?? symbols[0];
 
-        return CreateDescriptionAsync(workspaceServices, semanticModel, position, symbol, overloadCount: symbols.Count - 1, options, supportedPlatforms, cancellationToken);
+        return CreateDescriptionAsync(workspaceServices, semanticModel, position, symbol, overloadCount: symbols.Length - 1, options, supportedPlatforms, cancellationToken);
     }
 
     private static void AddOverloadPart(List<TaggedText> textContentBuilder, int overloadCount, bool isGeneric)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -66,7 +66,7 @@ internal abstract partial class AbstractPartialTypeCompletionProvider<TSyntaxCon
             displayText: displayText,
             displayTextSuffix: suffix,
             insertionText: insertionText,
-            symbols: ImmutableArray.Create(symbol),
+            symbols: [symbol],
             contextPosition: context.Position,
             properties: GetProperties(symbol, context),
             rules: CompletionItemRules.Default);

--- a/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api;
 
@@ -42,7 +43,7 @@ internal abstract class PythiaCompletionProviderBase : CommonCompletionProvider,
         SupportedPlatformData? supportedPlatforms = null,
         ImmutableDictionary<string, string>? properties = null,
         ImmutableArray<string> tags = default)
-        => SymbolCompletionItem.CreateWithSymbolId(displayText, displayTextSuffix: null, symbols, rules, contextPosition, sortText, insertionText,
+        => SymbolCompletionItem.CreateWithSymbolId(displayText, displayTextSuffix: null, symbols.ToImmutableArray(), rules, contextPosition, sortText, insertionText,
             filterText, displayTextPrefix: null, inlineDescription: null, glyph: null, supportedPlatforms, properties.AsImmutableOrNull(), tags);
 
     public static ImmutableArray<SymbolDisplayPart> CreateRecommendedKeywordDisplayParts(string keyword, string toolTip)

--- a/src/Features/Core/Portable/IntroduceUsingStatement/AbstractIntroduceUsingStatementCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/IntroduceUsingStatement/AbstractIntroduceUsingStatementCodeRefactoringProvider.cs
@@ -429,7 +429,7 @@ internal abstract class AbstractIntroduceUsingStatementCodeRefactoringProvider<
     private static void AddReferencedLocalVariables(
         HashSet<ISymbol> referencedVariables,
         SyntaxNode node,
-        IReadOnlyList<ISymbol> localVariables,
+        ArrayBuilder<ISymbol> localVariables,
         SemanticModel semanticModel,
         ISyntaxFactsService syntaxFactsService,
         CancellationToken cancellationToken)


### PR DESCRIPTION
This is a small allocation, only showing up as about 0.1% of allocationsi n the typing scenario in the csharp editing speedometer test. However, the change is fairly simple, and I prefer the change as it passes around ImmutableArrays instead of IReadOnlyLists.

*** relevant allocations from the csharp editing speedometer test ***
![image](https://github.com/user-attachments/assets/3b8ff0bd-6bc4-4b14-aa8e-a7882930ac02)