### PR TITLE
Load razor assembly directly:

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -1810,7 +1810,7 @@ Delta.2: Test D2
 
             public List<AssemblyName> CalledFor { get; } = [];
 
-            public Assembly? ResolveAssembly(AssemblyName assemblyName)
+            public Assembly? ResolveAssembly(AssemblyName assemblyName, string rootDirectory)
             {
                 CalledFor.Add(assemblyName);
                 return _func(assemblyName);

--- a/src/Compilers/Core/CodeAnalysisTest/CompilerAnalyzerAssemblyResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CompilerAnalyzerAssemblyResolverTests.cs
@@ -17,7 +17,7 @@ public sealed class CompilerAnalyzerAssemblyResolverTests
         var context = new AssemblyLoadContext(nameof(ExceptionReturnsNull), isCollectible: true);
         var resolver = new AnalyzerAssemblyLoader.CompilerAnalyzerAssemblyResolver(context);
         var name = new AssemblyName("NotARealAssembly");
-        Assert.Null(resolver.ResolveAssembly(name));
+        Assert.Null(resolver.ResolveAssembly(name, directoryName: ""));
         context.Unload();
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis
 
             protected override Assembly? Load(AssemblyName assemblyName)
             {
-                if (_loader.ResolveAssemblyExternally(assemblyName) is { } externallyResolvedAssembly)
+                if (_loader.ResolveAssemblyExternally(assemblyName, Directory) is { } externallyResolvedAssembly)
                 {
                     return externallyResolvedAssembly;
                 }
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly AssemblyLoadContext _compilerAlc = compilerContext;
 
-            public Assembly? ResolveAssembly(AssemblyName assemblyName)
+            public Assembly? ResolveAssembly(AssemblyName assemblyName, string directoryName)
             {
                 try
                 {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
         private partial Assembly? Load(AssemblyName assemblyName, string assemblyOriginalPath)
         {
             EnsureResolvedHooked();
-            if (ResolveAssemblyExternally(assemblyName) is { } externallyResolvedAssembly)
+            if (ResolveAssemblyExternally(assemblyName, Path.GetDirectoryName(assemblyOriginalPath)) is { } externallyResolvedAssembly)
             {
                 return externallyResolvedAssembly;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="assemblyName">The name of the assembly to resolve</param>
         /// <returns>An <see langword="assembly"/> if one of the resolvers is successful, or <see langword="null"/></returns>
-        internal Assembly? ResolveAssemblyExternally(AssemblyName assemblyName)
+        internal Assembly? ResolveAssemblyExternally(AssemblyName assemblyName, string rootDirectory)
         {
             CheckIfDisposed();
 
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     try
                     {
-                        if (resolver.ResolveAssembly(assemblyName) is { } resolvedAssembly)
+                        if (resolver.ResolveAssembly(assemblyName, rootDirectory) is { } resolvedAssembly)
                         {
                             return resolvedAssembly;
                         }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerAssemblyResolver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerAssemblyResolver.cs
@@ -14,8 +14,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Attempts to resolve an assembly by name.
         /// </summary>
-        /// <param name="assemblyName">The assembly to resolve</param>
+        /// <param name="assemblyName">The assembly to resolve.</param>
+        /// <param name="rootDirectory">The root directory the calling <see cref="AnalyzerAssemblyLoader"/> is configured with.</param>
         /// <returns>The resolved assembly, or <see langword="null"/></returns>
-        Assembly? ResolveAssembly(AssemblyName assemblyName);
+        Assembly? ResolveAssembly(AssemblyName assemblyName, string rootDirectory);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     [Export(typeof(IAnalyzerAssemblyResolver)), Shared]
     [method: ImportingConstructor]
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    internal class RazorAnalyzerAssemblyResolver() : IAnalyzerAssemblyResolver
+    internal sealed class RazorAnalyzerAssemblyResolver() : IAnalyzerAssemblyResolver
     {
         private const string RazorCompilerAssemblyName = "Microsoft.CodeAnalysis.Razor.Compiler";
         private const string RazorUtilsAssemblyName = "Microsoft.AspNetCore.Razor.Utilities.Shared";
@@ -25,11 +25,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         private static readonly object s_loaderLock = new();
 
-        public static Assembly? ResolveRazorAssembly(AssemblyName assemblyName, string directoryName)
+        public static Assembly? ResolveRazorAssembly(AssemblyName assemblyName, string rootDirectory)
         {
             if (assemblyName.Name is RazorCompilerAssemblyName or RazorUtilsAssemblyName or ObjectPoolAssemblyName)
             {
-                var assembly = Path.Combine(directoryName, $"{assemblyName.Name}.dll");
                 lock (s_loaderLock)
                 {
                     var compilerContext = AssemblyLoadContext.GetLoadContext(typeof(Compilation).Assembly)!;
@@ -37,6 +36,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                     {
                         return loadedAssembly;
                     }
+
+                    var assembly = Path.Combine(rootDirectory, $"{assemblyName.Name}.dll");
                     return compilerContext.LoadFromAssemblyPath(assembly);
                 }
             }

--- a/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorAnalyzerAssemblyResolver.cs
@@ -1,14 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#if NET
 
 using System;
-using System.Collections.Generic;
 using System.Composition;
-using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
@@ -18,41 +19,31 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     internal class RazorAnalyzerAssemblyResolver() : IAnalyzerAssemblyResolver
     {
-        private static Func<AssemblyName, Assembly?>? s_assemblyResolver;
+        private const string RazorCompilerAssemblyName = "Microsoft.CodeAnalysis.Razor.Compiler";
+        private const string RazorUtilsAssemblyName = "Microsoft.AspNetCore.Razor.Utilities.Shared";
+        private const string ObjectPoolAssemblyName = "Microsoft.Extensions.ObjectPool";
 
-        private static readonly HashSet<AssemblyName> s_assembliesRequested = [];
+        private static readonly object s_loaderLock = new();
 
-        private static readonly object s_resolverLock = new();
-
-        /// <summary>
-        /// Attempts to set the assembly resolver. Will only succeed if the <paramref name="canaryAssembly"/> has not already been requested to load and the resolver has not been set previously.
-        /// </summary>
-        /// <param name="resolver">The resolver function to set.</param>
-        /// <param name="canaryAssembly">The name of an assembly that is checked to see if it has been requested to load. Setting the resolver will fail if this has already been requested.</param>
-        /// <returns><c>true</c> when the resolver was successfully set.</returns>
-        internal static bool TrySetAssemblyResolver(Func<AssemblyName, Assembly?> resolver, AssemblyName canaryAssembly)
+        public static Assembly? ResolveRazorAssembly(AssemblyName assemblyName, string directoryName)
         {
-            lock (s_resolverLock)
+            if (assemblyName.Name is RazorCompilerAssemblyName or RazorUtilsAssemblyName or ObjectPoolAssemblyName)
             {
-                if (s_assemblyResolver is null && !s_assembliesRequested.Contains(canaryAssembly))
+                var assembly = Path.Combine(directoryName, $"{assemblyName.Name}.dll");
+                lock (s_loaderLock)
                 {
-                    s_assemblyResolver = resolver;
-                    return true;
+                    var compilerContext = AssemblyLoadContext.GetLoadContext(typeof(Compilation).Assembly)!;
+                    if (compilerContext.Assemblies.SingleOrDefault(a => a.GetName().Name == assemblyName.Name) is Assembly loadedAssembly)
+                    {
+                        return loadedAssembly;
+                    }
+                    return compilerContext.LoadFromAssemblyPath(assembly);
                 }
-                return false;
             }
+            return null;
         }
 
-        public Assembly? ResolveAssembly(AssemblyName assemblyName)
-        {
-            Func<AssemblyName, Assembly?>? resolver = null;
-            lock (s_resolverLock)
-            {
-                s_assembliesRequested.Add(assemblyName);
-                resolver = s_assemblyResolver;
-            }
-
-            return resolver?.Invoke(assemblyName);
-        }
+        public Assembly? ResolveAssembly(AssemblyName assemblyName, string directoryName) => ResolveRazorAssembly(assemblyName, directoryName);
     }
 }
+#endif

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
@@ -26,7 +26,7 @@ internal class RemoteWorkspaceManager
         MefHostServices.DefaultAssemblies
             .Add(typeof(AspNetCoreEmbeddedLanguageClassifier).Assembly)
             .Add(typeof(BrokeredServiceBase).Assembly)
-            .Add(typeof(RazorAnalyzerAssemblyResolver).Assembly)
+            .Add(typeof(IRazorLanguageServerTarget).Assembly)
             .Add(typeof(RemoteWorkspacesResources).Assembly);
 
     /// <summary>


### PR DESCRIPTION
- Pass the root directory to assembly resolvers
- When looking for razor or its deps load them into the same ALC as the compiler