### PR TITLE
Change partial keyword recommender to better handle partial member syntax

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/PartialKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/PartialKeywordRecommenderTests.cs
@@ -486,5 +486,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                     async $$
                 """);
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/61439")]
+        public async Task TestAfterMemberButNonClassModifier()
+        {
+            await VerifyKeywordAsync("""
+                partial class C {
+                    virtual $$
+                """);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/PartialKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/PartialKeywordRecommender.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -15,12 +14,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders;
 
 internal class PartialKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
 {
-    private static readonly ISet<SyntaxKind> s_validMemberModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-    {
-        SyntaxKind.AsyncKeyword,
-        SyntaxKind.StaticKeyword
-    };
-
     public PartialKeywordRecommender()
         : base(SyntaxKind.PartialKeyword)
     {
@@ -36,7 +29,11 @@ internal class PartialKeywordRecommender : AbstractSyntacticSingleKeywordRecomme
 
     private static bool IsMemberDeclarationContext(CSharpSyntaxContext context, CancellationToken cancellationToken)
     {
-        if (context.IsMemberDeclarationContext(validModifiers: s_validMemberModifiers, validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken))
+        if (context.IsMemberDeclarationContext(
+            validModifiers: SyntaxKindSet.AllMemberModifiers,
+            validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations,
+            canBePartial: false,
+            cancellationToken: cancellationToken))
         {
             var token = context.LeftToken;
             var decl = token.GetRequiredAncestor<TypeDeclarationSyntax>();


### PR DESCRIPTION
The partial keyword recommender for members was previously only allowing async/static keywords to precede it and relying on the type modifier code to catch other supported keywords. A better approach would be to have the member modifier check not special case async/static, but instead check against all member modifiers (eg: virtual/override)

Fixes https://github.com/dotnet/roslyn/issues/61439