### PR TITLE
Add option to return suggestion diagnostics as LSP Information diagnostics in vscode

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.ImplementType;
@@ -55,6 +56,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             LspOptionsStorage.LspEnableReferencesCodeLens,
             LspOptionsStorage.LspEnableTestsCodeLens,
             LspOptionsStorage.LspEnableAutoInsert,
+            LspOptionsStorage.RenderSuggestionDiagnosticsAsHints,
             LanguageServerProjectSystemOptionsStorage.BinaryLogPath,
             LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore,
             MetadataAsSourceOptionsStorage.NavigateToSourceLinkAndEmbeddedSources,

--- a/src/LanguageServer/Protocol/LspOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/LspOptionsStorage.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         private static readonly OptionGroup s_autoInsertOptionGroup = new(name: "auto_insert", description: "");
 
+        private static readonly OptionGroup s_diagnosticsOptionGroup = new(name: "diagnostics", description: "");
+
         /// <summary>
         /// Flag indicating whether or not references should be returned in LSP codelens.
         /// </summary>
@@ -48,5 +50,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// Flag indicating whether or not auto-insert should be abled by default in LSP.
         /// </summary>
         public static readonly PerLanguageOption2<bool> LspEnableAutoInsert = new("dotnet_enable_auto_insert", defaultValue: true, group: s_autoInsertOptionGroup);
+
+        /// <summary>
+        /// Flag indicating whether suggestion diagnostics returned from the server should be categorized as LSP DiagnosticSeverity.Hint or LSP DiagnosticSeverity.Information.
+        /// This changes how the client will render these diagnostics in the editor.  By default we render them as hints as this is more similar to the rendering in VS.
+        /// </summary>
+        public static readonly PerLanguageOption2<bool> RenderSuggestionDiagnosticsAsHints = new("dotnet_render_suggestions_as_hints", defaultValue: true, group: s_diagnosticsOptionGroup);
     }
 }

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -894,6 +894,32 @@ class C
         Assert.Equal(LSP.DiagnosticSeverity.Hint, results.Single().Diagnostics.Single().Severity);
     }
 
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/6723")]
+    public async Task TestInfoDiagnosticsAreReportedAsInfoInVSCodeWhenOptionDisabled(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public A SomeA = new A();
+}";
+        await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, mutatingLspWorkspace, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics: false);
+        testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(
+            LspOptionsStorage.RenderSuggestionDiagnosticsAsHints, LanguageNames.CSharp, false);
+
+        // Calling GetTextBuffer will effectively open the file.
+        testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+        await OpenDocumentAsync(testLspServer, document);
+
+        var results = await RunGetDocumentPullDiagnosticsAsync(
+            testLspServer, document.GetURI(), useVSDiagnostics: false);
+
+        Assert.Equal("IDE0090", results.Single().Diagnostics.Single().Code);
+        Assert.Equal(LSP.DiagnosticSeverity.Information, results.Single().Diagnostics.Single().Severity);
+    }
+
     #endregion
 
     #region Workspace Diagnostics


### PR DESCRIPTION
Related to https://github.com/dotnet/vscode-csharp/issues/6723

On release we returned LSP.DiagnosticSeverity.Information (rendered as blue squiggles in VSCode) for our suggestion diagnostics - however we got a ton of feedback that the the noise was undesired, and so we switch to using LSP.DiagnosticSeverity.Information (ellipse underneath).  

However hints are not shown in the problems pane, so we have some users requesting information be brought back.  This adds an option to do so.

client side - https://github.com/dotnet/vscode-csharp/pull/7892