### PR TITLE
Reduce allocations in the C# lexer ctor

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -70,8 +70,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal sealed partial class Lexer : AbstractLexer
     {
-        private static readonly ObjectPool<LexerCache> s_lexerCachePool = new ObjectPool<LexerCache>(() => new LexerCache());
-
         private const int TriviaListInitialCapacity = 8;
 
         private readonly CSharpParseOptions _options;
@@ -126,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             _interpolationFollowedByColon = interpolationFollowedByColon;
 
             // Obtain pooled items
-            _cache = s_lexerCachePool.Allocate();
+            _cache = LexerCache.Allocate();
             _builder = _cache.StringBuilder;
             _identBuffer = _cache.IdentBuffer;
             _leadingTriviaCache = _cache.LeadingTriviaCache;
@@ -135,9 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public override void Dispose()
         {
-            _cache.Free();
-            s_lexerCachePool.Free(_cache);
-
+            LexerCache.Free(_cache);
             _xmlParser?.Dispose();
             _directiveParser?.Dispose();
 

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             _interpolationFollowedByColon = interpolationFollowedByColon;
 
             // Obtain pooled items
-            _cache = LexerCache.Allocate();
+            _cache = LexerCache.GetInstance();
             _builder = _cache.StringBuilder;
             _identBuffer = _cache.IdentBuffer;
             _leadingTriviaCache = _cache.LeadingTriviaCache;
@@ -133,7 +133,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public override void Dispose()
         {
-            LexerCache.Free(_cache);
+            _cache.Free();
+
             _xmlParser?.Dispose();
             _directiveParser?.Dispose();
 

--- a/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             get
             {
-                _triviaMap ??= new TextKeyedCache<SyntaxTrivia>();
+                _triviaMap ??= TextKeyedCache<SyntaxTrivia>.GetInstance();
 
                 return _triviaMap;
             }
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             get
             {
-                _tokenMap ??= new TextKeyedCache<SyntaxToken>();
+                _tokenMap ??= TextKeyedCache<SyntaxToken>.GetInstance();
 
                 return _tokenMap;
             }

--- a/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
@@ -5,12 +5,10 @@
 // #define COLLECT_STATS
 
 using System;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using System.Text;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
@@ -30,24 +28,72 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 return kind;
                             });
 
-        private readonly TextKeyedCache<SyntaxTrivia> _triviaMap;
-        private readonly TextKeyedCache<SyntaxToken> _tokenMap;
-        private readonly CachingIdentityFactory<string, SyntaxKind> _keywordKindMap;
+        private TextKeyedCache<SyntaxTrivia> _triviaMap;
+        private TextKeyedCache<SyntaxToken> _tokenMap;
+        private CachingIdentityFactory<string, SyntaxKind> _keywordKindMap;
         internal const int MaxKeywordLength = 10;
+
+        private PooledStringBuilder _stringBuilder;
+        private readonly char[] _identBuffer;
+        private SyntaxListBuilder _leadingTriviaCache;
+        private SyntaxListBuilder _trailingTriviaCache;
+
+        private const int LeadingTriviaCacheInitialCapacity = 128;
+        private const int TrailingTriviaCacheInitialCapacity = 16;
 
         internal LexerCache()
         {
             _triviaMap = TextKeyedCache<SyntaxTrivia>.GetInstance();
             _tokenMap = TextKeyedCache<SyntaxToken>.GetInstance();
             _keywordKindMap = s_keywordKindPool.Allocate();
+
+            _stringBuilder = PooledStringBuilder.GetInstance();
+            _identBuffer = new char[32];
+            _leadingTriviaCache = new SyntaxListBuilder(LeadingTriviaCacheInitialCapacity);
+            _trailingTriviaCache = new SyntaxListBuilder(TrailingTriviaCacheInitialCapacity);
         }
 
         internal void Free()
         {
             _keywordKindMap.Free();
+            _keywordKindMap = s_keywordKindPool.Allocate();
+
             _triviaMap.Free();
+            _triviaMap = TextKeyedCache<SyntaxTrivia>.GetInstance();
+
             _tokenMap.Free();
+            _tokenMap = TextKeyedCache<SyntaxToken>.GetInstance();
+
+            // Use a pooled string builder as it's Free method understands whether it's too large
+            // to return to the pool
+            _stringBuilder.Free();
+            _stringBuilder = PooledStringBuilder.GetInstance();
+
+            // Create new trivia caches if the existing ones have grown too large for pooling.
+            // Otherwise just clear the existing ones.
+            if (_leadingTriviaCache.Capacity > LeadingTriviaCacheInitialCapacity * 2)
+            {
+                _leadingTriviaCache = new SyntaxListBuilder(LeadingTriviaCacheInitialCapacity);
+            }
+            else
+            {
+                _leadingTriviaCache.Clear();
+            }
+
+            if (_trailingTriviaCache.Capacity > TrailingTriviaCacheInitialCapacity * 2)
+            {
+                _trailingTriviaCache = new SyntaxListBuilder(TrailingTriviaCacheInitialCapacity);
+            }
+            else
+            {
+                _trailingTriviaCache.Clear();
+            }
         }
+
+        internal StringBuilder StringBuilder => _stringBuilder;
+        internal char[] IdentBuffer => _identBuffer;
+        internal SyntaxListBuilder LeadingTriviaCache => _leadingTriviaCache;
+        internal SyntaxListBuilder TrailingTriviaCache => _trailingTriviaCache;
 
         internal bool TryGetKeywordKind(string key, out SyntaxKind kind)
         {

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
     {
         private ArrayElement<GreenNode?>[] _nodes;
         public int Count { get; private set; }
+        public int Capacity => _nodes.Length;
 
         public SyntaxListBuilder(int size)
         {
@@ -24,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
 
         public void Clear()
         {
+            Array.Clear(_nodes, 0, Count);
             this.Count = 0;
         }
 

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
 
         public void Clear()
         {
-            Array.Clear(_nodes, 0, Count);
+            Array.Clear(_nodes, 0, _nodes.Length);
             this.Count = 0;
         }
 


### PR DESCRIPTION
The lexer ctor shows as about 0.6% of all allocations over the lifetime of the RoslynCodeAnalysisProcess in the csharp editing speedometer tests.

There was already the concept of the LexerCache which had some pooling usage in it. This PR moves a couple other members to it to allow for their pooling.

Speedometer results look quite promising:

Allocations under Lexer.ctor in IncPaths reduced from 60 MB to 1.5 MB
Allocations under Lexer in IncPaths reduced from 1.57 GB to 1.36 GB