### PR TITLE
Support organizing imports as part of LSP document formatting 

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -171,19 +171,10 @@ namespace Roslyn.Test.Utilities
             return compareLine != 0 ? compareLine : compareChar;
         }
 
-        private protected static string ApplyTextEdits(LSP.TextEdit[] edits, SourceText originalMarkup)
+        private protected static string ApplyTextEdits(LSP.TextEdit[]? edits, SourceText originalMarkup)
         {
-            var text = originalMarkup;
-            foreach (var edit in edits)
-            {
-                var lines = text.Lines;
-                var startPosition = ProtocolConversions.PositionToLinePosition(edit.Range.Start);
-                var endPosition = ProtocolConversions.PositionToLinePosition(edit.Range.End);
-                var textSpan = lines.GetTextSpan(new LinePositionSpan(startPosition, endPosition));
-                text = text.Replace(textSpan, edit.NewText);
-            }
-
-            return text.ToString();
+            var changes = Array.ConvertAll(edits ?? [], edit => ProtocolConversions.TextEditToTextChange(edit, originalMarkup));
+            return originalMarkup.WithChanges(changes).ToString();
         }
 
         internal static LSP.SymbolInformation CreateSymbolInformation(LSP.SymbolKind kind, string name, LSP.Location location, Glyph glyph, string? containerName = null)

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -300,13 +301,13 @@ namespace Roslyn.Test.Utilities
         private protected static CodeActionResolveData CreateCodeActionResolveData(string uniqueIdentifier, LSP.Location location, string[] codeActionPath, IEnumerable<string>? customTags = null)
             => new(uniqueIdentifier, customTags.ToImmutableArrayOrEmpty(), location.Range, CreateTextDocumentIdentifier(location.Uri), fixAllFlavors: null, nestedCodeActions: null, codeActionPath: codeActionPath);
 
-        private protected Task<TestLspServer> CreateTestLspServerAsync(string markup, bool mutatingLspWorkspace, LSP.ClientCapabilities clientCapabilities, bool callInitialized = true)
+        private protected Task<TestLspServer> CreateTestLspServerAsync([StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string markup, bool mutatingLspWorkspace, LSP.ClientCapabilities clientCapabilities, bool callInitialized = true)
             => CreateTestLspServerAsync([markup], LanguageNames.CSharp, mutatingLspWorkspace, new InitializationOptions { ClientCapabilities = clientCapabilities, CallInitialized = callInitialized });
 
-        private protected Task<TestLspServer> CreateTestLspServerAsync(string markup, bool mutatingLspWorkspace, InitializationOptions? initializationOptions = null, TestComposition? composition = null)
+        private protected Task<TestLspServer> CreateTestLspServerAsync([StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string markup, bool mutatingLspWorkspace, InitializationOptions? initializationOptions = null, TestComposition? composition = null)
             => CreateTestLspServerAsync([markup], LanguageNames.CSharp, mutatingLspWorkspace, initializationOptions, composition);
 
-        private protected Task<TestLspServer> CreateTestLspServerAsync(string[] markups, bool mutatingLspWorkspace, InitializationOptions? initializationOptions = null, TestComposition? composition = null)
+        private protected Task<TestLspServer> CreateTestLspServerAsync([StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string[] markups, bool mutatingLspWorkspace, InitializationOptions? initializationOptions = null, TestComposition? composition = null)
             => CreateTestLspServerAsync(markups, LanguageNames.CSharp, mutatingLspWorkspace, initializationOptions, composition);
 
         private protected Task<TestLspServer> CreateVisualBasicTestLspServerAsync(string markup, bool mutatingLspWorkspace, InitializationOptions? initializationOptions = null, TestComposition? composition = null)

--- a/src/Features/TestUtilities/Microsoft.CodeAnalysis.Features.Test.Utilities.csproj
+++ b/src/Features/TestUtilities/Microsoft.CodeAnalysis.Features.Test.Utilities.csproj
@@ -29,6 +29,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures2.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.Features.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.DiagnosticsTests.Utilities" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities2" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures2.UnitTests" />

--- a/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             LanguageServerProjectSystemOptionsStorage.BinaryLogPath,
             LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore,
             MetadataAsSourceOptionsStorage.NavigateToSourceLinkAndEmbeddedSources,
+            LspOptionsStorage.LspFormattingSortImports,
         ];
     }
 }

--- a/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             LanguageServerProjectSystemOptionsStorage.BinaryLogPath,
             LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore,
             MetadataAsSourceOptionsStorage.NavigateToSourceLinkAndEmbeddedSources,
-            LspOptionsStorage.LspFormattingSortImports,
+            LspOptionsStorage.LspOrganizeImportsOnFormat,
         ];
     }
 }

--- a/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -9,10 +9,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.OrganizeImports;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             if (range is null && globalOptions.GetOption(LspOptionsStorage.LspFormattingSortImports, document.Project.Language))
             {
                 var organizeImports = document.GetRequiredLanguageService<IOrganizeImportsService>();
-                var organizeImportsOptions = await document.GetOrganizeImportsOptionsAsync(globalOptions, cancellationToken).ConfigureAwait(false);
+                var organizeImportsOptions = await document.GetOrganizeImportsOptionsAsync(cancellationToken).ConfigureAwait(false);
                 var organizedDocument = await organizeImports.OrganizeImportsAsync(document, organizeImportsOptions, cancellationToken).ConfigureAwait(false);
                 textChanges = (await organizedDocument.GetTextChangesAsync(document, cancellationToken).ConfigureAwait(false)).ToList();
                 document = organizedDocument;
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var formattingOptions = await ProtocolConversions.GetFormattingOptionsAsync(options, document, cancellationToken).ConfigureAwait(false);
 
             var services = document.Project.Solution.Services;
-            var formattingTextChanges = Formatter.GetFormattedTextChanges(root, SpecializedCollections.SingletonEnumerable(formattingSpan), services, formattingOptions, rules: null, cancellationToken);
+            var formattingTextChanges = Formatter.GetFormattedTextChanges(root, SpecializedCollections.SingletonEnumerable(formattingSpan), services, formattingOptions, cancellationToken);
             if (textChanges is { Count: > 0 })
             {
                 if (formattingTextChanges.Count > 0)

--- a/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.OrganizeImports;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -23,12 +25,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         protected static async Task<LSP.TextEdit[]?> GetTextEditsAsync(
             RequestContext context,
             LSP.FormattingOptions options,
+            IGlobalOptionService globalOptions,
             CancellationToken cancellationToken,
             LSP.Range? range = null)
         {
-            var document = context.Document;
-            if (document is null)
+            if (context.Document is not { } document)
                 return null;
+
+            IList<TextChange>? textChanges = null;
+            if (range is null && globalOptions.GetOption(LspOptionsStorage.LspFormattingSortImports, document.Project.Language))
+            {
+                var organizeImports = document.GetRequiredLanguageService<IOrganizeImportsService>();
+                var organizeImportsOptions = await document.GetOrganizeImportsOptionsAsync(globalOptions, cancellationToken).ConfigureAwait(false);
+                var organizedDocument = await organizeImports.OrganizeImportsAsync(document, organizeImportsOptions, cancellationToken).ConfigureAwait(false);
+                textChanges = (await organizedDocument.GetTextChangesAsync(document, cancellationToken).ConfigureAwait(false)).ToList();
+                document = organizedDocument;
+            }
 
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -40,8 +52,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var formattingOptions = await ProtocolConversions.GetFormattingOptionsAsync(options, document, cancellationToken).ConfigureAwait(false);
 
             var services = document.Project.Solution.Services;
-            var textChanges = Formatter.GetFormattedTextChanges(root, [formattingSpan], services, formattingOptions, rules: default, cancellationToken);
-            return [.. textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text))];
+            var formattingTextChanges = Formatter.GetFormattedTextChanges(root, SpecializedCollections.SingletonEnumerable(formattingSpan), services, formattingOptions, rules: null, cancellationToken);
+            if (textChanges is { Count: > 0 })
+            {
+                if (formattingTextChanges.Count > 0)
+                {
+                    // Translate the formatting changes as a follow-up operation to the organization operation
+                    var formattedDocument = document.WithText(text.WithChanges(formattingTextChanges));
+                    textChanges = (await formattedDocument.GetTextChangesAsync(context.Document, cancellationToken).ConfigureAwait(false)).ToList();
+                }
+                else
+                {
+                    // The only changes come from organizing imports
+                }
+            }
+            else
+            {
+                textChanges = formattingTextChanges;
+            }
+
+            var originalText = await context.Document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+            return [.. textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, originalText))];
         }
 
         public abstract LSP.TextDocumentIdentifier GetTextDocumentIdentifier(RequestType request);

--- a/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             // We only organize the imports when formatting the entire document. This means we can stop
             // if we are provided a range or sorting imports is disabled/
-            if (range is not null || !globalOptions.GetOption(LspOptionsStorage.LspFormattingSortImports, document.Project.Language))
+            if (range is not null || !globalOptions.GetOption(LspOptionsStorage.LspOrganizeImportsOnFormat, document.Project.Language))
             {
                 return [.. formattingChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text))];
             }

--- a/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -23,6 +23,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             LSP.DocumentFormattingParams request,
             RequestContext context,
             CancellationToken cancellationToken)
-            => GetTextEditsAsync(context, request.Options, cancellationToken);
+            => GetTextEditsAsync(context, request.Options, _globalOptions, cancellationToken);
     }
 }

--- a/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -15,8 +16,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     [Method(LSP.Methods.TextDocumentFormattingName)]
     [method: ImportingConstructor]
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    internal sealed class FormatDocumentHandler() : AbstractFormatDocumentHandlerBase<LSP.DocumentFormattingParams, LSP.TextEdit[]?>
+    internal sealed class FormatDocumentHandler(IGlobalOptionService globalOptions) : AbstractFormatDocumentHandlerBase<LSP.DocumentFormattingParams, LSP.TextEdit[]?>
     {
+        private readonly IGlobalOptionService _globalOptions = globalOptions;
+
         public override LSP.TextDocumentIdentifier GetTextDocumentIdentifier(LSP.DocumentFormattingParams request) => request.TextDocument;
 
         public override Task<LSP.TextEdit[]?> HandleRequestAsync(

--- a/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -15,8 +16,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     [Method(Methods.TextDocumentRangeFormattingName)]
     [method: ImportingConstructor]
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    internal sealed class FormatDocumentRangeHandler() : AbstractFormatDocumentHandlerBase<DocumentRangeFormattingParams, TextEdit[]?>
+    internal sealed class FormatDocumentRangeHandler(IGlobalOptionService globalOptions) : AbstractFormatDocumentHandlerBase<DocumentRangeFormattingParams, TextEdit[]?>
     {
+        private readonly IGlobalOptionService _globalOptions = globalOptions;
+
         public override TextDocumentIdentifier GetTextDocumentIdentifier(DocumentRangeFormattingParams request) => request.TextDocument;
 
         public override Task<TextEdit[]?> HandleRequestAsync(

--- a/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -23,6 +23,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             DocumentRangeFormattingParams request,
             RequestContext context,
             CancellationToken cancellationToken)
-            => GetTextEditsAsync(context, request.Options, cancellationToken, range: request.Range);
+            => GetTextEditsAsync(context, request.Options, _globalOptions, cancellationToken, range: request.Range);
     }
 }

--- a/src/LanguageServer/Protocol/LspOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/LspOptionsStorage.cs
@@ -53,6 +53,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// <summary>
         /// <see langword="true"/> to sort imports as part of LSP's Format Document handler; otherwise, <see langword="false"/>.
         /// </summary>
-        public static readonly PerLanguageOption2<bool> LspFormattingSortImports = new("dotnet_formatting_sortImports", defaultValue: false, group: s_formattingOptionGroup);
+        public static readonly PerLanguageOption2<bool> LspFormattingSortImports = new("dotnet_formatting_sort_imports", defaultValue: false, group: s_formattingOptionGroup);
     }
 }

--- a/src/LanguageServer/Protocol/LspOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/LspOptionsStorage.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static readonly Option2<bool> LspUsingDevkitFeatures = new("dotnet_lsp_using_devkit", defaultValue: false);
 
         private static readonly OptionGroup s_codeLensOptionGroup = new(name: "code_lens", description: "");
+        private static readonly OptionGroup s_formattingOptionGroup = new(name: "formatting", description: "");
 
         private static readonly OptionGroup s_autoInsertOptionGroup = new(name: "auto_insert", description: "");
 
@@ -48,5 +49,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// Flag indicating whether or not auto-insert should be abled by default in LSP.
         /// </summary>
         public static readonly PerLanguageOption2<bool> LspEnableAutoInsert = new("dotnet_enable_auto_insert", defaultValue: true, group: s_autoInsertOptionGroup);
+
+        /// <summary>
+        /// <see langword="true"/> to sort imports as part of LSP's Format Document handler; otherwise, <see langword="false"/>.
+        /// </summary>
+        public static readonly PerLanguageOption2<bool> LspFormattingSortImports = new("dotnet_formatting_sortImports", defaultValue: false, group: s_formattingOptionGroup);
     }
 }

--- a/src/LanguageServer/Protocol/LspOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/LspOptionsStorage.cs
@@ -51,8 +51,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static readonly PerLanguageOption2<bool> LspEnableAutoInsert = new("dotnet_enable_auto_insert", defaultValue: true, group: s_autoInsertOptionGroup);
 
         /// <summary>
-        /// <see langword="true"/> to sort imports as part of LSP's Format Document handler; otherwise, <see langword="false"/>.
+        /// <see langword="true"/> to organize imports as part of LSP's Format Document handler; otherwise, <see langword="false"/>.
         /// </summary>
-        public static readonly PerLanguageOption2<bool> LspFormattingSortImports = new("dotnet_formatting_sort_imports", defaultValue: false, group: s_formattingOptionGroup);
+        public static readonly PerLanguageOption2<bool> LspOrganizeImportsOnFormat = new("dotnet_organize_imports_on_format", defaultValue: false, group: s_formattingOptionGroup);
     }
 }

--- a/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -145,12 +145,15 @@ public class A { }";
                 "code_lens.dotnet_enable_references_code_lens",
                 "code_lens.dotnet_enable_tests_code_lens",
                 "auto_insert.dotnet_enable_auto_insert",
+                "formatting.dotnet_formatting_sort_imports",
                 "projects.dotnet_binary_log_path",
                 "projects.dotnet_enable_automatic_restore",
                 "navigation.dotnet_navigate_to_source_link_and_embedded_sources"
             };
 
-            AssertEx.SetEqual(expectedNames, actualNames);
+            AssertEx.EqualOrDiff(
+                string.Join(Environment.NewLine, expectedNames),
+                string.Join(Environment.NewLine, actualNames));
         }
 
         private static void VerifyValuesInServer(EditorTestWorkspace workspace, List<string> expectedValues)

--- a/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -145,10 +145,10 @@ public class A { }";
                 "code_lens.dotnet_enable_references_code_lens",
                 "code_lens.dotnet_enable_tests_code_lens",
                 "auto_insert.dotnet_enable_auto_insert",
-                "formatting.dotnet_formatting_sort_imports",
                 "projects.dotnet_binary_log_path",
                 "projects.dotnet_enable_automatic_restore",
-                "navigation.dotnet_navigate_to_source_link_and_embedded_sources"
+                "navigation.dotnet_navigate_to_source_link_and_embedded_sources",
+                "formatting.dotnet_organize_imports_on_format",
             };
 
             AssertEx.EqualOrDiff(

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;
@@ -46,7 +44,194 @@ void M()
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI);
             var actualText = ApplyTextEdits(results, documentText);
-            Assert.Equal(expected, actualText);
+            AssertEx.EqualOrDiff(expected, actualText);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestFormatDocumentWithOrganizeImports1Async(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                using System.Collections;
+                using System;
+
+                class A{|caret:|}
+                {
+                }
+                """;
+            var expected =
+                """
+                using System;
+                using System.Collections;
+
+                class A
+                {
+                }
+                """;
+
+            var options = new InitializationOptions
+            {
+                OptionUpdater = globalOptions =>
+                {
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                },
+            };
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
+            var documentURI = testLspServer.GetLocations("caret").Single().Uri;
+            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+
+            var results = await RunFormatDocumentAsync(testLspServer, documentURI);
+            var actualText = ApplyTextEdits(results, documentText);
+            AssertEx.EqualOrDiff(expected, actualText);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestFormatDocumentWithOrganizeImports2Async(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                using   System.Collections;
+                using  System;
+
+                class A{|caret:|}
+                {
+                }
+                """;
+            var expected =
+                """
+                using System;
+                using System.Collections;
+
+                class A
+                {
+                }
+                """;
+
+            var options = new InitializationOptions
+            {
+                OptionUpdater = globalOptions =>
+                {
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                },
+            };
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
+            var documentURI = testLspServer.GetLocations("caret").Single().Uri;
+            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+
+            var results = await RunFormatDocumentAsync(testLspServer, documentURI);
+            var actualText = ApplyTextEdits(results, documentText);
+            AssertEx.EqualOrDiff(expected, actualText);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestFormatDocumentWithOrganizeImports3Async(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                using  System;
+                using   System.Collections;
+
+                class A{|caret:|}
+                {
+                }
+                """;
+            var expected =
+                """
+                using System;
+                using System.Collections;
+
+                class A
+                {
+                }
+                """;
+
+            var options = new InitializationOptions
+            {
+                OptionUpdater = globalOptions =>
+                {
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                },
+            };
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
+            var documentURI = testLspServer.GetLocations("caret").Single().Uri;
+            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+
+            var results = await RunFormatDocumentAsync(testLspServer, documentURI);
+            var actualText = ApplyTextEdits(results, documentText);
+            AssertEx.EqualOrDiff(expected, actualText);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestFormatDocumentWithOrganizeImports4Async(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                using System;
+                using System.Collections;
+
+                class  A{|caret:|}
+                {
+                }
+                """;
+            var expected =
+                """
+                using System;
+                using System.Collections;
+
+                class A
+                {
+                }
+                """;
+
+            var options = new InitializationOptions
+            {
+                OptionUpdater = globalOptions =>
+                {
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                },
+            };
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
+            var documentURI = testLspServer.GetLocations("caret").Single().Uri;
+            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+
+            var results = await RunFormatDocumentAsync(testLspServer, documentURI);
+            var actualText = ApplyTextEdits(results, documentText);
+            AssertEx.EqualOrDiff(expected, actualText);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestFormatDocumentWithoutOrganizeImportsAsync(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                using System.Collections;
+                using System;
+
+                class A{|caret:|}
+                {
+                }
+                """;
+            var expected =
+                """
+                using System.Collections;
+                using System;
+
+                class A
+                {
+                }
+                """;
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+            var documentURI = testLspServer.GetLocations("caret").Single().Uri;
+            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+
+            var results = await RunFormatDocumentAsync(testLspServer, documentURI);
+            var actualText = ApplyTextEdits(results, documentText);
+            AssertEx.EqualOrDiff(expected, actualText);
         }
 
         [Theory, CombinatorialData]
@@ -74,7 +259,7 @@ void M()
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI, insertSpaces: false, tabSize: 4);
             var actualText = ApplyTextEdits(results, documentText);
-            Assert.Equal(expected, actualText);
+            AssertEx.EqualOrDiff(expected, actualText);
         }
 
         [Theory, CombinatorialData]
@@ -102,10 +287,10 @@ void M()
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI, insertSpaces: true, tabSize: 2);
             var actualText = ApplyTextEdits(results, documentText);
-            Assert.Equal(expected, actualText);
+            AssertEx.EqualOrDiff(expected, actualText);
         }
 
-        private static async Task<LSP.TextEdit[]> RunFormatDocumentAsync(
+        private static async Task<LSP.TextEdit[]?> RunFormatDocumentAsync(
             TestLspServer testLspServer,
             Uri uri,
             bool insertSpaces = true,

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
@@ -79,7 +79,7 @@ void M()
 
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
             var documentURI = testLspServer.GetLocations("caret").Single().Uri;
-            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+            var documentText = await testLspServer.GetDocumentTextAsync(documentURI);
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI);
             var actualText = ApplyTextEdits(results, documentText);
@@ -118,7 +118,7 @@ void M()
 
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
             var documentURI = testLspServer.GetLocations("caret").Single().Uri;
-            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+            var documentText = await testLspServer.GetDocumentTextAsync(documentURI);
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI);
             var actualText = ApplyTextEdits(results, documentText);
@@ -157,7 +157,7 @@ void M()
 
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
             var documentURI = testLspServer.GetLocations("caret").Single().Uri;
-            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+            var documentText = await testLspServer.GetDocumentTextAsync(documentURI);
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI);
             var actualText = ApplyTextEdits(results, documentText);
@@ -196,7 +196,7 @@ void M()
 
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, options);
             var documentURI = testLspServer.GetLocations("caret").Single().Uri;
-            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+            var documentText = await testLspServer.GetDocumentTextAsync(documentURI);
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI);
             var actualText = ApplyTextEdits(results, documentText);
@@ -227,7 +227,7 @@ void M()
 
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
             var documentURI = testLspServer.GetLocations("caret").Single().Uri;
-            var documentText = await testLspServer.GetCurrentSolution().GetDocuments(documentURI).Single().GetTextAsync();
+            var documentText = await testLspServer.GetDocumentTextAsync(documentURI);
 
             var results = await RunFormatDocumentAsync(testLspServer, documentURI);
             var actualText = ApplyTextEdits(results, documentText);

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentTests.cs
@@ -73,7 +73,7 @@ void M()
             {
                 OptionUpdater = globalOptions =>
                 {
-                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspOrganizeImportsOnFormat, LanguageNames.CSharp, true);
                 },
             };
 
@@ -112,7 +112,7 @@ void M()
             {
                 OptionUpdater = globalOptions =>
                 {
-                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspOrganizeImportsOnFormat, LanguageNames.CSharp, true);
                 },
             };
 
@@ -151,7 +151,7 @@ void M()
             {
                 OptionUpdater = globalOptions =>
                 {
-                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspOrganizeImportsOnFormat, LanguageNames.CSharp, true);
                 },
             };
 
@@ -190,7 +190,7 @@ void M()
             {
                 OptionUpdater = globalOptions =>
                 {
-                    globalOptions.SetGlobalOption(LspOptionsStorage.LspFormattingSortImports, LanguageNames.CSharp, true);
+                    globalOptions.SetGlobalOption(LspOptionsStorage.LspOrganizeImportsOnFormat, LanguageNames.CSharp, true);
                 },
             };
 

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -240,9 +240,10 @@ public class VisualStudioOptionStorageTests
             "dotnet_enable_references_code_lens",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_tests_code_lens",                                                // VSCode only option.  Does not apply to VS.
             "dotnet_enable_auto_insert",                                                    // VSCode only option.  Does not apply to VS.
+            "dotnet_formatting_sort_imports",                                               // VSCode only option.  Does not apply to VS.
             "end_of_line",                                                                  // persisted by the editor
             "ExtensionManagerOptions_DisableCrashingExtensions",                            // TODO: remove? https://github.com/dotnet/roslyn/issues/66063
-            "FeatureOnOffOptions_RefactoringVerification",                                  // TODO: remove? https://github.com/dotnet/roslyn/issues/66063 
+            "FeatureOnOffOptions_RefactoringVerification",                                  // TODO: remove? https://github.com/dotnet/roslyn/issues/66063
             "FeatureOnOffOptions_RenameTracking",                                           // TODO: remove? https://github.com/dotnet/roslyn/issues/66063
             "file_header_template",                                                         // repository specific
             "dotnet_unsupported_wrapping_column",                                           // TODO: https://github.com/dotnet/roslyn/issues/66062

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -240,7 +240,7 @@ public class VisualStudioOptionStorageTests
             "dotnet_enable_references_code_lens",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_tests_code_lens",                                                // VSCode only option.  Does not apply to VS.
             "dotnet_enable_auto_insert",                                                    // VSCode only option.  Does not apply to VS.
-            "dotnet_formatting_sort_imports",                                               // VSCode only option.  Does not apply to VS.
+            "dotnet_organize_imports_on_format",                                            // VSCode only option.  Does not apply to VS.
             "end_of_line",                                                                  // persisted by the editor
             "ExtensionManagerOptions_DisableCrashingExtensions",                            // TODO: remove? https://github.com/dotnet/roslyn/issues/66063
             "FeatureOnOffOptions_RefactoringVerification",                                  // TODO: remove? https://github.com/dotnet/roslyn/issues/66063

--- a/src/Workspaces/CSharp/Portable/OrganizeImports/CSharpOrganizeImportsService.cs
+++ b/src/Workspaces/CSharp/Portable/OrganizeImports/CSharpOrganizeImportsService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.OrganizeImports;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.OrganizeImports;
@@ -19,7 +20,7 @@ internal sealed partial class CSharpOrganizeImportsService() : IOrganizeImportsS
 {
     public async Task<Document> OrganizeImportsAsync(Document document, OrganizeImportsOptions options, CancellationToken cancellationToken)
     {
-        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
         var rewriter = new Rewriter(options);
         var newRoot = rewriter.Visit(root);


### PR DESCRIPTION
This supersedes https://github.com/dotnet/roslyn/pull/70538

This PR adds a new LSP option to sort imports during document formatting. 

Related C# extension change: https://github.com/dotnet/vscode-csharp/pull/7935

Related to https://github.com/dotnet/vscode-csharp/issues/6148