### PR TITLE
Reduce allocations in GlyphExtensions.GetFirstGlyph

### DIFF
--- a/src/Features/Core/Portable/Common/GlyphExtensions.cs
+++ b/src/Features/Core/Portable/Common/GlyphExtensions.cs
@@ -29,11 +29,14 @@ internal static class GlyphExtensions
 
     public static Glyph GetFirstGlyph(this ImmutableArray<string> tags)
     {
-        var glyphs = GetGlyphs(tags);
+        foreach (var tag in tags)
+        {
+            var glyph = GetGlyph(tag, tags);
+            if (glyph != Glyph.None)
+                return glyph;
+        }
 
-        return !glyphs.IsEmpty
-            ? glyphs[0]
-            : Glyph.None;
+        return Glyph.None;
     }
 
     private static Glyph GetGlyph(string tag, ImmutableArray<string> allTags)


### PR DESCRIPTION
This accounted for a small amount (0.2%) of allocations during the typing scenario of the csharpediting speedometer test.

*** relevant bit from speedometer allocation profile ***
![image](https://github.com/user-attachments/assets/cb51d0ae-a9e8-402a-9d8f-7fea9acab6ad)