### PR TITLE
Ensure VB parser is disposed

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Directives.vb
@@ -52,10 +52,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Me.GetNextTokenInState(ScannerState.VB)
 
             Else
-                Dim parser As New Parser(Me)
-
-                directiveTrivia = parser.ParseConditionalCompilationStatement()
-                directiveTrivia = parser.ConsumeStatementTerminatorAfterDirective(directiveTrivia)
+                Using parser = New Parser(Me)
+                    directiveTrivia = parser.ParseConditionalCompilationStatement()
+                    directiveTrivia = parser.ConsumeStatementTerminatorAfterDirective(directiveTrivia)
+                End Using
             End If
 
             Debug.Assert(directiveTrivia.FullWidth > 0, "should at least get #")

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
@@ -292,17 +292,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Using scanner As New InternalSyntax.Scanner(MakeSourceText(text, 0), VisualBasicParseOptions.Default) ' NOTE: Default options should be enough
                 scanner.ForceScanningXmlDocMode()
 
-                Dim parser = New InternalSyntax.Parser(scanner)
-                parser.GetNextToken(InternalSyntax.ScannerState.Element)
+                Using parser = New InternalSyntax.Parser(scanner)
+                    parser.GetNextToken(InternalSyntax.ScannerState.Element)
 
-                Dim xmlName = InternalSyntax.SyntaxFactory.XmlName(
+                    Dim xmlName = InternalSyntax.SyntaxFactory.XmlName(
                     Nothing, InternalSyntax.SyntaxFactory.XmlNameToken(parentElementName, SyntaxKind.XmlNameToken, Nothing, Nothing))
 
-                Return DirectCast(
+                    Return DirectCast(
                     parser.ParseXmlAttribute(
                         requireLeadingWhitespace:=False,
                         AllowNameAsExpression:=False,
                         xmlElementName:=xmlName).CreateRed(Nothing, 0), BaseXmlAttributeSyntax)
+                End Using
             End Using
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
@@ -126,7 +126,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim node As InternalSyntax.CompilationUnitSyntax
             Using scanner
-                node = New Parser(scanner).ParseCompilationUnit()
+                Using parser = New Parser(scanner)
+                    node = parser.ParseCompilationUnit()
+                End Using
             End Using
 
             Dim root = DirectCast(node.CreateRed(Nothing, 0), CompilationUnitSyntax)


### PR DESCRIPTION
Noticed then when I was trying out adding a pooled object to the parser and that the dispose wasn't always being called to release the object back to the pool. I'm still investigating whether I want to add the pooled data to the parser, but minimially, the existing dispose method should be called.