### PR TITLE
Fix ordering of 'params' vs 'scoped' in metadata as source

### DIFF
--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
@@ -45,9 +45,23 @@ public abstract partial class AbstractMetadataAsSourceTests : IAsyncLifetime
     }
 
     internal static async Task GenerateAndVerifySourceAsync(
-        string metadataSource, string symbolName, string projectLanguage, string expected, bool signaturesOnly = true, bool includeXmlDocComments = false, string languageVersion = null, string metadataLanguageVersion = null, string metadataCommonReferences = null)
+        string metadataSource,
+        string symbolName,
+        string projectLanguage,
+        string expected,
+        bool signaturesOnly = true,
+        bool includeXmlDocComments = false,
+        string languageVersion = null,
+        string metadataLanguageVersion = null,
+        string metadataCommonReferences = null,
+        string commonReferencesValue = null)
     {
-        using var context = TestContext.Create(projectLanguage, [metadataSource], includeXmlDocComments, languageVersion: languageVersion, metadataLanguageVersion: metadataLanguageVersion, metadataCommonReferences: metadataCommonReferences);
+        using var context = TestContext.Create(
+            projectLanguage, [metadataSource], includeXmlDocComments,
+            languageVersion: languageVersion,
+            metadataLanguageVersion: metadataLanguageVersion,
+            metadataCommonReferences: metadataCommonReferences,
+            commonReferencesValue: commonReferencesValue);
         await context.GenerateAndVerifySourceAsync(symbolName, expected, signaturesOnly: signaturesOnly);
     }
 

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -778,6 +780,51 @@ public partial class MetadataAsSourceTests
             };
 
             await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, languageVersion: "Preview", metadataLanguageVersion: "Preview", expected: expected, signaturesOnly: signaturesOnly);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42986")]
+        public async Task TestParamsScoped()
+        {
+            var metadataSource = """
+                public class C
+                {
+                    public void M(params scoped System.ReadOnlySpan<string> x) { }
+                }
+
+                namespace System
+                {
+                    public readonly ref struct ReadOnlySpan<T>
+                    {
+                    }
+                }
+                """;
+
+            var symbolName = "C";
+
+            var expected = $$"""
+                #region {{FeaturesResources.Assembly}} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+                // {{CodeAnalysisResources.InMemoryAssembly}}
+                #endregion
+
+                using System;
+
+                public class [|C|]
+                {
+                    public C();
+
+                    public void M(params scoped ReadOnlySpan<string> x);
+                }
+                """;
+
+            await GenerateAndVerifySourceAsync(
+                metadataSource,
+                symbolName,
+                LanguageNames.CSharp,
+                languageVersion: "Preview",
+                metadataLanguageVersion: "Preview",
+                expected: expected,
+                signaturesOnly: true,
+                commonReferencesValue: """CommonReferencesNet9="true" """);
         }
     }
 }

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
@@ -782,7 +782,7 @@ public partial class MetadataAsSourceTests
             await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, languageVersion: "Preview", metadataLanguageVersion: "Preview", expected: expected, signaturesOnly: signaturesOnly);
         }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42986")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76676")]
         public async Task TestParamsScoped()
         {
             var metadataSource = """

--- a/src/EditorFeatures/Test/Microsoft.CodeAnalysis.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/Test/Microsoft.CodeAnalysis.EditorFeatures.UnitTests.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <PackageReference Include="BasicUndo" />
     <PackageReference Include="Basic.Reference.Assemblies.Net60" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -68,6 +68,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private const string CommonReferencesNet6Name = "CommonReferencesNet6";
         private const string CommonReferencesNet7Name = "CommonReferencesNet7";
         private const string CommonReferencesNet8Name = "CommonReferencesNet8";
+        private const string CommonReferencesNet9Name = "CommonReferencesNet9";
         private const string CommonReferencesNetStandard20Name = "CommonReferencesNetStandard20";
         private const string CommonReferencesMinCorlibName = "CommonReferencesMinCorlib";
         private const string ReferencesOnDiskAttributeName = "ReferencesOnDisk";
@@ -936,6 +937,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 ((bool?)net8).Value)
             {
                 references = [.. TargetFrameworkUtil.GetReferences(TargetFramework.Net80)];
+            }
+
+            var net9 = element.Attribute(CommonReferencesNet9Name);
+            if (net9 != null &&
+                ((bool?)net9).HasValue &&
+                ((bool?)net9).Value)
+            {
+                references = [.. TargetFrameworkUtil.GetReferences(TargetFramework.Net90)];
             }
 
             var mincorlib = element.Attribute(CommonReferencesMinCorlibName);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
@@ -125,8 +125,8 @@ internal sealed class CSharpSyntaxGeneratorInternal() : SyntaxGeneratorInternal
 
     public override SyntaxNode InterpolationFormatClause(string format)
         => SyntaxFactory.InterpolationFormatClause(
-                ColonToken,
-                SyntaxFactory.Token(default, SyntaxKind.InterpolatedStringTextToken, format, format, default));
+            ColonToken,
+            SyntaxFactory.Token(default, SyntaxKind.InterpolatedStringTextToken, format, format, default));
 
     public override SyntaxNode TypeParameterList(IEnumerable<string> typeParameterNames)
         => SyntaxFactory.TypeParameterList([.. typeParameterNames.Select(SyntaxFactory.TypeParameter)]);
@@ -139,6 +139,9 @@ internal sealed class CSharpSyntaxGeneratorInternal() : SyntaxGeneratorInternal
         bool isScoped, RefKind refKind, bool isParams, bool forFunctionPointerReturnParameter = false)
     {
         using var _ = ArrayBuilder<SyntaxToken>.GetInstance(out var result);
+
+        if (isParams)
+            result.Add(ParamsKeyword);
 
         if (isScoped)
             result.Add(ScopedKeyword);
@@ -170,9 +173,6 @@ internal sealed class CSharpSyntaxGeneratorInternal() : SyntaxGeneratorInternal
                 result.Add(ReadOnlyKeyword);
                 break;
         }
-
-        if (isParams)
-            result.Add(ParamsKeyword);
 
         return SyntaxFactory.TokenList(result);
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76676