### PR TITLE
Remove helper extension in diagnostics

### DIFF
--- a/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
+++ b/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 ' Verify available diagnostics
                 Dim document = project.Documents.Single()
                 Dim diagnostics = Await diagnosticService.GetDiagnosticsForSpanAsync(document,
-                    range:=(Await document.GetSyntaxRootAsync()).FullSpan, CancellationToken.None)
+                    range:=(Await document.GetSyntaxRootAsync()).FullSpan, DiagnosticKind.All, includeSuppressedDiagnostics:=False, CancellationToken.None)
 
                 Assert.Equal(1, diagnostics.Count())
 
@@ -140,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 ' Verify available diagnostics
                 Dim document = project.Documents.Single()
                 Dim diagnostics = Await diagnosticService.GetDiagnosticsForSpanAsync(document,
-                    range:=(Await document.GetSyntaxRootAsync()).FullSpan, CancellationToken.None)
+                    range:=(Await document.GetSyntaxRootAsync()).FullSpan, DiagnosticKind.All, includeSuppressedDiagnostics:=False, CancellationToken.None)
 
                 Assert.Equal(1, diagnostics.Count())
 

--- a/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -457,7 +457,8 @@ class Class
                     fixers: [],
                     [suppressionProviderFactory]);
                 var document = GetDocumentAndSelectSpan(workspace, out var span);
-                var diagnostics = await diagnosticService.GetDiagnosticsForSpanAsync(document, span, CancellationToken.None);
+                var diagnostics = await diagnosticService.GetDiagnosticsForSpanAsync(
+                    document, span, DiagnosticKind.All, includeSuppressedDiagnostics: false, CancellationToken.None);
                 Assert.Equal(2, diagnostics.Where(d => d.Id == "CS0219").Count());
 
                 var allFixes = (await fixService.GetFixesAsync(document, span, CancellationToken.None))

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -118,16 +118,6 @@ internal interface IDiagnosticAnalyzerService
 internal static class IDiagnosticAnalyzerServiceExtensions
 {
     /// <summary>
-    /// Return up to date diagnostics for the given <paramref name="range"/> for the given <paramref name="document"/>.
-    /// <para>
-    /// This can be expensive since it is force analyzing diagnostics if it doesn't have up-to-date one yet.
-    /// </para>
-    /// </summary>
-    public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(this IDiagnosticAnalyzerService service,
-        TextDocument document, TextSpan? range, CancellationToken cancellationToken)
-        => service.GetDiagnosticsForSpanAsync(document, range, DiagnosticKind.All, includeSuppressedDiagnostics: false, cancellationToken);
-
-    /// <summary>
     /// Return up to date diagnostics of the given <paramref name="diagnosticKind"/> for the given <paramref name="range"/>
     /// for the given <paramref name="document"/>.
     /// <para>

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractWorkspaceDocumentDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractWorkspaceDocumentDiagnosticSource.cs
@@ -44,7 +44,8 @@ internal abstract class AbstractWorkspaceDocumentDiagnosticSource(TextDocument d
             if (Document is SourceGeneratedDocument sourceGeneratedDocument)
             {
                 // Unfortunately GetDiagnosticsForIdsAsync returns nothing for source generated documents.
-                var documentDiagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(sourceGeneratedDocument, range: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var documentDiagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(
+                    sourceGeneratedDocument, range: null, DiagnosticKind.All, includeSuppressedDiagnostics: false, cancellationToken).ConfigureAwait(false);
                 return documentDiagnostics;
             }
             else

--- a/src/Tools/ExternalAccess/Razor/Cohost/Handlers/Diagnostics.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Handlers/Diagnostics.cs
@@ -20,7 +20,8 @@ internal static class Diagnostics
         var globalOptionsService = document.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
         var diagnosticAnalyzerService = document.Project.Solution.Services.ExportProvider.GetService<IDiagnosticAnalyzerService>();
 
-        var diagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(document, range: null, cancellationToken).ConfigureAwait(false);
+        var diagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(
+            document, range: null, DiagnosticKind.All, includeSuppressedDiagnostics: false, cancellationToken).ConfigureAwait(false);
 
         var project = document.Project;
         // isLiveSource means build might override a diagnostics, but this method is only used by tooling, so builds aren't relevant


### PR DESCRIPTION
This is part of a larger piece of work that simplifies these diagnostics apis.  Removing this extension helps push out to the feature level the customization choices each is making.