### PR TITLE
Do not offer to to convert `new X(e)` to `[.. e]` when the type does not fullfill the collection expr pattern.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForNewDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForNewDiagnosticAnalyzer.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -51,13 +53,13 @@ internal sealed partial class CSharpUseCollectionExpressionForNewDiagnosticAnaly
             return;
 
         var symbol = semanticModel.GetSymbolInfo(objectCreationExpression, cancellationToken).Symbol;
-        if (symbol is not IMethodSymbol { MethodKind: MethodKind.Constructor, Parameters: [var parameter] } ||
-            parameter.Type.Name != nameof(IEnumerable<int>))
+        if (symbol is not IMethodSymbol { MethodKind: MethodKind.Constructor, Parameters: [var constructorParameter] } ||
+            constructorParameter.Type.Name != nameof(IEnumerable<int>))
         {
             return;
         }
 
-        if (!Equals(compilation.IEnumerableOfTType(), parameter.Type.OriginalDefinition))
+        if (!Equals(compilation.IEnumerableOfTType(), constructorParameter.Type.OriginalDefinition))
             return;
 
         if (!IsArgumentCompatibleWithIEnumerableOfT(semanticModel, argument, out var unwrapArgument, out var useSpread, cancellationToken))
@@ -67,6 +69,21 @@ internal sealed partial class CSharpUseCollectionExpressionForNewDiagnosticAnaly
         var allowSemanticsChange = option.Value is CollectionExpressionPreference.WhenTypesLooselyMatch;
         if (!CanReplaceWithCollectionExpression(
                 semanticModel, objectCreationExpression, expressionType, isSingletonInstance: false, allowSemanticsChange, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+        {
+            return;
+        }
+
+        // Because we want to replacing a `new X(enumerable)` with `[.. enumerable]` we need to make sure that the final
+        // type supports the collection initialization pattern (specifically that it exposes an Add method that takes
+        // the element type).  This prevents us from working on certain types that do allow the former form but not the
+        // latter.
+        // If the constructor took an IEnumerable<T>, ensure we find a `public Add(T)` method on the type.
+        var constructorParameterTypeArg = constructorParameter.Type.GetTypeArguments().Single();
+        if (!symbol.ContainingType
+                .GetMembers(nameof(IList.Add))
+                .OfType<IMethodSymbol>()
+                .Any(m => m is { DeclaredAccessibility: Accessibility.Public, IsStatic: false, Parameters: [var addParameter] } &&
+                        addParameter.Type.Equals(constructorParameterTypeArg)))
         {
             return;
         }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForNewDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForNewDiagnosticAnalyzer.cs
@@ -73,7 +73,7 @@ internal sealed partial class CSharpUseCollectionExpressionForNewDiagnosticAnaly
             return;
         }
 
-        // Because we want to replacing a `new X(enumerable)` with `[.. enumerable]` we need to make sure that the final
+        // Because we want to replace `new X(enumerable)` with `[.. enumerable]` we need to make sure that the final
         // type supports the collection initialization pattern (specifically that it exposes an Add method that takes
         // the element type).  This prevents us from working on certain types that do allow the former form but not the
         // latter.

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForNewTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForNewTests.cs
@@ -94,4 +94,27 @@ public sealed class UseCollectionExpressionForNewTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76683")]
+    public async Task TestNotOnStack()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                using System.Collections.Immutable;
+                
+                class C
+                {
+                    Stack<T> GetNumbers<T>(T[] values)
+                    {
+                        return new Stack<T>(values);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -5941,4 +5941,27 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76683")]
+    public async Task TestNotOnStack()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                using System.Collections.Immutable;
+                
+                class C
+                {
+                    Stack<T> GetNumbers<T>(T[] values)
+                    {
+                        return new Stack<T>(values);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76683