### PR TITLE
Opt in MS.CA.LS.Protocol into using optprof training data

### DIFF
--- a/src/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -9,6 +9,7 @@
     <PackageDescription>
       .NET Compiler Platform ("Roslyn") support for Language Server Protocol.
     </PackageDescription>
+    <ApplyNgenOptimization Condition="'$(TargetFramework)' == 'netstandard2.0'">full</ApplyNgenOptimization>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">


### PR DESCRIPTION
Verified this produces a dll with data embedded
```
PS C:\Users\dabarbet\Downloads\net472> .\ibcmerge.exe -dxml -mi C:\Users\dabarbet\Downloads\officual_build_vsix\new_official_build\Microsoft.CodeAnalysis.LanguageServer.Protocol.dll
Reading IBC resource from file: C:\Users\dabarbet\Downloads\officual_build_vsix\new_official_build\Microsoft.CodeAnalysis.LanguageServer.Protocol.dll
Xml output file: C:\Users\dabarbet\Downloads\officual_build_vsix\new_official_build\Microsoft.CodeAnalysis.LanguageServer.Protocol.ibc.xml
```

![image](https://github.com/user-attachments/assets/e67304b5-2f07-4a5d-b7ab-9160b171440b)
