### PR TITLE
Put WRN_InterceptsLocationAttributeUnsupportedSignature into .NET 9 warning wave

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -214,6 +214,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Warning level 10 is exclusively for warnings introduced in the compiler
                     // shipped with dotnet 10 (C# 14) and that can be reported for pre-existing code.
                     return 10;
+                case ErrorCode.WRN_InterceptsLocationAttributeUnsupportedSignature:
+                    // Warning level 9 is exclusively for warnings introduced in the compiler
+                    // shipped with dotnet 9 (C# 13) and that can be reported for pre-existing code.
+                    return 9;
                 case ErrorCode.WRN_AddressOfInAsync:
                 case ErrorCode.WRN_ByValArraySizeConstRequired:
                     // Warning level 8 is exclusively for warnings introduced in the compiler
@@ -567,7 +571,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_UninitializedNonNullableBackingField:
                 case ErrorCode.WRN_AccessorDoesNotUseBackingField:
                 case ErrorCode.WRN_UnscopedRefAttributeOldRules:
-                case ErrorCode.WRN_InterceptsLocationAttributeUnsupportedSignature:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -14475,7 +14475,8 @@ class C
                 includeCurrentAssemblyAsAnalyzerReference: false,
                 additionalFlags: ["/langversion:preview",
                     "/out:embed.exe",
-                    "/features:InterceptorsNamespaces=Generated"],
+                    "/features:InterceptorsNamespaces=Generated",
+                    "/warn:9"],
                 expectedWarningCount: 1,
                 generators: [generator],
                 analyzers: null);
@@ -14543,7 +14544,8 @@ class C
                 includeCurrentAssemblyAsAnalyzerReference: false,
                 additionalFlags: ["/langversion:preview",
                     $"/out:{objDir.Path}/embed.exe",
-                    "/features:InterceptorsNamespaces=Generated"],
+                    "/features:InterceptorsNamespaces=Generated",
+                    "/warn:9"],
                 expectedWarningCount: 1,
                 generators: [generator],
                 analyzers: null);
@@ -14617,6 +14619,7 @@ class C
                     "/langversion:preview",
                     "/out:embed.exe",
                     "/features:InterceptorsNamespaces=Generated",
+                    "/warn:9",
                     .. string.IsNullOrEmpty(pathMapArgument) ? default(Span<string>) : [pathMapArgument]
                     ],
                 expectedWarningCount: 1,

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -437,7 +437,6 @@ class X
                         case ErrorCode.WRN_FieldIsAmbiguous:
                         case ErrorCode.WRN_UninitializedNonNullableBackingField:
                         case ErrorCode.WRN_AccessorDoesNotUseBackingField:
-                        case ErrorCode.WRN_InterceptsLocationAttributeUnsupportedSignature:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_InvalidVersionFormat:
@@ -474,6 +473,10 @@ class X
                         case ErrorCode.WRN_ByValArraySizeConstRequired:
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 8 and C# 12.
                             Assert.Equal(8, ErrorFacts.GetWarningLevel(errorCode));
+                            break;
+                        case ErrorCode.WRN_InterceptsLocationAttributeUnsupportedSignature:
+                            // These are the warnings introduced with the warning "wave" shipped with dotnet 9 and C# 13.
+                            Assert.Equal(9, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_UnassignedInternalRefField:
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 10 and C# 14.


### PR DESCRIPTION
Closes #76641

https://github.com/dotnet/roslyn/issues/76641#issuecomment-2573729939
> It was not our goal to make generator authors service the .NET 8 versions of their generators to start using InterceptableLocation. The goal was just to get people moved to the new way for .NET 9 and up. Our plan is to leave in support for the "old way" in the SDK, for as long as .NET 8 is supported. At the time .NET 8 goes out of support, we will fully remove the support for the "old way" from the newest SDK.
> 
> I think the resolution here should be to adjust the compiler so that warning `InterceptsLocationAttribute(string, int, int) is not supported` is only reported when targeting .NET 9 or later.

