### PR TITLE
Expose NotificationService to OmniSharp

### DIFF
--- a/src/Features/ExternalAccess/OmniSharp/ExtractClass/IOmniSharpExtractClassOptionsService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/ExtractClass/IOmniSharpExtractClassOptionsService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.ExtractClass
 {
     internal interface IOmniSharpExtractClassOptionsService
     {
-        Task<OmniSharpExtractClassOptions?> GetExtractClassOptionsAsync(Document document, INamedTypeSymbol originalType, ImmutableArray<ISymbol> selectedMembers);
+        OmniSharpExtractClassOptions? GetExtractClassOptions(Document document, INamedTypeSymbol originalType, ImmutableArray<ISymbol> selectedMembers);
     }
 
     internal sealed class OmniSharpExtractClassOptions

--- a/src/Features/ExternalAccess/OmniSharp/ExtractInterface/IOmniSharpExtractInterfaceOptionsService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/ExtractInterface/IOmniSharpExtractInterfaceOptionsService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.ExtractInterface
     internal interface IOmniSharpExtractInterfaceOptionsService
     {
         // OmniSharp only uses these two arguments from the full IExtractInterfaceOptionsService
-        Task<OmniSharpExtractInterfaceOptionsResult> GetExtractInterfaceOptionsAsync(
+        OmniSharpExtractInterfaceOptionsResult GetExtractInterfaceOptions(
             List<ISymbol> extractableMembers,
             string defaultInterfaceName);
     }

--- a/src/Features/ExternalAccess/OmniSharp/Internal/ExtractClass/OmniSharpExtractClassOptionsService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Internal/ExtractClass/OmniSharpExtractClassOptionsService.cs
@@ -29,7 +29,7 @@ internal sealed class OmniSharpExtractClassOptionsService(
         SyntaxFormattingOptions formattingOptions,
         CancellationToken cancellationToken)
     {
-        var result = _omniSharpExtractClassOptionsService.GetExtractClassOptionsAsync(document, originalType, selectedMembers).WaitAndGetResult_CanCallOnBackground(cancellationToken);
+        var result = _omniSharpExtractClassOptionsService.GetExtractClassOptions(document, originalType, selectedMembers);
         return result == null
             ? null
             : new ExtractClassOptions(

--- a/src/Features/ExternalAccess/OmniSharp/Internal/ExtractInterface/OmniSharpExtractInterfaceOptionsService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Internal/ExtractInterface/OmniSharpExtractInterfaceOptionsService.cs
@@ -34,7 +34,7 @@ internal sealed class OmniSharpExtractInterfaceOptionsService(
         string languageName,
         CancellationToken cancellationToken)
     {
-        var result = _omniSharpExtractInterfaceOptionsService.GetExtractInterfaceOptionsAsync(extractableMembers, defaultInterfaceName).WaitAndGetResult_CanCallOnBackground(cancellationToken);
+        var result = _omniSharpExtractInterfaceOptionsService.GetExtractInterfaceOptions(extractableMembers, defaultInterfaceName);
         return new(
             result.IsCancelled,
             result.IncludedMembers,

--- a/src/Features/ExternalAccess/OmniSharp/Internal/Notification/OmniSharpNotificationService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Internal/Notification/OmniSharpNotificationService.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Notification;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Internal.Notification;
+
+[ExportWorkspaceService(typeof(INotificationService)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class OmniSharpNotificationService(
+    IOmniSharpNotificationService omniSharpNotificationService) : INotificationService
+{
+    public bool ConfirmMessageBox(string message, string? title = null, NotificationSeverity severity = NotificationSeverity.Warning)
+    {
+        return omniSharpNotificationService.ConfirmMessageBox(message, title, (OmniSharpNotificationSeverity)severity);
+    }
+
+    public void SendNotification(string message, string? title = null, NotificationSeverity severity = NotificationSeverity.Warning)
+    {
+        omniSharpNotificationService.SendNotification(message, title, (OmniSharpNotificationSeverity)severity);
+    }
+}

--- a/src/Features/ExternalAccess/OmniSharp/InternalAPI.Unshipped.txt
+++ b/src/Features/ExternalAccess/OmniSharp/InternalAPI.Unshipped.txt
@@ -173,6 +173,13 @@ Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation.OmniSharpNavigableIte
 Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation.OmniSharpNavigableItem.OmniSharpNavigableItem() -> void
 Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation.OmniSharpNavigableItem.OmniSharpNavigableItem(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.TaggedText> displayTaggedParts, Microsoft.CodeAnalysis.Document! document, Microsoft.CodeAnalysis.Text.TextSpan sourceSpan) -> void
 Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation.OmniSharpNavigableItem.SourceSpan.get -> Microsoft.CodeAnalysis.Text.TextSpan
+Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.IOmniSharpNotificationService
+Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.IOmniSharpNotificationService.ConfirmMessageBox(string! message, string? title = null, Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity severity = Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity.Warning) -> bool
+Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.IOmniSharpNotificationService.SendNotification(string! message, string? title = null, Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity severity = Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity.Warning) -> void
+Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity
+Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity.Error = 2 -> Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity
+Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity.Information = 0 -> Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity
+Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity.Warning = 1 -> Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification.OmniSharpNotificationSeverity
 Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions
 Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions.Deconstruct(out bool RenameInComments, out bool RenameInStrings, out bool RenameOverloads) -> void
 Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions.Equals(Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions other) -> bool
@@ -375,6 +382,12 @@ virtual Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.NavigateTo.OmniSharpNavi
 ~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.InlineHints.OmniSharpInlineTypeHintsOptions.ToString() -> string
 ~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.NavigateTo.OmniSharpNavigateToSearchResult.Equals(object obj) -> bool
 ~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.NavigateTo.OmniSharpNavigateToSearchResult.ToString() -> string
+~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions.Equals(object obj) -> bool
+~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions.ToString() -> string
+~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenamer.RenameResult.Equals(object obj) -> bool
+~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenamer.RenameResult.ToString() -> string
+~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Structure.OmniSharpBlockStructureOptions.Equals(object obj) -> bool
+~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Structure.OmniSharpBlockStructureOptions.ToString() -> string
 ~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions.Equals(object obj) -> bool
 ~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenameOptions.ToString() -> string
 ~override Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.OmniSharpRenamer.RenameResult.Equals(object obj) -> bool

--- a/src/Features/ExternalAccess/OmniSharp/Notification/IOmniSharpNotificationService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Notification/IOmniSharpNotificationService.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification;
+
+internal interface IOmniSharpNotificationService
+{
+    /// <summary>
+    /// Displays a message box with an OK button to the user.
+    /// </summary>
+    /// <param name="message">The message shown within the message box.</param>
+    /// <param name="title">The title bar to be shown in the message box. May be ignored by some implementations.</param>
+    /// <param name="severity">The severity of the message.</param>
+    void SendNotification(
+        string message,
+        string? title = null,
+        OmniSharpNotificationSeverity severity = OmniSharpNotificationSeverity.Warning);
+
+    /// <summary>
+    /// Displays a message box with a yes/no question to the user.
+    /// </summary>
+    /// <param name="message">The message shown within the message box.</param>
+    /// <param name="title">The title bar to be shown in the message box. May be ignored by some implementations.</param>
+    /// <param name="severity">The severity of the message.</param>
+    /// <returns>true if yes was clicked, false otherwise.</returns>
+    bool ConfirmMessageBox(
+        string message,
+        string? title = null,
+        OmniSharpNotificationSeverity severity = OmniSharpNotificationSeverity.Warning);
+}

--- a/src/Features/ExternalAccess/OmniSharp/Notification/OmniSharpNotificationSeverity.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Notification/OmniSharpNotificationSeverity.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Notification;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Notification;
+
+internal enum OmniSharpNotificationSeverity
+{
+    Information = NotificationSeverity.Information,
+    Warning = NotificationSeverity.Warning,
+    Error = NotificationSeverity.Error
+}


### PR DESCRIPTION
An implementation of INotificationService is [now required](https://github.com/dotnet/roslyn/pull/76510/files#diff-ee57f8ea8866dad6ed1842766c60de5011571b13c376c524a53301d46714a2f8R268) for GetExtractInterfaceOptions. This change allows OmniSharp to provide a no-op implementation.

Also removes the use of WaitAndGetResults from the OmniSharp extract class and interface option services.