### PR TITLE
Testing time

### DIFF
--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -13,8 +13,6 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text.Json;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.TeamFoundation.TestManagement.WebApi;
-using Moq;
 
 namespace RunTests
 {

--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -28,7 +28,7 @@ namespace RunTests
         ///   3.  Setting up the test host for each assembly.
         ///   
         /// </summary>
-        private static readonly TimeSpan s_maxExecutionTime = TimeSpan.FromSeconds(60 * 2);
+        private static readonly TimeSpan s_maxExecutionTime = TimeSpan.FromSeconds(60 * 10);
 
         /// <summary>
         /// If we were unable to find the test execution history, we fall back to partitioning by just method count.

--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -24,7 +24,7 @@ namespace RunTests
         ///   3.  Setting up the test host for each assembly.
         ///   
         /// </summary>
-        private static readonly TimeSpan s_maxExecutionTime = TimeSpan.FromSeconds(60 * 10);
+        private static readonly TimeSpan s_maxExecutionTime = TimeSpan.FromSeconds(60 * 2);
 
         /// <summary>
         /// If we were unable to find the test execution history, we fall back to partitioning by just method count.


### PR DESCRIPTION
Couple of changes:

- Use the new `INumber<T>` to simplify the partitioning code
- Cleaned up partition strategy a bit to put long tests into a dedicated work item
- Log tests that exceed work item time slice to the console