### PR TITLE
Slightly reduce allocations in SymbolCompletionItem.AddSymbolInfo

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/SmallNumberFormatter.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SmallNumberFormatter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-
 namespace Microsoft.CodeAnalysis.Completion.Providers;
 
 internal static class SmallNumberFormatter
@@ -21,10 +19,6 @@ internal static class SmallNumberFormatter
         if (value >= SmallNumberCacheLength)
             return value.ToString();
 
-        return s_smallNumberCache[value] ?? CreateAndCacheString(value);
-
-        [MethodImpl(MethodImplOptions.NoInlining)] // keep rare usage out of fast path
-        static string CreateAndCacheString(int value)
-            => s_smallNumberCache[value] = value.ToString();
+        return s_smallNumberCache[value] ??= value.ToString();
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/SmallNumberFormatter.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SmallNumberFormatter.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.CodeAnalysis.Completion.Providers;
+
+internal static class SmallNumberFormatter
+{
+    private const int SmallNumberCacheLength = 32;
+
+    /// <summary>
+    /// Lazily-populated cache of strings for values in the range [0, <see cref="SmallNumberFormatter"/>).
+    /// Inspired by corresponding field in core runtime's Number class. 
+    /// </summary>
+    private static readonly string[] s_smallNumberCache = new string[SmallNumberCacheLength];
+
+    internal static string ToString(int value)
+    {
+        if (value >= SmallNumberCacheLength)
+            return value.ToString();
+
+        return s_smallNumberCache[value] ?? CreateAndCacheString(value);
+
+        [MethodImpl(MethodImplOptions.NoInlining)] // keep rare usage out of fast path
+        static string CreateAndCacheString(int value)
+            => s_smallNumberCache[value] = value.ToString();
+    }
+}

--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -85,7 +85,7 @@ internal static class SymbolCompletionItem
     {
         var symbol = symbols[0];
         var isGeneric = symbol.GetArity() > 0;
-        properties.Add(KeyValuePairUtil.Create("SymbolKind", ((int)symbol.Kind).ToString()));
+        properties.Add(KeyValuePairUtil.Create("SymbolKind", SmallNumberFormatter.ToString((int)symbol.Kind)));
         properties.Add(KeyValuePairUtil.Create("SymbolName", symbol.Name));
 
         if (isGeneric)


### PR DESCRIPTION
This code creates a string from the SymbolKind enum and was showing up as 0.2% of allocations in the typing scenario in the csharp editing speedometer test.

Instead, mimic what the core runtime does in the Number class by keeping a small cache mapping int => string that is lazily populated. 

I did check to see whether other places in the profile implicating FormatInt32 were candidates for changing to this, and neither of the two found locations fit well. The call from SymbolCompletionItem.CreateWorker has values that are too large and varied to consider caching, and the usage in SymbolKeyWriter.WriteIntegerRaw_DoNotCallDirectly would require the helper class to be available at the CodeStyle layer.

*** Allocations targeted with this PR ***
![image](https://github.com/user-attachments/assets/3f34609e-7bac-48eb-bd1e-fcd8bc93839f)