### PR TITLE
Cache the compilation states in compilation order to avoid recalculation

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -397,6 +397,22 @@ namespace Roslyn.Utilities
             return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
+        public static ImmutableArray<TResult> SelectAsArray<TSource, TResult, TArg>(this IReadOnlyCollection<TSource>? source, Func<TSource, TArg, TResult> selector, TArg arg)
+        {
+            if (source == null)
+                return ImmutableArray<TResult>.Empty;
+
+            var builder = new TResult[source.Count];
+            var index = 0;
+            foreach (var item in source)
+            {
+                builder[index] = selector(item, arg);
+                index++;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
+        }
+
         public static ImmutableArray<TResult> SelectManyAsArray<TSource, TResult>(this IEnumerable<TSource>? source, Func<TSource, IEnumerable<TResult>> selector)
         {
             if (source == null)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -49,6 +49,7 @@ internal sealed class TextDocumentStates<TState>
 #endif
 
     private readonly ImmutableList<DocumentId> _ids;
+    private ImmutableArray<TState> _statesInCompilationOrder;
     private FilePathToDocumentIds? _filePathToDocumentIds;
 
     private TextDocumentStates(
@@ -61,6 +62,7 @@ internal sealed class TextDocumentStates<TState>
         _ids = ids;
         States = map;
         _filePathToDocumentIds = filePathToDocumentIds;
+        _statesInCompilationOrder = ImmutableArray<TState>.Empty;
     }
 
     public TextDocumentStates(IEnumerable<TState> states)
@@ -117,10 +119,15 @@ internal sealed class TextDocumentStates<TState>
     /// Get states ordered in compilation order.
     /// </summary>
     /// <returns></returns>
-    public IEnumerable<TState> GetStatesInCompilationOrder()
+    public ImmutableArray<TState> GetStatesInCompilationOrder()
     {
-        var map = States;
-        return Ids.Select(id => map[id]);
+        if (_statesInCompilationOrder.IsEmpty)
+        {
+            var map = States;
+            _statesInCompilationOrder = Ids.SelectAsArray(static (id, map) => map[id], map);
+        }
+
+        return _statesInCompilationOrder;
     }
 
     public ImmutableArray<TValue> SelectAsArray<TValue>(Func<TState, TValue> selector)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -62,7 +62,6 @@ internal sealed class TextDocumentStates<TState>
         _ids = ids;
         States = map;
         _filePathToDocumentIds = filePathToDocumentIds;
-        _statesInCompilationOrder = ImmutableArray<TState>.Empty;
     }
 
     public TextDocumentStates(IEnumerable<TState> states)
@@ -121,11 +120,8 @@ internal sealed class TextDocumentStates<TState>
     /// <returns></returns>
     public ImmutableArray<TState> GetStatesInCompilationOrder()
     {
-        if (_statesInCompilationOrder.IsEmpty)
-        {
-            var map = States;
-            _statesInCompilationOrder = Ids.SelectAsArray(static (id, map) => map[id], map);
-        }
+        if (_statesInCompilationOrder.IsDefault)
+            _statesInCompilationOrder = Ids.SelectAsArray(static (id, map) => map[id], States);
 
         return _statesInCompilationOrder;
     }


### PR DESCRIPTION
Cache the compilation states in compilation order to avoid recalculation

GetStatesInCompilationOrder shows up pretty heavily in CPU usage in the typing scenario in the csharp editing speedometer. The enumerating of the ImmutableList and the repeated searching in the ImmutableSortedDictionary are actually more expensive than one would think.

GetStatesInCompilationOrder is optimized out of the profile, but it looks like it is accounting for about 5% of CPU.

I'm going to run a test insertion with this change and see what the CPU/memory delta of this method looks like with this change.

*** CPU in typing scenario in csharp editing speedometer test ***
![image](https://github.com/user-attachments/assets/0dd18978-269f-4a1e-9a69-b8c07cdc0566)

*** Memory allocations under RegularCompilationTracker.WithDoNotCreateCreationPolicy ***
![image](https://github.com/user-attachments/assets/cdadb11f-c4eb-4854-b19e-fec0bb24961c)
 