### PR TITLE
Hook brace-matching up to the 'responsive completion' editor option

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/CSharpBraceCompletionServiceFactory.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/CSharpBraceCompletionServiceFactory.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 using Microsoft.CodeAnalysis.AutomaticCompletion;
 using Microsoft.CodeAnalysis.BraceCompletion;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -15,7 +14,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion;
 [ExportLanguageService(typeof(IBraceCompletionServiceFactory), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal class CSharpBraceCompletionServiceFactory(
-    [ImportMany] IEnumerable<Lazy<IBraceCompletionService, LanguageMetadata>> braceCompletionServices) : AbstractBraceCompletionServiceFactory(braceCompletionServices, LanguageNames.CSharp)
-{
-}
+internal sealed class CSharpBraceCompletionServiceFactory(
+    [ImportMany] IEnumerable<Lazy<IBraceCompletionService, LanguageMetadata>> braceCompletionServices)
+    : AbstractBraceCompletionServiceFactory(braceCompletionServices, LanguageNames.CSharp);

--- a/src/EditorFeatures/Core/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
+++ b/src/EditorFeatures/Core/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
@@ -68,15 +68,14 @@ internal partial class BraceCompletionSessionProvider
         {
             ThreadingContext.ThrowIfNotOnUIThread();
 
+            // Brace completion is cancellable if the user has the 'responsive completion' option enabled.
             var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
             if (_timeoutThreshold > 0)
                 cancellationTokenSource.CancelAfter(_timeoutThreshold);
 
             try
             {
-                var success = ThreadingContext.JoinableTaskFactory.Run(() => TryStartAsync(cancellationToken));
+                var success = ThreadingContext.JoinableTaskFactory.Run(() => TryStartAsync(cancellationTokenSource.Token));
                 if (!success)
                     EndSession();
             }

--- a/src/EditorFeatures/Core/AutomaticCompletion/BraceCompletionSessionProvider.cs
+++ b/src/EditorFeatures/Core/AutomaticCompletion/BraceCompletionSessionProvider.cs
@@ -48,8 +48,7 @@ internal partial class BraceCompletionSessionProvider(
     {
         _threadingContext.ThrowIfNotOnUIThread();
 
-        var isResponsive = textView.Options.GetOptionValue(DefaultOptions.ResponsiveCompletionOptionId);
-        var responsiveThreshold = isResponsive ? textView.Options.GetOptionValue(DefaultOptions.ResponsiveCompletionThresholdOptionId) : -1;
+        var responsiveCompletion = textView.Options.GetOptionValue(DefaultOptions.ResponsiveCompletionOptionId);
 
         var textSnapshot = openingPoint.Snapshot;
         var document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges();
@@ -69,7 +68,7 @@ internal partial class BraceCompletionSessionProvider(
                     session = new BraceCompletionSession(
                         this, textView, openingPoint.Snapshot.TextBuffer,
                         openingPoint, openingBrace, closingBrace,
-                        undoHistory, editorSession, responsiveThreshold);
+                        undoHistory, editorSession, responsiveCompletion);
                     return true;
                 }
             }

--- a/src/EditorFeatures/Core/AutomaticCompletion/BraceCompletionSessionProvider.cs
+++ b/src/EditorFeatures/Core/AutomaticCompletion/BraceCompletionSessionProvider.cs
@@ -47,6 +47,10 @@ internal partial class BraceCompletionSessionProvider(
     public bool TryCreateSession(ITextView textView, SnapshotPoint openingPoint, char openingBrace, char closingBrace, out IBraceCompletionSession session)
     {
         _threadingContext.ThrowIfNotOnUIThread();
+
+        var isResponsive = textView.Options.GetOptionValue(DefaultOptions.ResponsiveCompletionOptionId);
+        var responsiveThreshold = isResponsive ? textView.Options.GetOptionValue(DefaultOptions.ResponsiveCompletionThresholdOptionId) : -1;
+
         var textSnapshot = openingPoint.Snapshot;
         var document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges();
         if (document != null)
@@ -63,9 +67,9 @@ internal partial class BraceCompletionSessionProvider(
                 {
                     var undoHistory = _undoManager.GetTextBufferUndoManager(textView.TextBuffer).TextBufferUndoHistory;
                     session = new BraceCompletionSession(
-                        textView, openingPoint.Snapshot.TextBuffer, openingPoint, openingBrace, closingBrace,
-                        undoHistory, _editorOperationsFactoryService, _editorOptionsService,
-                        editorSession, _threadingContext);
+                        this, textView, openingPoint.Snapshot.TextBuffer,
+                        openingPoint, openingBrace, closingBrace,
+                        undoHistory, editorSession, responsiveThreshold);
                     return true;
                 }
             }

--- a/src/Features/Core/Portable/BraceCompletion/AbstractBraceCompletionService.cs
+++ b/src/Features/Core/Portable/BraceCompletion/AbstractBraceCompletionService.cs
@@ -40,6 +40,7 @@ internal abstract class AbstractBraceCompletionService : IBraceCompletionService
 
     public ValueTask<bool> HasBraceCompletionAsync(BraceCompletionContext context, Document document, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!context.HasCompletionForOpeningBrace(OpeningBrace))
             return ValueTaskFactory.FromResult(false);
 


### PR DESCRIPTION
This way, if brace matching is taking too long, we can responsibly cancel it and unblock typing.