### PR TITLE
Adding checks for mutable structs.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
@@ -135,6 +135,15 @@ internal sealed class CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer(
         if (invokedMethod.IsPartialDefinition && invokedMethod.PartialImplementationPart is null)
             return;
 
+        // Check if the invoked method is a member of a struct. If it is, and it is not readonly and the invoked method
+        // is not readonly, then we don't want to convert it to a method group. If we did, we may accidently change the
+        // behaviour of the code, since structs are value types and the method group will be copied rather than referenced.
+        if (invokedMethod.ContainingType?.TypeKind == TypeKind.Struct)
+        {
+            if (!invokedMethod.IsReadOnly && !invokedMethod.ContainingType.IsReadOnly)
+                return;
+        }
+
         // If we're calling a generic method, we have to have supplied type arguments.  They cannot be inferred once
         // we remove the arguments during simplification.
         var invokedTypeArguments = invokedExpression.GetRightmostName() is GenericNameSyntax genericName

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
@@ -138,11 +138,8 @@ internal sealed class CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer(
         // Check if the invoked method is a member of a struct. If it is, and it is not readonly and the invoked method
         // is not readonly, then we don't want to convert it to a method group. If we did, we may accidently change the
         // behaviour of the code, since structs are value types and the method group will be copied rather than referenced.
-        if (invokedMethod.ContainingType?.TypeKind == TypeKind.Struct)
-        {
-            if (!invokedMethod.IsReadOnly && !invokedMethod.ContainingType.IsReadOnly)
-                return;
-        }
+        if (invokedMethod.ContainingType.TypeKind == TypeKind.Struct && !invokedMethod.IsReadOnly && !invokedMethod.ContainingType.IsReadOnly)
+            return;
 
         // If we're calling a generic method, we have to have supplied type arguments.  They cannot be inferred once
         // we remove the arguments during simplification.

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
@@ -2102,7 +2102,7 @@ public sealed class RemoveUnnecessaryLambdaExpressionTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66950")]
-    public async Task TestWithMutableStructAndReadonlyMethod()
+    public async Task TestWithNonReadonlyStructAndReadonlyMethod()
     {
         await TestInRegularAndScriptAsync(
             """
@@ -2146,7 +2146,7 @@ public sealed class RemoveUnnecessaryLambdaExpressionTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66950")]
-    public async Task TestWithImmutableStruct()
+    public async Task TestWithReadonlyStruct()
     {
         await TestInRegularAndScriptAsync(
             """

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
@@ -2075,4 +2075,117 @@ public sealed class RemoveUnnecessaryLambdaExpressionTests
             }
             """);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66950")]
+    public async Task TestMissingWithMutableStructs()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+
+            class C
+            {
+                void M1()
+                {
+                    S s = new S();
+                    M2(() => s.M());
+                }
+
+                static void M2(Action a) { }
+            }
+
+            struct S
+            {
+                public void M() { }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66950")]
+    public async Task TestWithMutableStructAndReadonlyMethod()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System;
+
+            class C
+            {
+                void M1()
+                {
+                    S s = new S();
+                    M2([|() => |]s.M());
+                }
+
+                static void M2(Action a) { }
+            }
+
+            struct S
+            {
+                public readonly void M() { }
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                void M1()
+                {
+                    S s = new S();
+                    M2(s.M);
+                }
+
+                static void M2(Action a) { }
+            }
+
+            struct S
+            {
+                public readonly void M() { }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66950")]
+    public async Task TestWithImmutableStruct()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System;
+
+            class C
+            {
+                void M1()
+                {
+                    S s = new S();
+                    M2([|() => |]s.M());
+                }
+
+                static void M2(Action a) { }
+            }
+
+            readonly struct S
+            {
+                public void M() { }
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                void M1()
+                {
+                    S s = new S();
+                    M2(s.M);
+                }
+
+                static void M2(Action a) { }
+            }
+
+            readonly struct S
+            {
+                public void M() { }
+            }
+            """);
+    }
 }


### PR DESCRIPTION
This fixes https://github.com/dotnet/roslyn/issues/66950.

These changes modify IDE0200 so that lambda expressions accessing methods in mutable structs are no longer picked up. If one of either the struct or the instance method are read-only, IDE0200 is still raised.

This PR doesn't add warnings for method group usage with mutable structs.

Unit tests added for coverage and all analyser tests pass.