### PR TITLE
Don't introduce prebuilts for 8.0.10 packs when building source only

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -18,8 +18,8 @@
 
       We should try to keep this version in sync with the version of app-local runtime in VS.
     -->
-    <MicrosoftNetCoreAppRuntimePackagesVersion>8.0.10</MicrosoftNetCoreAppRuntimePackagesVersion>
-    <MicrosoftWindowsDesktopAppRuntimePackagesVersion>8.0.10</MicrosoftWindowsDesktopAppRuntimePackagesVersion>
+    <MicrosoftNetCoreAppRuntimePackagesVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">8.0.10</MicrosoftNetCoreAppRuntimePackagesVersion>
+    <MicrosoftWindowsDesktopAppRuntimePackagesVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">8.0.10</MicrosoftWindowsDesktopAppRuntimePackagesVersion>
     <_xunitVersion>2.9.2</_xunitVersion>
     <SqliteVersion>2.1.0</SqliteVersion>
   </PropertyGroup>
@@ -131,11 +131,11 @@
       We should try to keep this version in sync with the version of app-local runtime in VS.
     -->
 
-    <PackageVersion Include="Microsoft.NETCore.App.Runtime.win-arm64" Version="$(MicrosoftNetCoreAppRuntimePackagesVersion)" />
-    <PackageVersion Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNetCoreAppRuntimePackagesVersion)" />
-    <PackageVersion Include="Microsoft.NETCore.App.crossgen2.win-x64" Version="$(MicrosoftNetCoreAppRuntimePackagesVersion)" />
-    <PackageVersion Include="Microsoft.WindowsDesktop.App.Runtime.win-arm64" Version="$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)" />
-    <PackageVersion Include="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)" />
+    <PackageVersion Include="Microsoft.NETCore.App.Runtime.win-arm64" Version="$(MicrosoftNetCoreAppRuntimePackagesVersion)" Condition="'$(MicrosoftNetCoreAppRuntimePackagesVersion)' != ''" />
+    <PackageVersion Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNetCoreAppRuntimePackagesVersion)" Condition="'$(MicrosoftNetCoreAppRuntimePackagesVersion)' != ''" />
+    <PackageVersion Include="Microsoft.NETCore.App.crossgen2.win-x64" Version="$(MicrosoftNetCoreAppRuntimePackagesVersion)" Condition="'$(MicrosoftNetCoreAppRuntimePackagesVersion)' != ''" />
+    <PackageVersion Include="Microsoft.WindowsDesktop.App.Runtime.win-arm64" Version="$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)" Condition="'$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)' != ''" />
+    <PackageVersion Include="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)" Condition="'$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)' != ''" />
 
     <!--
       Language Server


### PR DESCRIPTION
Unblocks https://github.com/dotnet/sdk/pull/45561

Resolves prebuilts (pinned packs) that are showing up even when targeting the net10.0 TFM:

```
          "Microsoft.NETCore.App.crossgen2.win-x64": "8.0.10",
          "Microsoft.NETCore.App.Runtime.win-arm64": "8.0.10",
          "Microsoft.NETCore.App.Runtime.win-x64": "8.0.10",
```

---

I'm sure there are other and better ways to solve this. I opened this PR mainly to track a fix directly in this repo. I meanwhile added a patch with these changes to https://github.com/dotnet/sdk/pull/45563 to unblock the build.
