### PR TITLE
Pass caller argument expression through RoslynDebug.Assert

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -13,12 +13,21 @@ namespace Roslyn.Utilities
     internal static class RoslynDebug
     {
         /// <inheritdoc cref="Debug.Assert(bool)"/>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         [Conditional("DEBUG")]
         public static void Assert([DoesNotReturnIf(false)] bool condition) => Debug.Assert(condition);
 
         /// <inheritdoc cref="Debug.Assert(bool, string)"/>
         [Conditional("DEBUG")]
-        public static void Assert([DoesNotReturnIf(false)] bool condition, string message)
+        public static void Assert([DoesNotReturnIf(false)] bool condition,
+#if NET
+            [CallerArgumentExpression(nameof(condition))] string? message = null
+#else
+            string message
+#endif
+            )
             => Debug.Assert(condition, message);
 
         /// <inheritdoc cref="Debug.Assert(bool, string)"/>

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -13,9 +13,6 @@ namespace Roslyn.Utilities
     internal static class RoslynDebug
     {
         /// <inheritdoc cref="Debug.Assert(bool)"/>
-#if NET9_0_OR_GREATER
-        [OverloadResolutionPriority(-1)]
-#endif
         [Conditional("DEBUG")]
         public static void Assert([DoesNotReturnIf(false)] bool condition) => Debug.Assert(condition);
 


### PR DESCRIPTION
Makes RoslynDebug.Assert more consistent with Debug.Assert. Without this, on .NET 9, the message `"condition"` is effectively being passed into `Debug.Assert` which is not very useful.