### PR TITLE
Only target NetCurrent for source build

### DIFF
--- a/eng/targets/TargetFrameworks.props
+++ b/eng/targets/TargetFrameworks.props
@@ -40,7 +40,7 @@
         <!-- TODO until we figure out what is up with NetPrevious -->
         <NetPrevious>$(NetMinimum)</NetPrevious>
         <NetRoslyn>$(NetPrevious)</NetRoslyn>
-        <NetRoslynSourceBuild>$(NetCurrent);$(NetPrevious)</NetRoslynSourceBuild>
+        <NetRoslynSourceBuild>$(NetCurrent)</NetRoslynSourceBuild>
         <NetRoslynAll>$(NetCurrent);$(NetPrevious)</NetRoslynAll>
         <NetRoslynBuildHostNetCoreVersion>$(NetPrevious)</NetRoslynBuildHostNetCoreVersion>
         <NetRoslynNext>$(NetPrevious)</NetRoslynNext>
@@ -53,7 +53,7 @@
     <When Condition="'$(DotNetBuildSourceOnly)' == 'true' AND '$(DotNetBuildOrchestrator)' == 'true'">
       <PropertyGroup>
         <NetRoslyn>$(NetCurrent)</NetRoslyn>
-        <NetRoslynSourceBuild>$(NetCurrent);$(NetPrevious)</NetRoslynSourceBuild>
+        <NetRoslynSourceBuild>$(NetCurrent)</NetRoslynSourceBuild>
         <NetRoslynAll>$(NetCurrent);$(NetPrevious)</NetRoslynAll>
         <NetRoslynBuildHostNetCoreVersion>$(NetPrevious)</NetRoslynBuildHostNetCoreVersion>
         <NetRoslynNext>$(NetCurrent)</NetRoslynNext>


### PR DESCRIPTION
The `NetCurrent` property is the only value that should be targeted in the context of source build. Otherwise, when `NetCurrent` is `net10.0` and `NetPrevious` is `net9.0`, you can run into this error when building with the latest .NET 10 SDK build:

```
/repos/dotnet/.dotnet/sdk/10.0.100-alpha.1.24611.6/Microsoft.Common.CurrentVersion.targets(1889,5): Project '../MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj' targets 'net10.0'. It cannot be referenced by a project that targets '.NETCoreApp,Version=v9.0'. [/repos/dotnet/src/roslyn/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj]
```

Found as part of the work on https://github.com/dotnet/sdk/pull/45435.