### PR TITLE
WIP: See what happens when switching CompletionItem properties to have object as the value type instead of string

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -404,7 +404,7 @@ internal sealed class CompletionSource : IAsyncExpandingCompletionSource
 
         var suggestionItemOptions = new AsyncCompletionData.SuggestionItemOptions(
             completionList.SuggestionModeItem.DisplayText,
-            completionList.SuggestionModeItem.TryGetProperty(CommonCompletionItem.DescriptionProperty, out var description) ? description : string.Empty);
+            completionList.SuggestionModeItem.TryGetObjectProperty<CompletionDescription>(CommonCompletionItem.DescriptionProperty, out var description) ? description.Text : string.Empty);
 
         return (new(completionItemList, suggestionItemOptions, selectionHint: AsyncCompletionData.InitialSelectionHint.SoftSelection, filters, isIncomplete: false, null), completionList);
     }

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -127,7 +127,7 @@ public sealed class CompletionItem : IComparable<CompletionItem>
         return false;
     }
 
-    internal bool TryGetObjectProperty<ValueType>(string name, [NotNullWhen(true)] out ValueType? value)
+    internal bool TryGetObjectProperty<TValue>(string name, [NotNullWhen(true)] out TValue? value)
     {
         // Don't search in _lazyPropertiesAsImmutableDictionary as TryGetProperty does
         // as that contains the objects converted to strings
@@ -135,7 +135,7 @@ public sealed class CompletionItem : IComparable<CompletionItem>
         {
             if (name == propName)
             {
-                value = (ValueType)propValue;
+                value = (TValue)propValue;
                 return true;
             }
         }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -97,18 +97,18 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
         var leftToken = syntaxContext.LeftToken;
         var declaration = GetAsyncSupportingDeclaration(leftToken, position);
 
-        using var builder = TemporaryArray<KeyValuePair<string, string>>.Empty;
+        using var builder = TemporaryArray<KeyValuePair<string, object>>.Empty;
 
-        builder.Add(KeyValuePairUtil.Create(Position, position.ToString()));
-        builder.Add(KeyValuePairUtil.Create(LeftTokenPosition, leftToken.SpanStart.ToString()));
+        builder.Add(KeyValuePairUtil.Create<string, object>(Position, position.ToString()));
+        builder.Add(KeyValuePairUtil.Create<string, object>(LeftTokenPosition, leftToken.SpanStart.ToString()));
 
         var makeContainerAsync = declaration is not null && !SyntaxGenerator.GetGenerator(document).GetModifiers(declaration).IsAsync;
         if (makeContainerAsync)
-            builder.Add(KeyValuePairUtil.Create(MakeContainerAsync, string.Empty));
+            builder.Add(KeyValuePairUtil.Create<string, object>(MakeContainerAsync, string.Empty));
 
         if (isAwaitKeywordContext)
         {
-            builder.Add(KeyValuePairUtil.Create(AddAwaitAtCurrentPosition, string.Empty));
+            builder.Add(KeyValuePairUtil.Create<string, object>(AddAwaitAtCurrentPosition, string.Empty));
             var properties = builder.ToImmutableAndClear();
 
             context.AddItem(CreateCompletionItem(
@@ -133,7 +133,7 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
             if (dotAwaitContext == DotAwaitContext.AwaitAndConfigureAwait)
             {
                 // add the `awaitf` option to do the same, but also add .ConfigureAwait(false);
-                properties = properties.Add(KeyValuePairUtil.Create(AppendConfigureAwait, string.Empty));
+                properties = properties.Add(KeyValuePairUtil.Create<string, object>(AppendConfigureAwait, string.Empty));
                 context.AddItem(CreateCompletionItem(
                     properties, _awaitfDisplayText, _awaitfFilterText,
                     string.Format(FeaturesResources.Await_the_preceding_expression_and_add_ConfigureAwait_0, _falseKeyword),
@@ -145,7 +145,7 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
         return;
 
         static CompletionItem CreateCompletionItem(
-            ImmutableArray<KeyValuePair<string, string>> completionProperties, string displayText, string filterText, string tooltip, bool isComplexTextEdit, bool appendConfigureAwait)
+            ImmutableArray<KeyValuePair<string, object>> completionProperties, string displayText, string filterText, string tooltip, bool isComplexTextEdit, bool appendConfigureAwait)
         {
             var description = appendConfigureAwait
                 ? [new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, tooltip)]

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -151,13 +151,12 @@ internal abstract class AbstractInternalsVisibleToCompletionProvider : LSPComple
                 continue;
             }
 
-            var projectGuid = project.Id.Id.ToString();
             var completionItem = CommonCompletionItem.Create(
                 displayText: project.AssemblyName,
                 displayTextSuffix: "",
                 rules: CompletionItemRules.Default,
                 glyph: project.GetGlyph(),
-                properties: [KeyValuePairUtil.Create(ProjectGuidKey, projectGuid)]);
+                properties: [KeyValuePairUtil.Create<string, object>(ProjectGuidKey, project.Id.Id)]);
             context.AddItem(completionItem);
         }
 
@@ -267,8 +266,8 @@ internal abstract class AbstractInternalsVisibleToCompletionProvider : LSPComple
 
     public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey = null, CancellationToken cancellationToken = default)
     {
-        var projectIdGuid = item.GetProperty(ProjectGuidKey);
-        var projectId = ProjectId.CreateFromSerialized(new Guid(projectIdGuid));
+        item.TryGetObjectProperty<Guid>(ProjectGuidKey, out var projectIdGuid);
+        var projectId = ProjectId.CreateFromSerialized(projectIdGuid);
         var project = document.Project.Solution.GetRequiredProject(projectId);
         var assemblyName = item.DisplayText;
         var publicKey = await GetPublicKeyOfProjectAsync(project, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
@@ -39,27 +39,27 @@ internal static class ImportCompletionItem
         (string methodSymbolKey, string receiverTypeSymbolKey, int overloadCount)? extensionMethodData,
         bool includedInTargetTypeCompletion = false)
     {
-        ImmutableArray<KeyValuePair<string, string>> properties = default;
+        ImmutableArray<KeyValuePair<string, object>> properties = default;
 
         if (extensionMethodData != null || arity > 0)
         {
-            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
+            using var _ = ArrayBuilder<KeyValuePair<string, object>>.GetInstance(out var builder);
 
             if (extensionMethodData.HasValue)
             {
-                builder.Add(KeyValuePairUtil.Create(MethodKey, extensionMethodData.Value.methodSymbolKey));
-                builder.Add(KeyValuePairUtil.Create(ReceiverKey, extensionMethodData.Value.receiverTypeSymbolKey));
+                builder.Add(KeyValuePairUtil.Create<string, object>(MethodKey, extensionMethodData.Value.methodSymbolKey));
+                builder.Add(KeyValuePairUtil.Create<string, object>(ReceiverKey, extensionMethodData.Value.receiverTypeSymbolKey));
 
                 if (extensionMethodData.Value.overloadCount > 0)
                 {
-                    builder.Add(KeyValuePairUtil.Create(OverloadCountKey, extensionMethodData.Value.overloadCount.ToString()));
+                    builder.Add(KeyValuePairUtil.Create<string, object>(OverloadCountKey, extensionMethodData.Value.overloadCount.ToString()));
                 }
             }
             else
             {
                 // We don't need arity to recover symbol if we already have SymbolKeyData or it's 0.
                 // (but it still needed below to decide whether to show generic suffix)
-                builder.Add(KeyValuePairUtil.Create(TypeAritySuffixName, ArityUtilities.GetMetadataAritySuffix(arity)));
+                builder.Add(KeyValuePairUtil.Create<string, object>(TypeAritySuffixName, ArityUtilities.GetMetadataAritySuffix(arity)));
             }
 
             properties = builder.ToImmutable();
@@ -98,9 +98,9 @@ internal static class ImportCompletionItem
         var attributeItems = attributeItem.GetProperties();
 
         // Remember the full type name so we can get the symbol when description is displayed.
-        var builder = new FixedSizeArrayBuilder<KeyValuePair<string, string>>(attributeItems.Length + 1);
+        var builder = new FixedSizeArrayBuilder<KeyValuePair<string, object>>(attributeItems.Length + 1);
         builder.AddRange(attributeItems);
-        builder.Add(KeyValuePairUtil.Create(AttributeFullName, attributeItem.DisplayText));
+        builder.Add(KeyValuePairUtil.Create<string, object>(AttributeFullName, attributeItem.DisplayText));
 
         var sortTextBuilder = PooledStringBuilder.GetInstance();
         sortTextBuilder.Builder.AppendFormat(GetSortTextFormatString(attributeItem.InlineDescription), attributeNameWithoutSuffix, attributeItem.InlineDescription);
@@ -220,7 +220,7 @@ internal static class ImportCompletionItem
     public static CompletionItem MarkItemToAlwaysFullyQualify(CompletionItem item)
     {
         var itemProperties = item.GetProperties();
-        ImmutableArray<KeyValuePair<string, string>> properties = [.. itemProperties, KeyValuePairUtil.Create(AlwaysFullyQualifyKey, AlwaysFullyQualifyKey)];
+        ImmutableArray<KeyValuePair<string, object>> properties = [.. itemProperties, KeyValuePairUtil.Create<string, object>(AlwaysFullyQualifyKey, AlwaysFullyQualifyKey)];
         return item.WithProperties(properties);
     }
 

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
@@ -31,8 +31,8 @@ internal sealed class SnippetCompletionItem
             sortText: snippetIdentifier + " ",
             filterText: snippetIdentifier,
             properties: [
-                KeyValuePairUtil.Create("Position", position.ToString()),
-                KeyValuePairUtil.Create(SnippetIdentifierKey, snippetIdentifier)],
+                KeyValuePairUtil.Create<string, object>("Position", position.ToString()),
+                KeyValuePairUtil.Create<string, object>(SnippetIdentifierKey, snippetIdentifier)],
             isComplexTextEdit: true,
             inlineDescription: inlineDescription,
             rules: CompletionItemRules.Default)

--- a/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
@@ -23,8 +23,8 @@ internal static class XmlDocCommentCompletionItem
             displayTextSuffix: "",
             glyph: Glyph.Keyword,
             properties: [
-                KeyValuePairUtil.Create(BeforeCaretText, beforeCaretText),
-                KeyValuePairUtil.Create(AfterCaretText, afterCaretText)],
+                KeyValuePairUtil.Create<string, object>(BeforeCaretText, beforeCaretText),
+                KeyValuePairUtil.Create<string, object>(AfterCaretText, afterCaretText)],
             rules: rules,
             isComplexTextEdit: true);
     }

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -103,7 +103,7 @@ internal sealed partial class DateAndTimeEmbeddedCompletionProvider(DateAndTimeE
         if (items.Count == 0)
             return;
 
-        using var _2 = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var properties);
+        using var _2 = ArrayBuilder<KeyValuePair<string, object>>.GetInstance(out var properties);
         foreach (var embeddedItem in items)
         {
             properties.Clear();

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
@@ -89,7 +89,7 @@ internal sealed partial class RegexEmbeddedCompletionProvider(RegexEmbeddedLangu
             return;
         }
 
-        using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var properties);
+        using var _ = ArrayBuilder<KeyValuePair<string, object>>.GetInstance(out var properties);
         foreach (var embeddedItem in embeddedContext.Items)
         {
             properties.Clear();
@@ -97,15 +97,15 @@ internal sealed partial class RegexEmbeddedCompletionProvider(RegexEmbeddedLangu
             var change = embeddedItem.Change;
             var textChange = change.TextChange;
 
-            properties.Add(KeyValuePairUtil.Create(StartKey, textChange.Span.Start.ToString()));
-            properties.Add(KeyValuePairUtil.Create(LengthKey, textChange.Span.Length.ToString()));
-            properties.Add(KeyValuePairUtil.Create(NewTextKey, textChange.NewText));
-            properties.Add(KeyValuePairUtil.Create(DescriptionKey, embeddedItem.FullDescription));
-            properties.Add(KeyValuePairUtil.Create(AbstractAggregateEmbeddedLanguageCompletionProvider.EmbeddedProviderName, Name));
+            properties.Add(KeyValuePairUtil.Create<string, object>(StartKey, textChange.Span.Start.ToString()));
+            properties.Add(KeyValuePairUtil.Create<string, object>(LengthKey, textChange.Span.Length.ToString()));
+            properties.Add(KeyValuePairUtil.Create<string, object>(NewTextKey, textChange.NewText));
+            properties.Add(KeyValuePairUtil.Create<string, object>(DescriptionKey, embeddedItem.FullDescription));
+            properties.Add(KeyValuePairUtil.Create<string, object>(AbstractAggregateEmbeddedLanguageCompletionProvider.EmbeddedProviderName, Name));
 
             if (change.NewPosition != null)
             {
-                properties.Add(new KeyValuePair<string, string>(NewPositionKey, change.NewPosition.ToString()));
+                properties.Add(new KeyValuePair<string, object>(NewPositionKey, change.NewPosition.ToString()));
             }
 
             // Keep everything sorted in the order we just produced the items in.

--- a/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api;
 
@@ -30,7 +29,7 @@ internal abstract class PythiaCompletionProviderBase : CommonCompletionProvider,
         ImmutableDictionary<string, string>? properties = null,
         ImmutableArray<string> tags = default,
         string? inlineDescription = null)
-        => CommonCompletionItem.Create(displayText, displayTextSuffix, rules, (Glyph?)glyph, description, sortText, filterText, showsWarningIcon, properties.AsImmutableOrNull(), tags, inlineDescription);
+        => CommonCompletionItem.Create(displayText, displayTextSuffix, rules, (Glyph?)glyph, description, sortText, filterText, showsWarningIcon, CompletionItem.ConvertToArrayWithObjectValues(properties), tags, inlineDescription);
 
     public static CompletionItem CreateSymbolCompletionItem(
         string displayText,

--- a/src/VisualStudio/ExternalAccess/FSharp/Completion/FSharpCommonCompletionItem.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/Completion/FSharpCommonCompletionItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
         {
             var roslynGlyph = glyph.HasValue ? FSharpGlyphHelpers.ConvertTo(glyph.Value) : (Glyph?)null;
             return CommonCompletionItem.Create(
-                displayText, displayTextSuffix, rules, roslynGlyph, description, sortText, filterText, showsWarningIcon, properties.AsImmutableOrNull(), tags, inlineDescription);
+                displayText, displayTextSuffix, rules, roslynGlyph, description, sortText, filterText, showsWarningIcon, CompletionItem.ConvertToArrayWithObjectValues(properties), tags, inlineDescription);
         }
     }
 }


### PR DESCRIPTION
There are perf implications for having our CompletionItem properties be typed to string values. Creating this as a draft PR to get some perf numbers with the property value changed to object.

Will add more details if the ci passes tests, the test insertion PR numbers come back good, and Cyrus indicates there isn't a reason preventing this change.