### PR TITLE
Allow users to define EmbeddedAttribute

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
@@ -156,3 +156,24 @@ struct S
     public static void M([UnscopedRef] ref int x) { }
 }
 ```
+
+## `Microsoft.CodeAnalysis.EmbeddedAttribute` is validated on declaration
+
+***Introduced in Visual Studio 2022 version 17.13***
+
+The compiler now validates the shape of `Microsoft.CodeAnalysis.EmbeddedAttribute` when declared in source. Previously, the compiler
+would allow user-defined declarations of this attribute, but only when it didn't need to generate one itself. We now validate that:
+
+1. It must be internal
+2. It must be a class
+3. It must be sealed
+4. It must be non-static
+5. It must have an internal or public parameterless constructor
+6. It must be attributed with itself
+
+```cs
+namespace Microsoft.CodeAnalysis;
+
+// Previously, sometimes allowed. Now, CS9271
+public class EmbeddedAttribute : Attribute {}
+```

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
@@ -169,7 +169,8 @@ would allow user-defined declarations of this attribute, but only when it didn't
 3. It must be sealed
 4. It must be non-static
 5. It must have an internal or public parameterless constructor
-6. It must be attributed with itself
+6. It must inherit from System.Attribute.
+7. It must be allowed on any type declaration (class, struct, interface, enum, or delegate)
 
 ```cs
 namespace Microsoft.CodeAnalysis;

--- a/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
@@ -40,7 +40,7 @@ End Class
 ***Introduced in Visual Studio 2022 version 17.13***
 
 The compiler now validates the shape of `Microsoft.CodeAnalysis.EmbeddedAttribute` when declared in source. Previously, the compiler
-would allow user-defined declarations of this attribute, but only when it didn't need to generate one itself. We now validate that:
+would allow user-defined declarations of this attribute with any shape. We now validate that:
 
 1. It must be Friend
 2. It must be a Class
@@ -50,9 +50,12 @@ would allow user-defined declarations of this attribute, but only when it didn't
 6. It must inherit from System.Attribute.
 7. It must be allowed on any type declaration (class, struct, interface, enum, or delegate)
 
-```cs
-namespace Microsoft.CodeAnalysis;
+```vb
+Namespace Microsoft.CodeAnalysis
 
-// Previously, sometimes allowed. Now, CS9271
-public class EmbeddedAttribute : Attribute {}
-`
+    ' Previously allowed. Now, CS9271
+    Public Class EmbeddedAttribute
+        Inherits Attribute
+    End Class
+End Namespace
+```

--- a/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
@@ -48,12 +48,12 @@ would allow user-defined declarations of this attribute with any shape. We now v
 4. It must not be a Module
 5. It must have a Public parameterless constructor
 6. It must inherit from System.Attribute.
-7. It must be allowed on any type declaration (class, struct, interface, enum, or delegate)
+7. It must be allowed on any type declaration (Class, Struct, Interface, Enum, or Delegate)
 
 ```vb
 Namespace Microsoft.CodeAnalysis
 
-    ' Previously allowed. Now, CS9271
+    ' Previously allowed. Now, BC37335
     Public Class EmbeddedAttribute
         Inherits Attribute
     End Class

--- a/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
@@ -35,3 +35,24 @@ Class C
 End Class
 ```
 
+## `Microsoft.CodeAnalysis.EmbeddedAttribute` is validated on declaration
+
+***Introduced in Visual Studio 2022 version 17.13***
+
+The compiler now validates the shape of `Microsoft.CodeAnalysis.EmbeddedAttribute` when declared in source. Previously, the compiler
+would allow user-defined declarations of this attribute, but only when it didn't need to generate one itself. We now validate that:
+
+1. It must be Friend
+2. It must be a Class
+3. It must be NotInheritable
+4. It must not be a Module
+5. It must have a Public parameterless constructor
+6. It must inherit from System.Attribute.
+7. It must be allowed on any type declaration (class, struct, interface, enum, or delegate)
+
+```cs
+namespace Microsoft.CodeAnalysis;
+
+// Previously, sometimes allowed. Now, CS9271
+public class EmbeddedAttribute : Attribute {}
+`

--- a/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/Visual Basic/Compiler Breaking Changes - DotNet 10.md
@@ -48,7 +48,7 @@ would allow user-defined declarations of this attribute with any shape. We now v
 4. It must not be a Module
 5. It must have a Public parameterless constructor
 6. It must inherit from System.Attribute.
-7. It must be allowed on any type declaration (Class, Struct, Interface, Enum, or Delegate)
+7. It must be allowed on any type declaration (Class, Structure, Interface, Enum, or Delegate)
 
 ```vb
 Namespace Microsoft.CodeAnalysis

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5909,7 +5909,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type name '{0}' is reserved to be used by the compiler.</value>
   </data>
   <data name="ERR_EmbeddedAttributeMustFollowPattern" xml:space="preserve">
-    <value>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</value>
+    <value>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</value>
   </data>
   <data name="ERR_InExtensionMustBeValueType" xml:space="preserve">
     <value>The first 'in' or 'ref readonly' parameter of the extension method '{0}' must be a concrete (non-generic) value type.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5908,6 +5908,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TypeReserved" xml:space="preserve">
     <value>The type name '{0}' is reserved to be used by the compiler.</value>
   </data>
+  <data name="ERR_ReservedTypeMustFollowPattern" xml:space="preserve">
+    <value>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</value>
+  </data>
   <data name="ERR_InExtensionMustBeValueType" xml:space="preserve">
     <value>The first 'in' or 'ref readonly' parameter of the extension method '{0}' must be a concrete (non-generic) value type.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5909,7 +5909,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type name '{0}' is reserved to be used by the compiler.</value>
   </data>
   <data name="ERR_ReservedTypeMustFollowPattern" xml:space="preserve">
-    <value>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</value>
+    <value>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</value>
   </data>
   <data name="ERR_InExtensionMustBeValueType" xml:space="preserve">
     <value>The first 'in' or 'ref readonly' parameter of the extension method '{0}' must be a concrete (non-generic) value type.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5909,7 +5909,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type name '{0}' is reserved to be used by the compiler.</value>
   </data>
   <data name="ERR_ReservedTypeMustFollowPattern" xml:space="preserve">
-    <value>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</value>
+    <value>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</value>
   </data>
   <data name="ERR_InExtensionMustBeValueType" xml:space="preserve">
     <value>The first 'in' or 'ref readonly' parameter of the extension method '{0}' must be a concrete (non-generic) value type.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5908,8 +5908,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TypeReserved" xml:space="preserve">
     <value>The type name '{0}' is reserved to be used by the compiler.</value>
   </data>
-  <data name="ERR_ReservedTypeMustFollowPattern" xml:space="preserve">
-    <value>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</value>
+  <data name="ERR_EmbeddedAttributeMustFollowPattern" xml:space="preserve">
+    <value>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</value>
   </data>
   <data name="ERR_InExtensionMustBeValueType" xml:space="preserve">
     <value>The first 'in' or 'ref readonly' parameter of the extension method '{0}' must be a concrete (non-generic) value type.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2356,6 +2356,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UnscopedRefAttributeOldRules = 9269,
         WRN_InterceptsLocationAttributeUnsupportedSignature = 9270,
 
+        ERR_ReservedTypeMustFollowPattern = 9271,
+
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2356,7 +2356,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UnscopedRefAttributeOldRules = 9269,
         WRN_InterceptsLocationAttributeUnsupportedSignature = 9270,
 
-        ERR_ReservedTypeMustFollowPattern = 9271,
+        ERR_EmbeddedAttributeMustFollowPattern = 9271,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -1844,7 +1844,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_RefReturnReadonlyNotField2
                 or ErrorCode.ERR_ExplicitReservedAttr
                 or ErrorCode.ERR_TypeReserved
-                or ErrorCode.ERR_ReservedTypeMustFollowPattern
+                or ErrorCode.ERR_EmbeddedAttributeMustFollowPattern
                 or ErrorCode.ERR_RefExtensionMustBeValueTypeOrConstrainedToOne
                 or ErrorCode.ERR_InExtensionMustBeValueType
                 or ErrorCode.ERR_FieldsInRoStruct

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -1844,6 +1844,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_RefReturnReadonlyNotField2
                 or ErrorCode.ERR_ExplicitReservedAttr
                 or ErrorCode.ERR_TypeReserved
+                or ErrorCode.ERR_ReservedTypeMustFollowPattern
                 or ErrorCode.ERR_RefExtensionMustBeValueTypeOrConstrainedToOne
                 or ErrorCode.ERR_InExtensionMustBeValueType
                 or ErrorCode.ERR_FieldsInRoStruct

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2541,6 +2541,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             do
             {
                 stack.Push(binary);
+                EnterRegionIfNeeded(binary);
                 binary = binary.Left as BoundBinaryOperator;
             }
             while (binary != null && !binary.OperatorKind.IsLogical() && binary.InterpolatedStringHandlerData is null);
@@ -2550,6 +2551,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
+        /// <param name="stack">Nested left-associative binary operators, pushed on from outermost to innermost.</param>
         protected virtual void VisitBinaryOperatorChildren(ArrayBuilder<BoundBinaryOperator> stack)
         {
             var binary = stack.Pop();
@@ -2592,6 +2594,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 SetConditionalState(isNullConstant == isEquals(binary)
                     ? (State, stateWhenNotNull)
                     : (stateWhenNotNull, State));
+                LeaveRegionIfNeeded(binary);
 
                 if (stack.Count == 0)
                 {
@@ -2609,6 +2612,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Unsplit();
                     VisitRvalue(binary.Right);
                 }
+                LeaveRegionIfNeeded(binary);
 
                 if (stack.Count == 0)
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -462,6 +462,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isSpeculative = false)
             : base(compilation, symbol, node, EmptyStructTypeCache.CreatePrecise(), trackUnassignments: true)
         {
+            Debug.Assert(!TrackingRegions);
             Debug.Assert(!useDelegateInvokeParameterTypes || delegateInvokeMethodOpt is object);
             Debug.Assert(baseOrThisInitializer is null or { MethodKind: MethodKind.Constructor });
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1414,7 +1414,6 @@ next:;
         {
             get
             {
-
                 var data = GetEarlyDecodedWellKnownAttributeData();
                 return (data != null && data.HasCodeAnalysisEmbeddedAttribute)
                     // If this is Microsoft.CodeAnalysis.EmbeddedAttribute, we'll synthesize EmbeddedAttribute even if it's not applied.
@@ -1947,8 +1946,8 @@ next:;
                     || !this.DeclaringCompilation.IsAttributeType(this)
                     || (GetAttributeUsageInfo().ValidTargets & expectedTargets) != expectedTargets)
                 {
-                    // The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
-                    diagnostics.Add(ErrorCode.ERR_ReservedTypeMustFollowPattern, GetFirstLocation(), AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
+                    // The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
+                    diagnostics.Add(ErrorCode.ERR_EmbeddedAttributeMustFollowPattern, GetFirstLocation());
                 }
 
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1944,11 +1944,10 @@ next:;
                     || !IsSealed
                     || IsStatic
                     || !InstanceConstructors.Any(c => c is { ParameterCount: 0, DeclaredAccessibility: Accessibility.Internal or Accessibility.Public })
-                    || !HasCodeAnalysisEmbeddedAttribute
                     || !this.DeclaringCompilation.IsAttributeType(this)
                     || (GetAttributeUsageInfo().ValidTargets & ExpectedTargets) != ExpectedTargets)
                 {
-                    // The type '{0}' must be non-generic, internal, sealed, non-static, and have a parameterless constructor.
+                    // The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                     diagnostics.Add(ErrorCode.ERR_ReservedTypeMustFollowPattern, GetFirstLocation(), AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1922,7 +1922,7 @@ next:;
                     }
                 })
             {
-                // This is a user-defined implement of the special attribute Microsoft.CodeAnalysis.EmbeddedAttribute. It needs to follow specific rules:
+                // This is a user-defined implementation of the special attribute Microsoft.CodeAnalysis.EmbeddedAttribute. It needs to follow specific rules:
                 // 1. It must be internal
                 // 2. It must be a class
                 // 3. It must be sealed

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1937,7 +1937,7 @@ next:;
                 // 7. It must be allowed on any type declaration (class, struct, interface, enum, or delegate)
                 // 8. It must be non-generic (checked as part of IsMicrosoftCodeAnalysisEmbeddedAttribute, we don't error on this because both types can exist)
 
-                const AttributeTargets ExpectedTargets = AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Delegate;
+                const AttributeTargets expectedTargets = AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Delegate;
 
                 if (DeclaredAccessibility != Accessibility.Internal
                     || TypeKind != TypeKind.Class
@@ -1945,7 +1945,7 @@ next:;
                     || IsStatic
                     || !InstanceConstructors.Any(c => c is { ParameterCount: 0, DeclaredAccessibility: Accessibility.Internal or Accessibility.Public })
                     || !this.DeclaringCompilation.IsAttributeType(this)
-                    || (GetAttributeUsageInfo().ValidTargets & ExpectedTargets) != ExpectedTargets)
+                    || (GetAttributeUsageInfo().ValidTargets & expectedTargets) != expectedTargets)
                 {
                     // The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                     diagnostics.Add(ErrorCode.ERR_ReservedTypeMustFollowPattern, GetFirstLocation(), AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -2137,6 +2137,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 typeSymbol.IsContainedInNamespace(nameof(System), nameof(System.Threading));
         }
 
+        internal static bool IsMicrosoftCodeAnalysisEmbeddedAttribute(this TypeSymbol typeSymbol)
+        {
+            return typeSymbol is NamedTypeSymbol
+            {
+                Name: "EmbeddedAttribute",
+                Arity: 0,
+                ContainingType: null,
+            }
+            && typeSymbol.IsContainedInNamespace("Microsoft", "CodeAnalysis");
+        }
+
         private static bool IsWellKnownInteropServicesTopLevelType(this TypeSymbol typeSymbol, string name)
         {
             if (typeSymbol.Name != name || typeSymbol.ContainingType is object)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">Typy a aliasy nemůžou mít název required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">Cílový modul runtime nepodporuje obecné typy by-ref-like.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">Typy a aliasy nemůžou mít název required.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">Typen und Aliase können nicht als "erforderlich" bezeichnet werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">Typen und Aliase können nicht als "erforderlich" bezeichnet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">Die Zielruntime unterstützt keine by-ref-like-Generics.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">Los tipos y alias no se pueden denominar 'required'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">Los tipos y alias no se pueden denominar 'required'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">El entorno de ejecución de destino no admite tipos genéricos similares a ref.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">Les types et alias ne peuvent pas être nommés « required ».</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">Le runtime cible ne prend pas en charge les génériques by-ref-like.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">Les types et alias ne peuvent pas être nommés « required ».</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">I tipi e gli alias non possono essere denominati 'obbligatori'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">I tipi e gli alias non possono essere denominati 'obbligatori'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">Il runtime di destinazione non supporta generics simili a by-ref.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">型とエイリアスに 'required' という名前を付けることはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">型とエイリアスに 'required' という名前を付けることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">対象のランタイムは、参照渡しのようなジェネリックをサポートしていません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">유형 및 별칭은 '필수'로 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">대상 런타임은 참조와 유사한 제네릭을 지원하지 않습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">유형 및 별칭은 '필수'로 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">Typy i aliasy nie mogą mieć nazwy „required”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">Typy i aliasy nie mogą mieć nazwy „required”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">Docelowe środowisko uruchomieniowe nie obsługuje typów ogólnych by-ref-like.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">Tipos e pseudônimos não podem ser nomeados 'requeridos'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">Tipos e pseudônimos não podem ser nomeados 'requeridos'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">O runtime de destino não dá suporte a genéricos by-ref-like.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">У типов и псевдонимов не может быть имя "required".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">Целевая среда выполнения не поддерживает параметрические полиморфизмы, подобные ref.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">У типов и псевдонимов не может быть имя "required".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">Türler ve diğer adlar 'gerekli' olarak adlandırılamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">Türler ve diğer adlar 'gerekli' olarak adlandırılamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">Hedef çalışma zamanı başvuru benzeri genel türleri desteklemez.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">类型和别名不能命名为 “required”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">类型和别名不能命名为 “required”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">目标运行时不支持类似 ref 的泛型。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
-        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1993,8 +1993,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.</target>
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1992,9 +1992,9 @@
         <target state="translated">類型和別名不能命名為 'required'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
-        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</source>
+        <target state="new">The type 'Microosft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1992,6 +1992,11 @@
         <target state="translated">類型和別名不能命名為 'required'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</source>
+        <target state="new">The type '{0}' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportByRefLikeGenerics">
         <source>Target runtime doesn't support by-ref-like generics.</source>
         <target state="translated">目標執行階段不支援泛型之類 by-ref-。</target>

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Embedded.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Embedded.cs
@@ -280,7 +280,7 @@ class Test
                 """;
 
             CreateCompilation(code, assemblyName: "testModule", targetFramework: TargetFramework.NetStandard20).VerifyEmitDiagnostics(
-                // (4,25): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.
+                // (4,25): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                 //     public sealed class EmbeddedAttribute : System.Attribute
                 Diagnostic(ErrorCode.ERR_ReservedTypeMustFollowPattern, "EmbeddedAttribute").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(4, 25));
         }
@@ -307,7 +307,7 @@ class Test
                 """;
 
             CreateCompilation(code, assemblyName: "testModule", targetFramework: TargetFramework.NetStandard20).VerifyEmitDiagnostics(
-                // (4,20): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.
+                // (4,20): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                 //     internal class EmbeddedAttribute : System.Attribute
                 Diagnostic(ErrorCode.ERR_ReservedTypeMustFollowPattern, "EmbeddedAttribute").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(4, 20));
         }
@@ -372,7 +372,7 @@ class Test
                 """;
 
             List<DiagnosticDescription> diagnostics = [
-                // (4,27): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.
+                // (4,27): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                 //     internal sealed class EmbeddedAttribute : System.Attribute
                 Diagnostic(ErrorCode.ERR_ReservedTypeMustFollowPattern, "EmbeddedAttribute").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(4, 27),
             ];
@@ -486,7 +486,7 @@ class Test
                 // (4,34): error CS0441: 'EmbeddedAttribute': a type cannot be both static and sealed
                 //     internal sealed static class EmbeddedAttribute : System.Attribute
                 Diagnostic(ErrorCode.ERR_SealedStaticClass, "EmbeddedAttribute").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(4, 34),
-                // (4,34): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.
+                // (4,34): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                 //     internal sealed static class EmbeddedAttribute : System.Attribute
                 Diagnostic(ErrorCode.ERR_ReservedTypeMustFollowPattern, "EmbeddedAttribute").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(4, 34),
                 // (4,54): error CS0713: Static class 'EmbeddedAttribute' cannot derive from type 'Attribute'. Static classes must derive from object.
@@ -519,7 +519,7 @@ class Test
                 // (3,6): error CS0616: 'EmbeddedAttribute' is not an attribute class
                 //     [Embedded]
                 Diagnostic(ErrorCode.ERR_NotAnAttributeClass, "Embedded").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(3, 6),
-                // (4,27): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, be attributed with 'Microsoft.CodeAnalysis.EmbeddedAttribute', and have a parameterless constructor.
+                // (4,27): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                 //     internal sealed class EmbeddedAttribute
                 Diagnostic(ErrorCode.ERR_ReservedTypeMustFollowPattern, "EmbeddedAttribute").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(4, 27));
         }
@@ -562,7 +562,7 @@ class Test
             }
 
             diagnostics.Add(
-                // (5,27): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, and be able to be applied to any type.
+                // (5,27): error CS9271: The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, internal, sealed, non-static, have a parameterless constructor, inherit from System.Attribute, and be able to be applied to any type.
                 //     internal sealed class EmbeddedAttribute : System.Attribute
                 Diagnostic(ErrorCode.ERR_ReservedTypeMustFollowPattern, "EmbeddedAttribute").WithArguments("Microsoft.CodeAnalysis.EmbeddedAttribute").WithLocation(5, 27)
             );

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Embedded.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Embedded.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var code = @"
 namespace Microsoft.CodeAnalysis
 {
-    [Embedded]
     internal sealed class EmbeddedAttribute : System.Attribute { }
 }
 namespace TestReference
@@ -94,7 +93,6 @@ class Program
             var module = CreateCompilation(@"
 namespace Microsoft.CodeAnalysis
 {
-    [Embedded]
     internal sealed class EmbeddedAttribute : System.Attribute { }
 }
 namespace TestReference
@@ -175,7 +173,6 @@ class Program
             var code = @"
 namespace Microsoft.CodeAnalysis
 {
-    [Embedded]
     internal sealed class EmbeddedAttribute : System.Attribute { }
 }
 namespace OtherNamespace
@@ -274,7 +271,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating another EmbeddedAttribute, if we hadn't already defined one
                     }
                 }
                 """;
@@ -301,7 +298,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating another EmbeddedAttribute, if we hadn't already defined one
                     }
                 }
                 """;
@@ -328,7 +325,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating another EmbeddedAttribute, if we hadn't already defined one
                     }
                 }
                 """;
@@ -366,7 +363,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating another EmbeddedAttribute, if we hadn't already defined one
                     }
                 }
                 """;
@@ -390,12 +387,13 @@ class Test
                 .VerifyEmitDiagnostics(diagnostics.ToArray());
         }
 
-        [Fact]
-        public void EmbeddedAttributeFromSourceValidation_MissingEmbeddedAttributeGeneratesAttributeApplication()
+        [Theory, CombinatorialData]
+        public void EmbeddedAttributeFromSourceValidation_MissingEmbeddedAttributeApplicationGeneratesAttributeApplication(bool hasObsolete)
         {
-            var code = """
+            var code = $$"""
                 namespace Microsoft.CodeAnalysis
                 {
+                    {{(hasObsolete ? "[System.Obsolete]" : "")}}
                     internal sealed class EmbeddedAttribute : System.Attribute
                     {
                         public EmbeddedAttribute() { }
@@ -405,7 +403,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating EmbeddedAttribute if we hadn't defined one
                     }
                 }
                 """;
@@ -418,7 +416,7 @@ class Test
                 {
                     var embeddedAttribute = module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                     Assert.NotNull(embeddedAttribute);
-                    Assert.Equal(["Microsoft.CodeAnalysis.EmbeddedAttribute"], embeddedAttribute.GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()));
+                    Assert.Equal(["Microsoft.CodeAnalysis.EmbeddedAttribute"], embeddedAttribute.GetAttributes().Where(a => a.AttributeClass.Name != "ObsoleteAttribute").Select(a => a.AttributeClass.ToTestDisplayString()));
                 })
                 .VerifyDiagnostics();
         }
@@ -439,7 +437,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating another EmbeddedAttribute, if we hadn't already defined one
                     }
                 }
                 """;
@@ -474,7 +472,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating another EmbeddedAttribute, if we hadn't already defined one
                     }
                 }
                 """;
@@ -510,7 +508,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating another EmbeddedAttribute, if we hadn't already defined one
                     }
                 }
                 """;
@@ -546,7 +544,7 @@ class Test
                 {
                     public void M(in int p)
                     {
-                        // This should trigger generating another EmbeddedAttribute
+                        // This would trigger generating EmbeddedAttribute if we hadn't defined one
                     }
                 }
                 """;
@@ -855,7 +853,6 @@ public class Test
             var compilation1 = CreateCompilation(parseOptions: TestOptions.Regular.WithNoRefSafetyRulesAttribute(), source: @"
 namespace Microsoft.CodeAnalysis
 {
-    [Embedded]
     internal sealed class EmbeddedAttribute : System.Attribute { }
 }
 [Microsoft.CodeAnalysis.Embedded]

--- a/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
@@ -1546,7 +1546,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      ERRID.ERR_InvalidExperimentalDiagID,
                      ERRID.ERR_LockTypeUnsupported,
                      ERRID.WRN_ConvertingLock,
-                     ERRID.ERR_ReservedTypeMustFollowPattern
+                     ERRID.ERR_EmbeddedAttributeMustFollowPattern
                     Return False
                 Case Else
                     ' NOTE: All error codes must be explicitly handled in the below select case statement

--- a/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
@@ -1545,7 +1545,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      ERRID.WRN_DuplicateAnalyzerReference,
                      ERRID.ERR_InvalidExperimentalDiagID,
                      ERRID.ERR_LockTypeUnsupported,
-                     ERRID.WRN_ConvertingLock
+                     ERRID.WRN_ConvertingLock,
+                     ERRID.ERR_ReservedTypeMustFollowPattern
                     Return False
                 Case Else
                     ' NOTE: All error codes must be explicitly handled in the below select case statement

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1786,7 +1786,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_CannotApplyOverloadResolutionPriorityToOverride = 37333
         ERR_CannotApplyOverloadResolutionPriorityToMember = 37334
 
-        ERR_ReservedTypeMustFollowPattern = 37335
+        ERR_EmbeddedAttributeMustFollowPattern = 37335
 
         ERR_NextAvailable = 37336
 

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1786,7 +1786,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_CannotApplyOverloadResolutionPriorityToOverride = 37333
         ERR_CannotApplyOverloadResolutionPriorityToMember = 37334
 
-        ERR_NextAvailable = 37335
+        ERR_ReservedTypeMustFollowPattern = 37335
+
+        ERR_NextAvailable = 37336
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -60,6 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ReportedVarianceDiagnostics = &H2    ' Set if variance diagnostics have been reported.
             ReportedBaseClassConstraintsDiagnostics = &H4    ' Set if base class constraints diagnostics have been reported.
             ReportedInterfacesConstraintsDiagnostics = &H8    ' Set if constraints diagnostics for base/implemented interfaces have been reported.
+            ReportedCodeAnalysisEmbeddedAttributeDiagnostics = &H10 ' Set if 
         End Enum
 
         ' Containing symbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ReportedVarianceDiagnostics = &H2    ' Set if variance diagnostics have been reported.
             ReportedBaseClassConstraintsDiagnostics = &H4    ' Set if base class constraints diagnostics have been reported.
             ReportedInterfacesConstraintsDiagnostics = &H8    ' Set if constraints diagnostics for base/implemented interfaces have been reported.
-            ReportedCodeAnalysisEmbeddedAttributeDiagnostics = &H10 ' Set if 
+            ReportedCodeAnalysisEmbeddedAttributeDiagnostics = &H10 ' Set if whether the symbol has been checked for Microsoft.CodeAnalysis.EmbeddedAttribute definition diagnostics.
         End Enum
 
         ' Containing symbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ReportedVarianceDiagnostics = &H2    ' Set if variance diagnostics have been reported.
             ReportedBaseClassConstraintsDiagnostics = &H4    ' Set if base class constraints diagnostics have been reported.
             ReportedInterfacesConstraintsDiagnostics = &H8    ' Set if constraints diagnostics for base/implemented interfaces have been reported.
-            ReportedCodeAnalysisEmbeddedAttributeDiagnostics = &H10 ' Set if whether the symbol has been checked for Microsoft.CodeAnalysis.EmbeddedAttribute definition diagnostics.
+            ReportedCodeAnalysisEmbeddedAttributeDiagnostics = &H10 ' Set if the symbol has been checked for Microsoft.CodeAnalysis.EmbeddedAttribute definition diagnostics.
         End Enum
 
         ' Containing symbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -1706,15 +1706,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If Me.IsMicrosoftCodeAnalysisEmbeddedAttribute() Then
                 ' This Is a user-defined implementation of the special attribute Microsoft.CodeAnalysis.EmbeddedAttribute. It needs to follow specific rules
                 ' 1. It must be Friend
-                ' 2. It must be a class
+                ' 2. It must be a Class
                 ' 3. It must be NotInheritable
                 ' 4. It must not be a Module
-                ' 5. It must have a Public parameterless constructor. This is different from C#, because VB requires public parameterless attribute constructors in general
+                ' 5. It must have a Public parameterless constructor. This is different from C#, because VB requires any attribute to have a Public parameterless constructor.
                 ' 6. It must inherit from System.Attribute
-                ' 7. It must be allowed on any type declaration (class, struct, interface, enum, Or delegate)
-                ' 8. It must be non-generic
+                ' 7. It must be allowed on any type declaration (Class, Struct, Interface, Enum, or Delegate)
+                ' 8. It must be non-generic. Note that generic attributes are not supported in VB, and won't pass the `IsMicrosoftCodeAnalysisEmbeddedAttribute` check, it's just listed here for completeness.
 
-                Dim expectedTargets = AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Enum Or AttributeTargets.Delegate
+                Const expectedTargets = AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Enum Or AttributeTargets.Delegate
 
                 If DeclaredAccessibility <> Accessibility.Friend OrElse
                         TypeKind <> TypeKind.Class OrElse

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -120,6 +120,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             cancellationToken.ThrowIfCancellationRequested()
             CheckInterfacesConstraints()
+
+            cancellationToken.ThrowIfCancellationRequested()
+            CheckEmbeddedAttributeImplementation()
         End Sub
 #End Region
 
@@ -1687,16 +1690,52 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             End If
 
+            m_containingModule.AtomicSetFlagAndStoreDiagnostics(m_lazyState, StateFlags.ReportedInterfacesConstraintsDiagnostics, 0, diagnostics)
+
+            If diagnostics IsNot Nothing Then
+                diagnostics.Free()
+            End If
+        End Sub
+
+        Private Sub CheckEmbeddedAttributeImplementation()
+            If (m_lazyState And StateFlags.ReportedCodeAnalysisEmbeddedAttributeDiagnostics) <> 0 Then
+                Return
+            End If
+
+            Dim diagnostics As BindingDiagnosticBag = Nothing
+            If Me.IsMicrosoftCodeAnalysisEmbeddedAttribute() Then
+                ' This Is a user-defined implementation of the special attribute Microsoft.CodeAnalysis.EmbeddedAttribute. It needs to follow specific rules
+                ' 1. It must be Friend
+                ' 2. It must be a class
+                ' 3. It must be NotInheritable
+                ' 4. It must not be a Module
+                ' 5. It must have a Public parameterless constructor. This is different from C#, because VB requires public parameterless attribute constructors in general
+                ' 6. It must inherit from System.Attribute
+                ' 7. It must be allowed on any type declaration (class, struct, interface, enum, Or delegate)
+                ' 8. It must be non-generic
+
+                Dim expectedTargets = AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Enum Or AttributeTargets.Delegate
+
+                If DeclaredAccessibility <> Accessibility.Friend OrElse
+                        TypeKind <> TypeKind.Class OrElse
+                        (Not IsNotInheritable) OrElse
+                        IsShared OrElse
+                        (Not InstanceConstructors.Any(Function(c) c.ParameterCount = 0 AndAlso c.DeclaredAccessibility = Accessibility.Public)) OrElse
+                        (Not DeclaringCompilation.IsAttributeType(Me)) OrElse
+                        (GetAttributeUsageInfo().ValidTargets And expectedTargets) <> expectedTargets Then
+                    diagnostics = BindingDiagnosticBag.GetInstance()
+                    diagnostics.Add(ERRID.ERR_ReservedTypeMustFollowPattern, TypeDeclaration.Declarations(0).Location, Me)
+                End If
+            End If
+
             If m_containingModule.AtomicSetFlagAndStoreDiagnostics(m_lazyState,
-                                                                   StateFlags.ReportedInterfacesConstraintsDiagnostics,
+                                                                   StateFlags.ReportedCodeAnalysisEmbeddedAttributeDiagnostics,
                                                                    0,
                                                                    diagnostics) Then
                 DeclaringCompilation.SymbolDeclaredEvent(Me)
             End If
 
-            If diagnostics IsNot Nothing Then
-                diagnostics.Free()
-            End If
+            diagnostics?.Free()
         End Sub
 
         ''' <summary>
@@ -1870,7 +1909,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides ReadOnly Property HasCodeAnalysisEmbeddedAttribute As Boolean
             Get
                 Dim data As TypeEarlyWellKnownAttributeData = GetEarlyDecodedWellKnownAttributeData()
-                Return data IsNot Nothing AndAlso data.HasCodeAnalysisEmbeddedAttribute
+                ' We synthesize an application of Microsoft.CodeAnalysis.EmbeddedAttribute on Microsoft.CodeAnalysis.EmbeddedAttribute if one wasn't present
+                Return (data IsNot Nothing AndAlso data.HasCodeAnalysisEmbeddedAttribute) OrElse Me.IsMicrosoftCodeAnalysisEmbeddedAttribute()
             End Get
         End Property
 
@@ -2532,6 +2572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         ImmutableArray.Create(
                             New TypedConstant(GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, eventInterfaceName))))
                 End If
+
             End If
 
             Dim baseType As NamedTypeSymbol = Me.BaseTypeNoUseSiteDiagnostics
@@ -2558,6 +2599,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor,
                         ImmutableArray.Create(New TypedConstant(compilation.GetWellKnownType(WellKnownType.System_Type), TypedConstantKind.Type, originalType)),
                         isOptionalUse:=True))
+            End If
+
+            If Me.IsMicrosoftCodeAnalysisEmbeddedAttribute() Then
+                Dim earlyAttributeData = GetEarlyDecodedWellKnownAttributeData()
+
+                If earlyAttributeData Is Nothing OrElse Not earlyAttributeData.HasCodeAnalysisEmbeddedAttribute Then
+                    ' Get the parameterless constructor and apply it to the current type. If there wasn't a parameterless constructor, we would have
+                    ' issued a declaration diagnostic
+
+                    Dim parameterlessConstructor = InstanceConstructors.FirstOrDefault(Function(c) c.ParameterCount = 0)
+                    If parameterlessConstructor IsNot Nothing Then
+                        AddSynthesizedAttribute(
+                                attributes,
+                                New SynthesizedAttributeData(
+                                    DeclaringCompilation,
+                                    parameterlessConstructor,
+                                    arguments:=ImmutableArray(Of TypedConstant).Empty,
+                                    namedArgs:=ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty))
+                    End If
+                End If
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -1704,7 +1704,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim diagnostics As BindingDiagnosticBag = Nothing
             If Me.IsMicrosoftCodeAnalysisEmbeddedAttribute() Then
-                ' This Is a user-defined implementation of the special attribute Microsoft.CodeAnalysis.EmbeddedAttribute. It needs to follow specific rules
+                ' This is a user-defined implementation of the special attribute Microsoft.CodeAnalysis.EmbeddedAttribute. It needs to follow specific rules
                 ' 1. It must be Friend
                 ' 2. It must be a Class
                 ' 3. It must be NotInheritable
@@ -1724,7 +1724,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         (Not DeclaringCompilation.IsAttributeType(Me)) OrElse
                         (GetAttributeUsageInfo().ValidTargets And expectedTargets) <> expectedTargets Then
                     diagnostics = BindingDiagnosticBag.GetInstance()
-                    diagnostics.Add(ERRID.ERR_ReservedTypeMustFollowPattern, TypeDeclaration.Declarations(0).Location, Me)
+                    diagnostics.Add(ERRID.ERR_EmbeddedAttributeMustFollowPattern, TypeDeclaration.Declarations(0).Location)
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -1334,6 +1334,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension>
+        Friend Function IsMicrosoftCodeAnalysisEmbeddedAttribute(typeSymbol As TypeSymbol) As Boolean
+            Dim namedTypeSymbol = TryCast(typeSymbol, NamedTypeSymbol)
+
+            Return namedTypeSymbol IsNot Nothing AndAlso
+                namedTypeSymbol.Name = "EmbeddedAttribute" AndAlso
+                namedTypeSymbol.Arity = 0 AndAlso
+                typeSymbol.ContainingType Is Nothing AndAlso
+                IsContainedInNamespace(typeSymbol, "Microsoft", "CodeAnalysis")
+        End Function
+
+        <Extension>
         Private Function IsContainedInNamespace(typeSymbol As TypeSymbol, outerNS As String, midNS As String, Optional innerNS As String = Nothing) As Boolean
             Dim midNamespace As NamespaceSymbol
 

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5731,4 +5731,7 @@
   <data name="FEATURE_OverloadResolutionPriority" xml:space="preserve">
     <value>overload resolution priority</value>
   </data>
+  <data name="ERR_ReservedTypeMustFollowPattern" xml:space="preserve">
+    <value>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5731,7 +5731,7 @@
   <data name="FEATURE_OverloadResolutionPriority" xml:space="preserve">
     <value>overload resolution priority</value>
   </data>
-  <data name="ERR_ReservedTypeMustFollowPattern" xml:space="preserve">
-    <value>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</value>
+  <data name="ERR_EmbeddedAttributeMustFollowPattern" xml:space="preserve">
+    <value>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</value>
   </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -107,9 +107,9 @@
         <target state="translated">Seznam požadovaných členů pro {0} má chybný formát a nelze ho interpretovat.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Seznam požadovaných členů pro {0} má chybný formát a nelze ho interpretovat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">Cílový modul runtime nepodporuje implementaci výchozího rozhraní.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Die erforderliche Mitgliederliste für '{0}' ist falsch formatiert und kann nicht interpretiert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">Die Standardschnittstellenimplementierung wird von der Zielruntime nicht unterstützt.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -107,9 +107,9 @@
         <target state="translated">Die erforderliche Mitgliederliste für '{0}' ist falsch formatiert und kann nicht interpretiert werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -107,9 +107,9 @@
         <target state="translated">La lista de miembros necesarios para '{0}' tiene un formato incorrecto y no se puede interpretar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -107,6 +107,11 @@
         <target state="translated">La lista de miembros necesarios para '{0}' tiene un formato incorrecto y no se puede interpretar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">El tiempo de ejecución de destino no admite la implementación de interfaz predeterminada.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -107,9 +107,9 @@
         <target state="translated">La liste des membres requis pour «{0}» est incorrecte et ne peut pas être interprétée.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">La liste des membres requis pour «{0}» est incorrecte et ne peut pas être interprétée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">Le runtime cible ne prend pas en charge l'implémentation d'interface par défaut.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -107,6 +107,11 @@
         <target state="translated">L'elenco dei membri obbligatori per '{0}' non è valido e non può essere interpretato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">Il runtime di destinazione non supporta l'implementazione di interfaccia predefinita.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -107,9 +107,9 @@
         <target state="translated">L'elenco dei membri obbligatori per '{0}' non è valido e non può essere interpretato.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -107,9 +107,9 @@
         <target state="translated">'{0}' に必要なメンバーの一覧の形式が正しくないため、解釈できません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -107,6 +107,11 @@
         <target state="translated">'{0}' に必要なメンバーの一覧の形式が正しくないため、解釈できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">ターゲット ランタイムは、既定のインターフェイスの実装をサポートしていません。</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -107,9 +107,9 @@
         <target state="translated">'{0}'에 대한 필수 구성원 목록 형식이 잘못되어 해석할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -107,6 +107,11 @@
         <target state="translated">'{0}'에 대한 필수 구성원 목록 형식이 잘못되어 해석할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">대상 런타임이 기본 인터페이스 구현을 지원하지 않습니다.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -107,9 +107,9 @@
         <target state="translated">Lista wymaganych składowych dla „{0}” jest źle sformułowana i nie można jej zinterpretować.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Lista wymaganych składowych dla „{0}” jest źle sformułowana i nie można jej zinterpretować.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">Docelowe środowisko uruchomieniowe nie obsługuje domyślnej implementacji interfejsu.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -107,9 +107,9 @@
         <target state="translated">A lista de membros requeridos '{0}' está malformada e não pode ser interpretada.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="translated">A lista de membros requeridos '{0}' está malformada e não pode ser interpretada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">O runtime de destino não é compatível com a implementação de interface padrão.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -107,9 +107,9 @@
         <target state="translated">Неправильный формат списка обязательных элементов для "{0}", его не удается интерпретировать.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Неправильный формат списка обязательных элементов для "{0}", его не удается интерпретировать.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">Целевая среда выполнения не поддерживает реализацию интерфейса по умолчанию.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -107,9 +107,9 @@
         <target state="translated">'{0}' için gerekli üye listesi hatalı biçimlendirilmiş ve yorumlanamıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">'{0}' için gerekli üye listesi hatalı biçimlendirilmiş ve yorumlanamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">Hedef çalışma zamanı varsayılan arabirim uygulamasını desteklemiyor.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -107,9 +107,9 @@
         <target state="translated">'{0}' 所需的成员列表格式不正确，无法解释。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="translated">'{0}' 所需的成员列表格式不正确，无法解释。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">目标运行时不支持默认接口实现。</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="translated">'{0}' 的必要成員清單格式錯誤，無法解譯。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
+        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">
         <source>Target runtime doesn't support default interface implementation.</source>
         <target state="translated">目標執行階段不支援預設介面實作。</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -107,9 +107,9 @@
         <target state="translated">'{0}' 的必要成員清單格式錯誤，無法解譯。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReservedTypeMustFollowPattern">
-        <source>The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
-        <target state="new">The type '{0}' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
+      <trans-unit id="ERR_EmbeddedAttributeMustFollowPattern">
+        <source>The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</source>
+        <target state="new">The type 'Microsoft.CodeAnalysis.EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -5172,7 +5172,6 @@ Namespace Microsoft.CodeAnalysis
 End Namespace
 "
 
-
             If ctorAccessModifier <> "Private" Then
             End If
 
@@ -5183,10 +5182,12 @@ BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritabl
 ]]>)
         End Sub
 
-        <Fact>
-        Public Sub EmbeddedAttributeFromSourceValidation_MissingEmbeddedAttributeGeneratesAttributeApplication()
-            Dim code = "
+        <Theory, CombinatorialData>
+        Public Sub EmbeddedAttributeFromSourceValidation_MissingEmbeddedAttributeApplicationGeneratesAttributeApplication(hasObsolete As Boolean)
+            Dim obsolete = If(hasObsolete, "<System.Obsolete>", "")
+            Dim code = $"
 Namespace Microsoft.CodeAnalysis
+    {obsolete}
     Friend NotInheritable Class EmbeddedAttribute
         Inherits System.Attribute
 
@@ -5203,7 +5204,8 @@ End Namespace
             CompileAndVerify(comp, symbolValidator:=Sub([module])
                                                         Dim embeddedAttr = [module].ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName)
                                                         Assert.NotNull(embeddedAttr)
-                                                        Assert.Equal({"Microsoft.CodeAnalysis.EmbeddedAttribute"}, embeddedAttr.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()))
+                                                        Assert.Equal({"Microsoft.CodeAnalysis.EmbeddedAttribute"},
+                                                            embeddedAttr.GetAttributes().Where(Function(a) a.AttributeClass.Name <> "ObsoleteAttribute").Select(Function(a) a.AttributeClass.ToTestDisplayString()))
                                                     End Sub).VerifyDiagnostics()
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -5227,7 +5227,7 @@ End Namespace"
                                                         Dim embeddedAttr = [module].ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName)
                                                         Assert.NotNull(embeddedAttr)
                                                         Assert.Equal({"Microsoft.CodeAnalysis.EmbeddedAttribute"},
-                                                            embeddedAttr.GetAttributes().Where(Function(a) a.AttributeClass.Name <> "ObsoleteAttribute").Select(Function(a) a.AttributeClass.ToTestDisplayString()))
+                                                            embeddedAttr.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()))
                                                     End Sub)
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -4852,12 +4852,12 @@ BC30002: Type 'xyz' is not defined.
         <Fact>
         Public Sub ReferencingEmbeddedAttributesFromADifferentAssemblyFails_Internal()
 
-            Dim reference =
+            Dim referenceCode =
 <compilation>
     <file name="a.vb"><![CDATA[
 <Assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Source")>
 Namespace Microsoft.CodeAnalysis
-    Friend Class EmbeddedAttribute
+    Friend NotInheritable Class EmbeddedAttribute
         Inherits System.Attribute
     End Class
 End Namespace
@@ -4875,7 +4875,9 @@ End Namespace
     </file>
 </compilation>
 
-            Dim referenceCompilation = CreateCompilationWithMscorlib40(reference).ToMetadataReference()
+            Dim referenceCompilation As VisualBasicCompilation = CreateCompilationWithMscorlib40(referenceCode)
+            referenceCompilation.AssertTheseDiagnostics()
+            Dim reference = referenceCompilation.ToMetadataReference()
 
             Dim code = "
 Public Class Program
@@ -4886,7 +4888,7 @@ Public Class Program
     End Sub
 End Class"
 
-            Dim compilation = CreateCompilationWithMscorlib40(code, references:={referenceCompilation}, assemblyName:="Source")
+            Dim compilation = CreateCompilationWithMscorlib40(code, references:={reference}, assemblyName:="Source")
 
             AssertTheseDiagnostics(compilation, <![CDATA[
 BC30002: Type 'TestReference.TestType1' is not defined.
@@ -4905,7 +4907,7 @@ BC30002: Type 'TestReference.TestType2' is not defined.
 <compilation>
     <file name="a.vb"><![CDATA[
 Namespace Microsoft.CodeAnalysis
-    Friend Class EmbeddedAttribute
+    Friend NotInheritable Class EmbeddedAttribute
         Inherits System.Attribute
     End Class
 End Namespace
@@ -4951,7 +4953,7 @@ BC30002: Type 'TestReference.TestType2' is not defined.
 
             Dim moduleCode = CreateCompilationWithMscorlib40(options:=TestOptions.ReleaseModule, source:="
 Namespace Microsoft.CodeAnalysis
-    Friend Class EmbeddedAttribute
+    Friend NotInheritable Class EmbeddedAttribute
         Inherits System.Attribute
     End Class
 End Namespace
@@ -4994,7 +4996,7 @@ BC30002: Type 'TestReference.TestType2' is not defined.
 
             Dim compilation = CreateCompilationWithMscorlib40(source:="
 Namespace Microsoft.CodeAnalysis
-    Friend Class EmbeddedAttribute
+    Friend NotInheritable Class EmbeddedAttribute
         Inherits System.Attribute
     End Class
 End Namespace
@@ -5027,7 +5029,7 @@ End Class")
 <compilation>
     <file name="a.vb"><![CDATA[
 Namespace Microsoft.CodeAnalysis
-    Friend Class EmbeddedAttribute
+    Friend NotInheritable Class EmbeddedAttribute
         Inherits System.Attribute
     End Class
 End Namespace
@@ -5059,7 +5061,7 @@ End Class
 <compilation>
     <file name="a.vb"><![CDATA[
 Namespace Microsoft.CodeAnalysis
-    Friend Class EmbeddedAttribute
+    Friend NotInheritable Class EmbeddedAttribute
         Inherits System.Attribute
     End Class
 End Namespace
@@ -5079,6 +5081,252 @@ End Class
 
             Assert.Null(compilation2.GetTypeByMetadataName("TestReference1"))
             Assert.NotNull(compilation2.GetTypeByMetadataName("TestReference2"))
+        End Sub
+
+        <Theory>
+        <CombinatorialData>
+        Public Sub EmbeddedAttributeFromSourceValidation_Valid(includeTargetsList As Boolean)
+            Dim targets = If(includeTargetsList, ", System.AttributeUsage(System.AttributeTargets.Class Or System.AttributeTargets.Struct Or System.AttributeTargets.Interface Or System.AttributeTargets.Enum Or System.AttributeTargets.Delegate)", "")
+
+            Dim code = $"
+Namespace Microsoft.CodeAnalysis
+    <Embedded{targets}>
+    Friend NotInheritable Class EmbeddedAttribute
+        Inherits System.Attribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+            Dim comp = CreateCompilationWithMscorlib40(code)
+            comp.AssertNoDiagnostics()
+
+            Dim comp2 = CreateCSharpCompilation("CSharpTest", "
+public class Test
+{
+    public static void M(in int p) {}
+}
+", referencedCompilations:={comp})
+
+            CompileAndVerify(comp2).VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub EmbeddedAttributeFromSourceValidation_Public()
+            Dim code = "
+Namespace Microsoft.CodeAnalysis
+    <Embedded>
+    Public NotInheritable Class EmbeddedAttribute
+        Inherits System.Attribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+            CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20).AssertTheseDiagnostics(<![CDATA[
+BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type
+    <Embedded>
+    ~~~~~~~~~~~
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub EmbeddedAttributeFromSourceValidation_NoSealed()
+            Dim code = "
+Namespace Microsoft.CodeAnalysis
+    <Embedded>
+    Friend Class EmbeddedAttribute
+        Inherits System.Attribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+            CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20).AssertTheseDiagnostics(
+                "BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type
+    <Embedded>
+    ~~~~~~~~~~~")
+        End Sub
+
+        <Theory>
+        <InlineData("Friend")>
+        <InlineData("Private")>
+        <InlineData("Protected")>
+        <InlineData("Protected Friend")>
+        <InlineData("Private Protected")>
+        Public Sub EmbeddedAttributeFromSourceValidation_CtorAccessibility(ctorAccessModifier As String)
+            Dim code = $"
+Namespace Microsoft.CodeAnalysis
+    Friend NotInheritable Class EmbeddedAttribute
+        Inherits System.Attribute
+
+        {ctorAccessModifier} Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+
+            If ctorAccessModifier <> "Private" Then
+            End If
+
+            CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20).AssertTheseDiagnostics(<![CDATA[
+BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type
+    Friend NotInheritable Class EmbeddedAttribute
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub EmbeddedAttributeFromSourceValidation_MissingEmbeddedAttributeGeneratesAttributeApplication()
+            Dim code = "
+Namespace Microsoft.CodeAnalysis
+    Friend NotInheritable Class EmbeddedAttribute
+        Inherits System.Attribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+            Dim comp = CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20)
+            Dim embeddedAttribute = comp.Assembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName)
+            Assert.True(embeddedAttribute.HasCodeAnalysisEmbeddedAttribute)
+
+            CompileAndVerify(comp, symbolValidator:=Sub([module])
+                                                        Dim embeddedAttr = [module].ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName)
+                                                        Assert.NotNull(embeddedAttr)
+                                                        Assert.Equal({"Microsoft.CodeAnalysis.EmbeddedAttribute"}, embeddedAttr.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()))
+                                                    End Sub).VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub EmbeddedAttributeFromSourceValidation_Generic()
+            Dim code = "
+Namespace Microsoft.CodeAnalysis
+    <Embedded(Of Integer)>
+    Friend NotInheritable Class EmbeddedAttribute(Of T)
+        Inherits System.Attribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+            Dim comp = CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20)
+            comp.AssertTheseDiagnostics(<![CDATA[
+BC30002: Type 'Embedded' is not defined.
+    <Embedded(Of Integer)>
+     ~~~~~~~~
+BC32066: Type arguments are not valid because attributes cannot be generic.
+    <Embedded(Of Integer)>
+     ~~~~~~~~
+BC32074: Classes that are generic or contained in a generic type cannot inherit from an attribute class.
+    Friend NotInheritable Class EmbeddedAttribute(Of T)
+                                ~~~~~~~~~~~~~~~~~
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub EmbeddedAttributeFromSourceValidation_Static()
+            Dim code = "
+Namespace Microsoft.CodeAnalysis
+    <Embedded>
+    Friend Module EmbeddedAttribute
+        Inherits System.Attribute
+    End Module
+End Namespace
+"
+
+            CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20).AssertTheseDiagnostics(<![CDATA[
+BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type
+    <Embedded>
+    ~~~~~~~~~~~
+BC31504: 'EmbeddedAttribute' cannot be used as an attribute because it does not inherit from 'System.Attribute'.
+    <Embedded>
+     ~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute..ctor' is not defined.
+    Friend Module EmbeddedAttribute
+                  ~~~~~~~~~~~~~~~~~
+BC30230: 'Inherits' not valid in Modules.
+        Inherits System.Attribute
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub EmbeddedAttributeFromSourceValidation_WrongBaseType()
+            Dim code = "
+Namespace Microsoft.CodeAnalysis
+    <Embedded>
+    Friend NotInheritable Class EmbeddedAttribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+            CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20).AssertTheseDiagnostics(<![CDATA[
+BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type
+    <Embedded>
+    ~~~~~~~~~~~
+BC31504: 'EmbeddedAttribute' cannot be used as an attribute because it does not inherit from 'System.Attribute'.
+    <Embedded>
+     ~~~~~~~~
+]]>)
+        End Sub
+
+        <Theory>
+        <InlineData("AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Enum Or AttributeTargets.Delegate")>
+        <InlineData("AttributeTargets.Class Or AttributeTargets.Interface Or AttributeTargets.Enum Or AttributeTargets.Delegate")>
+        <InlineData("AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Enum Or AttributeTargets.Delegate")>
+        <InlineData("AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Delegate")>
+        <InlineData("AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Enum")>
+        Public Sub EmbeddedAttributeFromSourceValidation_AttributeUsage(targets As String)
+            Dim code = $"
+Imports System
+Namespace Microsoft.CodeAnalysis
+    <Embedded, AttributeUsage({targets})>
+    Friend NotInheritable Class EmbeddedAttribute
+        Inherits System.Attribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+"
+
+            If Not targets.Contains("Class") Then
+            End If
+
+            Dim comp = CreateCompilation(code, assemblyName:="testModule", targetFramework:=TargetFramework.NetStandard20)
+
+            If targets.Contains("Class") Then
+                comp.AssertTheseDiagnostics($"BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type
+    <Embedded, AttributeUsage({targets})>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~{(New String("~"c, targets.Length))}~~~"
+)
+            Else
+
+                comp.AssertTheseDiagnostics(<![CDATA[
+BC37335: The type 'EmbeddedAttribute' must be non-generic, Friend, NotInheritable, have a Public parameterless constructor, inherit from System.Attribute, and be able to be applied to any type
+    <Embedded, AttributeUsage(AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Enum Or AttributeTargets.Delegate)>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30662: Attribute 'EmbeddedAttribute' cannot be applied to 'EmbeddedAttribute' because the attribute is not valid on this declaration type.
+    <Embedded, AttributeUsage(AttributeTargets.Struct Or AttributeTargets.Interface Or AttributeTargets.Enum Or AttributeTargets.Delegate)>
+     ~~~~~~~~
+]]>)
+            End If
         End Sub
 
         <Fact>

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodCodeRefactoringTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodCodeRefactoringTests.cs
@@ -6048,4 +6048,35 @@ $@"
             }
             """);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38087")]
+    public async Task TestPartialSelectionOfArithmeticExpression()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                private void Repro()
+                {
+                    int i = 1, j = 2;
+                    int k = [|i + j|] + 1;
+                }
+            }
+            """,
+            """
+            class C
+            {
+                private void Repro()
+                {
+                    int i = 1, j = 2;
+                    int k = {|Rename:NewMethod|}(i, j) + 1;
+                }
+
+                private static int NewMethod(int i, int j)
+                {
+                    return i + j;
+                }
+            }
+            """);
+    }
 }


### PR DESCRIPTION
Alternative approach to https://github.com/dotnet/roslyn/pull/71546. Today, our enforcement of whether to allow users to define `Microsoft.CodeAnalysis.EmbeddedAttribute` is inconsistent; if we need to generate it, we error if the user defines one. But if the we don't need to generate it (as we increasingly do not since .NET 6), we allow the user to define their own version. This PR standardizes our enforcement, and enables the compiler to use the user-declared attribute instead generating one. We also document the breaking change from the standardized enforcement.