### PR TITLE
Reduce allocations again in ComputeReverseReferencesMap

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -228,7 +228,8 @@ public partial class ProjectDependencyGraph
             }
         }
 
-        using var _2 = PooledDictionary<ProjectId, ImmutableHashSet<ProjectId>>.GetInstance(out var reverseReferencesMap);
+        // Convert all the populated ImmutableHashSet.Builder objects to ImmutableHashSets
+        var reverseReferencesBuilder = ImmutableDictionary.CreateBuilder<ProjectId, ImmutableHashSet<ProjectId>>();
         foreach (var (projectId, builder) in reverseReferencesMapBuilders)
         {
             // Realize an ImmutableHashSet from the builder
@@ -238,10 +239,10 @@ public partial class ProjectDependencyGraph
             builder.Clear();
             s_reverseReferencesBuilderPool.Free(builder);
 
-            reverseReferencesMap.Add(projectId, reverseReferencesForProject);
+            reverseReferencesBuilder.Add(projectId, reverseReferencesForProject);
         }
 
-        return reverseReferencesMap.ToImmutableDictionary();
+        return reverseReferencesBuilder.ToImmutable();
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
@@ -54,6 +55,9 @@ public partial class ProjectDependencyGraph
     // These accumulate results on demand. They are never null, but a missing key/value pair indicates it needs to be computed.
     private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap;
     private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap;
+
+    // Pool of ImmutableHashSet builders used in ComputeReverseReferencesMap to avoid temporary HashSet allocations.
+    private static readonly ObjectPool<ImmutableHashSet<ProjectId>.Builder> s_reverseReferencesBuilderPool = new(static () => ImmutableHashSet.CreateBuilder<ProjectId>(), size: 128);
 
     /// <remarks>
     ///   Intentionally created with a null reverseReferencesMap. Doing so indicates _lazyReverseReferencesMap
@@ -209,16 +213,36 @@ public partial class ProjectDependencyGraph
 
     private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeReverseReferencesMap()
     {
-        var reverseReferencesMap = new Dictionary<ProjectId, HashSet<ProjectId>>();
+        using var _ = PooledDictionary<ProjectId, ImmutableHashSet<ProjectId>.Builder>.GetInstance(out var reverseReferencesMap);
 
         foreach (var (projectId, references) in _referencesMap)
         {
             foreach (var referencedId in references)
-                reverseReferencesMap.MultiAdd(referencedId, projectId);
+            {
+                if (!reverseReferencesMap.TryGetValue(referencedId, out var builder))
+                {
+                    builder = s_reverseReferencesBuilderPool.Allocate();
+                    reverseReferencesMap.Add(referencedId, builder);
+                }
+
+                builder.Add(projectId);
+            }
         }
 
         return reverseReferencesMap
-            .Select(kvp => KeyValuePairUtil.Create(kvp.Key, kvp.Value.ToImmutableHashSet()))
+            .Select(kvp =>
+            {
+                var builder = kvp.Value;
+
+                // Realize an ImmutableHashSet from the builder
+                var reverseReferencesForProject = builder.ToImmutableHashSet();
+
+                // Clear out the builder and release it back to the pool
+                builder.Clear();
+                s_reverseReferencesBuilderPool.Free(builder);
+
+                return KeyValuePairUtil.Create(kvp.Key, reverseReferencesForProject);
+            })
             .ToImmutableDictionary();
     }
 


### PR DESCRIPTION
Speedometer results from the[ last PR](https://github.com/dotnet/roslyn/pull/76399) didn't improve allocations in the ProjectDependencyGraph as much as I had hoped. This PR instead changes ComputeReverseReferencesMap to use pooled data structures and ImmutableHashSet.Builder to build up it's final result.

The speedometer test is still showing about 100 MB of allocations in this method during typing, my hope is that this should cut that in about half. Will create a test insertion for validation.

*** allocations that are being targeted by this PR ***
![image](https://github.com/user-attachments/assets/7d40e4f5-adf9-4311-84d9-99518f4a4b18)