### PR TITLE
Remove workaround for old version of SRM.

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
@@ -240,13 +240,6 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // Workaround of issue https://github.com/dotnet/corefx/issues/1815: 
-            if (peStream.Length == 0 && (options & PEStreamOptions.PrefetchEntireImage) != 0 && (options & PEStreamOptions.PrefetchMetadata) != 0)
-            {
-                // throws BadImageFormatException:
-                new PEHeaders(peStream);
-            }
-
             // ownership of the stream is passed on PEReader:
             return new ModuleMetadata(new PEReader(peStream, options), onDispose: null);
         }


### PR DESCRIPTION
The issue mentioned in the comment has been fixed since almost nine years ago.