### PR TITLE
Do not offer to inline a decl into a switch arm when it is referenced outside of it.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -305,13 +303,13 @@ internal sealed class CSharpInlineDeclarationDiagnosticAnalyzer()
     {
         for (var current = argumentExpression; current != null; current = current.Parent)
         {
-            if (current.Parent is LambdaExpressionSyntax lambda &&
-                current == lambda.Body)
-            {
-                // We were in a lambda.  The lambda body will be the new scope of the 
-                // out var.
+            // We were in a lambda.  The lambda body will be the new scope of the out var.
+            if (current.Parent is LambdaExpressionSyntax lambda && current == lambda.Body)
                 return current;
-            }
+
+            // The arm of a switch expression is its own isolated scope.
+            if (current.Parent is SwitchExpressionArmSyntax switchArm && current == switchArm.Expression)
+                return current;
 
             // Any loop construct defines a scope for out-variables, as well as each of the following:
             // * Using statements

--- a/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -246,20 +246,6 @@ internal sealed class CSharpInlineDeclarationDiagnosticAnalyzer()
             properties: null));
     }
 
-    private static StatementSyntax GetLastStatement(SyntaxNode enclosingBlock)
-    {
-        if (enclosingBlock is BlockSyntax block)
-            return block.Statements.Last();
-
-        if (enclosingBlock is SwitchSectionSyntax switchSection)
-            return switchSection.Statements.Last();
-
-        if (enclosingBlock is CompilationUnitSyntax compilationUnit)
-            return compilationUnit.Members.OfType<GlobalStatementSyntax>().Last().Statement;
-
-        throw ExceptionUtilities.Unreachable();
-    }
-
     private static bool WouldCauseDefiniteAssignmentErrors(
         SemanticModel semanticModel,
         LocalDeclarationStatementSyntax localStatement,
@@ -281,7 +267,7 @@ internal sealed class CSharpInlineDeclarationDiagnosticAnalyzer()
 
         var dataFlow = semanticModel.AnalyzeDataFlow(
             nextStatement,
-            GetLastStatement(enclosingBlock));
+            CSharpBlockFacts.Instance.GetExecutableBlockStatements(enclosingBlock).Last());
         Contract.ThrowIfNull(dataFlow);
         return dataFlow.DataFlowsIn.Contains(outLocalSymbol);
     }

--- a/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -174,7 +175,7 @@ internal sealed class CSharpInlineDeclarationDiagnosticAnalyzer()
         // for references to the local to make sure that no reads/writes happen before
         // the out-argument.  If there are any reads/writes we can't inline as those
         // accesses will become invalid.
-        var enclosingBlockOfLocalStatement = GetEnclosingPseudoBlock(localStatement.Parent);
+        var enclosingBlockOfLocalStatement = CSharpBlockFacts.Instance.GetImmediateParentExecutableBlockForStatement(localStatement);
         if (enclosingBlockOfLocalStatement is null)
             return;
 
@@ -243,20 +244,6 @@ internal sealed class CSharpInlineDeclarationDiagnosticAnalyzer()
             context.Options,
             additionalLocations: allLocations,
             properties: null));
-    }
-
-    public static SyntaxNode? GetEnclosingPseudoBlock(SyntaxNode? parent)
-    {
-        if (parent is BlockSyntax)
-            return parent;
-
-        if (parent is SwitchSectionSyntax)
-            return parent;
-
-        if (parent is GlobalStatementSyntax)
-            return parent.Parent as CompilationUnitSyntax;
-
-        return null;
     }
 
     private static StatementSyntax GetLastStatement(SyntaxNode enclosingBlock)

--- a/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -11,7 +11,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;

--- a/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Simplification;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -115,7 +116,7 @@ internal sealed partial class CSharpInlineDeclarationCodeFixProvider() : SyntaxE
             // this local statement will be moved to be above the statement containing
             // the out-var.
             var localDeclarationStatement = (LocalDeclarationStatementSyntax)declaration.Parent;
-            var block = CSharpInlineDeclarationDiagnosticAnalyzer.GetEnclosingPseudoBlock(localDeclarationStatement.Parent);
+            var block = CSharpBlockFacts.Instance.GetImmediateParentExecutableBlockForStatement(localDeclarationStatement);
             var statements = GetStatements(block);
             var declarationIndex = statements.IndexOf(localDeclarationStatement);
 

--- a/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -2735,7 +2735,7 @@ public sealed partial class CSharpInlineDeclarationTests(ITestOutputHelper logge
                 private static int Main(string[] args)
                 {
                     Dictionary<int, int> dict = new Dictionary<int, int> { /* ... */ };
-                    [|int|] price; // IDE0018 
+                    [|int|] price;
                     bool found = args[0] switch
                     {
                         "First" => dict.TryGetValue(1, out price) ? price == 1 : false,
@@ -2756,7 +2756,7 @@ public sealed partial class CSharpInlineDeclarationTests(ITestOutputHelper logge
                     Dictionary<int, int> dict = new Dictionary<int, int> { /* ... */ };
                     bool found = args[0] switch
                     {
-                        "First" => dict.TryGetValue(1, out var price) ? price == 1 : false,
+                        "First" => dict.TryGetValue(1, out int price) ? price == 1 : false,
                         _ => false,
                     };
 

--- a/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -2696,4 +2696,73 @@ public sealed partial class CSharpInlineDeclarationTests(ITestOutputHelper logge
             }
             """, options: ExplicitTypeEverywhere());
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40650")]
+    public async Task TestReferencedInSwitchArms1()
+    {
+        await TestMissingAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                private static int Main(string[] args)
+                {
+                    Dictionary<int, int> dict = new Dictionary<int, int> { /* ... */ };
+                    [|int|] price; // IDE0018 
+                    bool found = args[0] switch
+                    {
+                        "First" => dict.TryGetValue(1, out price),
+                        "Second" => dict.TryGetValue(2, out price),
+                        _ => dict.TryGetValue(3, out price)
+                    };
+
+                    return found ? -1 : price;
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40650")]
+    public async Task TestReferencedInSwitchArms2()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                private static int Main(string[] args)
+                {
+                    Dictionary<int, int> dict = new Dictionary<int, int> { /* ... */ };
+                    [|int|] price; // IDE0018 
+                    bool found = args[0] switch
+                    {
+                        "First" => dict.TryGetValue(1, out price) ? price == 1 : false,
+                        _ => false,
+                    };
+
+                    return found;
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                private static int Main(string[] args)
+                {
+                    Dictionary<int, int> dict = new Dictionary<int, int> { /* ... */ };
+                    bool found = args[0] switch
+                    {
+                        "First" => dict.TryGetValue(1, out var price) ? price == 1 : false,
+                        _ => false,
+                    };
+
+                    return found;
+                }
+            }
+            """);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/40650