### PR TITLE
Ensure 'remove unnecessary using' shows up before 'convert to program-main style program'

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryImports/CSharpRemoveUnnecessaryImportsCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryImports/CSharpRemoveUnnecessaryImportsCodeFixProvider.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.RemoveUnnecessaryImports), Shared]
 [ExtensionOrder(After = PredefinedCodeFixProviderNames.AddMissingReference)]
+[ExtensionOrder(Before = PredefinedCodeFixProviderNames.ConvertToProgramMain)]
 [method: ImportingConstructor]
 [method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
 internal sealed class CSharpRemoveUnnecessaryImportsCodeFixProvider() : AbstractRemoveUnnecessaryImportsCodeFixProvider

--- a/src/Analyzers/Core/CodeFixes/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsCodeFixProvider.cs
@@ -29,7 +29,10 @@ internal abstract class AbstractRemoveUnnecessaryImportsCodeFixProvider : CodeFi
             CodeAction.Create(
                 title,
                 cancellationToken => RemoveUnnecessaryImportsAsync(context.Document, cancellationToken),
-                title),
+                title,
+                // If the user is on a using/import that is marked as unnecessary, then we want to make sure that this
+                // code action is preferred over virtually any others that could be located at that position.
+                priority: CodeActionPriority.High),
             context.Diagnostics);
         return Task.CompletedTask;
     }

--- a/src/Features/CSharp/Portable/ConvertProgram/ConvertToProgramMainCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertProgram/ConvertToProgramMainCodeFixProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertProgram;
 using static ConvertProgramTransform;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.ConvertToProgramMain), Shared]
+[ExtensionOrder(After = PredefinedCodeFixProviderNames.RemoveUnnecessaryImports)]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class ConvertToProgramMainCodeFixProvider() : SyntaxEditorBasedCodeFixProvider


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76536
