### PR TITLE
Propagate marked attributes from method type parameters to type parameters of synthesized types.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (_factory.CompilationState.Compilation.ShouldEmitNullableAttributes(localFunction))
                 {
                     bool constraintsNeedNullableAttribute = typeParameters.Any(
-                       static typeParameter => ((SourceTypeParameterSymbolBase)typeParameter).ConstraintsNeedNullableAttribute());
+                       static typeParameter => ((SourceTypeParameterSymbol)typeParameter).ConstraintsNeedNullableAttribute());
 
                     if (constraintsNeedNullableAttribute || hasReturnTypeOrParameter(localFunction, static t => t.NeedsNullableAttribute()))
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// generic method. In those cases, additional constraint checks are applied.
         /// </summary>
         public static TypeParameterBounds ResolveBounds(
-            this SourceTypeParameterSymbolBase typeParameter,
+            this SourceTypeParameterSymbol typeParameter,
             AssemblySymbol corLibrary,
             ConsList<TypeParameterSymbol> inProgress,
             ImmutableArray<TypeWithAnnotations> constraintTypes,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(typeError, location, name, tpEnclosing.ContainingSymbol);
                 }
 
-                var typeParameter = new SourceMethodTypeParameterSymbol(
+                var typeParameter = new SourceNotOverridingMethodTypeParameterSymbol(
                         this,
                         name,
                         ordinal,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly FieldSymbol _internalField;
 
         public FixedFieldImplementationType(SourceMemberFieldSymbol field)
-            : base(GeneratedNames.MakeFixedFieldImplementationName(field.Name), typeParameters: ImmutableArray<TypeParameterSymbol>.Empty, typeMap: TypeMap.Empty)
+            : base(GeneratedNames.MakeFixedFieldImplementationName(field.Name))
         {
             _field = field;
             _constructor = new SynthesizedInstanceConstructor(this);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1153,7 +1153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             ordinal,
                             locations,
                             syntaxRefs) :
-                        new SourceMethodTypeParameterSymbol(
+                        new SourceNotOverridingMethodTypeParameterSymbol(
                             this,
                             name,
                             ordinal,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Base class for type and method type parameters.
     /// </summary>
-    internal abstract class SourceTypeParameterSymbolBase : TypeParameterSymbol, IAttributeTargetSymbol
+    internal abstract class SourceTypeParameterSymbol : TypeParameterSymbol, IAttributeTargetSymbol
     {
         private readonly ImmutableArray<SyntaxReference> _syntaxRefs;
         private readonly ImmutableArray<Location> _locations;
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private CustomAttributesBag<CSharpAttributeData> _lazyCustomAttributesBag;
         private TypeParameterBounds _lazyBounds = TypeParameterBounds.Unset;
 
-        protected SourceTypeParameterSymbolBase(string name, int ordinal, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
+        protected SourceTypeParameterSymbol(string name, int ordinal, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
         {
             Debug.Assert(!syntaxRefs.IsEmpty);
 
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var implementingPart = sourceMethod.SourcePartialImplementation;
                     if ((object)implementingPart != null)
                     {
-                        var typeParameter = (SourceTypeParameterSymbolBase)implementingPart.TypeParameters[_ordinal];
+                        var typeParameter = (SourceTypeParameterSymbol)implementingPart.TypeParameters[_ordinal];
                         mergedAttributesBuilder.AddRange(typeParameter.MergedAttributeDeclarationSyntaxLists);
                     }
                 }
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    var typeParameter = (SourceTypeParameterSymbolBase)sourceMethod.SourcePartialDefinition.TypeParameters[_ordinal];
+                    var typeParameter = (SourceTypeParameterSymbol)sourceMethod.SourcePartialDefinition.TypeParameters[_ordinal];
                     CustomAttributesBag<CSharpAttributeData> attributesBag = typeParameter.GetAttributesBag();
 
                     lazyAttributesStored = Interlocked.CompareExchange(ref _lazyCustomAttributesBag, attributesBag, null) == null;
@@ -456,12 +456,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
     }
 
-    internal sealed class SourceTypeParameterSymbol : SourceTypeParameterSymbolBase
+    internal sealed class SourceTypeTypeParameterSymbol : SourceTypeParameterSymbol
     {
         private readonly SourceNamedTypeSymbol _owner;
         private readonly VarianceKind _varianceKind;
 
-        public SourceTypeParameterSymbol(SourceNamedTypeSymbol owner, string name, int ordinal, VarianceKind varianceKind, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
+        public SourceTypeTypeParameterSymbol(SourceNamedTypeSymbol owner, string name, int ordinal, VarianceKind varianceKind, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
             : base(name, ordinal, locations, syntaxRefs)
         {
             _owner = owner;
@@ -602,20 +602,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
     }
 
-    internal sealed class SourceMethodTypeParameterSymbol : SourceTypeParameterSymbolBase
+    internal abstract class SourceMethodTypeParameterSymbol : SourceTypeParameterSymbol
     {
-        private readonly SourceMethodSymbol _owner;
-
-        public SourceMethodTypeParameterSymbol(SourceMethodSymbol owner, string name, int ordinal, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
+        protected SourceMethodTypeParameterSymbol(string name, int ordinal, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
             : base(name, ordinal, locations, syntaxRefs)
         {
-            _owner = owner;
         }
 
-        internal override void AddDeclarationDiagnostics(BindingDiagnosticBag diagnostics)
-            => _owner.AddDeclarationDiagnostics(diagnostics);
+        public abstract SourceMethodSymbol Owner { get; }
 
-        public override TypeParameterKind TypeParameterKind
+        internal sealed override void AddDeclarationDiagnostics(BindingDiagnosticBag diagnostics)
+            => Owner.AddDeclarationDiagnostics(diagnostics);
+
+        public sealed override TypeParameterKind TypeParameterKind
         {
             get
             {
@@ -623,10 +622,50 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override Symbol ContainingSymbol
+        public sealed override Symbol ContainingSymbol
         {
-            get { return _owner; }
+            get { return Owner; }
         }
+
+        public abstract override bool HasConstructorConstraint { get; }
+
+        public abstract override bool HasValueTypeConstraint { get; }
+
+        public abstract override bool AllowsRefLikeType { get; }
+
+        public abstract override bool IsValueTypeFromConstraintTypes { get; }
+
+        public abstract override bool HasReferenceTypeConstraint { get; }
+
+        public abstract override bool IsReferenceTypeFromConstraintTypes { get; }
+
+        public abstract override bool HasNotNullConstraint { get; }
+
+        internal abstract override bool? ReferenceTypeConstraintIsNullable { get; }
+
+        internal abstract override bool? IsNotNullable { get; }
+
+        public abstract override bool HasUnmanagedTypeConstraint { get; }
+
+        protected sealed override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters
+        {
+            get { return Owner.TypeParameters; }
+        }
+
+        protected abstract override TypeParameterBounds ResolveBounds(ConsList<TypeParameterSymbol> inProgress, BindingDiagnosticBag diagnostics);
+    }
+
+    internal sealed class SourceNotOverridingMethodTypeParameterSymbol : SourceMethodTypeParameterSymbol
+    {
+        private readonly SourceMethodSymbol _owner;
+
+        public SourceNotOverridingMethodTypeParameterSymbol(SourceMethodSymbol owner, string name, int ordinal, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
+            : base(name, ordinal, locations, syntaxRefs)
+        {
+            _owner = owner;
+        }
+
+        public override SourceMethodSymbol Owner => _owner;
 
         public override bool HasConstructorConstraint
         {
@@ -720,11 +759,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var constraints = this.GetConstraintKinds();
                 return (constraints & TypeParameterConstraintKind.Unmanaged) != 0;
             }
-        }
-
-        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters
-        {
-            get { return _owner.TypeParameters; }
         }
 
         protected override TypeParameterBounds ResolveBounds(ConsList<TypeParameterSymbol> inProgress, BindingDiagnosticBag diagnostics)
@@ -863,7 +897,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <remarks>
     /// Exists to copy constraints from the corresponding type parameter of an overridden method.
     /// </remarks>
-    internal sealed class SourceOverridingMethodTypeParameterSymbol : SourceTypeParameterSymbolBase
+    internal sealed class SourceOverridingMethodTypeParameterSymbol : SourceMethodTypeParameterSymbol
     {
         private readonly OverriddenMethodTypeParameterMapBase _map;
 
@@ -873,22 +907,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _map = map;
         }
 
-        public SourceOrdinaryMethodSymbol Owner
+        public override SourceMethodSymbol Owner
         {
             get { return _map.OverridingMethod; }
-        }
-
-        public override TypeParameterKind TypeParameterKind
-        {
-            get
-            {
-                return TypeParameterKind.Method;
-            }
-        }
-
-        public override Symbol ContainingSymbol
-        {
-            get { return this.Owner; }
         }
 
         public override bool HasConstructorConstraint
@@ -977,11 +998,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var typeParameter = this.OverriddenTypeParameter;
                 return ((object)typeParameter != null) && typeParameter.HasUnmanagedTypeConstraint;
             }
-        }
-
-        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters
-        {
-            get { return this.Owner.TypeParameters; }
         }
 
         protected override TypeParameterBounds ResolveBounds(ConsList<TypeParameterSymbol> inProgress, BindingDiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterBuilder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal TypeParameterSymbol MakeSymbol(int ordinal, IList<TypeParameterBuilder> builders, BindingDiagnosticBag diagnostics)
         {
             var syntaxNode = (TypeParameterSyntax)_syntaxRef.GetSyntax();
-            var result = new SourceTypeParameterSymbol(
+            var result = new SourceTypeTypeParameterSymbol(
                 _owner,
                 syntaxNode.Identifier.ValueText,
                 ordinal,

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1668,7 +1668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     builder.AddValue(((ParameterSymbol)this).TypeWithAnnotations);
                     break;
                 case SymbolKind.TypeParameter:
-                    if (this is SourceTypeParameterSymbolBase typeParameter)
+                    if (this is SourceTypeParameterSymbol typeParameter)
                     {
                         builder.AddValue(typeParameter.GetSynthesizedNullableAttributeValue());
                         foreach (var constraintType in typeParameter.ConstraintTypesNoUseSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -38,15 +38,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected SynthesizedContainer(string name, ImmutableArray<TypeParameterSymbol> typeParameters, TypeMap typeMap)
+        protected SynthesizedContainer(string name)
         {
             Debug.Assert(name != null);
-            Debug.Assert(!typeParameters.IsDefault);
-            Debug.Assert(typeMap != null);
 
             Name = name;
-            _typeParameters = typeParameters;
-            TypeMap = typeMap;
+            _typeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
+            TypeMap = TypeMap.Empty;
         }
 
         internal TypeMap TypeMap { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
@@ -34,6 +34,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
+            if (ContainingSymbol.Kind == SymbolKind.NamedType)
+            {
+                Debug.Assert(ContainingSymbol.ContainingModule == _underlyingTypeParameter.OriginalDefinition.ContainingModule);
+
+                if (ContainingSymbol.ContainingModule == _underlyingTypeParameter.OriginalDefinition.ContainingModule)
+                {
+                    foreach (CSharpAttributeData attr in _underlyingTypeParameter.OriginalDefinition.GetAttributes())
+                    {
+                        if (attr.AttributeClass is { HasCompilerLoweringPreserveAttribute: true })
+                        {
+                            AddSynthesizedAttribute(ref attributes, attr);
+                        }
+                    }
+                }
+            }
+
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
 
             if (this.HasUnmanagedTypeConstraint)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
             if (ContainingSymbol.Kind == SymbolKind.NamedType &&
+                _underlyingTypeParameter.OriginalDefinition is SourceMethodTypeParameterSymbol &&
                 ContainingSymbol.ContainingModule == _underlyingTypeParameter.OriginalDefinition.ContainingModule)
             {
                 foreach (CSharpAttributeData attr in _underlyingTypeParameter.OriginalDefinition.GetAttributes())

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
@@ -34,18 +34,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
-            if (ContainingSymbol.Kind == SymbolKind.NamedType)
+            if (ContainingSymbol.Kind == SymbolKind.NamedType &&
+                ContainingSymbol.ContainingModule == _underlyingTypeParameter.OriginalDefinition.ContainingModule)
             {
-                Debug.Assert(ContainingSymbol.ContainingModule == _underlyingTypeParameter.OriginalDefinition.ContainingModule);
-
-                if (ContainingSymbol.ContainingModule == _underlyingTypeParameter.OriginalDefinition.ContainingModule)
+                foreach (CSharpAttributeData attr in _underlyingTypeParameter.OriginalDefinition.GetAttributes())
                 {
-                    foreach (CSharpAttributeData attr in _underlyingTypeParameter.OriginalDefinition.GetAttributes())
+                    if (attr.AttributeClass is { HasCompilerLoweringPreserveAttribute: true })
                     {
-                        if (attr.AttributeClass is { HasCompilerLoweringPreserveAttribute: true })
-                        {
-                            AddSynthesizedAttribute(ref attributes, attr);
-                        }
+                        AddSynthesizedAttribute(ref attributes, attr);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -10557,5 +10557,44 @@ class C
 """;
             CompileAndVerify(src, expectedOutput: ExpectedOutput("True one False null"), verify: Verification.Skipped, targetFramework: TargetFramework.Net80).VerifyDiagnostics();
         }
+
+        [Fact]
+        public void CompilerLoweringPreserveAttribute_01()
+        {
+            string source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+
+[CompilerLoweringPreserve]
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve1Attribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve2Attribute : Attribute { }
+";
+
+            string source2 = @"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class Test1
+{
+    async IAsyncEnumerable<T> M2<[Preserve1][Preserve2]T>(T x)
+    {
+        await Task.Yield();
+        yield return x;
+    }
+}
+";
+            var comp1 = CreateCompilation([source1, source2, CompilerLoweringPreserveAttributeDefinition], targetFramework: TargetFramework.Net80);
+            CompileAndVerify(comp1, symbolValidator: validate, verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+            static void validate(ModuleSymbol m)
+            {
+                AssertEx.SequenceEqual(
+                    ["Preserve1Attribute"],
+                    m.GlobalNamespace.GetMember<NamedTypeSymbol>("Test1.<M2>d__0").TypeParameters.Single().GetAttributes().Select(a => a.ToString()));
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
@@ -6349,6 +6349,47 @@ class Test
 ");
     }
 
+    [Fact]
+    public void CompilerLoweringPreserveAttribute_01()
+    {
+        string source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+
+[CompilerLoweringPreserve]
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve1Attribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve2Attribute : Attribute { }
+";
+
+        string source2 = @"
+class Test1
+{
+    System.Action M2<[Preserve1][Preserve2]T>()
+    {
+        return (System.Action)D.Target<T>;
+    }
+}
+
+class D
+{
+    public static void Target<B>() { }
+}
+
+";
+        var comp1 = CreateCompilation([source1, source2, CompilerLoweringPreserveAttributeDefinition]);
+        CompileAndVerify(comp1, symbolValidator: validate).VerifyDiagnostics();
+
+        static void validate(ModuleSymbol m)
+        {
+            AssertEx.SequenceEqual(
+                ["Preserve1Attribute"],
+                m.GlobalNamespace.GetMember<NamedTypeSymbol>("Test1.<M2>O__0_0").TypeParameters.Single().GetAttributes().Select(a => a.ToString()));
+        }
+    }
+
     private static Action<ModuleSymbol> VerifyCacheContainer(string typeName, int arity, params string[] expectedFields)
     {
         return module =>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -8553,5 +8553,40 @@ class Program
                 // var lam = (params this int[] xs) => xs.Length;
                 Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(1, 19));
         }
+
+        [Fact]
+        public void CompilerLoweringPreserveAttribute_01()
+        {
+            string source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+
+[CompilerLoweringPreserve]
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve1Attribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve2Attribute : Attribute { }
+";
+
+            string source2 = @"
+class Test1
+{
+    System.Func<T> M2<[Preserve1][Preserve2]T>(T x)
+    {
+        return () => x;
+    }
+}
+";
+            var comp1 = CreateCompilation([source1, source2, CompilerLoweringPreserveAttributeDefinition]);
+            CompileAndVerify(comp1, symbolValidator: validate).VerifyDiagnostics();
+
+            static void validate(ModuleSymbol m)
+            {
+                AssertEx.SequenceEqual(
+                    ["Preserve1Attribute"],
+                    m.GlobalNamespace.GetMember<NamedTypeSymbol>("Test1.<>c__DisplayClass0_0").TypeParameters.Single().GetAttributes().Select(a => a.ToString()));
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -5564,7 +5564,7 @@ class C<T>
             Assert.IsType<CrefTypeParameterSymbol>(crefTypeParam.GetSymbol());
 
             var sourceTypeParam = referencedType.TypeParameters.Single();
-            Assert.IsType<SourceTypeParameterSymbol>(sourceTypeParam.GetSymbol());
+            Assert.IsType<SourceTypeTypeParameterSymbol>(sourceTypeParam.GetSymbol());
 
             Assert.NotEqual(crefTypeParam, sourceTypeParam);
             Assert.NotEqual(sourceTypeParam, crefTypeParam);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/LocalFunctionTests.cs
@@ -524,5 +524,111 @@ public class C<T1>
             Assert.Equal("void C<System.Int32>.M<System.String>()", symbol.ToTestDisplayString());
             Assert.Equal("C<System.Int32>", symbol.ContainingSymbol.ToTestDisplayString());
         }
+
+        [Fact]
+        public void CompilerLoweringPreserveAttribute_01()
+        {
+            string source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+
+[CompilerLoweringPreserve]
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve1Attribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve2Attribute : Attribute { }
+";
+
+            string source2 = @"
+class Test1
+{
+    System.Func<T> M2<[Preserve1][Preserve2]T>(T x)
+    {
+        return local;
+        T local() => x;
+    }
+}
+";
+            var comp1 = CreateCompilation([source1, source2, CompilerLoweringPreserveAttributeDefinition]);
+            CompileAndVerify(comp1, symbolValidator: validate).VerifyDiagnostics();
+
+            static void validate(ModuleSymbol m)
+            {
+                AssertEx.SequenceEqual(
+                    ["Preserve1Attribute"],
+                    m.GlobalNamespace.GetMember<NamedTypeSymbol>("Test1.<>c__DisplayClass0_0").TypeParameters.Single().GetAttributes().Select(a => a.ToString()));
+            }
+        }
+
+        [Fact]
+        public void CompilerLoweringPreserveAttribute_02()
+        {
+            string source1 = @"
+using System;
+
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve1Attribute : Attribute { }
+";
+
+            string source2 = @"
+class Test1
+{
+    System.Func<int, int> M2()
+    {
+        return local<int>;
+        T local<[Preserve1]T>(T x) => x;
+    }
+}
+";
+            var comp1 = CreateCompilation([source1, source2], options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            CompileAndVerify(comp1, symbolValidator: validate).VerifyDiagnostics();
+
+            static void validate(ModuleSymbol m)
+            {
+                AssertEx.SequenceEqual(
+                    ["Preserve1Attribute"],
+                    m.GlobalNamespace.GetMember<MethodSymbol>("Test1.<M2>g__local|0_0").TypeParameters.Single().GetAttributes().Select(a => a.ToString()));
+            }
+        }
+
+        [Fact]
+        public void CompilerLoweringPreserveAttribute_03()
+        {
+            string source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+
+[CompilerLoweringPreserve]
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve1Attribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public class Preserve2Attribute : Attribute { }
+";
+
+            string source2 = @"
+class Test1
+{
+    void M2<[Preserve1][Preserve2]T>(T x)
+    {
+        local();
+        void local() => x.ToString();
+    }
+}
+";
+            var comp1 = CreateCompilation([source1, source2, CompilerLoweringPreserveAttributeDefinition], options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            CompileAndVerify(comp1, symbolValidator: validate).VerifyDiagnostics();
+
+            static void validate(ModuleSymbol m)
+            {
+                AssertEx.SequenceEqual(
+                    ["Preserve1Attribute"],
+                    m.GlobalNamespace.GetMember<NamedTypeSymbol>("Test1.<>c__DisplayClass0_0").TypeParameters.Single().GetAttributes().Select(a => a.ToString()));
+                AssertEx.SequenceEqual(
+                    ["Preserve1Attribute", "Preserve2Attribute"],
+                    m.GlobalNamespace.GetMember<MethodSymbol>("Test1.<M2>g__local|0_0").TypeParameters.Single().GetAttributes().Select(a => a.ToString()));
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
@@ -666,7 +666,7 @@ public class C<T> where T : int
             var compilation = CreateCompilation(code).VerifyDiagnostics();
             var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
 
-            SourceTypeParameterSymbol sourceTypeParameter = (SourceTypeParameterSymbol)sourceAssembly.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
+            SourceTypeTypeParameterSymbol sourceTypeParameter = (SourceTypeTypeParameterSymbol)sourceAssembly.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
             Assert.Equal(isUnmanaged, sourceTypeParameter.HasUnmanagedTypeConstraint);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);


### PR DESCRIPTION
Related to https://github.com/dotnet/roslyn/issues/73920.
