### PR TITLE
Always create return conversions

### DIFF
--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IParenthesized.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IParenthesized.cs
@@ -488,9 +488,12 @@ class P
 ";
             string expectedOperationTree = @"
 IReturnOperation (OperationKind.Return, Type: null, IsInvalid) (Syntax: 'return (a);')
-  ReturnedValue: 
-    IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'a')
-      Children(0)
+  ReturnedValue:
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'a')
+      Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      Operand:
+        IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'a')
+          Children(0)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
                 // CS0103: The name 'a' does not exist in the current context

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -3102,6 +3102,37 @@ class A
             Assert.Null(symbolInfo.Symbol);
         }
 
+        [Fact]
+        public void TestGetSemanticModelReturnsInPresenceOfPatternConflicts()
+        {
+            var code = """
+                public class IssueClass
+                {
+                    public int ID;
+
+                    public object ConvertFieldValueForStorage(object value)
+                    {
+                        return value is IssueClass issue ? (decimal)issue.ID : (object)-1m;
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(code);
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var returnStatementCode = "return value is IssueClass issue ? (decimal)issue.ID : -1m;";
+            var returnStatement = (ReturnStatementSyntax)SyntaxFactory.ParseStatement(returnStatementCode);
+
+            var methodDeclLocation = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body!.SpanStart;
+
+            Assert.True(model.TryGetSpeculativeSemanticModel(methodDeclLocation, returnStatement, out var speculativeModel));
+
+            var typeInfo = speculativeModel.GetTypeInfo(returnStatement.Expression!);
+            Assert.Equal(SpecialType.System_Decimal, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Object, typeInfo.ConvertedType.SpecialType);
+        }
+
         [WorkItem(731108, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/731108")]
         [Fact]
         public void Repro731108()

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -3102,7 +3102,7 @@ class A
             Assert.Null(symbolInfo.Symbol);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76799")]
         public void TestGetSemanticModelReturnsInPresenceOfPatternConflicts()
         {
             var code = """


### PR DESCRIPTION
In `BindReturn`, we would try to suppress additional diagnostics and avoid extra work by seeing if there were any errors in the returned expression; if there were, we didn't do any further work and just returned a `BoundReturnStatement` without doing conversion work. However, this is bad for speculative scenarios; speculation can introduce false-positive "errors", such as having duplicated local names in pattern declarations because the speculation is about replacing some existing expression with a declaration pattern with some new expression. You then observe unexpected semantics in that `return` statement, because the conversion to the actual return type of the method is missing. To fix this, we now always do the return conversion, and only suppress diagnostics in that case. Fixes https://github.com/dotnet/roslyn/issues/76799.
