### PR TITLE
Fix extract method in top level

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodMiscellaneousTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodMiscellaneousTests.cs
@@ -126,6 +126,11 @@ public sealed class ExtractMethodMiscellaneousTests
             }
             """;
 
+        await TestCommandHandler(markupCode, result: null, expectNotification: true);
+    }
+
+    private static async Task TestCommandHandler(string markupCode, string? result, bool expectNotification)
+    {
         using var workspace = EditorTestWorkspace.CreateCSharp(markupCode, composition: EditorTestCompositions.EditorFeaturesWpf);
         var testDocument = workspace.Documents.Single();
 
@@ -133,9 +138,11 @@ public sealed class ExtractMethodMiscellaneousTests
         view.Selection.Select(new SnapshotSpan(
             view.TextBuffer.CurrentSnapshot, testDocument.SelectedSpans[0].Start, testDocument.SelectedSpans[0].Length), isReversed: false);
 
+        result ??= view.TextBuffer.CurrentSnapshot.GetText();
+
         var callBackService = (INotificationServiceCallback)workspace.Services.GetRequiredService<INotificationService>();
-        var called = false;
-        callBackService.NotificationCallback = (_, _, _) => called = true;
+        var gotNotification = false;
+        callBackService.NotificationCallback = (_, _, _) => gotNotification = true;
 
         var handler = workspace.ExportProvider.GetCommandHandler<ExtractMethodCommandHandler>(PredefinedCommandHandlerNames.ExtractMethod, ContentTypeNames.CSharpContentType);
 
@@ -144,6 +151,24 @@ public sealed class ExtractMethodMiscellaneousTests
         var waiter = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.ExtractMethod);
         await waiter.ExpeditedWaitAsync();
 
-        Assert.True(called);
+        Assert.Equal(expectNotification, gotNotification);
+        Assert.Equal(result, view.TextBuffer.CurrentSnapshot.GetText());
+    }
+
+    [WpfFact]
+    public async Task TestExtractLocalFunctionInTopLevelFromCommandHandler()
+    {
+        var markupCode = """
+            System.Console.WriteLine([|"string"|]);
+            """;
+
+        await TestCommandHandler(markupCode, """
+            System.Console.WriteLine(NewMethod());
+            
+            static string NewMethod()
+            {
+                return "string";
+            }
+            """, expectNotification: false);
     }
 }

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodMiscellaneousTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodMiscellaneousTests.cs
@@ -155,7 +155,7 @@ public sealed class ExtractMethodMiscellaneousTests
         Assert.Equal(result, view.TextBuffer.CurrentSnapshot.GetText());
     }
 
-    [WpfFact]
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/65465")]
     public async Task TestExtractLocalFunctionInTopLevelFromCommandHandler()
     {
         var markupCode = """

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -12208,13 +12208,12 @@ public sealed partial class ExtractMethodTests : ExtractMethodBase
             """;
         var expected = """
             bool local;
+            local = NewMethod();
 
             static bool NewMethod()
             {
                 return true;
             }
-
-            local = NewMethod();
             """;
         await TestExtractMethodAsync(code, expected, localFunction: true);
     }

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -12216,7 +12216,7 @@ public sealed partial class ExtractMethodTests : ExtractMethodBase
 
             local = NewMethod();
             """;
-        await TestExtractMethodAsync(code, expected);
+        await TestExtractMethodAsync(code, expected, localFunction: true);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/44260")]
@@ -12236,7 +12236,7 @@ public sealed partial class ExtractMethodTests : ExtractMethodBase
                 return "string";
             }
             """;
-        await TestExtractMethodAsync(code, expected);
+        await TestExtractMethodAsync(code, expected, localFunction: true);
     }
 
     [Theory]

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -12119,15 +12119,14 @@ $@"namespace ClassLibrary9
             """;
         var expected = """
             bool local;
+            local = NewMethod();
 
             static bool NewMethod()
             {
                 return true;
             }
-
-            local = NewMethod();
             """;
-        await TestExtractMethodAsync(code, expected);
+        await TestExtractMethodAsync(code, expected, localFunction: true);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/44260")]
@@ -12147,7 +12146,7 @@ $@"namespace ClassLibrary9
                 return "string";
             }
             """;
-        await TestExtractMethodAsync(code, expected);
+        await TestExtractMethodAsync(code, expected, localFunction: true);
     }
 
     [Theory]

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -12119,14 +12119,15 @@ $@"namespace ClassLibrary9
             """;
         var expected = """
             bool local;
-            local = NewMethod();
 
             static bool NewMethod()
             {
                 return true;
             }
+
+            local = NewMethod();
             """;
-        await TestExtractMethodAsync(code, expected, localFunction: true);
+        await TestExtractMethodAsync(code, expected);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/44260")]
@@ -12146,7 +12147,7 @@ $@"namespace ClassLibrary9
                 return "string";
             }
             """;
-        await TestExtractMethodAsync(code, expected, localFunction: true);
+        await TestExtractMethodAsync(code, expected);
     }
 
     [Theory]

--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -39,7 +39,6 @@ internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMetho
     private readonly IThreadingContext _threadingContext;
     private readonly ITextBufferUndoManagerProvider _undoManager;
     private readonly IInlineRenameService _renameService;
-    private readonly IGlobalOptionService _globalOptions;
     private readonly IAsynchronousOperationListener _asyncListener;
 
     [ImportingConstructor]
@@ -48,7 +47,6 @@ internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMetho
         IThreadingContext threadingContext,
         ITextBufferUndoManagerProvider undoManager,
         IInlineRenameService renameService,
-        IGlobalOptionService globalOptions,
         IAsynchronousOperationListenerProvider asyncListenerProvider)
     {
         Contract.ThrowIfNull(threadingContext);
@@ -58,7 +56,6 @@ internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMetho
         _threadingContext = threadingContext;
         _undoManager = undoManager;
         _renameService = renameService;
-        _globalOptions = globalOptions;
         _asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.ExtractMethod);
     }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
@@ -81,17 +81,16 @@ internal abstract partial class CSharpSelectionResult(
     }
 
     protected override bool UnderAnonymousOrLocalMethod(SyntaxToken token, SyntaxToken firstToken, SyntaxToken lastToken)
+        => IsUnderAnonymousOrLocalMethod(token, firstToken, lastToken);
+
+    public static bool IsUnderAnonymousOrLocalMethod(SyntaxToken token, SyntaxToken firstToken, SyntaxToken lastToken)
     {
         for (var current = token.Parent; current != null; current = current.Parent)
         {
             if (current is MemberDeclarationSyntax)
                 return false;
 
-            if (current is
-                    SimpleLambdaExpressionSyntax or
-                    ParenthesizedLambdaExpressionSyntax or
-                    AnonymousMethodExpressionSyntax or
-                    LocalFunctionStatementSyntax)
+            if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax)
             {
                 // make sure the selection contains the lambda
                 return firstToken.SpanStart <= current.GetFirstToken().SpanStart &&

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
@@ -94,15 +94,11 @@ internal sealed partial class CSharpSelectionValidator(
         {
             // Cannot extract a method from a top-level statement in normal code
             if (!localFunction && options is { Kind: SourceCodeKind.Regular })
-            {
                 return selectionInfo.WithStatus(s => s.With(succeeded: false, CSharpFeaturesResources.Selection_cannot_include_top_level_statements));
-            }
 
             // Cannot extract a local function from a global statement in script code
             if (localFunction && options is { Kind: SourceCodeKind.Script })
-            {
                 return selectionInfo.WithStatus(s => s.With(succeeded: false, CSharpFeaturesResources.Selection_cannot_include_global_statements));
-            }
         }
 
         if (_localFunction)
@@ -110,21 +106,15 @@ internal sealed partial class CSharpSelectionValidator(
             foreach (var ancestor in selectionInfo.CommonRootFromOriginalSpan.AncestorsAndSelf())
             {
                 if (ancestor.Kind() is SyntaxKind.BaseConstructorInitializer or SyntaxKind.ThisConstructorInitializer)
-                {
                     return selectionInfo.WithStatus(s => s.With(succeeded: false, CSharpFeaturesResources.Selection_cannot_be_in_constructor_initializer));
-                }
 
                 if (ancestor is AnonymousFunctionExpressionSyntax)
-                {
                     break;
-                }
             }
         }
 
         if (!selectionInfo.SelectionInExpression)
-        {
             return selectionInfo;
-        }
 
         var expressionNode = selectionInfo.FirstTokenInFinalSpan.GetCommonRoot(selectionInfo.LastTokenInFinalSpan);
         if (expressionNode is not AssignmentExpressionSyntax assign)
@@ -132,9 +122,7 @@ internal sealed partial class CSharpSelectionValidator(
 
         // make sure there is a visible token at right side expression
         if (assign.Right.GetLastToken().Kind() == SyntaxKind.None)
-        {
             return selectionInfo;
-        }
 
         return AssignFinalSpan(selectionInfo
             .With(s => s.FirstTokenInFinalSpan = assign.Right.GetFirstToken(includeZeroWidth: true))

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5366,6 +5366,7 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
+            CodeActionIndex = 1,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5399,6 +5400,7 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
+            CodeActionIndex = 1,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5422,7 +5424,7 @@ class Program
             }
             """;
 
-        await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9));
+        await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9), index: 1);
     }
 
     [Fact]

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5366,7 +5366,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 1,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5400,7 +5399,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 1,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5424,7 +5422,7 @@ class Program
             }
             """;
 
-        await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9), index: 1);
+        await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5366,8 +5366,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 1,
-            CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
 
@@ -5424,7 +5422,7 @@ class Program
             }
             """;
 
-        await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9), index: 1);
+        await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5398,7 +5398,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 1,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5412,13 +5411,11 @@ class Program
             """;
         var expected =
             """
-            {
-                System.Console.WriteLine({|Rename:NewMethod|}());
+            System.Console.WriteLine({|Rename:NewMethod|}());
 
-                static string NewMethod()
-                {
-                    return "string";
-                }
+            static string NewMethod()
+            {
+                return "string";
             }
             """;
 

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
@@ -5046,9 +5046,15 @@ $@"
                 Sources = { code },
                 OutputKind = OutputKind.ConsoleApplication,
             },
-            FixedCode = code,
+            FixedCode = """
+            NewMethod();
+            
+            static void NewMethod()
+            {
+                System.Console.WriteLine("string");
+            }
+            """,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_method),
         }.RunAsync();
     }
 
@@ -5115,19 +5121,24 @@ $@"
                 OutputKind = OutputKind.ConsoleApplication,
             },
             FixedCode = """
-            using System;
+                using System;
             
-            Console.WriteLine("string");
+                Console.WriteLine("string");
             
-            [|int x = int.Parse("0");
-            Console.WriteLine(x);|]
+                int x = NewMethod();
             
-            Console.WriteLine(x);
+                Console.WriteLine(x);
             
-            class Ignored { }
-            """,
+                class Ignored { }
+
+                static int NewMethod()
+                {
+                    int x = int.Parse("0");
+                    Console.WriteLine(x);
+                    return x;
+                }
+                """,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_method),
         }.RunAsync();
     }
 
@@ -5157,9 +5168,25 @@ $@"
                 Sources = { code },
                 OutputKind = OutputKind.ConsoleApplication,
             },
-            FixedCode = code,
+            FixedCode = """
+            using System;
+
+            Console.WriteLine("string");
+
+            class Ignored { }
+
+            int x = NewMethod();
+
+            Console.WriteLine(x);
+
+            static int NewMethod()
+            {
+                int x = int.Parse("0");
+                Console.WriteLine(x);
+                return x;
+            }
+            """,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_method),
         }.RunAsync();
     }
 

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
@@ -5044,9 +5044,19 @@ $@"
                 Sources = { code },
                 OutputKind = OutputKind.ConsoleApplication,
             },
-            FixedCode = code,
+            FixedCode = """
+            System.Console.WriteLine("string");
+            
+            static int NewMethod()
+            {
+                int x = int.Parse("0");
+                System.Console.WriteLine(x);
+                return x;
+            }
+
+            int x = NewMethod();
+            """,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_method),
         }.RunAsync();
     }
 
@@ -5074,7 +5084,18 @@ $@"
                 Sources = { code },
                 OutputKind = OutputKind.ConsoleApplication,
             },
-            FixedCode = code,
+            FixedCode = """
+            using System;
+            
+            Console.WriteLine("string");
+            
+            [|int x = int.Parse("0");
+            Console.WriteLine(x);|]
+            
+            Console.WriteLine(x);
+            
+            class Ignored { }
+            """,
             LanguageVersion = LanguageVersion.CSharp9,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_method),
         }.RunAsync();
@@ -5106,7 +5127,21 @@ $@"
                 Sources = { code },
                 OutputKind = OutputKind.ConsoleApplication,
             },
-            FixedCode = code,
+            FixedCode = """"
+            using System;
+
+            Console.WriteLine("string");
+
+            class Ignored { }
+
+            [|{|CS8803:int x = int.Parse("0");|}
+            Console.WriteLine(x);|]
+
+            Console.WriteLine(x);
+
+            class Ignored2 { }
+            """
+            """",
             LanguageVersion = LanguageVersion.CSharp9,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_method),
         }.RunAsync();

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
@@ -5074,6 +5074,10 @@ $@"
             },
             FixedCode = """
             System.Console.WriteLine("string");
+
+            int x = NewMethod();
+
+            System.Console.WriteLine(x);
             
             static int NewMethod()
             {
@@ -5081,8 +5085,6 @@ $@"
                 System.Console.WriteLine(x);
                 return x;
             }
-
-            int x = NewMethod();
             """,
             LanguageVersion = LanguageVersion.CSharp9,
         }.RunAsync();
@@ -5155,21 +5157,7 @@ $@"
                 Sources = { code },
                 OutputKind = OutputKind.ConsoleApplication,
             },
-            FixedCode = """"
-            using System;
-
-            Console.WriteLine("string");
-
-            class Ignored { }
-
-            [|{|CS8803:int x = int.Parse("0");|}
-            Console.WriteLine(x);|]
-
-            Console.WriteLine(x);
-
-            class Ignored2 { }
-            """
-            """",
+            FixedCode = code,
             LanguageVersion = LanguageVersion.CSharp9,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_method),
         }.RunAsync();

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests2.cs
@@ -5128,8 +5128,6 @@ $@"
                 int x = NewMethod();
             
                 Console.WriteLine(x);
-            
-                class Ignored { }
 
                 static int NewMethod()
                 {
@@ -5137,6 +5135,8 @@ $@"
                     Console.WriteLine(x);
                     return x;
                 }
+                
+                class Ignored { }
                 """,
             LanguageVersion = LanguageVersion.CSharp9,
         }.RunAsync();
@@ -5175,7 +5175,7 @@ $@"
 
             class Ignored { }
 
-            int x = NewMethod();
+            {|CS8803:int x = NewMethod();|}
 
             Console.WriteLine(x);
 
@@ -5185,6 +5185,8 @@ $@"
                 Console.WriteLine(x);
                 return x;
             }
+            
+            class Ignored2 { }
             """,
             LanguageVersion = LanguageVersion.CSharp9,
         }.RunAsync();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76188
Fixes https://github.com/dotnet/roslyn/issues/67647

Followup to https://github.com/dotnet/roslyn/pull/76383

The general idea here is that at the top level:

1. we should not offer extract method, we should offer 'extract local function' in our lightbulb.
2. if the user invokes the command handler, we should try 'extract method' first.  If that fails, we should try 'extract local function'.  If that produces a better outcome, we use that instead.  