### PR TITLE
CSharpIndentationService simplification

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -1266,6 +1266,25 @@ namespace NS
             expectedIndentation: 24);
     }
 
+    [WpfFact]
+    public void QueryExpression_InsideSeparatedSyntaxOnOneLine()
+    {
+        AssertSmartIndent(
+            """
+            class C
+            {
+                void M()
+                {
+                    var q = from v in M(1,
+
+                            select s;
+                }
+            }
+            """,
+            indentationLine: 5,
+            expectedIndentation: 16);
+    }
+
     [WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538333")]
     public void Statement1()
     {

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -1285,6 +1285,44 @@ namespace NS
             expectedIndentation: 16);
     }
 
+    [WpfFact]
+    public void QueryExpression_OpenBrace()
+    {
+        AssertSmartIndent(
+            """
+            class C
+            {
+                void M()
+                {
+                    var q = from v in new X {
+
+                            select s;
+                }
+            }
+            """,
+            indentationLine: 5,
+            expectedIndentation: 12); // Demonstrates status quo, but 20 would likely be better.
+    }
+
+    [WpfFact]
+    public void QueryExpression_CloseBrace()
+    {
+        AssertSmartIndent(
+            """
+            class C
+            {
+                void M()
+                {
+                    var q = from v in new X { }
+
+                            select s;
+                }
+            }
+            """,
+            indentationLine: 5,
+            expectedIndentation: 16);
+    }
+
     [WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538333")]
     public void Statement1()
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -361,21 +361,22 @@ internal partial class CSharpIndentationService
 
     private static IndentationResult GetDefaultIndentationFromToken(Indenter indenter, SyntaxToken token)
     {
-        if (IsPartOfQueryExpression(token))
-        {
-            return GetIndentationForQueryExpression(indenter, token);
-        }
-
-        return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
+        return TryGetIndentationForQueryExpression(indenter, token)
+            ?? GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
     }
 
-    private static IndentationResult GetIndentationForQueryExpression(Indenter indenter, SyntaxToken token)
+    private static IndentationResult? TryGetIndentationForQueryExpression(Indenter indenter, SyntaxToken token)
     {
+        if (!IsPartOfQueryExpression(token))
+        {
+            return null;
+        }
+
         // find containing non terminal node
         var queryExpressionClause = GetQueryExpressionClause(token);
         if (queryExpressionClause == null)
         {
-            return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
+            return null;
         }
 
         // find line where first token of the node is
@@ -390,7 +391,7 @@ internal partial class CSharpIndentationService
         if (firstTokenLine.LineNumber != givenTokenLine.LineNumber)
         {
             // do default behavior
-            return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
+            return null;
         }
 
         // okay, we are right under the query expression.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -464,23 +464,18 @@ internal partial class CSharpIndentationService
     private static IndentationResult GetDefaultIndentationFromTokenLine(
         Indenter indenter, SyntaxToken token, bool addAdditionalIndentation)
     {
-        var spaceToAdd = addAdditionalIndentation ? indenter.Options.FormattingOptions.IndentationSize : 0;
-
-        var sourceText = indenter.LineToBeIndented.Text;
-        RoslynDebug.AssertNotNull(sourceText);
-
-        // find line where given token is
-        var givenTokenLine = sourceText.Lines.GetLineFromPosition(token.SpanStart);
-
-        // find right position
-        var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
-
         // find containing non expression node
         var nonExpressionNode = token.GetAncestors<SyntaxNode>().FirstOrDefault(n => n is StatementSyntax);
         if (nonExpressionNode != null)
         {
+            var sourceText = indenter.LineToBeIndented.Text;
+            RoslynDebug.AssertNotNull(sourceText);
+
             // find line where first token of the node is
             var firstTokenLine = sourceText.Lines.GetLineFromPosition(nonExpressionNode.GetFirstToken(includeZeroWidth: true).SpanStart);
+
+            // find line where given token is
+            var givenTokenLine = sourceText.Lines.GetLineFromPosition(token.SpanStart);
 
             // multiline expression
             if (firstTokenLine.LineNumber != givenTokenLine.LineNumber)
@@ -491,6 +486,10 @@ internal partial class CSharpIndentationService
         }
 
         // well, I can't find any non expression node. use default behavior
+        var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
+
+        var spaceToAdd = addAdditionalIndentation ? indenter.Options.FormattingOptions.IndentationSize : 0;
+
         return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -318,13 +318,17 @@ internal partial class CSharpIndentationService
                 }
         }
 
-        var result = TryGetIndentationForQueryExpression(indenter, token);
+        var result = TryGetIndentationForQueryExpression(indenter, token)
+            ?? TryGetIndentationFromMultilineStatement(indenter, token);
+
         if (result is not null)
         {
             return result.Value;
         }
 
-        return GetDefaultIndentationFromTokenLine(indenter, token);
+        var spaceToAdd = indenter.Options.FormattingOptions.IndentationSize;
+
+        return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
     }
 
     private static IndentationResult? TryGetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)
@@ -484,19 +488,5 @@ internal partial class CSharpIndentationService
         }
 
         return null;
-    }
-
-    private static IndentationResult GetDefaultIndentationFromTokenLine(Indenter indenter, SyntaxToken token)
-    {
-        if (TryGetIndentationFromMultilineStatement(indenter, token) is { } result)
-        {
-            return result;
-        }
-
-        var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
-
-        var spaceToAdd = indenter.Options.FormattingOptions.IndentationSize;
-
-        return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -230,6 +230,7 @@ internal partial class CSharpIndentationService
                 embeddedStatementOwner = embeddedStatementOwner.Parent;
             }
 
+            // Match the indentation level of the outermost embedded statement owner.
             return indenter.GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(embeddedStatementOwner.GetFirstToken(includeZeroWidth: true).SpanStart));
         }
 
@@ -276,6 +277,7 @@ internal partial class CSharpIndentationService
 
                     if (nonTerminalNode is SwitchLabelSyntax)
                     {
+                        // Match the indentation level on the line starting the switch, then add an extra level of indentation.
                         return indenter.GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart), indenter.Options.FormattingOptions.IndentationSize);
                     }
 
@@ -290,6 +292,7 @@ internal partial class CSharpIndentationService
                     // if this is closing an attribute, we shouldn't indent.
                     if (nonTerminalNode is AttributeListSyntax)
                     {
+                        // Match the indentation level of the line starting the attribute.
                         return indenter.GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart));
                     }
 
@@ -298,6 +301,7 @@ internal partial class CSharpIndentationService
 
             case SyntaxKind.XmlTextLiteralToken:
                 {
+                    // Match the indentation level of the line starting the XML doc comment.
                     return indenter.GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(token.SpanStart));
                 }
 
@@ -330,6 +334,8 @@ internal partial class CSharpIndentationService
             return result.Value;
         }
 
+        // Apply indentation from format rules' IndentBlockOperations, possibly adding an extra level of indentation for
+        // wrapping. This is only added if a relative IndentBlockOperation is not selected.
         var extraSpaces = allowExtraIndentationLevel ? indenter.Options.FormattingOptions.IndentationSize : 0;
 
         return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, extraSpaces, indenter.CancellationToken));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -318,7 +318,8 @@ internal partial class CSharpIndentationService
                 }
         }
 
-        return GetDefaultIndentationFromToken(indenter, token);
+        return TryGetIndentationForQueryExpression(indenter, token)
+            ?? GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
     }
 
     private static IndentationResult? TryGetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)
@@ -359,12 +360,6 @@ internal partial class CSharpIndentationService
         // smart indenter has a special indent block rule for comma separated list, so don't
         // need to add default additional space for multiline expressions
         return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: false);
-    }
-
-    private static IndentationResult GetDefaultIndentationFromToken(Indenter indenter, SyntaxToken token)
-    {
-        return TryGetIndentationForQueryExpression(indenter, token)
-            ?? GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
     }
 
     private static IndentationResult? TryGetIndentationForQueryExpression(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -311,7 +311,7 @@ internal partial class CSharpIndentationService
                 {
                     if (token.Parent.IsKind(SyntaxKind.ArgumentList))
                     {
-                        return GetDefaultIndentationFromToken(indenter, token.Parent.GetFirstToken(includeZeroWidth: true));
+                        token = token.Parent.GetFirstToken(includeZeroWidth: true);
                     }
 
                     break;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -299,9 +299,9 @@ internal partial class CSharpIndentationService
 
             case SyntaxKind.CommaToken:
                 {
-                    if (TryGetIndentationFromCommaSeparatedList(indenter, token) is { } result)
+                    if (TryGetIndentationFromCommaSeparatedList(indenter, token) is { } commaResult)
                     {
-                        return result;
+                        return commaResult;
                     }
 
                     break;
@@ -318,8 +318,13 @@ internal partial class CSharpIndentationService
                 }
         }
 
-        return TryGetIndentationForQueryExpression(indenter, token)
-            ?? GetDefaultIndentationFromTokenLine(indenter, token);
+        var result = TryGetIndentationForQueryExpression(indenter, token);
+        if (result is not null)
+        {
+            return result.Value;
+        }
+
+        return GetDefaultIndentationFromTokenLine(indenter, token);
     }
 
     private static IndentationResult? TryGetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -461,9 +461,8 @@ internal partial class CSharpIndentationService
         return queryExpression != null;
     }
 
-    private static IndentationResult GetDefaultIndentationFromTokenLine(Indenter indenter, SyntaxToken token)
+    private static IndentationResult? TryGetIndentationFromMultilineStatement(Indenter indenter, SyntaxToken token)
     {
-        // find containing non expression node
         var nonExpressionNode = token.GetAncestors<SyntaxNode>().FirstOrDefault(n => n is StatementSyntax);
         if (nonExpressionNode != null)
         {
@@ -484,7 +483,16 @@ internal partial class CSharpIndentationService
             }
         }
 
-        // well, I can't find any non expression node. use default behavior
+        return null;
+    }
+
+    private static IndentationResult GetDefaultIndentationFromTokenLine(Indenter indenter, SyntaxToken token)
+    {
+        if (TryGetIndentationFromMultilineStatement(indenter, token) is { } result)
+        {
+            return result;
+        }
+
         var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
 
         var spaceToAdd = indenter.Options.FormattingOptions.IndentationSize;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -233,6 +233,8 @@ internal partial class CSharpIndentationService
             return indenter.GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(embeddedStatementOwner.GetFirstToken(includeZeroWidth: true).SpanStart));
         }
 
+        var allowExtraIndentationLevel = true;
+
         switch (token.Kind())
         {
             case SyntaxKind.SemicolonToken:
@@ -243,7 +245,8 @@ internal partial class CSharpIndentationService
                         break;
                     }
 
-                    return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, indenter.CancellationToken));
+                    allowExtraIndentationLevel = false;
+                    break;
                 }
 
             case SyntaxKind.CloseBraceToken:
@@ -257,12 +260,14 @@ internal partial class CSharpIndentationService
                         }
                     }
 
-                    return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, indenter.CancellationToken));
+                    allowExtraIndentationLevel = false;
+                    break;
                 }
 
             case SyntaxKind.OpenBraceToken:
                 {
-                    return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, indenter.CancellationToken));
+                    allowExtraIndentationLevel = false;
+                    break;
                 }
 
             case SyntaxKind.ColonToken:
@@ -326,9 +331,9 @@ internal partial class CSharpIndentationService
             return result.Value;
         }
 
-        var spaceToAdd = indenter.Options.FormattingOptions.IndentationSize;
+        var extraSpaces = allowExtraIndentationLevel ? indenter.Options.FormattingOptions.IndentationSize : 0;
 
-        return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
+        return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, extraSpaces, indenter.CancellationToken));
     }
 
     private static IndentationResult? TryGetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -319,7 +319,7 @@ internal partial class CSharpIndentationService
         }
 
         return TryGetIndentationForQueryExpression(indenter, token)
-            ?? GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
+            ?? GetDefaultIndentationFromTokenLine(indenter, token);
     }
 
     private static IndentationResult? TryGetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)
@@ -357,7 +357,7 @@ internal partial class CSharpIndentationService
             }
         }
 
-        return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
+        return GetDefaultIndentationFromTokenLine(indenter, token);
     }
 
     private static IndentationResult? TryGetIndentationForQueryExpression(Indenter indenter, SyntaxToken token)
@@ -456,8 +456,7 @@ internal partial class CSharpIndentationService
         return queryExpression != null;
     }
 
-    private static IndentationResult GetDefaultIndentationFromTokenLine(
-        Indenter indenter, SyntaxToken token, bool addAdditionalIndentation)
+    private static IndentationResult GetDefaultIndentationFromTokenLine(Indenter indenter, SyntaxToken token)
     {
         // find containing non expression node
         var nonExpressionNode = token.GetAncestors<SyntaxNode>().FirstOrDefault(n => n is StatementSyntax);
@@ -483,7 +482,7 @@ internal partial class CSharpIndentationService
         // well, I can't find any non expression node. use default behavior
         var position = indenter.GetCurrentPositionNotBelongToEndOfFileToken(indenter.LineToBeIndented.Start);
 
-        var spaceToAdd = addAdditionalIndentation ? indenter.Options.FormattingOptions.IndentationSize : 0;
+        var spaceToAdd = indenter.Options.FormattingOptions.IndentationSize;
 
         return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -357,7 +357,7 @@ internal partial class CSharpIndentationService
             }
         }
 
-        return GetDefaultIndentationFromTokenLine(indenter, token);
+        return null;
     }
 
     private static IndentationResult? TryGetIndentationForQueryExpression(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -356,7 +356,7 @@ internal partial class CSharpIndentationService
 
         // smart indenter has a special indent block rule for comma separated list, so don't
         // need to add default additional space for multiline expressions
-        return GetDefaultIndentationFromTokenLine(indenter, token, additionalSpace: 0);
+        return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: false);
     }
 
     private static IndentationResult GetDefaultIndentationFromToken(Indenter indenter, SyntaxToken token)
@@ -366,7 +366,7 @@ internal partial class CSharpIndentationService
             return GetIndentationForQueryExpression(indenter, token);
         }
 
-        return GetDefaultIndentationFromTokenLine(indenter, token);
+        return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
     }
 
     private static IndentationResult GetIndentationForQueryExpression(Indenter indenter, SyntaxToken token)
@@ -375,7 +375,7 @@ internal partial class CSharpIndentationService
         var queryExpressionClause = GetQueryExpressionClause(token);
         if (queryExpressionClause == null)
         {
-            return GetDefaultIndentationFromTokenLine(indenter, token);
+            return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
         }
 
         // find line where first token of the node is
@@ -390,7 +390,7 @@ internal partial class CSharpIndentationService
         if (firstTokenLine.LineNumber != givenTokenLine.LineNumber)
         {
             // do default behavior
-            return GetDefaultIndentationFromTokenLine(indenter, token);
+            return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
         }
 
         // okay, we are right under the query expression.
@@ -461,9 +461,9 @@ internal partial class CSharpIndentationService
     }
 
     private static IndentationResult GetDefaultIndentationFromTokenLine(
-        Indenter indenter, SyntaxToken token, int? additionalSpace = null)
+        Indenter indenter, SyntaxToken token, bool addAdditionalIndentation)
     {
-        var spaceToAdd = additionalSpace ?? indenter.Options.FormattingOptions.IndentationSize;
+        var spaceToAdd = addAdditionalIndentation ? indenter.Options.FormattingOptions.IndentationSize : 0;
 
         var sourceText = indenter.LineToBeIndented.Text;
         RoslynDebug.AssertNotNull(sourceText);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -357,9 +357,7 @@ internal partial class CSharpIndentationService
             }
         }
 
-        // smart indenter has a special indent block rule for comma separated list, so don't
-        // need to add default additional space for multiline expressions
-        return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: false);
+        return GetDefaultIndentationFromTokenLine(indenter, token, addAdditionalIndentation: true);
     }
 
     private static IndentationResult? TryGetIndentationForQueryExpression(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -477,22 +477,20 @@ internal partial class CSharpIndentationService
 
         // find containing non expression node
         var nonExpressionNode = token.GetAncestors<SyntaxNode>().FirstOrDefault(n => n is StatementSyntax);
-        if (nonExpressionNode == null)
+        if (nonExpressionNode != null)
         {
-            // well, I can't find any non expression node. use default behavior
-            return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
+            // find line where first token of the node is
+            var firstTokenLine = sourceText.Lines.GetLineFromPosition(nonExpressionNode.GetFirstToken(includeZeroWidth: true).SpanStart);
+
+            // multiline expression
+            if (firstTokenLine.LineNumber != givenTokenLine.LineNumber)
+            {
+                // okay, looks like containing node is written over multiple lines, in that case, give same indentation as given token
+                return indenter.GetIndentationOfLine(givenTokenLine);
+            }
         }
 
-        // find line where first token of the node is
-        var firstTokenLine = sourceText.Lines.GetLineFromPosition(nonExpressionNode.GetFirstToken(includeZeroWidth: true).SpanStart);
-
-        // single line expression
-        if (firstTokenLine.LineNumber == givenTokenLine.LineNumber)
-        {
-            return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
-        }
-
-        // okay, looks like containing node is written over multiple lines, in that case, give same indentation as given token
-        return indenter.GetIndentationOfLine(givenTokenLine);
+        // well, I can't find any non expression node. use default behavior
+        return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, spaceToAdd, indenter.CancellationToken));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -299,7 +299,12 @@ internal partial class CSharpIndentationService
 
             case SyntaxKind.CommaToken:
                 {
-                    return GetIndentationFromCommaSeparatedList(indenter, token);
+                    if (TryGetIndentationFromCommaSeparatedList(indenter, token) is { } result)
+                    {
+                        return result;
+                    }
+
+                    break;
                 }
 
             case SyntaxKind.CloseParenToken:
@@ -316,25 +321,25 @@ internal partial class CSharpIndentationService
         return GetDefaultIndentationFromToken(indenter, token);
     }
 
-    private static IndentationResult GetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)
+    private static IndentationResult? TryGetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)
         => token.Parent switch
         {
-            BaseArgumentListSyntax argument => GetIndentationFromCommaSeparatedList(indenter, argument.Arguments, token),
-            BaseParameterListSyntax parameter => GetIndentationFromCommaSeparatedList(indenter, parameter.Parameters, token),
-            TypeArgumentListSyntax typeArgument => GetIndentationFromCommaSeparatedList(indenter, typeArgument.Arguments, token),
-            TypeParameterListSyntax typeParameter => GetIndentationFromCommaSeparatedList(indenter, typeParameter.Parameters, token),
-            EnumDeclarationSyntax enumDeclaration => GetIndentationFromCommaSeparatedList(indenter, enumDeclaration.Members, token),
-            InitializerExpressionSyntax initializerSyntax => GetIndentationFromCommaSeparatedList(indenter, initializerSyntax.Expressions, token),
-            _ => GetDefaultIndentationFromToken(indenter, token),
+            BaseArgumentListSyntax argument => TryGetIndentationFromCommaSeparatedList(indenter, argument.Arguments, token),
+            BaseParameterListSyntax parameter => TryGetIndentationFromCommaSeparatedList(indenter, parameter.Parameters, token),
+            TypeArgumentListSyntax typeArgument => TryGetIndentationFromCommaSeparatedList(indenter, typeArgument.Arguments, token),
+            TypeParameterListSyntax typeParameter => TryGetIndentationFromCommaSeparatedList(indenter, typeParameter.Parameters, token),
+            EnumDeclarationSyntax enumDeclaration => TryGetIndentationFromCommaSeparatedList(indenter, enumDeclaration.Members, token),
+            InitializerExpressionSyntax initializerSyntax => TryGetIndentationFromCommaSeparatedList(indenter, initializerSyntax.Expressions, token),
+            _ => null,
         };
 
-    private static IndentationResult GetIndentationFromCommaSeparatedList<T>(
+    private static IndentationResult? TryGetIndentationFromCommaSeparatedList<T>(
         Indenter indenter, SeparatedSyntaxList<T> list, SyntaxToken token) where T : SyntaxNode
     {
         var index = list.GetWithSeparators().IndexOf(token);
         if (index < 0)
         {
-            return GetDefaultIndentationFromToken(indenter, token);
+            return null;
         }
 
         // find node that starts at the beginning of a line

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -240,7 +240,7 @@ internal partial class CSharpIndentationService
                     // special cases
                     if (token.IsSemicolonInForStatement())
                     {
-                        return GetDefaultIndentationFromToken(indenter, token);
+                        break;
                     }
 
                     return indenter.IndentFromStartOfLine(indenter.Finder.GetIndentationOfCurrentPosition(indenter.Tree, token, position, indenter.CancellationToken));
@@ -253,7 +253,7 @@ internal partial class CSharpIndentationService
                     {
                         if (token.GetNextToken().IsEqualsTokenInAutoPropertyInitializers())
                         {
-                            return GetDefaultIndentationFromToken(indenter, token);
+                            break;
                         }
                     }
 
@@ -275,7 +275,7 @@ internal partial class CSharpIndentationService
                         return indenter.GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart), indenter.Options.FormattingOptions.IndentationSize);
                     }
 
-                    goto default;
+                    break;
                 }
 
             case SyntaxKind.CloseBracketToken:
@@ -289,7 +289,7 @@ internal partial class CSharpIndentationService
                         return indenter.GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart));
                     }
 
-                    goto default;
+                    break;
                 }
 
             case SyntaxKind.XmlTextLiteralToken:
@@ -309,14 +309,11 @@ internal partial class CSharpIndentationService
                         return GetDefaultIndentationFromToken(indenter, token.Parent.GetFirstToken(includeZeroWidth: true));
                     }
 
-                    goto default;
-                }
-
-            default:
-                {
-                    return GetDefaultIndentationFromToken(indenter, token);
+                    break;
                 }
         }
+
+        return GetDefaultIndentationFromToken(indenter, token);
     }
 
     private static IndentationResult GetIndentationFromCommaSeparatedList(Indenter indenter, SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -240,12 +240,11 @@ internal partial class CSharpIndentationService
             case SyntaxKind.SemicolonToken:
                 {
                     // special cases
-                    if (token.IsSemicolonInForStatement())
+                    if (!token.IsSemicolonInForStatement())
                     {
-                        break;
+                        allowExtraIndentationLevel = false;
                     }
 
-                    allowExtraIndentationLevel = false;
                     break;
                 }
 


### PR DESCRIPTION
While looking into https://github.com/dotnet/roslyn/issues/38057, with some interest in sharing smart indent logic so that the formatter can use it when it formats elastic whitespace, I did some simplification in CSharpIndentationService.

Methods that handle specific situations no longer decide what's next to try, if the situation they are responsible for does not apply. "What's next" is decided in one method now. There's no GetDefaultIndentation that can be independently called from elsewhere.

As a result, I found and fixed two smart indent bugs (see the added unit tests).

Another special case was also removed, deciding not to add an additional increment of indentation when inside a separated syntax list, since that decision is always ignored when inside a separated syntax list. This special case dates back to the initial commit in this repo. More details are in the commit message where this was done.