### PR TITLE
Add an equality comparer for AssemblyName in RazorAnalyzerAssemblyResolver

### DIFF
--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -59,6 +59,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         private sealed class AssemblyNameEqualityComparer : IEqualityComparer<AssemblyName>
         {
+            // Note that we explicitly consider the FullName here so that two assemblies with
+            // the same name but different versions are considered to be different
             public bool Equals(AssemblyName? x, AssemblyName? y) => x!.FullName.Equals(y!.FullName);
 
             public int GetHashCode(AssemblyName obj) => Hash.GetFNVHashCode(obj.FullName);

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             return resolver?.Invoke(assemblyName);
         }
 
-        private class AssemblyNameEqualityComparer : IEqualityComparer<AssemblyName>
+        private sealed class AssemblyNameEqualityComparer : IEqualityComparer<AssemblyName>
         {
             public bool Equals(AssemblyName? x, AssemblyName? y) => x!.FullName.Equals(y!.FullName);
 

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Composition;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     {
         private static Func<AssemblyName, Assembly?>? s_assemblyResolver;
 
-        private static readonly HashSet<AssemblyName> s_assembliesRequested = [];
+        private static readonly HashSet<AssemblyName> s_assembliesRequested = new(new AssemblyNameEqualityComparer());
 
         private static readonly object s_resolverLock = new();
 
@@ -53,6 +54,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             }
 
             return resolver?.Invoke(assemblyName);
+        }
+
+        private class AssemblyNameEqualityComparer : IEqualityComparer<AssemblyName>
+        {
+            public bool Equals(AssemblyName? x, AssemblyName? y) => x?.FullName.Equals(y?.FullName) == true;
+
+            public int GetHashCode(AssemblyName obj) => Hash.GetFNVHashCode(obj.FullName);
         }
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -58,7 +59,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         private class AssemblyNameEqualityComparer : IEqualityComparer<AssemblyName>
         {
-            public bool Equals(AssemblyName? x, AssemblyName? y) => x?.FullName.Equals(y?.FullName) == true;
+            public bool Equals(AssemblyName? x, AssemblyName? y) => x!.FullName.Equals(y!.FullName);
 
             public int GetHashCode(AssemblyName obj) => Hash.GetFNVHashCode(obj.FullName);
         }


### PR DESCRIPTION
`AssemblyName` doesn't implement `GetHashCode` so each instance was unique, leading to duplicates in the hash set. This PR adds an equality comparer that uses the `FullName` of the `AssemblyName` as the comparison item for the hash set. 