### PR TITLE
Make IServiceBrokerProvider available in all layers

### DIFF
--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -31,11 +31,11 @@
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
     <PackageReference Include="Microsoft.VisualStudio.Language" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.ServiceHub.Client" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Contracts" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="Utilities\IsExternalInit.cs" />
+    <Compile Include="..\..\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\BrokeredServices\ServiceBrokerProvider.cs" Link="BrokeredServices\ServiceBrokerProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" LoadsWithinVisualStudio="false" />
@@ -100,5 +100,8 @@
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="BrokeredServices\" />
   </ItemGroup>
 </Project>

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -46,6 +46,7 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
     private TestWorkspace CreateEditorWorkspace(out Solution solution, out EditAndContinueService service, out EditAndContinueLanguageService languageService, Type[] additionalParts = null)
     {
         var composition = EditorTestCompositions.EditorFeatures
+            .AddExcludedPartTypes(typeof(ServiceBrokerProvider))
             .AddParts(
                 typeof(MockHostWorkspaceProvider),
                 typeof(MockManagedHotReloadService),
@@ -87,7 +88,9 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
     public async Task Test(bool commitChanges)
     {
         var localComposition = EditorTestCompositions.LanguageServerProtocolEditorFeatures
-            .AddExcludedPartTypes(typeof(EditAndContinueService))
+            .AddExcludedPartTypes(
+                typeof(EditAndContinueService),
+                typeof(ServiceBrokerProvider))
             .AddParts(
                 typeof(NoCompilationLanguageService),
                 typeof(MockHostWorkspaceProvider),

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable RS0030 // Do not use banned APIs (MEFv1)
+
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -9,11 +11,6 @@ using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 
 namespace Microsoft.CodeAnalysis.BrokeredServices;
-
-internal interface IServiceBrokerProvider
-{
-    IServiceBroker ServiceBroker { get; }
-}
 
 /// <summary>
 /// MEF service that can be used to fetch an <see cref="IServiceBroker"/> instance without having to use legacy MEF imports.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerProvider.cs
@@ -2,23 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable RS0030 // Do not use banned APIs (MEFv1)
-
 using System;
-using System.ComponentModel.Composition;
+using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.ServiceHub.Framework;
-using Microsoft.VisualStudio.Shell.ServiceBroker;
 
 namespace Microsoft.CodeAnalysis.BrokeredServices;
 
 /// <summary>
 /// MEF service that can be used to fetch an <see cref="IServiceBroker"/> instance without having to use legacy MEF imports.
 /// </summary>
-[Export(typeof(IServiceBrokerProvider))]
+[Export(typeof(IServiceBrokerProvider)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class ServiceBrokerProvider([Import(typeof(SVsFullAccessServiceBroker))] IServiceBroker serviceBroker) : IServiceBrokerProvider
+internal sealed class ServiceBrokerProvider([Import("Microsoft.VisualStudio.Shell.ServiceBroker.SVsFullAccessServiceBroker")] IServiceBroker serviceBroker) : IServiceBrokerProvider
 {
     public IServiceBroker ServiceBroker { get; } = serviceBroker;
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerProvider.cs
@@ -2,20 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable RS0030 // Do not use banned APIs (MEFv1)
+
 using System;
-using System.Composition;
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
 
 namespace Microsoft.CodeAnalysis.BrokeredServices;
 
 /// <summary>
 /// MEF service that can be used to fetch an <see cref="IServiceBroker"/> instance without having to use legacy MEF imports.
 /// </summary>
-[Export(typeof(IServiceBrokerProvider)), Shared]
+[Export(typeof(IServiceBrokerProvider))]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class ServiceBrokerProvider([Import("Microsoft.VisualStudio.Shell.ServiceBroker.SVsFullAccessServiceBroker")] IServiceBroker serviceBroker) : IServiceBrokerProvider
+internal sealed class ServiceBrokerProvider([Import(typeof(SVsFullAccessServiceBroker))] IServiceBroker serviceBroker) : IServiceBrokerProvider
 {
     public IServiceBroker ServiceBroker { get; } = serviceBroker;
 }

--- a/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
+++ b/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
@@ -22,15 +22,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\Microsoft.CodeAnalysis.LanguageServer.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\..\..\Workspaces\Remote\Core\Microsoft.CodeAnalysis.Remote.Workspaces.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Composition" />
-    <PackageReference Include="Microsoft.ServiceHub.Framework" />
-
     <!-- 
     Additional runtime dependencies that we must include in the NuGet package as they are not a part of the main language server package.
     Do not remove GeneratePathProperty="True" as it is required below to add the package to the package we generate.

--- a/src/Workspaces/Remote/Core/IServiceBrokerProvider.cs
+++ b/src/Workspaces/Remote/Core/IServiceBrokerProvider.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.CodeAnalysis.BrokeredServices;
+
+internal interface IServiceBrokerProvider
+{
+    IServiceBroker ServiceBroker { get; }
+}

--- a/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
@@ -23,10 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
-
-    <!-- TODO: remove https://github.com/dotnet/roslyn/issues/71374 -->
-    <PackageReference Include="Microsoft.ServiceHub.Framework" />
-    <PackageReference Include="Microsoft.ServiceHub.Client" />
   </ItemGroup>
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />

--- a/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.FactoryBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.FactoryBase.cs
@@ -94,7 +94,7 @@ internal abstract partial class BrokeredServiceBase
         {
             // Register this service broker globally (if it's the first we encounter) so it can be used by other
             // global services that need it.
-            GlobalServiceBroker.RegisterServiceBroker(serviceBroker);
+            RemoteServiceBrokerProvider.RegisterServiceBroker(serviceBroker);
 
             var descriptor = ServiceDescriptors.Instance.GetServiceDescriptorForServiceFactory(typeof(TService));
             var serviceHubTraceSource = (TraceSource?)hostProvidedServices.GetService(typeof(TraceSource));


### PR DESCRIPTION
Previously the interface was not exported in OOP. MEF components that import it failed to compose when moved OOP.

Fixes https://github.com/dotnet/roslyn/issues/71374
