### PR TITLE
Optimize ProjectDependencyGraph.DoesProjectTransitivelyDependOnProject

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -543,9 +543,9 @@ public partial class ProjectDependencyGraph
         // Check the dependency graph to see if project 'id' directly or transitively depends on 'projectId'.
         // If the information is not available, do not compute it.
         var forwardDependencies = TryGetProjectsThatThisProjectTransitivelyDependsOn(id);
-        if (forwardDependencies is object && forwardDependencies.Contains(potentialDependency))
+        if (forwardDependencies is object)
         {
-            return true;
+            return forwardDependencies.Contains(potentialDependency);
         }
 
         // Compute the set of all projects that depend on 'potentialDependency'. This information answers the same


### PR DESCRIPTION
I believe that this method unnecessarilly obtains the reverse dependencies when the forward references are already defined. If the forward references are present, we should just use the result of trying to find the potential dependencies in it.

DoesProjectTransitivelyDependOnProject shows as 2.9% of allocations and 1.6% of CPU in the typing scenario in the scharp editing speedometer test. Will kick off a test insertion and see what those numbers are with this change.

*** CPU before change ***
![image](https://github.com/user-attachments/assets/c8952b63-f00d-4c66-b5fb-f7afa7345c07)

*** Allocations before change ***
![image](https://github.com/user-attachments/assets/e25ac28f-e806-4326-bc1c-30b4fa43c8e2)
