### PR TITLE
Fix: Set DOTNET_ROOT to DOTNET_ROOT_USER during test execution

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -58,7 +58,7 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             EnvironmentVariables = new()
             {
                 // Reset dotnet root so that vs test console can find the right runtimes.
-                { DotnetCliHelper.DotnetRootEnvVar, string.Empty },
+                { DotnetCliHelper.DotnetRootEnvVar, Environment.GetEnvironmentVariable("DOTNET_ROOT_USER") },
             }
         });
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -50,6 +50,8 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
         // Find the appropriate vstest.console.dll from the SDK.
         var vsTestConsolePath = await dotnetCliHelper.GetVsTestConsolePathAsync(projectOutputDirectory, cancellationToken);
 
+        var dotnetRootUser = Environment.GetEnvironmentVariable("DOTNET_ROOT_USER");
+
         // Instantiate the test platform wrapper.
         var vsTestConsoleWrapper = new VsTestConsoleWrapper(vsTestConsolePath, new ConsoleParameters
         {
@@ -58,11 +60,7 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             EnvironmentVariables = new()
             {
                 // Reset dotnet root so that vs test console can find the right runtimes.
-                { DotnetCliHelper.DotnetRootEnvVar,
-                string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_ROOT_USER")) ||
-                Environment.GetEnvironmentVariable("DOTNET_ROOT_USER") == "EMPTY" ?
-                string.Empty :
-                Environment.GetEnvironmentVariable("DOTNET_ROOT_USER") }
+                { DotnetCliHelper.DotnetRootEnvVar, string.IsNullOrEmpty(dotnetRootUser) || dotnetRootUser == "EMPTY" ? string.Empty : dotnetRootUser }
             }
         });
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -58,7 +58,11 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             EnvironmentVariables = new()
             {
                 // Reset dotnet root so that vs test console can find the right runtimes.
-                { DotnetCliHelper.DotnetRootEnvVar, Environment.GetEnvironmentVariable("DOTNET_ROOT_USER") },
+                { DotnetCliHelper.DotnetRootEnvVar,
+                string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_ROOT_USER")) ||
+                Environment.GetEnvironmentVariable("DOTNET_ROOT_USER") == "EMPTY" ?
+                string.Empty :
+                Environment.GetEnvironmentVariable("DOTNET_ROOT_USER") }
             }
         });
 


### PR DESCRIPTION
### Summary

This PR addresses the issue where the `DOTNET_ROOT` environment variable is set to an empty string during test execution, leading to failures when running external processes.

Related to https://github.com/dotnet/vscode-csharp/issues/6295