### PR TITLE
FIx build errors with live (SCI) runtime dependencies when targeting NetPrevious (net9.0) in source-build (VMR)

### DIFF
--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -31,9 +31,9 @@
       will import everything but content files from Microsoft.CodeAnalysis.Analyzers, specifically, analyzers.
     -->
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Condition="'$(DotNetBuildSourceOnly)' != 'true'" PrivateAssets="ContentFiles" />
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Text.Encoding.CodePages" Condition="'$(TargetFramework)' == 'netstandard2.0'" />

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -139,7 +139,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.AnalyzerUtilities" />
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <PackageReference Include="Microsoft.DiaSymReader" />
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
   <Import Project="..\..\..\Analyzers\Core\Analyzers\Analyzers.projitems" Label="Shared" />

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -29,8 +29,8 @@
          since it's now automatic, and Source Build will ensure we get a proper one automatically if we do nothing; if we reference the older version
          then source build may only give us a reference assembly would fail if we then try to actually run that output. -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.IO.Pipelines" />
-    <PackageReference Include="System.Threading.Channels" />
+    <PackageReference Include="System.IO.Pipelines" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" />
+    <PackageReference Include="System.Threading.Channels" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Remove="Storage\SQLite\**\*.cs" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />


### PR DESCRIPTION
Unblocks https://github.com/dotnet/sdk/pull/45427

Fixes the following two errors:
- src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs(217,13): error CS1503: Argument 4: cannot convert from 'System.Collections.Immutable.ImmutableHashSet<Microsoft.CodeAnalysis.Project>' to 'System.Collections.Generic.IReadOnlySet<Microsoft.CodeAnalysis.Project>' [src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj::TargetFramework=net9.0]
- src/roslyn/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs(218,13): error CS1503: Argument 5: cannot convert from 'System.Collections.Immutable.ImmutableHashSet<Microsoft.CodeAnalysis.Project>' to 'System.Collections.Generic.IReadOnlySet<Microsoft.CodeAnalysis.Project>' [src/roslyn/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj::TargetFramework=net9.0]

The underlying SDK being used is "10.0.100-alpha.1.24555.54"