### PR TITLE
Reduce pooled array allocations in the SyntaxParser

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private int _resetCount;
         private int _resetStart;
 
-        private static readonly ObjectPool<BlendedNode[]> s_blendedNodesPool = new ObjectPool<BlendedNode[]>(() => new BlendedNode[32], 2);
-        private static readonly ObjectPool<ArrayElement<SyntaxToken>[]> s_lexedTokensPool = new ObjectPool<ArrayElement<SyntaxToken>[]>(() => new ArrayElement<SyntaxToken>[CachedTokenArraySize], 2);
+        private static readonly ObjectPool<BlendedNode[]> s_blendedNodesPool = new ObjectPool<BlendedNode[]>(() => new BlendedNode[32]);
+        private static readonly ObjectPool<ArrayElement<SyntaxToken>[]> s_lexedTokensPool = new ObjectPool<ArrayElement<SyntaxToken>[]>(() => new ArrayElement<SyntaxToken>[CachedTokenArraySize]);
 
         // Array size held in token pool. This should be large enough to prevent most allocations, but
         //  not so large as to be wasteful when not in use.


### PR DESCRIPTION
These pooled array allocations are showing up in the roslyn editing speedometer test as 2.9% of allocations in the code analysis process.

The SyntaxParser has pools for holding the BlendedNode and SyntaxToken arrays it uses. However, it sets the size of the pool to be only 2 items. As these arrays are only released once the parser is disposed, and there are potentially quite a few concurrent parses going on during solution load, there ends up being quite a few allocations of these arrays due to earlier allocations not yet being released to the pool.

Instead, just switch these object pools to use the default for the array size.

Local testing for opening the Roslyn sln showed about 50K SyntaxParser objects constructed, and I was seeing the blended/token arrays allocated 3.5K/10.5K respectively. With this change, I saw those array allocations reduced to 18/54 respectively. Speedometer results look good (images below)

Without change speedometer allocations:
![image](https://github.com/user-attachments/assets/4fe77175-e6db-4a34-9eeb-10b07fa5f304)
 
With change speedometer allocations:
![image](https://github.com/user-attachments/assets/44e7c1e6-72cf-46c8-8bcf-aa1e4c108301)