### PR TITLE
Escape Creator Helix argument

### DIFF
--- a/src/Tools/Source/RunTests/HelixTestRunner.cs
+++ b/src/Tools/Source/RunTests/HelixTestRunner.cs
@@ -99,7 +99,7 @@ internal sealed class HelixTestRunner
         {
             // If we're not using authenticated access we need to specify a creator.
             var queuedBy = GetEnv("BUILD_QUEUEDBY", "roslyn");
-            arguments += $" -p:Creator={queuedBy}";
+            arguments += $" -p:Creator=\"{queuedBy}\"";
         }
 
         CopyPayloadFilesToLogs(logsDir, payloadsDir);


### PR DESCRIPTION
Without the change I get an error like this when manually queueing a roslyn-CI build ([example](https://dev.azure.com/dnceng-public/public/_build/results?buildId=921140&view=logs&j=644ea285-4692-54f6-2965-667c9562a0e2&t=b2948985-b3d8-5780-7b2b-b582fd83c893&l=57)):

```
MSBUILD : error MSB1008: Only one project can be specified.
    Full command line: '/mnt/vss/_work/1/s/.dotnet/sdk/9.0.100/MSBuild.dll -maxcpucount -verbosity:m -tlp:default=auto -nologo -restore -consoleloggerparameters:Summary --property:Creator=Jan -bl:/mnt/vss/_work/1/s/artifacts/log/Debug/helix.binlog /mnt/vss/_work/1/s/artifacts/helix.proj Jones'
  Switches appended by response files:
Switch: Jones
```