### PR TITLE
In addition to persisting the elfie index as a txt file, persist it as a binary file

### DIFF
--- a/src/Features/Core/Portable/SymbolSearch/Windows/IDatabaseFactoryService.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/IDatabaseFactoryService.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Elfie.Model;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch;
 
 internal interface IDatabaseFactoryService
 {
-    AddReferenceDatabase CreateDatabaseFromBytes(byte[] bytes);
+    AddReferenceDatabase CreateDatabaseFromBytes(byte[] bytes, bool isBinary);
 }

--- a/src/Features/Core/Portable/SymbolSearch/Windows/IIOService.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/IIOService.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
 using System.IO;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch;
@@ -17,7 +16,7 @@ internal interface IIOService
     void Delete(FileInfo file);
     bool Exists(FileSystemInfo info);
     byte[] ReadAllBytes(string path);
-    void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors);
+    void Replace(string sourceFileName, string destinationFileName, string? destinationBackupFileName, bool ignoreMetadataErrors);
     void Move(string sourceFileName, string destinationFileName);
-    void WriteAndFlushAllBytes(string path, byte[] bytes);
+    void WriteAndFlushAllBytes(string path, ArraySegment<byte> bytes);
 }

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.DatabaseFactoryService.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.DatabaseFactoryService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.IO;
 using Microsoft.CodeAnalysis.Elfie.Model;
 
@@ -13,12 +11,22 @@ internal sealed partial class SymbolSearchUpdateEngine
 {
     private sealed class DatabaseFactoryService : IDatabaseFactoryService
     {
-        public AddReferenceDatabase CreateDatabaseFromBytes(byte[] bytes)
+        public AddReferenceDatabase CreateDatabaseFromBytes(byte[] bytes, bool isBinary)
         {
             using var memoryStream = new MemoryStream(bytes);
-            using var streamReader = new StreamReader(memoryStream);
             var database = new AddReferenceDatabase(ArdbVersion.V1);
-            database.ReadText(streamReader);
+
+            if (isBinary)
+            {
+                using var binaryReader = new BinaryReader(memoryStream);
+                database.ReadBinary(binaryReader);
+            }
+            else
+            {
+                using var streamReader = new StreamReader(memoryStream);
+                database.ReadText(streamReader);
+            }
+
             return database;
         }
     }

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.IOService.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.IOService.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
 using System.IO;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch;
@@ -20,16 +19,17 @@ internal sealed partial class SymbolSearchUpdateEngine
 
         public byte[] ReadAllBytes(string path) => File.ReadAllBytes(path);
 
-        public void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        public void Replace(string sourceFileName, string destinationFileName, string? destinationBackupFileName, bool ignoreMetadataErrors)
             => File.Replace(sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
 
         public void Move(string sourceFileName, string destinationFileName)
             => File.Move(sourceFileName, destinationFileName);
 
-        public void WriteAndFlushAllBytes(string path, byte[] bytes)
+        public void WriteAndFlushAllBytes(string path, ArraySegment<byte> bytes)
         {
             using var fileStream = new FileStream(path, FileMode.Create);
-            fileStream.Write(bytes, 0, bytes.Length);
+
+            fileStream.Write(bytes.Array!, bytes.Offset, bytes.Count);
             fileStream.Flush(flushToDisk: true);
         }
     }

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -18,6 +16,7 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.Elfie.Model;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Roslyn.Utilities;
 using static System.FormattableString;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch;
@@ -267,13 +266,14 @@ internal sealed partial class SymbolSearchUpdateEngine
                 return (succeeded: false, failureDelay);
             }
 
-            var bytes = contentBytes;
+            var bytes = contentBytes!;
+            AddReferenceDatabase database;
 
             // Make a database out of that and set it to our in memory database that we'll be 
             // searching.
             try
             {
-                CreateAndSetInMemoryDatabase(bytes);
+                database = CreateAndSetInMemoryDatabase(bytes, isBinary: false);
             }
             catch (Exception e) when (_service._reportAndSwallowExceptionUnlessCanceled(e, cancellationToken))
             {
@@ -289,17 +289,45 @@ internal sealed partial class SymbolSearchUpdateEngine
             // Write the file out to disk so we'll have it the next time we launch VS.  Do this
             // after we set the in-memory instance so we at least have something to search while
             // we're waiting to write.
-            await WriteDatabaseFileAsync(databaseFileInfo, bytes, cancellationToken).ConfigureAwait(false);
+            await WriteDatabaseTextFileAsync(databaseFileInfo, bytes, cancellationToken).ConfigureAwait(false);
+            await WriteDatabaseBinaryFileAsync(database, databaseFileInfo, cancellationToken).ConfigureAwait(false);
 
             var delay = _service._delayService.UpdateSucceededDelay;
             LogInfo($"Processing full database element completed. Update again in {delay}");
             return (succeeded: true, delay);
         }
 
-        private async Task WriteDatabaseFileAsync(FileInfo databaseFileInfo, byte[] bytes, CancellationToken cancellationToken)
+        private async Task WriteDatabaseTextFileAsync(FileInfo databaseFileInfo, byte[] bytes, CancellationToken cancellationToken)
         {
             LogInfo("Writing database file");
 
+            await WriteDatabaseFileAsync(databaseFileInfo, new ArraySegment<byte>(bytes), cancellationToken).ConfigureAwait(false);
+
+            LogInfo("Writing database file completed");
+        }
+
+        private async Task WriteDatabaseBinaryFileAsync(AddReferenceDatabase database, FileInfo databaseFileInfo, CancellationToken cancellationToken)
+        {
+            using var memoryStream = new MemoryStream();
+            using var writer = new BinaryWriter(memoryStream);
+
+            LogInfo("Writing database binary file");
+
+            database.WriteBinary(writer);
+            writer.Flush();
+            memoryStream.Position = 0;
+
+            if (!memoryStream.TryGetBuffer(out var arraySegmentBuffer))
+                arraySegmentBuffer = new ArraySegment<byte>(writer.BaseStream.ReadAllBytes());
+
+            var databaseBinaryFileInfo = GetBinaryFileInfo(databaseFileInfo);
+            await WriteDatabaseFileAsync(databaseBinaryFileInfo, arraySegmentBuffer, cancellationToken).ConfigureAwait(false);
+
+            LogInfo("Writing database binary file completed");
+        }
+
+        private async Task WriteDatabaseFileAsync(FileInfo databaseFileInfo, ArraySegment<byte> bytes, CancellationToken cancellationToken)
+        {
             await RepeatIOAsync(
                 cancellationToken =>
                 {
@@ -343,9 +371,10 @@ internal sealed partial class SymbolSearchUpdateEngine
                         IOUtilities.PerformIO(() => _service._ioService.Delete(new FileInfo(tempFilePath)));
                     }
                 }, cancellationToken).ConfigureAwait(false);
-
-            LogInfo("Writing database file completed");
         }
+
+        private static FileInfo GetBinaryFileInfo(FileInfo databaseFileInfo)
+            => new FileInfo(Path.ChangeExtension(databaseFileInfo.FullName, ".bin"));
 
         private async Task<TimeSpan> PatchLocalDatabaseAsync(FileInfo databaseFileInfo, CancellationToken cancellationToken)
         {
@@ -353,7 +382,10 @@ internal sealed partial class SymbolSearchUpdateEngine
 
             LogInfo("Reading in local database");
             // (intentionally not wrapped in IOUtilities.  If this throws we want to restart).
-            var databaseBytes = _service._ioService.ReadAllBytes(databaseFileInfo.FullName);
+            var databaseBinaryFileInfo = GetBinaryFileInfo(databaseFileInfo);
+            var isBinary = _service._ioService.Exists(databaseBinaryFileInfo);
+            var databaseBytes = _service._ioService.ReadAllBytes(isBinary ? databaseBinaryFileInfo.FullName : databaseFileInfo.FullName);
+
             LogInfo($"Reading in local database completed. databaseBytes.Length={databaseBytes.Length}");
 
             // Make a database instance out of those bytes and set is as the current in memory database
@@ -363,7 +395,7 @@ internal sealed partial class SymbolSearchUpdateEngine
             AddReferenceDatabase database;
             try
             {
-                database = CreateAndSetInMemoryDatabase(databaseBytes);
+                database = CreateAndSetInMemoryDatabase(databaseBytes, isBinary);
             }
             catch (Exception e) when (_service._reportAndSwallowExceptionUnlessCanceled(e, cancellationToken))
             {
@@ -381,7 +413,11 @@ internal sealed partial class SymbolSearchUpdateEngine
             LogInfo("Downloading and processing patch file: " + serverPath);
 
             var element = await DownloadFileAsync(serverPath, cancellationToken).ConfigureAwait(false);
-            var delayUntilUpdate = await ProcessPatchXElementAsync(databaseFileInfo, element, databaseBytes, cancellationToken).ConfigureAwait(false);
+            var delayUntilUpdate = await ProcessPatchXElementAsync(
+                databaseFileInfo,
+                element,
+                getDatabaseBytes: () => isBinary ? _service._ioService.ReadAllBytes(databaseFileInfo.FullName) : databaseBytes,
+                cancellationToken).ConfigureAwait(false);
 
             LogInfo("Downloading and processing patch file completed");
             LogInfo("Patching local database completed");
@@ -395,20 +431,20 @@ internal sealed partial class SymbolSearchUpdateEngine
         /// indicates that our data is corrupt), the exception will bubble up and must be appropriately
         /// dealt with by the caller.
         /// </summary>
-        private AddReferenceDatabase CreateAndSetInMemoryDatabase(byte[] bytes)
+        private AddReferenceDatabase CreateAndSetInMemoryDatabase(byte[] bytes, bool isBinary)
         {
-            var database = CreateDatabaseFromBytes(bytes);
+            var database = CreateDatabaseFromBytes(bytes, isBinary);
             _service._sourceToDatabase[_source] = new AddReferenceDatabaseWrapper(database);
             return database;
         }
 
         private async Task<TimeSpan> ProcessPatchXElementAsync(
-            FileInfo databaseFileInfo, XElement patchElement, byte[] databaseBytes, CancellationToken cancellationToken)
+            FileInfo databaseFileInfo, XElement patchElement, Func<byte[]> getDatabaseBytes, CancellationToken cancellationToken)
         {
             try
             {
                 LogInfo("Processing patch element");
-                var delayUntilUpdate = await TryProcessPatchXElementAsync(databaseFileInfo, patchElement, databaseBytes, cancellationToken).ConfigureAwait(false);
+                var delayUntilUpdate = await TryProcessPatchXElementAsync(databaseFileInfo, patchElement, getDatabaseBytes, cancellationToken).ConfigureAwait(false);
                 if (delayUntilUpdate != null)
                 {
                     LogInfo($"Processing patch element completed. Update again in {delayUntilUpdate.Value}");
@@ -427,13 +463,19 @@ internal sealed partial class SymbolSearchUpdateEngine
         }
 
         private async Task<TimeSpan?> TryProcessPatchXElementAsync(
-            FileInfo databaseFileInfo, XElement patchElement, byte[] databaseBytes, CancellationToken cancellationToken)
+            FileInfo databaseFileInfo, XElement patchElement, Func<byte[]> getDatabaseBytes, CancellationToken cancellationToken)
         {
             ParsePatchElement(patchElement, out var upToDate, out var tooOld, out var patchBytes);
+            AddReferenceDatabase database;
 
             if (upToDate)
             {
                 LogInfo("Local version is up to date");
+
+                var databaseBinaryFileInfo = GetBinaryFileInfo(databaseFileInfo);
+                if (!_service._ioService.Exists(databaseBinaryFileInfo))
+                    await WriteDatabaseBinaryFileAsync(_service._sourceToDatabase[_source].Database, databaseFileInfo, cancellationToken).ConfigureAwait(false);
+
                 return _service._delayService.UpdateSucceededDelay;
             }
 
@@ -443,7 +485,8 @@ internal sealed partial class SymbolSearchUpdateEngine
                 return null;
             }
 
-            LogInfo($"Got patch. databaseBytes.Length={databaseBytes.Length} patchBytes.Length={patchBytes.Length}.");
+            var databaseBytes = getDatabaseBytes();
+            LogInfo($"Got patch. databaseBytes.Length={databaseBytes.Length} patchBytes.Length={patchBytes!.Length}.");
 
             // We have patch data.  Apply it to our current database bytes to produce the new
             // database.
@@ -451,14 +494,15 @@ internal sealed partial class SymbolSearchUpdateEngine
             var finalBytes = _service._patchService.ApplyPatch(databaseBytes, patchBytes);
             LogInfo($"Applying patch completed. finalBytes.Length={finalBytes.Length}");
 
-            CreateAndSetInMemoryDatabase(finalBytes);
+            database = CreateAndSetInMemoryDatabase(finalBytes, isBinary: false);
 
-            await WriteDatabaseFileAsync(databaseFileInfo, finalBytes, cancellationToken).ConfigureAwait(false);
+            await WriteDatabaseTextFileAsync(databaseFileInfo, finalBytes, cancellationToken).ConfigureAwait(false);
+            await WriteDatabaseBinaryFileAsync(database, databaseFileInfo, cancellationToken).ConfigureAwait(false);
 
             return _service._delayService.UpdateSucceededDelay;
         }
 
-        private static void ParsePatchElement(XElement patchElement, out bool upToDate, out bool tooOld, out byte[] patchBytes)
+        private static void ParsePatchElement(XElement patchElement, out bool upToDate, out bool tooOld, out byte[]? patchBytes)
         {
             patchBytes = null;
 
@@ -486,10 +530,10 @@ internal sealed partial class SymbolSearchUpdateEngine
             }
         }
 
-        private AddReferenceDatabase CreateDatabaseFromBytes(byte[] bytes)
+        private AddReferenceDatabase CreateDatabaseFromBytes(byte[] bytes, bool isBinary)
         {
             LogInfo("Creating database from bytes");
-            var result = _service._databaseFactoryService.CreateDatabaseFromBytes(bytes);
+            var result = _service._databaseFactoryService.CreateDatabaseFromBytes(bytes, isBinary);
             LogInfo("Creating database from bytes completed");
             return result;
         }
@@ -534,7 +578,7 @@ internal sealed partial class SymbolSearchUpdateEngine
         }
 
         /// <summary>Returns 'null' if download is not available and caller should keep polling.</summary>
-        private async Task<(XElement element, TimeSpan delay)> TryDownloadFileAsync(IFileDownloader fileDownloader, CancellationToken cancellationToken)
+        private async Task<(XElement? element, TimeSpan delay)> TryDownloadFileAsync(IFileDownloader fileDownloader, CancellationToken cancellationToken)
         {
             LogInfo("Read file from client");
 
@@ -609,7 +653,7 @@ internal sealed partial class SymbolSearchUpdateEngine
             }
         }
 
-        private async Task<(bool succeeded, byte[] contentBytes)> TryParseDatabaseElementAsync(XElement element, CancellationToken cancellationToken)
+        private async Task<(bool succeeded, byte[]? contentBytes)> TryParseDatabaseElementAsync(XElement element, CancellationToken cancellationToken)
         {
             LogInfo("Parsing database element");
             var contentsAttribute = element.Attribute(ContentAttributeName);

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
@@ -391,7 +391,7 @@ internal sealed partial class SymbolSearchUpdateEngine
 
             LogInfo("Reading in local database");
 
-            var databaseBytes = GetDatabaseBytes(databaseFileInfo, out var isBinary);
+            var (databaseBytes, isBinary) = GetDatabaseBytes(databaseFileInfo);
 
             LogInfo($"Reading in local database completed. databaseBytes.Length={databaseBytes.Length}");
 
@@ -432,24 +432,21 @@ internal sealed partial class SymbolSearchUpdateEngine
 
             return delayUntilUpdate;
 
-            byte[] GetDatabaseBytes(FileInfo databaseFileInfo, out bool isBinary)
+            (byte[] dataBytes, bool isBinary) GetDatabaseBytes(FileInfo databaseFileInfo)
             {
                 var databaseBinaryFileInfo = GetBinaryFileInfo(databaseFileInfo);
-                isBinary = true;
 
                 try
                 {
                     // First attempt to read from the binary file. If that fails, fall back to the text file.
-                    return _service._ioService.ReadAllBytes(databaseBinaryFileInfo.FullName);
+                    return (_service._ioService.ReadAllBytes(databaseBinaryFileInfo.FullName), isBinary: true);
                 }
                 catch (Exception e) when (IOUtilities.IsNormalIOException(e))
                 {
                 }
 
-                isBinary = false;
-
                 // (intentionally not wrapped in IOUtilities.  If this throws we want to restart).
-                return _service._ioService.ReadAllBytes(databaseFileInfo.FullName);
+                return (_service._ioService.ReadAllBytes(databaseFileInfo.FullName), isBinary: false);
             }
         }
 

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
@@ -288,7 +288,10 @@ internal sealed partial class SymbolSearchUpdateEngine
 
             // Write the file out to disk so we'll have it the next time we launch VS.  Do this
             // after we set the in-memory instance so we at least have something to search while
-            // we're waiting to write.
+            // we're waiting to write. It's ok if either of these writes don't succeed. If the txt
+            // file fails to persist, a subsequent VS session will redownload the index and again try
+            // to persist. If the binary file fails to persist, a subsequent VS session will just load
+            // the index from the txt file and again try to persist the binary file.
             await WriteDatabaseTextFileAsync(databaseFileInfo, bytes, cancellationToken).ConfigureAwait(false);
             await WriteDatabaseBinaryFileAsync(database, databaseFileInfo, cancellationToken).ConfigureAwait(false);
 
@@ -517,6 +520,10 @@ internal sealed partial class SymbolSearchUpdateEngine
 
             database = CreateAndSetInMemoryDatabase(finalBytes, isBinary: false);
 
+            // Attempt to persist the txt and binary forms of the index. It's ok if either of these writes
+            // don't succeed. If the txt file fails to persist, a subsequent VS session will redownload the
+            // index and again try to persist. If the binary file fails to persist, a subsequent VS session
+            // will just load the index from the txt file and again try to persist the binary file.
             await WriteDatabaseTextFileAsync(databaseFileInfo, finalBytes, cancellationToken).ConfigureAwait(false);
             await WriteDatabaseBinaryFileAsync(database, databaseFileInfo, cancellationToken).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
+++ b/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
@@ -258,7 +258,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
                 Dim factoryMock = New Mock(Of IDatabaseFactoryService)(MockBehavior.Strict)
                 ' Simulate Elfie throwing when trying to make a database from the contents of that response
-                factoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()))).
+                factoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()), It.IsAny(Of Boolean))).
                     Throws(New NotImplementedException())
 
                 ' Because the parsing failed we will expect to call into the 'UpdateFailedDelay' to
@@ -303,7 +303,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
                 ' Successfully create a database from that response.
                 Dim factoryMock = New Mock(Of IDatabaseFactoryService)(MockBehavior.Strict)
-                factoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()))).
+                factoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()), It.IsAny(Of Boolean))).
                     Returns(New AddReferenceDatabase())
 
                 ' Expect that we'll write the database to disk successfully.
@@ -352,13 +352,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
                 ' Create a database from the client response.
                 Dim factoryMock = New Mock(Of IDatabaseFactoryService)(MockBehavior.Strict)
-                factoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()))).
+                factoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()), It.IsAny(Of Boolean))).
                     Returns(New AddReferenceDatabase())
 
                 Dim delayMock = New Mock(Of IDelayService)(MockBehavior.Strict)
 
                 ' Write the temp file out to disk.
-                ioMock.Setup(Sub(s) s.WriteAndFlushAllBytes(It.IsAny(Of String), It.IsAny(Of Byte())))
+                ioMock.Setup(Sub(s) s.WriteAndFlushAllBytes(It.IsAny(Of String), It.IsAny(Of ArraySegment(Of Byte))))
 
                 ' Simulate a failure doing the first 'replace' of the database file.
                 ioMock.Setup(Sub(s) s.Replace(It.IsAny(Of String), It.IsAny(Of String), It.IsAny(Of String), It.IsAny(Of Boolean))).
@@ -405,7 +405,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
                 ' We'll successfully read in the local database.
                 Dim databaseFactoryMock = New Mock(Of IDatabaseFactoryService)(MockBehavior.Strict)
-                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()))).
+                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()), It.IsAny(Of Boolean))).
                     Returns(New AddReferenceDatabase())
 
                 ' Create a client that will return a patch that says things are up to date.
@@ -450,7 +450,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
                 ' We'll successfully read in the local database.
                 Dim databaseFactoryMock = New Mock(Of IDatabaseFactoryService)(MockBehavior.Strict)
-                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()))).
+                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()), It.IsAny(Of Boolean))).
                     Returns(New AddReferenceDatabase())
 
                 ' Create a client that will return a patch that says things are too old.
@@ -504,7 +504,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
                 ' We'll successfully read in the local database.
                 Dim databaseFactoryMock = New Mock(Of IDatabaseFactoryService)(MockBehavior.Strict)
-                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()))).
+                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()), It.IsAny(Of Boolean))).
                     Returns(New AddReferenceDatabase())
 
                 ' Create a client that will return a patch with contents.
@@ -564,7 +564,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
                 ' We'll successfully read in the local database.
                 Dim databaseFactoryMock = New Mock(Of IDatabaseFactoryService)(MockBehavior.Strict)
-                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()))).
+                databaseFactoryMock.Setup(Function(f) f.CreateDatabaseFromBytes(It.IsAny(Of Byte()), It.IsAny(Of Boolean))).
                     Returns(New AddReferenceDatabase())
 
                 ' Create a client that will return a patch with contents.
@@ -606,10 +606,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
 
         Private Shared Sub SetupWritesDatabaseSuccessfullyToDisk(ioMock As Mock(Of IIOService))
             ' Expect that we'll write out the temp file.
-            ioMock.Setup(Sub(s) s.WriteAndFlushAllBytes(It.IsRegex(".*tmp"), It.IsAny(Of Byte())))
+            ioMock.Setup(Sub(s) s.WriteAndFlushAllBytes(It.IsRegex(".*tmp"), It.IsAny(Of ArraySegment(Of Byte))))
 
             ' Expect that we'll replace the existing file with the temp file.
-            ioMock.Setup(Sub(s) s.Replace(It.IsRegex(".*tmp"), It.IsRegex(".*txt"), Nothing, It.IsAny(Of Boolean)))
+            ioMock.Setup(Sub(s) s.Replace(It.IsRegex(".*tmp"), It.IsRegex(".*(txt|bin)"), Nothing, It.IsAny(Of Boolean)))
         End Sub
 
         Private Shared Function CreatefileDownloaderFactoryMock(


### PR DESCRIPTION
This will allow subsequent loads of this index to be read from the binary file (which ScottLo indicated should be more allocation friendly).

Speedometer results (from commit 1) came back good. Filtered CPU/Allocations with IncPaths "elfie"

Old CPU:
![image](https://github.com/user-attachments/assets/dbd70eea-d8d9-4e7f-88ec-a722285752fe)

Old Allocations:
![image](https://github.com/user-attachments/assets/b53d9205-4df7-496f-9422-c421272dc945)

New CPU:
![image](https://github.com/user-attachments/assets/f6d25eaa-0660-4bda-aad7-788e153a963e)

New Allocations:
![image](https://github.com/user-attachments/assets/009f510c-d8ee-4b3a-ad61-f20191a2c250)
