### PR TITLE
WIP: Reduce allocations by adding more SyntaxList specializations

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
@@ -74,5 +74,61 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Assert.True(listOf3 != listOf2, $"{i} iterations");
             }
         }
+
+        [Fact]
+        public void TryGetNode_With3Of4Children()
+        {
+            const int nIterations = 1_000_000;
+
+            for (int i = 0; i < nIterations; i++)
+            {
+                var child0 = new SyntaxTokenWithTrivia(SyntaxKind.InternalKeyword, null, null);
+                var child1 = new SyntaxTokenWithTrivia(SyntaxKind.StaticKeyword, null, null);
+                var child2 = new SyntaxTokenWithTrivia(SyntaxKind.ReadOnlyKeyword, null, null);
+                var child3 = new SyntaxTokenWithTrivia(SyntaxKind.AsyncKeyword, null, null);
+                SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
+                SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
+                SyntaxNodeCache.AddNode(child2, child2.GetCacheHash());
+                SyntaxNodeCache.AddNode(child3, child3.GetCacheHash());
+
+                var listOf4 = new CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithFourChildren(child0, child1, child2, child3);
+                SyntaxNodeCache.AddNode(listOf4, listOf4.GetCacheHash());
+
+                var listCached = (CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithFourChildren)SyntaxNodeCache.TryGetNode(listOf4.RawKind, child0, child1, child2, child3, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.NotNull(listCached);
+
+                var listOf3 = SyntaxNodeCache.TryGetNode(listOf4.RawKind, child0, child1, child2, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.True(listOf4 != listOf3, $"{i} iterations");
+            }
+        }
+
+        [Fact]
+        public void TryGetNode_With4Of5Children()
+        {
+            const int nIterations = 1_000_000;
+
+            for (int i = 0; i < nIterations; i++)
+            {
+                var child0 = new SyntaxTokenWithTrivia(SyntaxKind.InternalKeyword, null, null);
+                var child1 = new SyntaxTokenWithTrivia(SyntaxKind.StaticKeyword, null, null);
+                var child2 = new SyntaxTokenWithTrivia(SyntaxKind.ReadOnlyKeyword, null, null);
+                var child3 = new SyntaxTokenWithTrivia(SyntaxKind.AsyncKeyword, null, null);
+                var child4 = new SyntaxTokenWithTrivia(SyntaxKind.OverrideKeyword, null, null);
+                SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
+                SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
+                SyntaxNodeCache.AddNode(child2, child2.GetCacheHash());
+                SyntaxNodeCache.AddNode(child3, child3.GetCacheHash());
+                SyntaxNodeCache.AddNode(child4, child4.GetCacheHash());
+
+                var listOf5 = new CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithFiveChildren(child0, child1, child2, child3, child4);
+                SyntaxNodeCache.AddNode(listOf5, listOf5.GetCacheHash());
+
+                var listCached = (CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithFiveChildren)SyntaxNodeCache.TryGetNode(listOf5.RawKind, child0, child1, child2, child3, child4, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.NotNull(listCached);
+
+                var listOf4 = SyntaxNodeCache.TryGetNode(listOf5.RawKind, child0, child1, child2, child3, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.True(listOf5 != listOf4, $"{i} iterations");
+            }
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -920,6 +920,10 @@ namespace Microsoft.CodeAnalysis
                     return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]));
                 case 3:
                     return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]), select(list[2]));
+                case 4:
+                    return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]), select(list[2]), select(list[3]));
+                case 5:
+                    return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]), select(list[2]), select(list[3]), select(list[4]));
                 default:
                     {
                         var array = new ArrayElement<GreenNode>[list.Count];
@@ -942,6 +946,10 @@ namespace Microsoft.CodeAnalysis
                     return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]));
                 case 3:
                     return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]), select(list[2]));
+                case 4:
+                    return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]), select(list[2]), select(list[3]));
+                case 5:
+                    return Syntax.InternalSyntax.SyntaxList.List(select(list[0]), select(list[1]), select(list[2]), select(list[3]), select(list[4]));
                 default:
                     {
                         var array = new ArrayElement<GreenNode>[list.Count];
@@ -963,7 +971,7 @@ namespace Microsoft.CodeAnalysis
 
         #region Caching
 
-        internal const int MaxCachedChildNum = 3;
+        internal const int MaxCachedChildNum = 5;
 
         internal bool IsCacheable
         {
@@ -1023,6 +1031,33 @@ namespace Microsoft.CodeAnalysis
                 this.GetSlot(0) == child1 &&
                 this.GetSlot(1) == child2 &&
                 this.GetSlot(2) == child3;
+        }
+
+        internal bool IsCacheEquivalent(int kind, NodeFlags flags, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4)
+        {
+            Debug.Assert(this.IsCacheable);
+
+            return this.RawKind == kind &&
+                this.Flags == flags &&
+                this.SlotCount == 4 &&
+                this.GetSlot(0) == child1 &&
+                this.GetSlot(1) == child2 &&
+                this.GetSlot(2) == child3 &&
+                this.GetSlot(3) == child4;
+        }
+
+        internal bool IsCacheEquivalent(int kind, NodeFlags flags, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4, GreenNode? child5)
+        {
+            Debug.Assert(this.IsCacheable);
+
+            return this.RawKind == kind &&
+                this.Flags == flags &&
+                this.SlotCount == 5 &&
+                this.GetSlot(0) == child1 &&
+                this.GetSlot(1) == child2 &&
+                this.GetSlot(2) == child3 &&
+                this.GetSlot(3) == child4 &&
+                this.GetSlot(4) == child5;
         }
         #endregion //Caching
 

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithFiveChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithFiveChildren.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
+{
+    internal partial class SyntaxList
+    {
+        internal class WithFiveChildren : SyntaxList
+        {
+            private readonly GreenNode _child0;
+            private readonly GreenNode _child1;
+            private readonly GreenNode _child2;
+            private readonly GreenNode _child3;
+            private readonly GreenNode _child4;
+
+            internal WithFiveChildren(GreenNode child0, GreenNode child1, GreenNode child2, GreenNode child3, GreenNode child4)
+            {
+                this.SlotCount = 5;
+                this.AdjustFlagsAndWidth(child0);
+                _child0 = child0;
+                this.AdjustFlagsAndWidth(child1);
+                _child1 = child1;
+                this.AdjustFlagsAndWidth(child2);
+                _child2 = child2;
+                this.AdjustFlagsAndWidth(child3);
+                _child3 = child3;
+                this.AdjustFlagsAndWidth(child4);
+                _child4 = child4;
+            }
+
+            internal WithFiveChildren(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations, GreenNode child0, GreenNode child1, GreenNode child2, GreenNode child3, GreenNode child4)
+                : base(diagnostics, annotations)
+            {
+                this.SlotCount = 5;
+                this.AdjustFlagsAndWidth(child0);
+                _child0 = child0;
+                this.AdjustFlagsAndWidth(child1);
+                _child1 = child1;
+                this.AdjustFlagsAndWidth(child2);
+                _child2 = child2;
+                this.AdjustFlagsAndWidth(child3);
+                _child3 = child3;
+                this.AdjustFlagsAndWidth(child4);
+                _child4 = child4;
+            }
+
+            internal override GreenNode? GetSlot(int index)
+            {
+                switch (index)
+                {
+                    case 0:
+                        return _child0;
+                    case 1:
+                        return _child1;
+                    case 2:
+                        return _child2;
+                    case 3:
+                        return _child3;
+                    case 4:
+                        return _child4;
+                    default:
+                        return null;
+                }
+            }
+
+            internal override void CopyTo(ArrayElement<GreenNode>[] array, int offset)
+            {
+                array[offset].Value = _child0;
+                array[offset + 1].Value = _child1;
+                array[offset + 2].Value = _child2;
+                array[offset + 3].Value = _child3;
+                array[offset + 4].Value = _child4;
+            }
+
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position)
+            {
+                return new Syntax.SyntaxList.WithFiveChildren(this, parent, position);
+            }
+
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? errors)
+            {
+                return new WithFiveChildren(errors, this.GetAnnotations(), _child0, _child1, _child2, _child3, _child4);
+            }
+
+            internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
+            {
+                return new WithFiveChildren(GetDiagnostics(), annotations, _child0, _child1, _child2, _child3, _child4);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithFourChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.WithFourChildren.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
+{
+    internal partial class SyntaxList
+    {
+        internal class WithFourChildren : SyntaxList
+        {
+            private readonly GreenNode _child0;
+            private readonly GreenNode _child1;
+            private readonly GreenNode _child2;
+            private readonly GreenNode _child3;
+
+            internal WithFourChildren(GreenNode child0, GreenNode child1, GreenNode child2, GreenNode child3)
+            {
+                this.SlotCount = 4;
+                this.AdjustFlagsAndWidth(child0);
+                _child0 = child0;
+                this.AdjustFlagsAndWidth(child1);
+                _child1 = child1;
+                this.AdjustFlagsAndWidth(child2);
+                _child2 = child2;
+                this.AdjustFlagsAndWidth(child3);
+                _child3 = child3;
+            }
+
+            internal WithFourChildren(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations, GreenNode child0, GreenNode child1, GreenNode child2, GreenNode child3)
+                : base(diagnostics, annotations)
+            {
+                this.SlotCount = 4;
+                this.AdjustFlagsAndWidth(child0);
+                _child0 = child0;
+                this.AdjustFlagsAndWidth(child1);
+                _child1 = child1;
+                this.AdjustFlagsAndWidth(child2);
+                _child2 = child2;
+                this.AdjustFlagsAndWidth(child3);
+                _child3 = child3;
+            }
+
+            internal override GreenNode? GetSlot(int index)
+            {
+                switch (index)
+                {
+                    case 0:
+                        return _child0;
+                    case 1:
+                        return _child1;
+                    case 2:
+                        return _child2;
+                    case 3:
+                        return _child3;
+                    default:
+                        return null;
+                }
+            }
+
+            internal override void CopyTo(ArrayElement<GreenNode>[] array, int offset)
+            {
+                array[offset].Value = _child0;
+                array[offset + 1].Value = _child1;
+                array[offset + 2].Value = _child2;
+                array[offset + 3].Value = _child3;
+            }
+
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position)
+            {
+                return new Syntax.SyntaxList.WithFourChildren(this, parent, position);
+            }
+
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? errors)
+            {
+                return new WithFourChildren(errors, this.GetAnnotations(), _child0, _child1, _child2, _child3);
+            }
+
+            internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
+            {
+                return new WithFourChildren(GetDiagnostics(), annotations, _child0, _child1, _child2, _child3);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.cs
@@ -63,6 +63,49 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
             return result;
         }
 
+        internal static WithFourChildren List(GreenNode child0, GreenNode child1, GreenNode child2, GreenNode child3)
+        {
+            RoslynDebug.Assert(child0 != null);
+            RoslynDebug.Assert(child1 != null);
+            RoslynDebug.Assert(child2 != null);
+            RoslynDebug.Assert(child3 != null);
+
+            int hash;
+            GreenNode? cached = SyntaxNodeCache.TryGetNode(GreenNode.ListKind, child0, child1, child2, child3, out hash);
+            if (cached != null)
+                return (WithFourChildren)cached;
+
+            var result = new WithFourChildren(child0, child1, child2, child3);
+            if (hash >= 0)
+            {
+                SyntaxNodeCache.AddNode(result, hash);
+            }
+
+            return result;
+        }
+
+        internal static WithFiveChildren List(GreenNode child0, GreenNode child1, GreenNode child2, GreenNode child3, GreenNode child4)
+        {
+            RoslynDebug.Assert(child0 != null);
+            RoslynDebug.Assert(child1 != null);
+            RoslynDebug.Assert(child2 != null);
+            RoslynDebug.Assert(child3 != null);
+            RoslynDebug.Assert(child4 != null);
+
+            int hash;
+            GreenNode? cached = SyntaxNodeCache.TryGetNode(GreenNode.ListKind, child0, child1, child2, child3, child4, out hash);
+            if (cached != null)
+                return (WithFiveChildren)cached;
+
+            var result = new WithFiveChildren(child0, child1, child2, child3, child4);
+            if (hash >= 0)
+            {
+                SyntaxNodeCache.AddNode(result, hash);
+            }
+
+            return result;
+        }
+
         internal static GreenNode List(GreenNode?[] nodes)
         {
             return List(nodes, nodes.Length);

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListBuilder.cs
@@ -181,6 +181,10 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
                     return SyntaxList.List(_nodes[0]!, _nodes[1]!);
                 case 3:
                     return SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!);
+                case 4:
+                    return SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!, _nodes[3]!);
+                case 5:
+                    return SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!, _nodes[3]!, _nodes[4]!);
                 default:
                     var tmp = new ArrayElement<GreenNode>[this.Count];
                     Array.Copy(_nodes, tmp, this.Count);

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
@@ -156,6 +156,16 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
             return CanBeCached(child1) && CanBeCached(child2) && CanBeCached(child3);
         }
 
+        private static bool CanBeCached(GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4)
+        {
+            return CanBeCached(child1) && CanBeCached(child2) && CanBeCached(child3) && CanBeCached(child4);
+        }
+
+        private static bool CanBeCached(GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4, GreenNode? child5)
+        {
+            return CanBeCached(child1) && CanBeCached(child2) && CanBeCached(child3) && CanBeCached(child4) && CanBeCached(child5);
+        }
+
         private static bool ChildInCache(GreenNode? child)
         {
             // for the purpose of this function consider that 
@@ -267,6 +277,62 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
             return null;
         }
 
+        internal static GreenNode? TryGetNode(int kind, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4, out int hash)
+        {
+            return TryGetNode(kind, child1, child2, child3, child4, GetDefaultNodeFlags(), out hash);
+        }
+
+        internal static GreenNode? TryGetNode(int kind, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4, GreenNode.NodeFlags flags, out int hash)
+        {
+            if (CanBeCached(child1, child2, child3, child4))
+            {
+                GreenStats.ItemCacheable();
+
+                int h = hash = GetCacheHash(kind, flags, child1, child2, child3, child4);
+                int idx = h & CacheMask;
+                var e = s_cache[idx];
+                if (e.hash == h && e.node != null && e.node.IsCacheEquivalent(kind, flags, child1, child2, child3, child4))
+                {
+                    GreenStats.CacheHit();
+                    return e.node;
+                }
+            }
+            else
+            {
+                hash = -1;
+            }
+
+            return null;
+        }
+
+        internal static GreenNode? TryGetNode(int kind, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4, GreenNode? child5, out int hash)
+        {
+            return TryGetNode(kind, child1, child2, child3, child4, child5, GetDefaultNodeFlags(), out hash);
+        }
+
+        internal static GreenNode? TryGetNode(int kind, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4, GreenNode? child5, GreenNode.NodeFlags flags, out int hash)
+        {
+            if (CanBeCached(child1, child2, child3, child4, child5))
+            {
+                GreenStats.ItemCacheable();
+
+                int h = hash = GetCacheHash(kind, flags, child1, child2, child3, child4, child5);
+                int idx = h & CacheMask;
+                var e = s_cache[idx];
+                if (e.hash == h && e.node != null && e.node.IsCacheEquivalent(kind, flags, child1, child2, child3, child4, child5))
+                {
+                    GreenStats.CacheHit();
+                    return e.node;
+                }
+            }
+            else
+            {
+                hash = -1;
+            }
+
+            return null;
+        }
+
         public static GreenNode.NodeFlags GetDefaultNodeFlags()
         {
             return GreenNode.NodeFlags.IsNotMissing;
@@ -313,6 +379,60 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
             if (child3 != null)
             {
                 code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child3), code);
+            }
+
+            // ensure nonnegative hash
+            return code & Int32.MaxValue;
+        }
+
+        private static int GetCacheHash(int kind, GreenNode.NodeFlags flags, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4)
+        {
+            int code = (int)(flags) ^ kind;
+
+            if (child1 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code);
+            }
+            if (child2 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child2), code);
+            }
+            if (child3 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child3), code);
+            }
+            if (child4 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child4), code);
+            }
+
+            // ensure nonnegative hash
+            return code & Int32.MaxValue;
+        }
+
+        private static int GetCacheHash(int kind, GreenNode.NodeFlags flags, GreenNode? child1, GreenNode? child2, GreenNode? child3, GreenNode? child4, GreenNode? child5)
+        {
+            int code = (int)(flags) ^ kind;
+
+            if (child1 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code);
+            }
+            if (child2 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child2), code);
+            }
+            if (child3 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child3), code);
+            }
+            if (child4 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child4), code);
+            }
+            if (child5 != null)
+            {
+                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child5), code);
             }
 
             // ensure nonnegative hash

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithFiveChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithFiveChildren.cs
@@ -8,13 +8,15 @@ namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal sealed class WithThreeChildren : SyntaxList
+        internal sealed class WithFiveChildren : SyntaxList
         {
             private SyntaxNode? _child0;
             private SyntaxNode? _child1;
             private SyntaxNode? _child2;
+            private SyntaxNode? _child3;
+            private SyntaxNode? _child4;
 
-            internal WithThreeChildren(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
+            internal WithFiveChildren(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
                 : base(green, parent, position)
             {
             }
@@ -29,6 +31,10 @@ namespace Microsoft.CodeAnalysis.Syntax
                         return this.GetRedElementIfNotToken(ref _child1, 1);
                     case 2:
                         return this.GetRedElement(ref _child2, 2);
+                    case 3:
+                        return this.GetRedElementIfNotToken(ref _child3, 3);
+                    case 4:
+                        return this.GetRedElement(ref _child4, 4);
                     default:
                         return null;
                 }
@@ -44,6 +50,10 @@ namespace Microsoft.CodeAnalysis.Syntax
                         return _child1;
                     case 2:
                         return _child2;
+                    case 3:
+                        return _child3;
+                    case 4:
+                        return _child4;
                     default:
                         return null;
                 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithFourChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithFourChildren.cs
@@ -8,13 +8,14 @@ namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal sealed class WithThreeChildren : SyntaxList
+        internal sealed class WithFourChildren : SyntaxList
         {
             private SyntaxNode? _child0;
             private SyntaxNode? _child1;
             private SyntaxNode? _child2;
+            private SyntaxNode? _child3;
 
-            internal WithThreeChildren(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
+            internal WithFourChildren(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
                 : base(green, parent, position)
             {
             }
@@ -29,6 +30,8 @@ namespace Microsoft.CodeAnalysis.Syntax
                         return this.GetRedElementIfNotToken(ref _child1, 1);
                     case 2:
                         return this.GetRedElement(ref _child2, 2);
+                    case 3:
+                        return this.GetRedElementIfNotToken(ref _child3, 3);
                     default:
                         return null;
                 }
@@ -44,6 +47,8 @@ namespace Microsoft.CodeAnalysis.Syntax
                         return _child1;
                     case 2:
                         return _child2;
+                    case 3:
+                        return _child3;
                     default:
                         return null;
                 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithTwoChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithTwoChildren.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Syntax
                     case 0:
                         return this.GetRedElement(ref _child0, 0);
                     case 1:
-                        return this.GetRedElementIfNotToken(ref _child1);
+                        return this.GetRedElementIfNotToken(ref _child1, 1);
                     default:
                         return null;
                 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxListBuilder.cs
@@ -177,6 +177,10 @@ namespace Microsoft.CodeAnalysis.Syntax
                     return InternalSyntax.SyntaxList.List(_nodes[0].Value!, _nodes[1].Value!);
                 case 3:
                     return InternalSyntax.SyntaxList.List(_nodes[0].Value!, _nodes[1].Value!, _nodes[2].Value!);
+                case 4:
+                    return InternalSyntax.SyntaxList.List(_nodes[0].Value!, _nodes[1].Value!, _nodes[2].Value!, _nodes[3].Value!);
+                case 5:
+                    return InternalSyntax.SyntaxList.List(_nodes[0].Value!, _nodes[1].Value!, _nodes[2].Value!, _nodes[3].Value!, _nodes[4].Value!);
                 default:
                     var tmp = new ArrayElement<GreenNode>[this.Count];
                     for (int i = 0; i < this.Count; i++)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -31,6 +31,8 @@ namespace Microsoft.CodeAnalysis
                     case 1: return nodes[0].Green;
                     case 2: return Syntax.InternalSyntax.SyntaxList.List(nodes[0].Green, nodes[1].Green);
                     case 3: return Syntax.InternalSyntax.SyntaxList.List(nodes[0].Green, nodes[1].Green, nodes[2].Green);
+                    case 4: return Syntax.InternalSyntax.SyntaxList.List(nodes[0].Green, nodes[1].Green, nodes[2].Green, nodes[3].Green);
+                    case 5: return Syntax.InternalSyntax.SyntaxList.List(nodes[0].Green, nodes[1].Green, nodes[2].Green, nodes[3].Green, nodes[4].Green);
                     default:
                         {
                             var copy = new ArrayElement<GreenNode>[nodes.Length];

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -226,9 +226,9 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// special cased helper for 2 and 3 children lists where child #1 may map to a token
+        /// special cased helper for >= 2 children lists where child at specified slot may map to a token
         /// </summary>
-        internal SyntaxNode? GetRedElementIfNotToken(ref SyntaxNode? element)
+        internal SyntaxNode? GetRedElementIfNotToken(ref SyntaxNode? element, int slot)
         {
             Debug.Assert(this.IsList);
 
@@ -236,11 +236,11 @@ namespace Microsoft.CodeAnalysis
 
             if (result == null)
             {
-                var green = this.Green.GetRequiredSlot(1);
+                var green = this.Green.GetRequiredSlot(slot);
                 if (!green.IsToken)
                 {
                     // passing list's parent
-                    Interlocked.CompareExchange(ref element, green.CreateRed(this.Parent, this.GetChildPosition(1)), null);
+                    Interlocked.CompareExchange(ref element, green.CreateRed(this.Parent, this.GetChildPosition(slot)), null);
                     result = element;
                 }
             }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -87,6 +87,8 @@ namespace Microsoft.CodeAnalysis
                         : nodesAndTokens[0].AsNode();
                 case 2: return Syntax.InternalSyntax.SyntaxList.List(nodesAndTokens[0].UnderlyingNode!, nodesAndTokens[1].UnderlyingNode!).CreateRed();
                 case 3: return Syntax.InternalSyntax.SyntaxList.List(nodesAndTokens[0].UnderlyingNode!, nodesAndTokens[1].UnderlyingNode!, nodesAndTokens[2].UnderlyingNode!).CreateRed();
+                case 4: return Syntax.InternalSyntax.SyntaxList.List(nodesAndTokens[0].UnderlyingNode!, nodesAndTokens[1].UnderlyingNode!, nodesAndTokens[2].UnderlyingNode!, nodesAndTokens[3].UnderlyingNode!).CreateRed();
+                case 5: return Syntax.InternalSyntax.SyntaxList.List(nodesAndTokens[0].UnderlyingNode!, nodesAndTokens[1].UnderlyingNode!, nodesAndTokens[2].UnderlyingNode!, nodesAndTokens[3].UnderlyingNode!, nodesAndTokens[4].UnderlyingNode!).CreateRed();
                 default:
                     {
                         var copy = new ArrayElement<GreenNode>[nodesAndTokens.Length];

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenListBuilder.cs
@@ -152,6 +152,14 @@ namespace Microsoft.CodeAnalysis.Syntax
                         return new SyntaxNodeOrTokenList(
                             InternalSyntax.SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!).CreateRed(),
                             index: 0);
+                    case 4:
+                        return new SyntaxNodeOrTokenList(
+                            InternalSyntax.SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!, _nodes[3]!).CreateRed(),
+                            index: 0);
+                    case 5:
+                        return new SyntaxNodeOrTokenList(
+                            InternalSyntax.SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!, _nodes[3]!, _nodes[4]!).CreateRed(),
+                            index: 0);
                     default:
                         var tmp = new ArrayElement<GreenNode>[_count];
                         for (int i = 0; i < _count; i++)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenList.cs
@@ -78,6 +78,8 @@ namespace Microsoft.CodeAnalysis
                 case 1: return tokens[0].Node;
                 case 2: return Syntax.InternalSyntax.SyntaxList.List(tokens[0].Node!, tokens[1].Node!);
                 case 3: return Syntax.InternalSyntax.SyntaxList.List(tokens[0].Node!, tokens[1].Node!, tokens[2].Node!);
+                case 4: return Syntax.InternalSyntax.SyntaxList.List(tokens[0].Node!, tokens[1].Node!, tokens[2].Node!, tokens[3].Node!);
+                case 5: return Syntax.InternalSyntax.SyntaxList.List(tokens[0].Node!, tokens[1].Node!, tokens[2].Node!, tokens[3].Node!, tokens[4].Node!);
                 default:
                     {
                         var copy = new ArrayElement<GreenNode>[tokens.Length];

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTokenListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTokenListBuilder.cs
@@ -103,6 +103,19 @@ namespace Microsoft.CodeAnalysis.Syntax
                         Debug.Assert(_nodes[1] is object);
                         Debug.Assert(_nodes[2] is object);
                         return new SyntaxTokenList(null, InternalSyntax.SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!), 0, 0);
+                    case 4:
+                        Debug.Assert(_nodes[0] is object);
+                        Debug.Assert(_nodes[1] is object);
+                        Debug.Assert(_nodes[2] is object);
+                        Debug.Assert(_nodes[3] is object);
+                        return new SyntaxTokenList(null, InternalSyntax.SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!, _nodes[3]!), 0, 0);
+                    case 5:
+                        Debug.Assert(_nodes[0] is object);
+                        Debug.Assert(_nodes[1] is object);
+                        Debug.Assert(_nodes[2] is object);
+                        Debug.Assert(_nodes[3] is object);
+                        Debug.Assert(_nodes[4] is object);
+                        return new SyntaxTokenList(null, InternalSyntax.SyntaxList.List(_nodes[0]!, _nodes[1]!, _nodes[2]!, _nodes[3]!, _nodes[4]!), 0, 0);
                     default:
                         return new SyntaxTokenList(null, InternalSyntax.SyntaxList.List(_nodes, _count), 0, 0);
                 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaList.cs
@@ -84,6 +84,8 @@ namespace Microsoft.CodeAnalysis
                 case 1: return trivias[0].UnderlyingNode!;
                 case 2: return Syntax.InternalSyntax.SyntaxList.List(trivias[0].UnderlyingNode!, trivias[1].UnderlyingNode!);
                 case 3: return Syntax.InternalSyntax.SyntaxList.List(trivias[0].UnderlyingNode!, trivias[1].UnderlyingNode!, trivias[2].UnderlyingNode!);
+                case 4: return Syntax.InternalSyntax.SyntaxList.List(trivias[0].UnderlyingNode!, trivias[1].UnderlyingNode!, trivias[2].UnderlyingNode!, trivias[3].UnderlyingNode!);
+                case 5: return Syntax.InternalSyntax.SyntaxList.List(trivias[0].UnderlyingNode!, trivias[1].UnderlyingNode!, trivias[2].UnderlyingNode!, trivias[3].UnderlyingNode!, trivias[4].UnderlyingNode!);
                 default:
                     {
                         var copy = new ArrayElement<GreenNode>[trivias.Length];

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
@@ -150,6 +150,23 @@ namespace Microsoft.CodeAnalysis.Syntax
                                 _nodes[1].UnderlyingNode!,
                                 _nodes[2].UnderlyingNode!),
                             position: 0, index: 0);
+                    case 4:
+                        return new SyntaxTriviaList(default(SyntaxToken),
+                            InternalSyntax.SyntaxList.List(
+                                _nodes[0].UnderlyingNode!,
+                                _nodes[1].UnderlyingNode!,
+                                _nodes[2].UnderlyingNode!,
+                                _nodes[3].UnderlyingNode!),
+                            position: 0, index: 0);
+                    case 5:
+                        return new SyntaxTriviaList(default(SyntaxToken),
+                            InternalSyntax.SyntaxList.List(
+                                _nodes[0].UnderlyingNode!,
+                                _nodes[1].UnderlyingNode!,
+                                _nodes[2].UnderlyingNode!,
+                                _nodes[3].UnderlyingNode!,
+                                _nodes[4].UnderlyingNode!),
+                            position: 0, index: 0);
                     default:
                         {
                             var tmp = new ArrayElement<GreenNode>[_count];


### PR DESCRIPTION
Created as a draft PR to get speedometer allocation information to determine whether this is worth pursuing.

Currently, we specialize and cache SyntaxLists with up to 3 children. Not only do these specializations avoid an array allocation, but these specialized lists are also pooled. This PR increases that number to 5 to determine if this would have a positive allocation impact.

Speedometer test shows 1.4% of codeanalysis process allocations are ArrayElement<GreenNode> arrays allocated from SyntaxListBuilder.ToListNode. Additionally, WithManyChildren objects account for 0.7% of allocations. I'm going to run a test insertion with this change to determine whether these numbers are reduced by increasing the specialization size from 3 to 5.

Local testing opening the Roslyn sln showed 22.7 million calls to SyntaxListBuilder.ToListNode. Of that, 1.32 million were for lists with length > 3, but only 600 thousand were for lists with length > 5.

If the speedometer numbers look promising, I'm considering creating another draft PR to get numbers on what adding specializations up to 9 in size would look like (there were only 172K lists that had size >= 10)