### PR TITLE
Release a SeparatedSyntaxListBuilder back to the SyntaxListPool

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -10123,11 +10123,12 @@ done:
                     awaitKeyword,
                     usingKeyword,
                     mods.ToList(),
-                    _syntaxFactory.VariableDeclaration(type, _pool.ToListAndFree(variables)),
+                    _syntaxFactory.VariableDeclaration(type, variables.ToList()),
                     this.EatToken(SyntaxKind.SemicolonToken));
             }
             finally
             {
+                _pool.Free(variables);
                 _pool.Free(mods);
             }
         }


### PR DESCRIPTION
I noticed this when looking at the SyntaxListPool and that it's _allocated debug info was not reducing back to zero length. 

The early return codepaths in LanguageParser.ParseLocalDeclarationStatement are commonly hit, preventing the current code from releasing "variables" back into the pool. Changed to account for the early returns by utilizing the existing finally block similar to what is done for the "mods" pooled item.