### PR TITLE
Proffer CssVisualDiagnosticsService brokered service from C# DevKit to C# Extension

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/Services/Descriptors.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/Services/Descriptors.cs
@@ -52,6 +52,7 @@ internal class Descriptors
         { BrokeredServiceDescriptors.DebuggerSymbolLocatorService.Moniker, new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: false) },
         { BrokeredServiceDescriptors.DebuggerSourceLinkService.Moniker, new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: false) },
         { BrokeredServiceDescriptors.ProjectSystemQueryExecutionService.Moniker, new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: false) },
+        { BrokeredServiceDescriptors.CssVisualDiagnosticsService.Moniker, new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: false) },
     }.ToImmutableDictionary();
 
     public static ServiceJsonRpcDescriptor CreateDescriptor(ServiceMoniker serviceMoniker) => new(

--- a/src/Workspaces/Remote/Core/BrokeredServiceDescriptors.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceDescriptors.cs
@@ -77,6 +77,7 @@ internal static class BrokeredServiceDescriptors
     public static readonly ServiceRpcDescriptor GenericHotReloadAgentManagerService = CreateDebuggerServiceDescriptor("GenericHotReloadAgentManagerService", new Version(0, 1));
     public static readonly ServiceRpcDescriptor HotReloadOptionService = CreateDebuggerClientServiceDescriptor("HotReloadOptionService", new Version(0, 1));
     public static readonly ServiceRpcDescriptor MauiLaunchCustomizerService = CreateMauiServiceDescriptor("MauiLaunchCustomizerService", new Version(0, 1));
+    public static readonly ServiceRpcDescriptor CssVisualDiagnosticsService = CreateWebToolsServiceDescriptor("CssVisualDiagnosticsService", new Version(0, 1));
     public static readonly ServiceRpcDescriptor DebuggerSymbolLocatorService =
         CreateDebuggerServiceDescriptor("SymbolLocatorService", new Version(0, 1), new MultiplexingStream.Options { ProtocolMajorVersion = 3 });
     public static readonly ServiceRpcDescriptor DebuggerSourceLinkService =
@@ -88,39 +89,44 @@ internal static class BrokeredServiceDescriptors
         => new(namespaceName + "." + componentName + "." + serviceName, version);
 
     /// <summary>
-    /// Descriptor for services proferred by the client extension (implemented in TypeScript).
+    /// Descriptor for services proffered by the client extension (implemented in TypeScript).
     /// </summary>
     public static ServiceJsonRpcDescriptor CreateClientServiceDescriptor(string serviceName, Version? version = null)
         => new ClientServiceDescriptor(CreateMoniker(LanguageServerComponentNamespace, LanguageClientComponentName, serviceName, version), clientInterface: null)
            .WithExceptionStrategy(ExceptionProcessing.ISerializable);
 
     /// <summary>
-    /// Descriptor for services proferred by Roslyn server or Visual Studio in-proc (implemented in C#). 
+    /// Descriptor for services proffered by Roslyn server or Visual Studio in-proc (implemented in C#). 
     /// </summary>
     public static ServiceJsonRpcDescriptor CreateServerServiceDescriptor(string serviceName, Version? version = null)
         => CreateDescriptor(CreateMoniker(LanguageServerComponentNamespace, LanguageServerComponentName, serviceName, version));
 
     /// <summary>
-    /// Descriptor for services proferred by the debugger server (implemented in C#). 
+    /// Descriptor for services proffered by the debugger server (implemented in C#). 
     /// </summary>
     public static ServiceJsonRpcDescriptor CreateDebuggerServiceDescriptor(string serviceName, Version? version = null, MultiplexingStream.Options? streamOptions = null)
         => CreateDescriptor(CreateMoniker(VisualStudioComponentNamespace, DebuggerComponentName, serviceName, version), streamOptions);
 
     /// <summary>
-    /// Descriptor for services proferred by the debugger server (implemented in TypeScript).
+    /// Descriptor for services proffered by the debugger server (implemented in TypeScript).
     /// </summary>
     public static ServiceJsonRpcDescriptor CreateDebuggerClientServiceDescriptor(string serviceName, Version? version = null)
         => new ClientServiceDescriptor(CreateMoniker(VisualStudioComponentNamespace, DebuggerComponentName, serviceName, version), clientInterface: null)
            .WithExceptionStrategy(ExceptionProcessing.ISerializable);
 
     /// <summary>
-    /// Descriptor for services proferred by the MAUI extension (implemented in TypeScript).
+    /// Descriptor for services proffered by the WebTools component (implemented in C# DevKit).
     /// </summary>
-    public static ServiceJsonRpcDescriptor CreateMauiServiceDescriptor(string serviceName, Version? version)
-        => new ServiceJsonRpcDescriptor(CreateMoniker(VisualStudioComponentNamespace, "Maui", serviceName, version), clientInterface: null,
-            Formatters.MessagePack, MessageDelimiters.BigEndianInt32LengthHeader,
-            new MultiplexingStream.Options { ProtocolMajorVersion = 3 })
-           .WithExceptionStrategy(ExceptionProcessing.ISerializable);
+    public static ServiceJsonRpcDescriptor CreateWebToolsServiceDescriptor(string serviceName, Version version)
+        => CreateDescriptor(CreateMoniker(VisualStudioComponentNamespace, "WebTools", serviceName, version),
+            new MultiplexingStream.Options { ProtocolMajorVersion = 3 });
+
+    /// <summary>
+    /// Descriptor for services proffered by the MAUI extension (implemented in TypeScript).
+    /// </summary>
+    public static ServiceJsonRpcDescriptor CreateMauiServiceDescriptor(string serviceName, Version version)
+        => CreateDescriptor(CreateMoniker(VisualStudioComponentNamespace, "Maui", serviceName, version),
+            new MultiplexingStream.Options { ProtocolMajorVersion = 3 });
 
     private static ServiceJsonRpcDescriptor CreateDescriptor(ServiceMoniker moniker, MultiplexingStream.Options? streamOptions = null)
     {


### PR DESCRIPTION
This adds a brokered service that will be used for CSS Hot Reload. It comes from C# DevKit and will become available to C# Extension. The implementation is not in C# DevKit yet, but the plan is to add it soon and this brokered service container in Roslyn will be ready for it.