### PR TITLE
Calculate the hash code in an unchecked block

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/TypeRef.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/TypeRef.cs
@@ -61,14 +61,16 @@ internal sealed partial class TypeRef : IEquatable<TypeRef>
         var comparer = StringComparer.Ordinal;
 
         var hashCode = 2037759866;
-        hashCode = hashCode * -1521134295 + comparer.GetHashCode(TypeName);
-        hashCode = hashCode * -1521134295 + comparer.GetHashCode(AssemblyName);
-
-        if (CodeBase is string codeBase)
+        unchecked
         {
-            hashCode = hashCode * -1521134295 + comparer.GetHashCode(codeBase);
-        }
+            hashCode = hashCode * -1521134295 + comparer.GetHashCode(TypeName);
+            hashCode = hashCode * -1521134295 + comparer.GetHashCode(AssemblyName);
 
+            if (CodeBase is string codeBase)
+            {
+                hashCode = hashCode * -1521134295 + comparer.GetHashCode(codeBase);
+            }
+        }
         return hashCode;
     }
 


### PR DESCRIPTION
CLaSP is a source package, and Web Tools bring it into a project that has overflow checking turned on in Debug, which means their language server crashes on startup in this code block. This should fix that.