### PR TITLE
Push task-ifying extract-method return type to the code gen stage.

### DIFF
--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -209,7 +209,7 @@ internal sealed partial class CSharpExtractMethodService
             private DeclarationModifiers CreateMethodModifiers()
             {
                 var isUnsafe = ShouldPutUnsafeModifier();
-                var isAsync = this.SelectionResult.CreateAsyncMethod();
+                var isAsync = this.SelectionResult.ContainsAwaitExpression();
                 var isStatic = !AnalyzerResult.UseInstanceMember;
                 var isReadOnly = AnalyzerResult.ShouldBeReadOnly;
 
@@ -604,21 +604,20 @@ internal sealed partial class CSharpExtractMethodService
                 }
 
                 var invocation = (ExpressionSyntax)InvocationExpression(methodExpression, ArgumentList([.. arguments]));
+
+                // If we're extracting any code that contained an 'await' then we'll have to await the new method we're
+                // calling as well.  If we also see any use of .ConfigureAwait(false) in the extracted code, keep that
+                // pattern on the await expression we produce.
                 if (this.SelectionResult.ContainsAwaitExpression())
                 {
                     if (this.SelectionResult.ContainsConfigureAwaitFalse())
                     {
-                        if (this.GetFinalReturnType()
-                                .GetMembers(nameof(Task.ConfigureAwait))
-                                .Any(static x => x is IMethodSymbol { Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }] }))
-                        {
-                            invocation = InvocationExpression(
-                                MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
-                                    invocation,
-                                    IdentifierName(nameof(Task.ConfigureAwait))),
-                                ArgumentList([Argument(LiteralExpression(SyntaxKind.FalseLiteralExpression))]));
-                        }
+                        invocation = InvocationExpression(
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                invocation,
+                                IdentifierName(nameof(Task.ConfigureAwait))),
+                            ArgumentList([Argument(LiteralExpression(SyntaxKind.FalseLiteralExpression))]));
                     }
 
                     invocation = AwaitExpression(invocation);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -604,9 +604,9 @@ internal sealed partial class CSharpExtractMethodService
                 }
 
                 var invocation = (ExpressionSyntax)InvocationExpression(methodExpression, ArgumentList([.. arguments]));
-                if (this.SelectionResult.CreateAsyncMethod())
+                if (this.SelectionResult.ContainsAwaitExpression())
                 {
-                    if (this.SelectionResult.ShouldCallConfigureAwaitFalse())
+                    if (this.SelectionResult.ContainsConfigureAwaitFalse())
                     {
                         if (this.GetFinalReturnType()
                                 .GetMembers(nameof(Task.ConfigureAwait))

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -89,7 +89,7 @@ internal sealed partial class CSharpExtractMethodService
                     attributes: [],
                     accessibility: Accessibility.Private,
                     modifiers: CreateMethodModifiers(),
-                    returnType: AnalyzerResult.ReturnType,
+                    returnType: this.GetFinalReturnType(),
                     refKind: AnalyzerResult.ReturnsByRef ? RefKind.Ref : RefKind.None,
                     explicitInterfaceImplementations: default,
                     name: _methodName.ToString(),
@@ -608,11 +608,9 @@ internal sealed partial class CSharpExtractMethodService
                 {
                     if (this.SelectionResult.ShouldCallConfigureAwaitFalse())
                     {
-                        if (AnalyzerResult.ReturnType.GetMembers().Any(static x => x is IMethodSymbol
-                            {
-                                Name: nameof(Task.ConfigureAwait),
-                                Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }],
-                            }))
+                        if (this.GetFinalReturnType()
+                                .GetMembers(nameof(Task.ConfigureAwait))
+                                .Any(static x => x is IMethodSymbol { Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }] }))
                         {
                             invocation = InvocationExpression(
                                 MemberAccessExpression(

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
@@ -27,17 +27,13 @@ internal sealed partial class CSharpExtractMethodService
             : CSharpSelectionResult(document, selectionType, finalSpan)
         {
             public override bool ContainingScopeHasAsyncKeyword()
-            {
-                var node = GetContainingScope();
-
-                return node switch
+                => GetContainingScope() switch
                 {
                     MethodDeclarationSyntax method => method.Modifiers.Any(SyntaxKind.AsyncKeyword),
                     LocalFunctionStatementSyntax localFunction => localFunction.Modifiers.Any(SyntaxKind.AsyncKeyword),
                     AnonymousFunctionExpressionSyntax anonymousFunction => anonymousFunction.AsyncKeyword != default,
                     _ => false,
                 };
-            }
 
             public override SyntaxNode GetContainingScope()
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
@@ -10,10 +10,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.ExtractMethod;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -66,27 +64,6 @@ internal sealed partial class CSharpExtractMethodService
             return node is RefExpressionSyntax refExpression
                 ? refExpression.Expression
                 : node;
-        }
-
-        protected override bool UnderAnonymousOrLocalMethod(SyntaxToken token, SyntaxToken firstToken, SyntaxToken lastToken)
-            => IsUnderAnonymousOrLocalMethod(token, firstToken, lastToken);
-
-        public static bool IsUnderAnonymousOrLocalMethod(SyntaxToken token, SyntaxToken firstToken, SyntaxToken lastToken)
-        {
-            for (var current = token.Parent; current != null; current = current.Parent)
-            {
-                if (current is MemberDeclarationSyntax)
-                    return false;
-
-                if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax)
-                {
-                    // make sure the selection contains the lambda
-                    return firstToken.SpanStart <= current.GetFirstToken().SpanStart &&
-                        current.GetLastToken().Span.End <= lastToken.Span.End;
-                }
-            }
-
-            return false;
         }
 
         public override StatementSyntax GetFirstStatementUnderContainer()

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
@@ -4,13 +4,12 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExtractMethod;
 
@@ -27,7 +26,6 @@ internal abstract partial class AbstractExtractMethodService<
             ImmutableArray<VariableInfo> variables,
             ITypeSymbol returnType,
             bool returnsByRef,
-            bool awaitTaskReturn,
             bool instanceMemberIsUsed,
             bool shouldBeReadOnly,
             bool endOfSelectionReachable,
@@ -52,12 +50,16 @@ internal abstract partial class AbstractExtractMethodService<
             /// </summary>
             public bool EndOfSelectionReachable { get; } = endOfSelectionReachable;
 
-            /// <summary>
-            /// flag to show whether task return type is due to await
-            /// </summary>
-            public bool AwaitTaskReturn { get; } = awaitTaskReturn;
+            // <summary>
+            // flag to show whether task return type is due to await
+            // </summary>
+            //public bool AwaitTaskReturn { get; } = awaitTaskReturn;
 
-            public ITypeSymbol ReturnType { get; } = returnType;
+            /// <summary>
+            /// Initial computed return type for the extract method.  This does not include any wrapping in a type like
+            /// <see cref="Task{TResult}"/> for async methods.
+            /// </summary>
+            public ITypeSymbol CoreReturnType { get; } = returnType;
             public bool ReturnsByRef { get; } = returnsByRef;
 
             /// <summary>
@@ -67,13 +69,8 @@ internal abstract partial class AbstractExtractMethodService<
 
             public ImmutableArray<VariableInfo> Variables { get; } = variables;
 
-            public bool HasReturnType
-            {
-                get
-                {
-                    return ReturnType.SpecialType != SpecialType.System_Void && !AwaitTaskReturn;
-                }
-            }
+            //public bool IsVoidMethod
+            //    => ReturnType.SpecialType == SpecialType.System_Void;
 
             public ImmutableArray<VariableInfo> GetVariablesToSplitOrMoveIntoMethodDefinition()
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
@@ -50,11 +50,6 @@ internal abstract partial class AbstractExtractMethodService<
             /// </summary>
             public bool EndOfSelectionReachable { get; } = endOfSelectionReachable;
 
-            // <summary>
-            // flag to show whether task return type is due to await
-            // </summary>
-            //public bool AwaitTaskReturn { get; } = awaitTaskReturn;
-
             /// <summary>
             /// Initial computed return type for the extract method.  This does not include any wrapping in a type like
             /// <see cref="Task{TResult}"/> for async methods.
@@ -68,9 +63,6 @@ internal abstract partial class AbstractExtractMethodService<
             public OperationStatus Status { get; } = status;
 
             public ImmutableArray<VariableInfo> Variables { get; } = variables;
-
-            //public bool IsVoidMethod
-            //    => ReturnType.SpecialType == SpecialType.System_Void;
 
             public ImmutableArray<VariableInfo> GetVariablesToSplitOrMoveIntoMethodDefinition()
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -54,6 +55,8 @@ internal abstract partial class AbstractExtractMethodService<
             protected readonly TCodeGenerationOptions Options;
 
             protected readonly bool LocalFunction;
+
+            private ITypeSymbol? _finalReturnType;
 
             protected CodeGenerator(
                 SelectionResult selectionResult,
@@ -359,14 +362,25 @@ internal abstract partial class AbstractExtractMethodService<
                     _ => RefKind.None
                 };
 
-            protected TStatementSyntax GetStatementContainingInvocationToExtractedMethodWorker()
+            protected TExecutableStatementSyntax GetStatementContainingInvocationToExtractedMethodWorker()
             {
                 var callSignature = CreateCallSignature();
 
                 var generator = this.SemanticDocument.Document.GetRequiredLanguageService<SyntaxGenerator>();
-                return AnalyzerResult.HasReturnType
-                    ? (TStatementSyntax)generator.ReturnStatement(callSignature)
-                    : (TStatementSyntax)generator.ExpressionStatement(callSignature);
+
+                return AnalyzerResult.CoreReturnType.SpecialType != SpecialType.System_Void
+                    ? (TExecutableStatementSyntax)generator.ReturnStatement(callSignature)
+                    : (TExecutableStatementSyntax)generator.ExpressionStatement(callSignature);
+            }
+
+            public ITypeSymbol GetFinalReturnType()
+            {
+                return _finalReturnType ??= ComputeFinalReturnType();
+            }
+
+            private ITypeSymbol ComputeFinalReturnType()
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -56,7 +56,7 @@ internal abstract partial class AbstractExtractMethodService<
 
             protected readonly bool LocalFunction;
 
-            private ITypeSymbol? _finalReturnType;
+            private ITypeSymbol _finalReturnType;
 
             protected CodeGenerator(
                 SelectionResult selectionResult,

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.cs
@@ -208,7 +208,7 @@ internal abstract partial class AbstractExtractMethodService<
                     return status;
             }
 
-            return status.With(CheckType(semanticModel, analyzeResult.ReturnType));
+            return status.With(CheckType(semanticModel, analyzeResult.CoreReturnType));
         }
 
         private OperationStatus CheckType(

--- a/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
@@ -47,8 +47,6 @@ internal abstract partial class AbstractExtractMethodService<
         /// </summary>
         private ControlFlowAnalysis? _statementControlFlowAnalysis;
 
-        // protected abstract bool UnderAnonymousOrLocalMethod(SyntaxToken token, SyntaxToken firstToken, SyntaxToken lastToken);
-
         public abstract TExecutableStatementSyntax GetFirstStatementUnderContainer();
         public abstract TExecutableStatementSyntax GetLastStatementUnderContainer();
 

--- a/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
@@ -144,7 +144,7 @@ internal abstract partial class AbstractExtractMethodService<
                 if (syntaxFacts.IsAnonymousOrLocalFunction(current))
                     continue;
 
-                if (predicate(syntaxFacts, current))
+                if (current.Span.OverlapsWith(span) && predicate(syntaxFacts, current))
                     return true;
 
                 // Only dive into child nodes within the span being extracted.

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.ExpressionCodeGenerator.vb
@@ -86,15 +86,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         End If
                     End Function
 
-                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
-                        Return Me.SelectionResult.GetContainingScopeOf(Of ExecutableStatementSyntax)()
+                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As StatementSyntax
+                        Return Me.SelectionResult.GetContainingScopeOf(Of StatementSyntax)()
                     End Function
 
-                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
+                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As StatementSyntax
                         Return GetFirstStatementOrInitializerSelectedAtCallSite()
                     End Function
 
-                    Protected Overrides Async Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of ExecutableStatementSyntax)
+                    Protected Overrides Async Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
                         Dim enclosingStatement = GetFirstStatementOrInitializerSelectedAtCallSite()
                         Dim callSignature = CreateCallSignature().WithAdditionalAnnotations(CallSiteAnnotation)
 
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Dim updatedDocument = Await Me.SemanticDocument.Document.ReplaceNodeAsync(enclosingStatement, newEnclosingStatement, cancellationToken).ConfigureAwait(False)
                         Dim updatedRoot = Await updatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
 
-                        newEnclosingStatement = DirectCast(updatedRoot.GetAnnotatedNodesAndTokens(enclosingStatementAnnotation).Single().AsNode(), ExecutableStatementSyntax)
+                        newEnclosingStatement = DirectCast(updatedRoot.GetAnnotatedNodesAndTokens(enclosingStatementAnnotation).Single().AsNode(), StatementSyntax)
 
                         ' because of the complexification we cannot guarantee that there is only one annotation.
                         ' however complexification of names is prepended, so the last annotation should be the original one.

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
@@ -49,16 +49,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Return nodes.ToImmutableArray()
                     End Function
 
-                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
+                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As StatementSyntax
                         Return Me.SelectionResult.GetFirstStatementUnderContainer()
                     End Function
 
-                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
+                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As StatementSyntax
                         Return Me.SelectionResult.GetLastStatementUnderContainer()
                     End Function
 
-                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of ExecutableStatementSyntax)
-                        Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
+                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
+                        Return Task.FromResult(Of StatementSyntax)(
+                            GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
                     End Function
                 End Class
             End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.MultipleStatementsCodeGenerator.vb
@@ -43,21 +43,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Contract.ThrowIfFalse(lastStatementIndex >= 0)
 
                         Dim nodes = statements.
-                                    Skip(firstStatementIndex).
-                                    Take(lastStatementIndex - firstStatementIndex + 1)
+                            Skip(firstStatementIndex).
+                            Take(lastStatementIndex - firstStatementIndex + 1)
 
                         Return nodes.ToImmutableArray()
                     End Function
 
-                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As StatementSyntax
+                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
                         Return Me.SelectionResult.GetFirstStatementUnderContainer()
                     End Function
 
-                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As StatementSyntax
+                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
                         Return Me.SelectionResult.GetLastStatementUnderContainer()
                     End Function
 
-                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
+                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of ExecutableStatementSyntax)
                         Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
                     End Function
                 End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
@@ -37,17 +37,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Return ImmutableArray.Create(Of StatementSyntax)(Me.SelectionResult.GetFirstStatement())
                     End Function
 
-                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As StatementSyntax
+                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
                         Return Me.SelectionResult.GetFirstStatement()
                     End Function
 
-                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As StatementSyntax
+                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
                         ' it is a single statement case. either first statement is same as last statement or
                         ' last statement belongs (embedded statement) to the first statement.
                         Return Me.SelectionResult.GetFirstStatement()
                     End Function
 
-                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
+                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of ExecutableStatementSyntax)
                         Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
                     End Function
                 End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.SingleStatementCodeGenerator.vb
@@ -37,18 +37,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                         Return ImmutableArray.Create(Of StatementSyntax)(Me.SelectionResult.GetFirstStatement())
                     End Function
 
-                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
+                    Protected Overrides Function GetFirstStatementOrInitializerSelectedAtCallSite() As StatementSyntax
                         Return Me.SelectionResult.GetFirstStatement()
                     End Function
 
-                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As ExecutableStatementSyntax
+                    Protected Overrides Function GetLastStatementOrInitializerSelectedAtCallSite() As StatementSyntax
                         ' it is a single statement case. either first statement is same as last statement or
                         ' last statement belongs (embedded statement) to the first statement.
                         Return Me.SelectionResult.GetFirstStatement()
                     End Function
 
-                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of ExecutableStatementSyntax)
-                        Return Task.FromResult(GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
+                    Protected Overrides Function GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(cancellationToken As CancellationToken) As Task(Of StatementSyntax)
+                        Return Task.FromResult(Of StatementSyntax)(
+                            GetStatementContainingInvocationToExtractedMethodWorker().WithAdditionalAnnotations(CallSiteAnnotation))
                     End Function
                 End Class
             End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
     Partial Friend NotInheritable Class VisualBasicExtractMethodService
         Partial Friend Class VisualBasicMethodExtractor
             Partial Private MustInherit Class VisualBasicCodeGenerator
-                Inherits CodeGenerator(Of ExecutableStatementSyntax, VisualBasicCodeGenerationOptions)
+                Inherits CodeGenerator(Of StatementSyntax, VisualBasicCodeGenerationOptions)
 
                 Private ReadOnly _methodName As SyntaxToken
 

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -43,27 +43,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 MyBase.New(document, selectionType, finalSpan)
             End Sub
 
-            Protected Overrides Function UnderAnonymousOrLocalMethod(token As SyntaxToken, firstToken As SyntaxToken, lastToken As SyntaxToken) As Boolean
-                Dim current = token.Parent
-
-                While current IsNot Nothing
-                    If TypeOf current Is DeclarationStatementSyntax OrElse
-                       TypeOf current Is LambdaExpressionSyntax Then
-                        Exit While
-                    End If
-
-                    current = current.Parent
-                End While
-
-                If current Is Nothing OrElse TypeOf current Is DeclarationStatementSyntax Then
-                    Return False
-                End If
-
-                ' make sure selection contains the lambda
-                Return firstToken.SpanStart <= current.GetFirstToken().SpanStart AndAlso
-                       current.GetLastToken().Span.End <= lastToken.Span.End
-            End Function
-
             Public Overrides Function GetOutermostCallSiteContainerToProcess(cancellationToken As CancellationToken) As SyntaxNode
                 If Me.IsExtractMethodOnExpression Then
                     Dim container = Me.InnermostStatementContainer()


### PR DESCRIPTION
The goal here is to have the internal model for EM store the true type of the value returned by the extract method, as a distinct concept from what the final return-type might be (which might be wrapped in something like 'Task<T>').

This benefits the work being down in another branch to extract methods with complex flow control, but allowing manipulation of the original return type, a new return value for flow control purposes, and then any wrapping that needs to happen around that.  