### PR TITLE
VB: Don't capture conditional access receiver into a temp local during lowering.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -1480,7 +1480,7 @@ lUnsplitAndFinish:
         End Function
 
         Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess) As BoundNode
-            VisitRvalue(node.ReceiverOrCondition)
+            VisitRvalue(node.Receiver)
             Dim savedState As LocalState = Me.State.Clone()
 
             VisitRvalue(node.WhenNotNull)

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundLoweredConditionalAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundLoweredConditionalAccess.vb
@@ -1,0 +1,16 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Namespace Microsoft.CodeAnalysis.VisualBasic
+
+    Partial Friend Class BoundLoweredConditionalAccess
+
+#If DEBUG Then
+        Private Sub Validate()
+            Debug.Assert(Me.PlaceholderId <> 0)
+        End Sub
+#End If
+    End Class
+
+End Namespace

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -1890,9 +1890,13 @@
     <Field Name="Capture" Type="Boolean" Null="NotApplicable"/>
   </Node>
 
+  <!-- 
+       When receiver is of Nullable(Of T) type, the creator of this node is responsible for 
+       checking availability and good-ness of the Nullable(Of T).get_HasValue method
+  -->
   <Node Name="BoundLoweredConditionalAccess" Base="BoundExpression" HasValidate="true">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <Field Name="ReceiverOrCondition" Type="BoundExpression"/>
+    <Field Name="Receiver" Type="BoundExpression"/>
     <Field Name="CaptureReceiver" Type="Boolean" Null="NotApplicable"/>
     <Field Name="PlaceholderId" Type="Integer"/>
     <Field Name="WhenNotNull" Type="BoundExpression"/>

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitAddress.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitAddress.vb
@@ -71,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Case BoundKind.ConditionalAccessReceiverPlaceholder
                     ' do nothing receiver ref must be already pushed
                     Debug.Assert(Not expression.Type.IsReferenceType)
-                    Debug.Assert(Not expression.Type.IsValueType)
+                    Debug.Assert(Not expression.Type.IsValueType OrElse expression.Type.IsNullableType())
 
                 Case BoundKind.ComplexConditionalAccessReceiver
                     EmitComplexConditionalAccessReceiverAddress(DirectCast(expression, BoundComplexConditionalAccessReceiver))
@@ -290,7 +290,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             If expression.Kind = BoundKind.ConditionalAccessReceiverPlaceholder OrElse
                expression.Kind = BoundKind.ComplexConditionalAccessReceiver Then
-                Return addressKind = AddressKind.ReadOnly OrElse addressKind = AddressKind.Immutable
+                Return addressKind = AddressKind.ReadOnly OrElse addressKind = AddressKind.Immutable Or expression.Type.IsNullableType()
             End If
 
             ' taking immutable addresses is ok as long as expression has home

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -248,16 +248,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             Debug.Assert(conditional.WhenNullOpt IsNot Nothing OrElse Not used)
 
-            If conditional.ReceiverOrCondition.Type.IsBooleanType() Then
-                ' This is a trivial case 
-                Debug.Assert(Not conditional.CaptureReceiver)
-                Debug.Assert(conditional.PlaceholderId = 0)
+            Dim receiverTemp As LocalDefinition = Nothing
+
+            Dim receiver As BoundExpression = conditional.Receiver
+            Dim receiverType As TypeSymbol = receiver.Type
+
+            If receiverType.IsNullableType() Then
+
+                If conditional.CaptureReceiver Then
+                    EmitExpression(receiver, used:=True)
+                    receiverTemp = AllocateTemp(receiverType, receiver.Syntax)
+                    _builder.EmitLocalStore(receiverTemp)
+                    _builder.EmitLocalAddress(receiverTemp)
+                Else
+                    receiverTemp = EmitAddress(receiver, addressKind:=AddressKind.Immutable)
+                End If
 
                 Dim doneLabel = New Object()
 
                 Dim consequenceLabel = New Object()
 
-                EmitCondBranch(conditional.ReceiverOrCondition, consequenceLabel, sense:=True)
+                Dim hasValue = DirectCast(Me._module.Compilation.GetSpecialTypeMember(SpecialMember.System_Nullable_T_get_HasValue), MethodSymbol)
+                Debug.Assert(hasValue IsNot Nothing)
+
+                _builder.EmitOpCode(ILOpCode.Call, stackAdjustment:=0)
+                EmitSymbolToken(hasValue.AsMember(DirectCast(receiverType, NamedTypeSymbol)), conditional.Syntax)
+
+                _builder.EmitBranch(ILOpCode.Brtrue, consequenceLabel)
 
                 If conditional.WhenNullOpt IsNot Nothing Then
                     EmitExpression(conditional.WhenNullOpt, used)
@@ -272,13 +289,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 End If
 
                 _builder.MarkLabel(consequenceLabel)
+
+                If receiverTemp Is Nothing Then
+                    receiverTemp = EmitAddress(receiver, addressKind:=AddressKind.Immutable)
+                    Debug.Assert(receiverTemp Is Nothing)
+                Else
+                    _builder.EmitLocalAddress(receiverTemp)
+                End If
+
                 EmitExpression(conditional.WhenNotNull, used)
 
                 _builder.MarkLabel(doneLabel)
             Else
-                Debug.Assert(Not conditional.ReceiverOrCondition.Type.IsValueType)
+                Debug.Assert(Not receiverType.IsValueType)
 
-                Dim receiverTemp As LocalDefinition = Nothing
                 Dim temp As LocalDefinition = Nothing
 
                 ' labels
@@ -287,9 +311,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
                 ' we need a copy if we deal with nonlocal value (to capture the value)
                 ' Or if we have a ref-constrained T (to do box just once)
-                Dim receiver As BoundExpression = conditional.ReceiverOrCondition
-                Dim receiverType As TypeSymbol = receiver.Type
-
                 Debug.Assert(Not (Not receiverType.IsReferenceType AndAlso
                                    Not receiverType.IsValueType AndAlso
                                    Not DirectCast(receiverType, TypeParameterSymbol).HasInterfaceConstraint) OrElse ' This could be a nullable value type, which must be copied in order to not mutate the original value
@@ -392,10 +413,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 If temp IsNot Nothing Then
                     FreeTemp(temp)
                 End If
+            End If
 
-                If receiverTemp IsNot Nothing Then
-                    FreeTemp(receiverTemp)
-                End If
+            If receiverTemp IsNot Nothing Then
+                FreeTemp(receiverTemp)
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
@@ -841,16 +841,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End Function
 
             Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess) As BoundNode
-                If Not node.ReceiverOrCondition.Type.IsBooleanType() Then
-                    ' We may need to load a reference to the receiver, or may need to  
-                    ' reload it after the null check. This won't work well 
-                    ' with a stack local.
-                    EnsureOnlyEvalStack()
-                End If
+                ' We may need to load a reference to the receiver, or may need to  
+                ' reload it after the null check. This won't work well 
+                ' with a stack local.
+                EnsureOnlyEvalStack()
 
                 Dim origStack = StackDepth()
 
-                Dim receiverOrCondition = DirectCast(Me.Visit(node.ReceiverOrCondition), BoundExpression)
+                Dim receiver = DirectCast(Me.Visit(node.Receiver), BoundExpression)
 
                 Dim cookie = GetStackStateCookie()     ' implicit branch here
 
@@ -870,7 +868,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     EnsureStackState(cookie) ' implicit label here
                 End If
 
-                Return node.Update(receiverOrCondition, node.CaptureReceiver, node.PlaceholderId, whenNotNull, whenNull, node.Type)
+                Return node.Update(receiver, node.CaptureReceiver, node.PlaceholderId, whenNotNull, whenNull, node.Type)
             End Function
 
             Public Overrides Function VisitConditionalAccessReceiverPlaceholder(node As BoundConditionalAccessReceiverPlaceholder) As BoundNode

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Rewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Rewriter.vb
@@ -224,7 +224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End Function
 
             Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess) As BoundNode
-                Dim receiverOrCondition As BoundExpression = DirectCast(Me.Visit(node.ReceiverOrCondition), BoundExpression)
+                Dim receiver As BoundExpression = DirectCast(Me.Visit(node.Receiver), BoundExpression)
                 Dim whenNotNull As BoundExpression = DirectCast(Me.Visit(node.WhenNotNull), BoundExpression)
                 Dim whenNullOpt As BoundExpression = node.WhenNullOpt
 
@@ -232,7 +232,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     whenNullOpt = DirectCast(Me.Visit(whenNullOpt), BoundExpression)
                 End If
 
-                Return node.Update(receiverOrCondition, node.CaptureReceiver, node.PlaceholderId, whenNotNull, whenNullOpt, node.Type)
+                Return node.Update(receiver, node.CaptureReceiver, node.PlaceholderId, whenNotNull, whenNullOpt, node.Type)
             End Function
 
         End Class

--- a/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
@@ -9029,14 +9029,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend NotInheritable Class BoundLoweredConditionalAccess
         Inherits BoundExpression
 
-        Public Sub New(syntax As SyntaxNode, receiverOrCondition As BoundExpression, captureReceiver As Boolean, placeholderId As Integer, whenNotNull As BoundExpression, whenNullOpt As BoundExpression, type As TypeSymbol, Optional hasErrors As Boolean = False)
-            MyBase.New(BoundKind.LoweredConditionalAccess, syntax, type, hasErrors OrElse receiverOrCondition.NonNullAndHasErrors() OrElse whenNotNull.NonNullAndHasErrors() OrElse whenNullOpt.NonNullAndHasErrors())
+        Public Sub New(syntax As SyntaxNode, receiver As BoundExpression, captureReceiver As Boolean, placeholderId As Integer, whenNotNull As BoundExpression, whenNullOpt As BoundExpression, type As TypeSymbol, Optional hasErrors As Boolean = False)
+            MyBase.New(BoundKind.LoweredConditionalAccess, syntax, type, hasErrors OrElse receiver.NonNullAndHasErrors() OrElse whenNotNull.NonNullAndHasErrors() OrElse whenNullOpt.NonNullAndHasErrors())
 
-            Debug.Assert(receiverOrCondition IsNot Nothing, "Field 'receiverOrCondition' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
+            Debug.Assert(receiver IsNot Nothing, "Field 'receiver' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
             Debug.Assert(whenNotNull IsNot Nothing, "Field 'whenNotNull' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
             Debug.Assert(type IsNot Nothing, "Field 'type' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
 
-            Me._ReceiverOrCondition = receiverOrCondition
+            Me._Receiver = receiver
             Me._CaptureReceiver = captureReceiver
             Me._PlaceholderId = placeholderId
             Me._WhenNotNull = whenNotNull
@@ -9049,10 +9049,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
 
-        Private ReadOnly _ReceiverOrCondition As BoundExpression
-        Public ReadOnly Property ReceiverOrCondition As BoundExpression
+        Private ReadOnly _Receiver As BoundExpression
+        Public ReadOnly Property Receiver As BoundExpression
             Get
-                Return _ReceiverOrCondition
+                Return _Receiver
             End Get
         End Property
 
@@ -9089,9 +9089,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return visitor.VisitLoweredConditionalAccess(Me)
         End Function
 
-        Public Function Update(receiverOrCondition As BoundExpression, captureReceiver As Boolean, placeholderId As Integer, whenNotNull As BoundExpression, whenNullOpt As BoundExpression, type As TypeSymbol) As BoundLoweredConditionalAccess
-            If receiverOrCondition IsNot Me.ReceiverOrCondition OrElse captureReceiver <> Me.CaptureReceiver OrElse placeholderId <> Me.PlaceholderId OrElse whenNotNull IsNot Me.WhenNotNull OrElse whenNullOpt IsNot Me.WhenNullOpt OrElse type IsNot Me.Type Then
-                Dim result = New BoundLoweredConditionalAccess(Me.Syntax, receiverOrCondition, captureReceiver, placeholderId, whenNotNull, whenNullOpt, type, Me.HasErrors)
+        Public Function Update(receiver As BoundExpression, captureReceiver As Boolean, placeholderId As Integer, whenNotNull As BoundExpression, whenNullOpt As BoundExpression, type As TypeSymbol) As BoundLoweredConditionalAccess
+            If receiver IsNot Me.Receiver OrElse captureReceiver <> Me.CaptureReceiver OrElse placeholderId <> Me.PlaceholderId OrElse whenNotNull IsNot Me.WhenNotNull OrElse whenNullOpt IsNot Me.WhenNullOpt OrElse type IsNot Me.Type Then
+                Dim result = New BoundLoweredConditionalAccess(Me.Syntax, receiver, captureReceiver, placeholderId, whenNotNull, whenNullOpt, type, Me.HasErrors)
                 result.CopyAttributes(Me)
                 Return result
             End If
@@ -12013,7 +12013,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess) As BoundNode
-            Me.Visit(node.ReceiverOrCondition)
+            Me.Visit(node.Receiver)
             Me.Visit(node.WhenNotNull)
             Me.Visit(node.WhenNullOpt)
             Return Nothing
@@ -13097,11 +13097,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess) As BoundNode
-            Dim receiverOrCondition As BoundExpression = DirectCast(Me.Visit(node.ReceiverOrCondition), BoundExpression)
+            Dim receiver As BoundExpression = DirectCast(Me.Visit(node.Receiver), BoundExpression)
             Dim whenNotNull As BoundExpression = DirectCast(Me.Visit(node.WhenNotNull), BoundExpression)
             Dim whenNullOpt As BoundExpression = DirectCast(Me.Visit(node.WhenNullOpt), BoundExpression)
             Dim type as TypeSymbol = Me.VisitType(node.Type)
-            Return node.Update(receiverOrCondition, node.CaptureReceiver, node.PlaceholderId, whenNotNull, whenNullOpt, type)
+            Return node.Update(receiver, node.CaptureReceiver, node.PlaceholderId, whenNotNull, whenNullOpt, type)
         End Function
 
         Public Overrides Function VisitComplexConditionalAccessReceiver(node As BoundComplexConditionalAccessReceiver) As BoundNode
@@ -14554,7 +14554,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess, arg As Object) As TreeDumperNode
             Return New TreeDumperNode("loweredConditionalAccess", Nothing, New TreeDumperNode() {
-                New TreeDumperNode("receiverOrCondition", Nothing, new TreeDumperNode() {Visit(node.ReceiverOrCondition, Nothing)}),
+                New TreeDumperNode("receiver", Nothing, new TreeDumperNode() {Visit(node.Receiver, Nothing)}),
                 New TreeDumperNode("captureReceiver", node.CaptureReceiver, Nothing),
                 New TreeDumperNode("placeholderId", node.PlaceholderId, Nothing),
                 New TreeDumperNode("whenNotNull", Nothing, new TreeDumperNode() {Visit(node.WhenNotNull, Nothing)}),

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -1439,10 +1439,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess) As BoundNode
             Dim result = DirectCast(MyBase.VisitLoweredConditionalAccess(node), BoundLoweredConditionalAccess)
 
-            If Not result.CaptureReceiver AndAlso Not node.ReceiverOrCondition.Type.IsBooleanType() AndAlso
-               node.ReceiverOrCondition.Kind <> result.ReceiverOrCondition.Kind Then
+            If Not result.CaptureReceiver AndAlso
+               node.Receiver.Kind <> result.Receiver.Kind Then
                 ' It looks like the receiver got lifted into a closure, we cannot assume that it will not change between null check and the following access.
-                Return result.Update(result.ReceiverOrCondition, True, result.PlaceholderId, result.WhenNotNull, result.WhenNullOpt, result.Type)
+                Return result.Update(result.Receiver, True, result.PlaceholderId, result.WhenNotNull, result.WhenNullOpt, result.Type)
             Else
                 Return result
             End If

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -12374,6 +12374,509 @@ End Class
             CompileAndVerify(comp1, symbolValidator:=validate).VerifyDiagnostics()
         End Sub
 
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/29634")>
+        Public Sub ConditionalAccessInAsyncMethod_01()
+            Dim source =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Runtime.CompilerServices
+Imports System.Threading.Tasks
+
+#disable warning BC42356 ' This async method lacks 'Await' operators
+
+Module Program
+
+    Public Sub Main()
+
+        Dim result = Test("").GetAwaiter().GetResult()
+        Console.Write("({0})", result)
+
+        result = Test(Nothing).GetAwaiter().GetResult()
+        Console.Write("({0})", result)
+
+        Value = Nothing
+        result = Test("").GetAwaiter().GetResult()
+        Console.Write("({0})", result)
+    End Sub
+
+    Public Async Function Test(input As String) As Task(Of Integer?)
+        Return input?.Parse()?.Truncate()
+    End Function
+
+    Dim Value As Integer? = 3
+
+    <Extension>
+    Public Function Parse(input As String) As Integer?
+	    Console.Write("1")
+        Return Value
+    End Function
+
+    <Extension>
+    Public Function Truncate(value As Integer) As Integer
+	    Console.Write("2")
+        Return value
+    End Function
+
+End Module
+    ]]></file>
+</compilation>
+            Dim c = CreateCompilation(source, options:=TestOptions.DebugExe)
+
+            Dim verifier = CompileAndVerify(c, expectedOutput:="12(3)()1()").VerifyDiagnostics()
+
+            verifier.VerifyIL("Program.VB$StateMachine_2_Test.MoveNext",
+            <![CDATA[
+{
+  // Code size      141 (0x8d)
+  .maxstack  3
+  .locals init (Integer? V_0,
+                Integer V_1,
+                System.Threading.Tasks.Task(Of Integer?) V_2,
+                Integer? V_3,
+                Integer? V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_0006:  stloc.1
+  .try
+  {
+    IL_0007:  nop
+    IL_0008:  ldarg.0
+    IL_0009:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_000e:  brtrue.s   IL_001b
+    IL_0010:  ldloca.s   V_3
+    IL_0012:  initobj    "Integer?"
+    IL_0018:  ldloc.3
+    IL_0019:  br.s       IL_004d
+    IL_001b:  ldarg.0
+    IL_001c:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_0021:  call       "Function Program.Parse(String) As Integer?"
+    IL_0026:  stloc.3
+    IL_0027:  ldloca.s   V_3
+    IL_0029:  call       "Function Integer?.get_HasValue() As Boolean"
+    IL_002e:  brtrue.s   IL_003c
+    IL_0030:  ldloca.s   V_4
+    IL_0032:  initobj    "Integer?"
+    IL_0038:  ldloc.s    V_4
+    IL_003a:  br.s       IL_004d
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       "Function Integer?.GetValueOrDefault() As Integer"
+    IL_0043:  call       "Function Program.Truncate(Integer) As Integer"
+    IL_0048:  newobj     "Sub Integer?..ctor(Integer)"
+    IL_004d:  stloc.0
+    IL_004e:  leave.s    IL_0075
+  }
+  catch System.Exception
+  {
+    IL_0050:  dup
+    IL_0051:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_0056:  stloc.s    V_5
+    IL_0058:  ldarg.0
+    IL_0059:  ldc.i4.s   -2
+    IL_005b:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_0060:  ldarg.0
+    IL_0061:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+    IL_0066:  ldloc.s    V_5
+    IL_0068:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetException(System.Exception)"
+    IL_006d:  nop
+    IL_006e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0073:  leave.s    IL_008c
+  }
+  IL_0075:  ldarg.0
+  IL_0076:  ldc.i4.s   -2
+  IL_0078:  dup
+  IL_0079:  stloc.1
+  IL_007a:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_007f:  ldarg.0
+  IL_0080:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+  IL_0085:  ldloc.0
+  IL_0086:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetResult(Integer?)"
+  IL_008b:  nop
+  IL_008c:  ret
+}
+]]>)
+
+            c = CreateCompilation(source, options:=TestOptions.ReleaseExe)
+
+            verifier = CompileAndVerify(c, expectedOutput:="12(3)()1()").VerifyDiagnostics()
+
+            verifier.VerifyIL("Program.VB$StateMachine_2_Test.MoveNext",
+            <![CDATA[
+{
+  // Code size      137 (0x89)
+  .maxstack  3
+  .locals init (Integer? V_0,
+                Integer V_1,
+                Integer? V_2,
+                Integer? V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_0006:  stloc.1
+  .try
+  {
+    IL_0007:  ldarg.0
+    IL_0008:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_000d:  brtrue.s   IL_001a
+    IL_000f:  ldloca.s   V_2
+    IL_0011:  initobj    "Integer?"
+    IL_0017:  ldloc.2
+    IL_0018:  br.s       IL_004b
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_0020:  call       "Function Program.Parse(String) As Integer?"
+    IL_0025:  stloc.2
+    IL_0026:  ldloca.s   V_2
+    IL_0028:  call       "Function Integer?.get_HasValue() As Boolean"
+    IL_002d:  brtrue.s   IL_003a
+    IL_002f:  ldloca.s   V_3
+    IL_0031:  initobj    "Integer?"
+    IL_0037:  ldloc.3
+    IL_0038:  br.s       IL_004b
+    IL_003a:  ldloca.s   V_2
+    IL_003c:  call       "Function Integer?.GetValueOrDefault() As Integer"
+    IL_0041:  call       "Function Program.Truncate(Integer) As Integer"
+    IL_0046:  newobj     "Sub Integer?..ctor(Integer)"
+    IL_004b:  stloc.0
+    IL_004c:  leave.s    IL_0072
+  }
+  catch System.Exception
+  {
+    IL_004e:  dup
+    IL_004f:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_0054:  stloc.s    V_4
+    IL_0056:  ldarg.0
+    IL_0057:  ldc.i4.s   -2
+    IL_0059:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_005e:  ldarg.0
+    IL_005f:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+    IL_0064:  ldloc.s    V_4
+    IL_0066:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetException(System.Exception)"
+    IL_006b:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0070:  leave.s    IL_0088
+  }
+  IL_0072:  ldarg.0
+  IL_0073:  ldc.i4.s   -2
+  IL_0075:  dup
+  IL_0076:  stloc.1
+  IL_0077:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_007c:  ldarg.0
+  IL_007d:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+  IL_0082:  ldloc.0
+  IL_0083:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetResult(Integer?)"
+  IL_0088:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/29634")>
+        Public Sub ConditionalAccessInAsyncMethod_02()
+            Dim source =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Runtime.CompilerServices
+Imports System.Threading.Tasks
+
+Module Program
+
+    Public Sub Main()
+
+        Dim result = Test("").GetAwaiter().GetResult()
+        Console.Write("({0})", result)
+
+        result = Test(Nothing).GetAwaiter().GetResult()
+        Console.Write("({0})", result)
+
+        Value = Nothing
+        result = Test("").GetAwaiter().GetResult()
+        Console.Write("({0})", result)
+    End Sub
+
+    Public Async Function Test(input As String) As Task(Of Integer?)
+        Return input?.Parse()?.Truncate(Await GetInt())
+    End Function
+
+    Dim Value As Integer? = 3
+
+    <Extension>
+    Public Function Parse(input As String) As Integer?
+	    Console.Write("1")
+        Return Value
+    End Function
+
+    <Extension>
+    Public Function Truncate(value As Integer, x As Integer) As Integer
+	    Console.Write("2")
+        Return value
+    End Function
+    
+    Async Function GetInt() As Task(Of Integer)
+        await Task.Yield()    
+        Return 0
+    End Function
+
+End Module
+    ]]></file>
+</compilation>
+            Dim c = CreateCompilation(source, options:=TestOptions.DebugExe)
+
+            Dim verifier = CompileAndVerify(c, expectedOutput:="12(3)()1()").VerifyDiagnostics()
+
+            verifier.VerifyIL("Program.VB$StateMachine_2_Test.MoveNext",
+            <![CDATA[
+{
+  // Code size      285 (0x11d)
+  .maxstack  3
+  .locals init (Integer? V_0,
+                Integer V_1,
+                System.Threading.Tasks.Task(Of Integer?) V_2,
+                Integer? V_3,
+                Integer? V_4,
+                Integer? V_5,
+                Integer? V_6,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_7,
+                Program.VB$StateMachine_2_Test V_8,
+                Integer V_9,
+                System.Exception V_10)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_0006:  stloc.1
+  .try
+  {
+    IL_0007:  ldloc.1
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0081
+    IL_000e:  nop
+    IL_000f:  ldarg.0
+    IL_0010:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_0015:  brfalse    IL_00d4
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_0020:  call       "Function Program.Parse(String) As Integer?"
+    IL_0025:  dup
+    IL_0026:  stloc.s    V_4
+    IL_0028:  stloc.s    V_6
+    IL_002a:  ldloca.s   V_6
+    IL_002c:  call       "Function Integer?.get_HasValue() As Boolean"
+    IL_0031:  brfalse    IL_00c7
+    IL_0036:  ldarg.0
+    IL_0037:  ldloca.s   V_4
+    IL_0039:  call       "Function Integer?.GetValueOrDefault() As Integer"
+    IL_003e:  stfld      "Program.VB$StateMachine_2_Test.$U1 As Integer"
+    IL_0043:  call       "Function Program.GetInt() As System.Threading.Tasks.Task(Of Integer)"
+    IL_0048:  callvirt   "Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_004d:  stloc.s    V_7
+    IL_004f:  ldloca.s   V_7
+    IL_0051:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
+    IL_0056:  brtrue.s   IL_00a0
+    IL_0058:  ldarg.0
+    IL_0059:  ldc.i4.0
+    IL_005a:  dup
+    IL_005b:  stloc.1
+    IL_005c:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_0061:  ldarg.0
+    IL_0062:  ldloc.s    V_7
+    IL_0064:  stfld      "Program.VB$StateMachine_2_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0069:  ldarg.0
+    IL_006a:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+    IL_006f:  ldloca.s   V_7
+    IL_0071:  ldarg.0
+    IL_0072:  stloc.s    V_8
+    IL_0074:  ldloca.s   V_8
+    IL_0076:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), Program.VB$StateMachine_2_Test)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef Program.VB$StateMachine_2_Test)"
+    IL_007b:  nop
+    IL_007c:  leave      IL_011c
+    IL_0081:  ldarg.0
+    IL_0082:  ldc.i4.m1
+    IL_0083:  dup
+    IL_0084:  stloc.1
+    IL_0085:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_008a:  ldarg.0
+    IL_008b:  ldfld      "Program.VB$StateMachine_2_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0090:  stloc.s    V_7
+    IL_0092:  ldarg.0
+    IL_0093:  ldflda     "Program.VB$StateMachine_2_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0098:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_009e:  br.s       IL_00a0
+    IL_00a0:  ldarg.0
+    IL_00a1:  ldfld      "Program.VB$StateMachine_2_Test.$U1 As Integer"
+    IL_00a6:  ldloca.s   V_7
+    IL_00a8:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer"
+    IL_00ad:  stloc.s    V_9
+    IL_00af:  ldloca.s   V_7
+    IL_00b1:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_00b7:  ldloc.s    V_9
+    IL_00b9:  call       "Function Program.Truncate(Integer, Integer) As Integer"
+    IL_00be:  newobj     "Sub Integer?..ctor(Integer)"
+    IL_00c3:  stloc.s    V_5
+    IL_00c5:  br.s       IL_00cf
+    IL_00c7:  ldloca.s   V_5
+    IL_00c9:  initobj    "Integer?"
+    IL_00cf:  ldloc.s    V_5
+    IL_00d1:  stloc.3
+    IL_00d2:  br.s       IL_00dc
+    IL_00d4:  ldloca.s   V_3
+    IL_00d6:  initobj    "Integer?"
+    IL_00dc:  ldloc.3
+    IL_00dd:  stloc.0
+    IL_00de:  leave.s    IL_0105
+  }
+  catch System.Exception
+  {
+    IL_00e0:  dup
+    IL_00e1:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00e6:  stloc.s    V_10
+    IL_00e8:  ldarg.0
+    IL_00e9:  ldc.i4.s   -2
+    IL_00eb:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_00f0:  ldarg.0
+    IL_00f1:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+    IL_00f6:  ldloc.s    V_10
+    IL_00f8:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetException(System.Exception)"
+    IL_00fd:  nop
+    IL_00fe:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0103:  leave.s    IL_011c
+  }
+  IL_0105:  ldarg.0
+  IL_0106:  ldc.i4.s   -2
+  IL_0108:  dup
+  IL_0109:  stloc.1
+  IL_010a:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_010f:  ldarg.0
+  IL_0110:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+  IL_0115:  ldloc.0
+  IL_0116:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetResult(Integer?)"
+  IL_011b:  nop
+  IL_011c:  ret
+}
+]]>)
+
+            c = CreateCompilation(source, options:=TestOptions.ReleaseExe)
+
+            verifier = CompileAndVerify(c, expectedOutput:="12(3)()1()").VerifyDiagnostics()
+
+            verifier.VerifyIL("Program.VB$StateMachine_2_Test.MoveNext",
+            <![CDATA[
+{
+  // Code size      266 (0x10a)
+  .maxstack  3
+  .locals init (Integer? V_0,
+                Integer V_1,
+                Integer? V_2,
+                Integer? V_3,
+                Integer? V_4,
+                Integer? V_5,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_6,
+                System.Exception V_7)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_0006:  stloc.1
+  .try
+  {
+    IL_0007:  ldloc.1
+    IL_0008:  brfalse.s  IL_0076
+    IL_000a:  ldarg.0
+    IL_000b:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_0010:  brfalse    IL_00c3
+    IL_0015:  ldarg.0
+    IL_0016:  ldfld      "Program.VB$StateMachine_2_Test.$VB$Local_input As String"
+    IL_001b:  call       "Function Program.Parse(String) As Integer?"
+    IL_0020:  dup
+    IL_0021:  stloc.3
+    IL_0022:  stloc.s    V_5
+    IL_0024:  ldloca.s   V_5
+    IL_0026:  call       "Function Integer?.get_HasValue() As Boolean"
+    IL_002b:  brfalse    IL_00b6
+    IL_0030:  ldarg.0
+    IL_0031:  ldloca.s   V_3
+    IL_0033:  call       "Function Integer?.GetValueOrDefault() As Integer"
+    IL_0038:  stfld      "Program.VB$StateMachine_2_Test.$U1 As Integer"
+    IL_003d:  call       "Function Program.GetInt() As System.Threading.Tasks.Task(Of Integer)"
+    IL_0042:  callvirt   "Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0047:  stloc.s    V_6
+    IL_0049:  ldloca.s   V_6
+    IL_004b:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
+    IL_0050:  brtrue.s   IL_0093
+    IL_0052:  ldarg.0
+    IL_0053:  ldc.i4.0
+    IL_0054:  dup
+    IL_0055:  stloc.1
+    IL_0056:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_005b:  ldarg.0
+    IL_005c:  ldloc.s    V_6
+    IL_005e:  stfld      "Program.VB$StateMachine_2_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0063:  ldarg.0
+    IL_0064:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+    IL_0069:  ldloca.s   V_6
+    IL_006b:  ldarg.0
+    IL_006c:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), Program.VB$StateMachine_2_Test)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef Program.VB$StateMachine_2_Test)"
+    IL_0071:  leave      IL_0109
+    IL_0076:  ldarg.0
+    IL_0077:  ldc.i4.m1
+    IL_0078:  dup
+    IL_0079:  stloc.1
+    IL_007a:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_007f:  ldarg.0
+    IL_0080:  ldfld      "Program.VB$StateMachine_2_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0085:  stloc.s    V_6
+    IL_0087:  ldarg.0
+    IL_0088:  ldflda     "Program.VB$StateMachine_2_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_008d:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0093:  ldarg.0
+    IL_0094:  ldfld      "Program.VB$StateMachine_2_Test.$U1 As Integer"
+    IL_0099:  ldloca.s   V_6
+    IL_009b:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer"
+    IL_00a0:  ldloca.s   V_6
+    IL_00a2:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_00a8:  call       "Function Program.Truncate(Integer, Integer) As Integer"
+    IL_00ad:  newobj     "Sub Integer?..ctor(Integer)"
+    IL_00b2:  stloc.s    V_4
+    IL_00b4:  br.s       IL_00be
+    IL_00b6:  ldloca.s   V_4
+    IL_00b8:  initobj    "Integer?"
+    IL_00be:  ldloc.s    V_4
+    IL_00c0:  stloc.2
+    IL_00c1:  br.s       IL_00cb
+    IL_00c3:  ldloca.s   V_2
+    IL_00c5:  initobj    "Integer?"
+    IL_00cb:  ldloc.2
+    IL_00cc:  stloc.0
+    IL_00cd:  leave.s    IL_00f3
+  }
+  catch System.Exception
+  {
+    IL_00cf:  dup
+    IL_00d0:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00d5:  stloc.s    V_7
+    IL_00d7:  ldarg.0
+    IL_00d8:  ldc.i4.s   -2
+    IL_00da:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+    IL_00df:  ldarg.0
+    IL_00e0:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+    IL_00e5:  ldloc.s    V_7
+    IL_00e7:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetException(System.Exception)"
+    IL_00ec:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_00f1:  leave.s    IL_0109
+  }
+  IL_00f3:  ldarg.0
+  IL_00f4:  ldc.i4.s   -2
+  IL_00f6:  dup
+  IL_00f7:  stloc.1
+  IL_00f8:  stfld      "Program.VB$StateMachine_2_Test.$State As Integer"
+  IL_00fd:  ldarg.0
+  IL_00fe:  ldflda     "Program.VB$StateMachine_2_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?)"
+  IL_0103:  ldloc.0
+  IL_0104:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer?).SetResult(Integer?)"
+  IL_0109:  ret
+}
+]]>)
+        End Sub
+
     End Class
 End Namespace
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
@@ -4873,6 +4873,107 @@ S1.CallAsync
 Null
 ---
 ]]>)
+
+            verifier.VerifyIL("Module1.VB$StateMachine_1_Test.MoveNext",
+            <![CDATA[
+{
+  // Code size      219 (0xdb)
+  .maxstack  3
+  .locals init (Object V_0,
+                Integer V_1,
+                Object V_2,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "Module1.VB$StateMachine_1_Test.$State As Integer"
+  IL_0006:  stloc.1
+  .try
+  {
+    IL_0007:  ldloc.1
+    IL_0008:  brfalse.s  IL_005c
+    IL_000a:  ldarg.0
+    IL_000b:  ldflda     "Module1.VB$StateMachine_1_Test.$VB$Local_x As S1?"
+    IL_0010:  call       "Function S1?.get_HasValue() As Boolean"
+    IL_0015:  brfalse.s  IL_0095
+    IL_0017:  ldarg.0
+    IL_0018:  ldarg.0
+    IL_0019:  ldflda     "Module1.VB$StateMachine_1_Test.$VB$Local_x As S1?"
+    IL_001e:  call       "Function S1?.GetValueOrDefault() As S1"
+    IL_0023:  stfld      "Module1.VB$StateMachine_1_Test.$U1 As S1"
+    IL_0028:  call       "Function Module1.PassAsync() As System.Threading.Tasks.Task(Of Integer)"
+    IL_002d:  callvirt   "Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0032:  stloc.3
+    IL_0033:  ldloca.s   V_3
+    IL_0035:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
+    IL_003a:  brtrue.s   IL_0078
+    IL_003c:  ldarg.0
+    IL_003d:  ldc.i4.0
+    IL_003e:  dup
+    IL_003f:  stloc.1
+    IL_0040:  stfld      "Module1.VB$StateMachine_1_Test.$State As Integer"
+    IL_0045:  ldarg.0
+    IL_0046:  ldloc.3
+    IL_0047:  stfld      "Module1.VB$StateMachine_1_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_004c:  ldarg.0
+    IL_004d:  ldflda     "Module1.VB$StateMachine_1_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)"
+    IL_0052:  ldloca.s   V_3
+    IL_0054:  ldarg.0
+    IL_0055:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), Module1.VB$StateMachine_1_Test)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef Module1.VB$StateMachine_1_Test)"
+    IL_005a:  leave.s    IL_00da
+    IL_005c:  ldarg.0
+    IL_005d:  ldc.i4.m1
+    IL_005e:  dup
+    IL_005f:  stloc.1
+    IL_0060:  stfld      "Module1.VB$StateMachine_1_Test.$State As Integer"
+    IL_0065:  ldarg.0
+    IL_0066:  ldfld      "Module1.VB$StateMachine_1_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_006b:  stloc.3
+    IL_006c:  ldarg.0
+    IL_006d:  ldflda     "Module1.VB$StateMachine_1_Test.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0072:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0078:  ldarg.0
+    IL_0079:  ldflda     "Module1.VB$StateMachine_1_Test.$U1 As S1"
+    IL_007e:  ldloca.s   V_3
+    IL_0080:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer"
+    IL_0085:  ldloca.s   V_3
+    IL_0087:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_008d:  call       "Function S1.CallAsync(Integer) As Object"
+    IL_0092:  stloc.2
+    IL_0093:  br.s       IL_0097
+    IL_0095:  ldnull
+    IL_0096:  stloc.2
+    IL_0097:  ldloc.2
+    IL_0098:  stloc.0
+    IL_0099:  leave.s    IL_00bf
+  }
+  catch System.Exception
+  {
+    IL_009b:  dup
+    IL_009c:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00a1:  stloc.s    V_4
+    IL_00a3:  ldarg.0
+    IL_00a4:  ldc.i4.s   -2
+    IL_00a6:  stfld      "Module1.VB$StateMachine_1_Test.$State As Integer"
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldflda     "Module1.VB$StateMachine_1_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)"
+    IL_00b1:  ldloc.s    V_4
+    IL_00b3:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).SetException(System.Exception)"
+    IL_00b8:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_00bd:  leave.s    IL_00da
+  }
+  IL_00bf:  ldarg.0
+  IL_00c0:  ldc.i4.s   -2
+  IL_00c2:  dup
+  IL_00c3:  stloc.1
+  IL_00c4:  stfld      "Module1.VB$StateMachine_1_Test.$State As Integer"
+  IL_00c9:  ldarg.0
+  IL_00ca:  ldflda     "Module1.VB$StateMachine_1_Test.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)"
+  IL_00cf:  ldloc.0
+  IL_00d0:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_00d5:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).SetResult(Object)"
+  IL_00da:  ret
+}
+]]>)
         End Sub
 
         <Fact()>


### PR DESCRIPTION
Fixes #29634