### PR TITLE
Revert "Change PR Val builds to be unsigned (#76358)"

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -33,8 +33,6 @@ variables:
     value: false
   - name: Codeql.SkipTaskAutoInjection
     value: true
-  - name: SignType
-    value: ''
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # If the pipeline is running in DevDiv, the account has access to the VS drop storage.

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -61,19 +61,4 @@
     <FileSignInfo Include="Microsoft.VisualStudio.Threading.dll" CertificateName="MicrosoftSHA2" />
     <FileSignInfo Include="StreamJsonRpc.dll" CertificateName="MicrosoftSHA2" />
   </ItemGroup>
-
-  <!--
-    We do not intend to ship the artifacts produced for PR validation build so we can skip signing the artifacts.
-   -->
-  <Choose>
-    <When Condition="'$(PreReleaseVersionLabel)' == 'pr-validation' And '$(SignType)' == ''">
-      <ItemGroup>
-        <ItemsToSign Remove="@(ItemsToSign)" />
-      </ItemGroup>
-
-      <PropertyGroup>
-        <AllowEmptySignList>true</AllowEmptySignList>
-      </PropertyGroup>
-    </When>
-  </Choose>
 </Project>


### PR DESCRIPTION
Current guess is that this is the cause of the rps/speedometer ngen failures.
Also the signing variable override doesn't appear to work (variable already defined in pipeline UI gets overriden to empty.  and the msbuild condition I think should be DotNetSignType)

This reverts commit 2eca5b28c9dd60e09fe4ebdc8544b9efce18d713, reversing changes made to fe3a243bd58966b3e683c9d038321ddb498ff043.