### PR TITLE
Change SupportedPlatformData to use ImmutableArrays

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -299,7 +299,7 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
         if (relatedDocumentIds.IsEmpty)
         {
             var itemsForCurrentDocument = await GetSymbolsAsync(completionContext, syntaxContext, position, options, cancellationToken).ConfigureAwait(false);
-            return CreateItems(completionContext, itemsForCurrentDocument, _ => syntaxContext, invalidProjectMap: null, totalProjects: ImmutableArray<ProjectId>.Empty);
+            return CreateItems(completionContext, itemsForCurrentDocument, _ => syntaxContext, invalidProjectMap: null, totalProjects: []);
         }
 
         using var _ = PooledDictionary<DocumentId, int>.GetInstance(out var documentIdToIndex);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -98,8 +98,8 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
         CompletionContext completionContext,
         ImmutableArray<SymbolAndSelectionInfo> symbols,
         Func<SymbolAndSelectionInfo, TSyntaxContext> contextLookup,
-        Dictionary<ISymbol, List<ProjectId>>? invalidProjectMap,
-        List<ProjectId>? totalProjects)
+        Dictionary<ISymbol, ArrayBuilder<ProjectId>>? invalidProjectMap,
+        ImmutableArray<ProjectId> totalProjects)
     {
         // We might get symbol w/o name but CanBeReferencedByName is still set to true, 
         // need to filter them out.
@@ -197,13 +197,13 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
     private static SupportedPlatformData? ComputeSupportedPlatformData(
         CompletionContext completionContext,
         ImmutableArray<SymbolAndSelectionInfo> symbols,
-        Dictionary<ISymbol, List<ProjectId>>? invalidProjectMap,
-        List<ProjectId>? totalProjects)
+        Dictionary<ISymbol, ArrayBuilder<ProjectId>>? invalidProjectMap,
+        ImmutableArray<ProjectId> totalProjects)
     {
         SupportedPlatformData? supportedPlatformData = null;
         if (invalidProjectMap != null)
         {
-            List<ProjectId>? invalidProjects = null;
+            ArrayBuilder<ProjectId>? invalidProjects = null;
             foreach (var symbol in symbols)
             {
                 if (invalidProjectMap.TryGetValue(symbol.Symbol, out invalidProjects))
@@ -211,7 +211,7 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
             }
 
             if (invalidProjects != null)
-                supportedPlatformData = new SupportedPlatformData(completionContext.Document.Project.Solution, invalidProjects, totalProjects);
+                supportedPlatformData = new SupportedPlatformData(completionContext.Document.Project.Solution, invalidProjects.ToImmutable(), totalProjects);
         }
 
         return supportedPlatformData;
@@ -299,7 +299,7 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
         if (relatedDocumentIds.IsEmpty)
         {
             var itemsForCurrentDocument = await GetSymbolsAsync(completionContext, syntaxContext, position, options, cancellationToken).ConfigureAwait(false);
-            return CreateItems(completionContext, itemsForCurrentDocument, _ => syntaxContext, invalidProjectMap: null, totalProjects: null);
+            return CreateItems(completionContext, itemsForCurrentDocument, _ => syntaxContext, invalidProjectMap: null, totalProjects: ImmutableArray<ProjectId>.Empty);
         }
 
         using var _ = PooledDictionary<DocumentId, int>.GetInstance(out var documentIdToIndex);
@@ -315,10 +315,15 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
 
         var symbolToContextMap = UnionSymbols(contextAndSymbolLists);
         var missingSymbolsMap = FindSymbolsMissingInLinkedContexts(symbolToContextMap, contextAndSymbolLists);
-        var totalProjects = contextAndSymbolLists.Select(t => t.documentId.ProjectId).ToList();
+        var totalProjects = contextAndSymbolLists.SelectAsArray(t => t.documentId.ProjectId);
 
-        return CreateItems(
+        var items = CreateItems(
             completionContext, [.. symbolToContextMap.Keys], symbol => symbolToContextMap[symbol], missingSymbolsMap, totalProjects);
+
+        foreach (var (_, builder) in missingSymbolsMap)
+            builder.Free();
+
+        return items;
     }
 
     protected virtual bool IsExclusive()
@@ -395,17 +400,17 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
     /// <param name="symbolToContext">The symbols recommended in the active context.</param>
     /// <param name="linkedContextSymbolLists">The symbols recommended in linked documents</param>
     /// <returns>The list of projects each recommended symbol did NOT appear in.</returns>
-    private static Dictionary<ISymbol, List<ProjectId>> FindSymbolsMissingInLinkedContexts(
+    private static Dictionary<ISymbol, ArrayBuilder<ProjectId>> FindSymbolsMissingInLinkedContexts(
         Dictionary<SymbolAndSelectionInfo, TSyntaxContext> symbolToContext,
         ImmutableArray<(DocumentId documentId, TSyntaxContext syntaxContext, ImmutableArray<SymbolAndSelectionInfo> symbols)> linkedContextSymbolLists)
     {
-        var missingSymbols = new Dictionary<ISymbol, List<ProjectId>>(LinkedFilesSymbolEquivalenceComparer.Instance);
+        var missingSymbols = new Dictionary<ISymbol, ArrayBuilder<ProjectId>>(LinkedFilesSymbolEquivalenceComparer.Instance);
 
         foreach (var (documentId, syntaxContext, symbols) in linkedContextSymbolLists)
         {
             var symbolsMissingInLinkedContext = symbolToContext.Keys.Except(symbols);
             foreach (var (symbol, _) in symbolsMissingInLinkedContext)
-                missingSymbols.GetOrAdd(symbol, m => []).Add(documentId.ProjectId);
+                missingSymbols.GetOrAdd(symbol, m => ArrayBuilder<ProjectId>.GetInstance()).Add(documentId.ProjectId);
         }
 
         return missingSymbols;

--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -236,8 +236,8 @@ internal static class SymbolCompletionItem
         {
             return new SupportedPlatformData(
                 solution,
-                [.. invalidProjects.Split(s_projectSeperators).Select(s => ProjectId.CreateFromSerialized(Guid.Parse(s)))],
-                candidateProjects.Split(s_projectSeperators).Select(s => ProjectId.CreateFromSerialized(Guid.Parse(s))).ToList());
+                invalidProjects.Split(s_projectSeperators).SelectAsArray(s => ProjectId.CreateFromSerialized(Guid.Parse(s))),
+                candidateProjects.Split(s_projectSeperators).SelectAsArray(s => ProjectId.CreateFromSerialized(Guid.Parse(s))));
         }
 
         return null;

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -86,9 +87,6 @@ internal abstract partial class CommonSemanticQuickInfoProvider : CommonQuickInf
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
         var mainTokenInformation = BindToken(services, semanticModel, token, cancellationToken);
 
-        var candidateProjects = new List<ProjectId> { document.Project.Id };
-        var invalidProjects = new List<ProjectId>();
-
         var candidateResults = new List<(DocumentId docId, TokenInformation tokenInformation)>
         {
             (document.Id, mainTokenInformation)
@@ -103,7 +101,6 @@ internal abstract partial class CommonSemanticQuickInfoProvider : CommonQuickInf
             if (linkedToken != default)
             {
                 // Not in an inactive region, so this file is a candidate.
-                candidateProjects.Add(linkedDocumentId.ProjectId);
                 var linkedSymbols = BindToken(services, linkedModel, linkedToken, cancellationToken);
                 candidateResults.Add((linkedDocumentId, linkedSymbols));
             }
@@ -117,7 +114,11 @@ internal abstract partial class CommonSemanticQuickInfoProvider : CommonQuickInf
         if (bestBinding.tokenInformation.Symbols.IsDefaultOrEmpty)
             return default;
 
+        // We calculate the set of projects that are candidates for the best binding
+        var candidateProjects = candidateResults.SelectAsArray(result => result.docId.ProjectId);
+
         // We calculate the set of supported projects
+        var invalidProjects = ArrayBuilder<ProjectId>.GetInstance();
         candidateResults.Remove(bestBinding);
         foreach (var (docId, tokenInformation) in candidateResults)
         {
@@ -126,7 +127,7 @@ internal abstract partial class CommonSemanticQuickInfoProvider : CommonQuickInf
                 invalidProjects.Add(docId.ProjectId);
         }
 
-        var supportedPlatforms = new SupportedPlatformData(solution, invalidProjects, candidateProjects);
+        var supportedPlatforms = new SupportedPlatformData(solution, invalidProjects.ToImmutableAndFree(), candidateProjects);
         return (bestBinding.tokenInformation, supportedPlatforms);
     }
 

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
@@ -118,7 +118,7 @@ internal abstract partial class CommonSemanticQuickInfoProvider : CommonQuickInf
         var candidateProjects = candidateResults.SelectAsArray(result => result.docId.ProjectId);
 
         // We calculate the set of supported projects
-        var invalidProjects = ArrayBuilder<ProjectId>.GetInstance();
+        using var _ = ArrayBuilder<ProjectId>.GetInstance(out var invalidProjects);
         candidateResults.Remove(bestBinding);
         foreach (var (docId, tokenInformation) in candidateResults)
         {
@@ -127,7 +127,7 @@ internal abstract partial class CommonSemanticQuickInfoProvider : CommonQuickInf
                 invalidProjects.Add(docId.ProjectId);
         }
 
-        var supportedPlatforms = new SupportedPlatformData(solution, invalidProjects.ToImmutableAndFree(), candidateProjects);
+        var supportedPlatforms = new SupportedPlatformData(solution, invalidProjects.ToImmutableAndClear(), candidateProjects);
         return (bestBinding.tokenInformation, supportedPlatforms);
     }
 

--- a/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
@@ -2,27 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities;
 
-internal sealed class SupportedPlatformData(Solution solution, List<ProjectId> invalidProjects, IEnumerable<ProjectId> candidateProjects)
+internal sealed class SupportedPlatformData(Solution solution, ImmutableArray<ProjectId> invalidProjects, ImmutableArray<ProjectId> candidateProjects)
 {
     // Because completion finds lots of symbols that exist in 
     // all projects, we'll instead maintain a list of projects 
     // missing the symbol.
-    public readonly List<ProjectId> InvalidProjects = invalidProjects;
-    public readonly IEnumerable<ProjectId> CandidateProjects = candidateProjects;
+    public readonly ImmutableArray<ProjectId> InvalidProjects = invalidProjects;
+    public readonly ImmutableArray<ProjectId> CandidateProjects = candidateProjects;
     public readonly Solution Solution = solution;
 
     public IList<SymbolDisplayPart> ToDisplayParts()
     {
-        if (InvalidProjects == null || InvalidProjects.Count == 0)
+        if (InvalidProjects.Length == 0)
             return [];
 
         var builder = new List<SymbolDisplayPart>();
@@ -46,5 +45,5 @@ internal sealed class SupportedPlatformData(Solution solution, List<ProjectId> i
         => supported ? FeaturesResources.Available : FeaturesResources.Not_Available;
 
     public bool HasValidAndInvalidProjects()
-        => InvalidProjects.Any() && InvalidProjects.Count != CandidateProjects.Count();
+        => InvalidProjects.Length > 0 && InvalidProjects.Length != CandidateProjects.Length;
 }

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -277,7 +277,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
                 symbolKey = SymbolKey.Create(methodSymbol.OriginalDefinition, cancellationToken);
             }
 
-            var invalidProjectsForCurrentSymbol = ArrayBuilder<ProjectId>.GetInstance();
+            using var _ = ArrayBuilder<ProjectId>.GetInstance(out var invalidProjectsForCurrentSymbol);
             foreach (var relatedDocument in relatedDocuments)
             {
                 // Try to resolve symbolKey in each related compilation,
@@ -289,7 +289,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
                 }
             }
 
-            var platformData = new SupportedPlatformData(document.Project.Solution, invalidProjectsForCurrentSymbol.ToImmutableAndFree(), totalProjects);
+            var platformData = new SupportedPlatformData(document.Project.Solution, invalidProjectsForCurrentSymbol.ToImmutableAndClear(), totalProjects);
             finalItems.Add(UpdateItem(item, platformData));
         }
 

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -254,7 +254,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
             return itemsForCurrentDocument;
         }
 
-        var totalProjects = relatedDocuments.Select(d => d.Project.Id).Concat(document.Project.Id);
+        var totalProjects = relatedDocuments.Concat(document).SelectAsArray(d => d.Project.Id);
 
         var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
         var compilation = semanticModel.Compilation;
@@ -277,7 +277,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
                 symbolKey = SymbolKey.Create(methodSymbol.OriginalDefinition, cancellationToken);
             }
 
-            var invalidProjectsForCurrentSymbol = new List<ProjectId>();
+            var invalidProjectsForCurrentSymbol = ArrayBuilder<ProjectId>.GetInstance();
             foreach (var relatedDocument in relatedDocuments)
             {
                 // Try to resolve symbolKey in each related compilation,
@@ -289,7 +289,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
                 }
             }
 
-            var platformData = new SupportedPlatformData(document.Project.Solution, invalidProjectsForCurrentSymbol, totalProjects);
+            var platformData = new SupportedPlatformData(document.Project.Solution, invalidProjectsForCurrentSymbol.ToImmutableAndFree(), totalProjects);
             finalItems.Add(UpdateItem(item, platformData));
         }
 


### PR DESCRIPTION
I'm looking at a different change to completion and the usage of IEnumerable and List in SupportedPlatformData was tripping it up. It's easy enough to just have it use ImmutableArrays instead.

One concern would be additional allocations due to the IEnumerable -> ImmutableArray conversion. However, I don't think this is an issue as the IEnumerable member is always passed in from a List except from AbstractSignatureHelpProvider. In that case, it's a constructed Linq Select/Concat expression, which is reused multiple times (and potentially enumerated multiple times in SupportedPlatformData). It's extremely likely that it's better to just realize that array once.