### PR TITLE
Update TargetFrameworks.props

### DIFF
--- a/eng/targets/TargetFrameworks.props
+++ b/eng/targets/TargetFrameworks.props
@@ -52,6 +52,8 @@
     -->
     <When Condition="'$(DotNetBuildSourceOnly)' == 'true' AND '$(DotNetBuildOrchestrator)' == 'true'">
       <PropertyGroup>
+        <!-- TODO until we figure out what is up with NetPrevious -->
+        <NetPrevious>$(NetMinimum)</NetPrevious>
         <NetRoslyn>$(NetCurrent)</NetRoslyn>
         <NetRoslynSourceBuild>$(NetCurrent);$(NetPrevious)</NetRoslynSourceBuild>
         <NetRoslynAll>$(NetCurrent);$(NetPrevious)</NetRoslynAll>


### PR DESCRIPTION
Unblocks https://github.com/dotnet/roslyn/pull/76506

Set NetPrevious to NetMinimum which is necessary when using the Arcade 9 SDK or an older Arcade 10 SDK without the TFM update.