### PR TITLE
Update formatOnType handler to support formatting on NewLine

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -80,21 +80,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // Take the following example of pressing enter after an opening brace.
                 //
                 // ```
-                // public void M() {||}
+                //    public void M() {||}
                 // ```
                 //
                 // The editor moves the cursor to the next line and uses it's languageconfig to add
                 // the appropriate level of indentation.
                 //
                 // ```
-                // public void M() {
-                //     ||
-                // }
+                //     public void M() {
+                //         ||
+                //     }
                 // ```
                 //
                 // At this point `formatOnType` is called. The formatting service will generate two
-                // text changes. The first moves the opening brace to the following line with proper
-                // indentation. The second removes the whitespace from the cursor line.
+                // text changes. The first moves the opening brace to a new line with proper
+                // indentation. The second removes the whitespace from the cursor line and rewrites
+                // the indentation prior to the closing brace.
                 // 
                 // Letting the second change go through would be a bad experience for the user as they
                 // will now be responsible for adding back the proper indentation.

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,65 +23,107 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Formatting
         public async Task TestFormatDocumentOnTypeAsync(bool mutatingLspWorkspace)
         {
             var markup =
-@"class A
-{
-    void M()
-    {
-        if (true)
-            {{|type:|}
-    }
-}";
+                """
+                class A
+                {
+                    void M()
+                    {
+                        if (true)
+                            {{|type:|}
+                    }
+                }
+                """;
             var expected =
-@"class A
-{
-    void M()
-    {
-        if (true)
-        {
-    }
-}";
+                """
+                class A
+                {
+                    void M()
+                    {
+                        if (true)
+                        {
+                    }
+                }
+                """;
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
             var characterTyped = ";";
             var locationTyped = testLspServer.GetLocations("type").Single();
-            var documentText = await testLspServer.GetDocumentTextAsync(locationTyped.Uri);
-
-            var results = await RunFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped);
-            var actualText = ApplyTextEdits(results, documentText);
-            Assert.Equal(expected, actualText);
+            await AssertFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, expected);
         }
 
         [Theory, CombinatorialData]
         public async Task TestFormatDocumentOnType_UseTabsAsync(bool mutatingLspWorkspace)
         {
             var markup =
-@"class A
-{
-	void M()
-	{
-		if (true)
-			{{|type:|}
-	}
-}";
+                """
+                class A
+                {
+                	void M()
+                	{
+                		if (true)
+                			{{|type:|}
+                	}
+                }
+                """;
             var expected =
-@"class A
-{
-	void M()
-	{
-		if (true)
-		{
-	}
-}";
+                """
+                class A
+                {
+                	void M()
+                	{
+                		if (true)
+                		{
+                	}
+                }
+                """;
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
             var characterTyped = ";";
             var locationTyped = testLspServer.GetLocations("type").Single();
-            var documentText = await testLspServer.GetDocumentTextAsync(locationTyped.Uri);
-
-            var results = await RunFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, insertSpaces: false, tabSize: 4);
-            var actualText = ApplyTextEdits(results, documentText);
-            Assert.Equal(expected, actualText);
+            await AssertFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, expected, insertSpaces: false, tabSize: 4);
         }
 
-        private static async Task<LSP.TextEdit[]> RunFormatDocumentOnTypeAsync(
+        [Theory, CombinatorialData]
+        public async Task TestFormatDocumentOnType_NewLine(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                class A
+                {
+                    void M() {
+                        {|type:|}
+                    }
+                }
+                """;
+            var expected =
+                """
+                class A
+                {
+                    void M()
+                    {
+                        
+                    }
+                }
+                """;
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+            var characterTyped = "\n";
+            var locationTyped = testLspServer.GetLocations("type").Single();
+            await AssertFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, expected);
+        }
+
+        private static async Task AssertFormatDocumentOnTypeAsync(
+            TestLspServer testLspServer,
+            string characterTyped,
+            LSP.Location locationTyped,
+            [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string expectedText,
+            bool insertSpaces = true,
+            int tabSize = 4)
+        {
+            var documentText = await testLspServer.GetDocumentTextAsync(locationTyped.Uri);
+            var results = await RunFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, insertSpaces, tabSize);
+            var actualText = ApplyTextEdits(results, documentText);
+            Assert.Equal(expectedText, actualText);
+        }
+
+        private static async Task<LSP.TextEdit[]?> RunFormatDocumentOnTypeAsync(
             TestLspServer testLspServer,
             string characterTyped,
             LSP.Location locationTyped,

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
@@ -118,21 +118,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Formatting
             int tabSize = 4)
         {
             var documentText = await testLspServer.GetDocumentTextAsync(locationTyped.Uri);
-            var results = await RunFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, insertSpaces, tabSize);
+            var results = await testLspServer.ExecuteRequestAsync<LSP.DocumentOnTypeFormattingParams, LSP.TextEdit[]>(
+                LSP.Methods.TextDocumentOnTypeFormattingName,
+                CreateDocumentOnTypeFormattingParams(characterTyped, locationTyped, insertSpaces, tabSize),
+                CancellationToken.None);
             var actualText = ApplyTextEdits(results, documentText);
             Assert.Equal(expectedText, actualText);
-        }
-
-        private static async Task<LSP.TextEdit[]?> RunFormatDocumentOnTypeAsync(
-            TestLspServer testLspServer,
-            string characterTyped,
-            LSP.Location locationTyped,
-            bool insertSpaces = true,
-            int tabSize = 4)
-        {
-            return await testLspServer.ExecuteRequestAsync<LSP.DocumentOnTypeFormattingParams, LSP.TextEdit[]>(LSP.Methods.TextDocumentOnTypeFormattingName,
-                CreateDocumentOnTypeFormattingParams(
-                    characterTyped, locationTyped, insertSpaces, tabSize), CancellationToken.None);
         }
 
         private static LSP.DocumentOnTypeFormattingParams CreateDocumentOnTypeFormattingParams(


### PR DESCRIPTION
Enables format on type when the trigger character is a newline. Removes text changes that contain the cursor as we do not want to remove the indentation.


https://github.com/user-attachments/assets/962f8229-f41b-4632-a8e9-b7660575e448



Resolves https://github.com/dotnet/vscode-csharp/issues/6834