### PR TITLE
CodeGenerator.EmitStackAlloc - Avoid capturing blob array

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 var sizeInBytes = elementType.EnumUnderlyingTypeOrSelf().SpecialType.SizeInBytes();
 
                 ImmutableArray<byte> data = GetRawData(initExprs);
-                if (data.All((d, first) => d == first, data[0]))
+                if (data.All(static (d, first) => d == first, data[0]))
                 {
                     // All bytes are the same, no need for metadata blob, just initblk to fill it with the repeated value.
                     _builder.EmitOpCode(ILOpCode.Dup);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
@@ -45,11 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 var sizeInBytes = elementType.EnumUnderlyingTypeOrSelf().SpecialType.SizeInBytes();
 
                 ImmutableArray<byte> data = GetRawData(initExprs);
-#if NET8_0_OR_GREATER
-                if (!data.AsSpan().ContainsAnyExcept(data[0]))
-#else
-                if (data.All(datum => datum == data[0]))
-#endif
+                if (data.All((d, first) => d == first, data[0]))
                 {
                     // All bytes are the same, no need for metadata blob, just initblk to fill it with the repeated value.
                     _builder.EmitOpCode(ILOpCode.Dup);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
@@ -45,7 +45,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 var sizeInBytes = elementType.EnumUnderlyingTypeOrSelf().SpecialType.SizeInBytes();
 
                 ImmutableArray<byte> data = GetRawData(initExprs);
+#if NET8_0_OR_GREATER
+                if (!data.AsSpan().ContainsAnyExcept(data[0]))
+#else
                 if (data.All(datum => datum == data[0]))
+#endif
                 {
                     // All bytes are the same, no need for metadata blob, just initblk to fill it with the repeated value.
                     _builder.EmitOpCode(ILOpCode.Dup);


### PR DESCRIPTION
I'm not sure if conditional code on dotnet version is acceptable as this API is only available in 8.0+.