### PR TITLE
Fix new document formatting

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -371,7 +372,7 @@ internal abstract class AbstractEditorFactory : IVsEditorFactory, IVsEditorFacto
 
         IOUtilities.PerformIO(() =>
         {
-            using var textWriter = new StreamWriter(filePath, append: false, encoding: formattedText.Encoding);
+            using var textWriter = new StreamWriter(filePath, append: false, encoding: formattedText.Encoding ?? Encoding.UTF8);
             // We pass null here for cancellation, since cancelling in the middle of the file write would leave the file corrupted
             formattedText.Write(textWriter, cancellationToken: CancellationToken.None);
         });

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpWinForms.cs
@@ -95,7 +95,7 @@ public class CSharpWinForms : AbstractEditorTest
         Assert.Contains(@"this.SomeButton.Click += new System.EventHandler(this.ExecuteWhenButtonClicked);", designerActualText);
         await TestServices.SolutionExplorer.OpenFileAsync(project, "Form1.cs", HangMitigatingCancellationToken);
         var codeFileActualText = await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken);
-        Assert.Contains(@"    public partial class Form1: Form
+        Assert.Contains(@"    public partial class Form1 : Form
     {
         public Form1()
         {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2317372

Presumably something changed in Roslyn where encoding can be null now? 🤷‍♂️