### PR TITLE
Small reduction in allocations in DateAndTimeLanguageDetector

### DIFF
--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
@@ -18,8 +18,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime.Language
 /// </summary>
 internal sealed class DateAndTimeLanguageDetector(
     EmbeddedLanguageInfo info,
-    INamedTypeSymbol? dateTimeType,
-    INamedTypeSymbol? dateTimeOffsetType)
+    Compilation compilation)
     : AbstractLanguageDetector<DateAndTimeOptions, DateTimeTree, DateAndTimeLanguageDetector, DateAndTimeLanguageDetector.DateAndTimeInfo>(
         info, LanguageIdentifiers, CommentDetector)
 {
@@ -28,18 +27,14 @@ internal sealed class DateAndTimeLanguageDetector(
         public ImmutableArray<string> LanguageIdentifiers => ["Date", "Time", "DateTime", "DateTimeFormat"];
 
         public DateAndTimeLanguageDetector Create(Compilation compilation, EmbeddedLanguageInfo info)
-        {
-            var dateTimeType = compilation.GetTypeByMetadataName(typeof(DateTime).FullName!);
-            var dateTimeOffsetType = compilation.GetTypeByMetadataName(typeof(DateTimeOffset).FullName!);
-
-            return new DateAndTimeLanguageDetector(info, dateTimeType, dateTimeOffsetType);
-        }
+            => new DateAndTimeLanguageDetector(info, compilation);
     }
 
     private const string FormatName = "format";
 
-    private readonly INamedTypeSymbol? _dateTimeType = dateTimeType;
-    private readonly INamedTypeSymbol? _dateTimeOffsetType = dateTimeOffsetType;
+    private readonly Compilation _compilation = compilation;
+    private INamedTypeSymbol? _dateTimeType;
+    private INamedTypeSymbol? _dateTimeOffsetType;
 
     protected override bool TryGetOptions(SemanticModel semanticModel, ITypeSymbol exprType, SyntaxNode expr, CancellationToken cancellationToken, out DateAndTimeOptions options)
     {
@@ -158,7 +153,15 @@ internal sealed class DateAndTimeLanguageDetector(
            AnalyzeStringLiteral(method, argName, argIndex);
 
     private bool IsDateTimeType(ITypeSymbol? type)
-        => type != null && (type.Equals(_dateTimeType) || type.Equals(_dateTimeOffsetType));
+    {
+        if (type == null)
+            return false;
+
+        _dateTimeType ??= _compilation.GetTypeByMetadataName(typeof(DateTime).FullName!);
+        _dateTimeOffsetType ??= _compilation.GetTypeByMetadataName(typeof(DateTimeOffset).FullName!);
+
+        return type.Equals(_dateTimeType) || type.Equals(_dateTimeOffsetType);
+    }
 
     private static bool AnalyzeStringLiteral(IMethodSymbol method, string? argName, int? argIndex)
     {


### PR DESCRIPTION
Previously, this class would obtain the DateTime and DateTimeOffset types from the compilation during construction. This PR defers obtaining that information until it's needed (it's very commonly not)

This is a pretty small benefit, only about 0.2% of allocations during the typing scenario in the csharp editing speedometer test.

*** Previous allocations during typing scenario in csharp editing speedometer test ***
![image](https://github.com/user-attachments/assets/1bd971f8-7b4a-474b-8a9e-e8894ac6d9db)