### PR TITLE
Fix parsing of for-loops

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9184,8 +9184,10 @@ done:
             var condition = this.CurrentToken.Kind is not SyntaxKind.SemicolonToken and not SyntaxKind.CommaToken
                 ? this.ParseExpressionCore()
                 : null;
-            // Pulled out as we need to track this when parsing incrementors to place skipped tokens.
+
+            // Used to place skipped tokens we run into when parsing the incrementors list.
             var secondSemicolonToken = eatCommaOrSemicolon();
+
             // Do allow semicolons (with diagnostics) in the incrementors list.  This allows us to consume
             // accidental extra incrementors that should have been separated by commas.
             var incrementors = this.CurrentToken.Kind != SyntaxKind.CloseParenToken

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9181,23 +9181,27 @@ done:
             var (variableDeclaration, initializers) = eatVariableDeclarationOrInitializers();
 
             // Pulled out as we need to track this when parsing incrementors to place skipped tokens.
-            SyntaxToken secondSemicolonToken;
+            var firstSemicolonToken = eatCommaOrSemicolon();
+            var condition = this.CurrentToken.Kind is not SyntaxKind.SemicolonToken and not SyntaxKind.CommaToken
+                ? this.ParseExpressionCore()
+                : null;
+            var secondSemicolonToken = eatCommaOrSemicolon();
+            // Do allow semicolons (with diagnostics) in the incrementors list.  This allows us to consume
+            // accidental extra incrementors that should have been separated by commas.
+            var incrementors = this.CurrentToken.Kind != SyntaxKind.CloseParenToken
+                ? parseForStatementExpressionList(ref secondSemicolonToken, allowSemicolonAsSeparator: true)
+                : default;
+
             var forStatement = _syntaxFactory.ForStatement(
                 attributes,
                 forToken,
                 openParen,
                 variableDeclaration,
                 initializers,
-                firstSemicolonToken: eatCommaOrSemicolon(),
-                condition: this.CurrentToken.Kind is not SyntaxKind.SemicolonToken and not SyntaxKind.CommaToken
-                    ? this.ParseExpressionCore()
-                    : null,
-                secondSemicolonToken = eatCommaOrSemicolon(),
-                // Do allow semicolons (with diagnostics) in the incrementors list.  This allows us to consume
-                // accidental extra incrementors that should have been separated by commas.
-                incrementors: this.CurrentToken.Kind != SyntaxKind.CloseParenToken
-                    ? parseForStatementExpressionList(ref secondSemicolonToken, allowSemicolonAsSeparator: true)
-                    : default,
+                firstSemicolonToken,
+                condition,
+                secondSemicolonToken,
+                incrementors,
                 eatUnexpectedTokensAndCloseParenToken(),
                 ParseEmbeddedStatement());
 

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -3680,14 +3680,24 @@ enum VirtualKey
             var tree = SyntaxFactory.ParseSyntaxTree(source);
             var text = tree.GetText();
 
+            // Update all the 'i's in the for-loop to be 'in' instead.
             var position1 = source.IndexOf("i =") + 1;
             var position2 = source.IndexOf("i <") + 1;
             var position3 = source.IndexOf("i++") + 1;
-
             text = text.WithChanges(
                 new TextChange(new TextSpan(position1, 0), "n"),
                 new TextChange(new TextSpan(position2, 0), "n"),
                 new TextChange(new TextSpan(position3, 0), "n"));
+
+            Assert.Equal("""
+                void Main()
+                {
+                    for (int in = 0; in < n; in++)
+                    {
+                    }
+                }
+                """, text.ToString());
+
             tree = tree.WithChangedText(text);
             var fullTree = SyntaxFactory.ParseSyntaxTree(text.ToString());
             WalkTreeAndVerify(tree.GetCompilationUnitRoot(), fullTree.GetCompilationUnitRoot());

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -3676,9 +3676,6 @@ enum VirtualKey
 
                     for (int i = -(count + 2); i < n; i++)
                     {
-                        for (int input2 = -(count + 2); input2 < n; input2++)
-                        {
-                        }
                     }
                 }
                 """;

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -3670,17 +3670,14 @@ enum VirtualKey
         public void InKeywordInsideAForBlock()
         {
             var source = """
-                public class Program
+                void Main()
                 {
-                    public void Main()
-                    {
-                        int count = 10, n = 15;
+                    int count = 10, n = 15;
 
-                        for (int i = -(count + 2); i < n; i++)
+                    for (int i = -(count + 2); i < n; i++)
+                    {
+                        for (int input2 = -(count + 2); input2 < n; input2++)
                         {
-                            for (int input2 = -(count + 2); input2 < n; input2++)
-                            {
-                            }
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -3672,7 +3672,7 @@ enum VirtualKey
             var source = """
                 void Main()
                 {
-                    for (int i = -(count + 2); i < n; i++)
+                    for (int i = 0; i < n; i++)
                     {
                     }
                 }

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -3672,8 +3672,6 @@ enum VirtualKey
             var source = """
                 void Main()
                 {
-                    int count = 10, n = 15;
-
                     for (int i = -(count + 2); i < n; i++)
                     {
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76439

Introduced with https://github.com/dotnet/roslyn/pull/75632.  So only in 17.13p2.  So fixing this will prevent the regression from making it out.

The core issue here was an incorrect understanding i had with order-of-evaluation and storage of values for args when invoking methods.  Specifically, i thought that the following:

```
M(
   x = y(),
   Z(ref x));
```

Was evaluated effectively as:

```
xloc = y();
__z_val = Z(ref xloc);
M(xloc, __z_val);
```

But it is not.  rather, it is:

```
__x_val = x = y();
__z_val = M(ref x);
M(__x_val, __z_val);
```

In other words, i thought the call to M woudl see the value of 'x' *after* the call to Z, while it actually evaluates and stores that value prior to the call to Z.  

This mattered during parsing as we use that value to store skipped tokens onto.  So if we use the value prior to updating, we lose those skipped tokens, leading to an invalid incremental parse. 