### PR TITLE
Switch ObjectPool to use Interlocked.Exchange instead of CompareExchange

### DIFF
--- a/src/Dependencies/PooledObjects/ObjectPool`1.cs
+++ b/src/Dependencies/PooledObjects/ObjectPool`1.cs
@@ -147,7 +147,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             // We will interlock only when we have a candidate. in a worst case we may miss some
             // recently returned objects. Not a big deal.
             var inst = _firstItem;
-            if (inst == null || inst != Interlocked.CompareExchange(ref _firstItem, null, inst))
+            if (inst == null ||
+                (inst = Interlocked.Exchange(ref _firstItem, null)) == null)
             {
                 inst = AllocateSlow();
             }
@@ -176,7 +177,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
                 var inst = items[i].Value;
                 if (inst != null)
                 {
-                    if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
+                    inst = Interlocked.Exchange(ref items[i].Value, null);
+                    if (inst != null)
                     {
                         return inst;
                     }


### PR DESCRIPTION
This may be beneficial if the location being queried has had a new non-null value placed into it since the optimistic read, allowing use of that value, instead of skipping it.

When opening Roslyn.sln, I verified both modified Allocate methods did indeed hit the case where Interlocked.Exchange returned a non-null value not equal to the optimistic read's value.

I'm a bit hesitant about this change, as the code has not changed for many years and there may be some low-level optimization that such a change will negate. However, on the surface, it seems like using Interlocked.Exchange should be sufficient, so I'll go ahead and create the PR and see if someone else can find something I'm missing.