### PR TITLE
Reduce work in ConversionsBase.AddUserDefinedConversionsToExplicitCandidateSet

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
@@ -231,8 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    var originalOperators = ArrayBuilder<MethodSymbol>.GetInstance(operators.Count);
-                    originalOperators.AddRange(operators);
+                    var originalOperatorCount = operators.Count;
 
                     var operators2 = ArrayBuilder<MethodSymbol>.GetInstance();
                     declaringType.AddOperators(WellKnownMemberNames.ExplicitConversionName, operators2);
@@ -242,9 +241,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Drop operators that have a match among the checked ones.
                         bool add = true;
 
-                        foreach (MethodSymbol op in originalOperators)
+                        for (var i = 0; i < originalOperatorCount; i++)
                         {
-                            if (SourceMemberContainerTypeSymbol.DoOperatorsPair(op, op2))
+                            if (SourceMemberContainerTypeSymbol.DoOperatorsPair(operators[i], op2))
                             {
                                 add = false;
                                 break;
@@ -257,7 +256,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
 
-                    originalOperators.Free();
                     operators2.Free();
                 }
             }


### PR DESCRIPTION
The ArrayBuilder usage in this method is showing up slightly in speedometer CPU profiles (0.1%) but more heavily in local profiles I've taken using a much larger version of the file that Kayle provided than what the speedometer tests use (2.6%)

This method is called quite often and the (isExplicit && isChecked) check seems to not hit very often (specifically, never in my testing of opening/simple editing of the file). The usage of the pool and populating the array builder aren't necessary unless that case is hit, so I've reshuffled the code around a bit to avoid that.