### PR TITLE
Stop escaped compiler args from being mangled by MSBuild

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ArgsTaskItem.cs
+++ b/src/Compilers/Core/MSBuildTask/ArgsTaskItem.cs
@@ -55,8 +55,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         public void CopyMetadataTo(ITaskItem destinationItem)
         {
+            // Implementation notes that we should not overwrite existing metadata on the destination.
+            var sourceMetadataNames = MetadataNames.OfType<string>();
             var destinationMetadataNames = destinationItem.MetadataNames.OfType<string>();
-            var metadataNamesToCopy = _metadata.Keys.Intersect(destinationMetadataNames, StringComparer.OrdinalIgnoreCase).ToArray();
+            var metadataNamesToCopy = sourceMetadataNames.Except(destinationMetadataNames, StringComparer.OrdinalIgnoreCase).ToArray();
 
             foreach (var metadataName in metadataNamesToCopy)
             {

--- a/src/Compilers/Core/MSBuildTask/ArgsTaskItem.cs
+++ b/src/Compilers/Core/MSBuildTask/ArgsTaskItem.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    internal sealed class ArgsTaskItem : ITaskItem
+    {
+        // This list is taken from src/Shared/Modifiers.cs in the dotnet/msbuild repo.
+        private static readonly string[] WellKnownItemSpecMetadataNames =
+        {
+            "FullPath",
+            "RootDir",
+            "Filename",
+            "Extension",
+            "RelativeDir",
+            "Directory",
+            "RecursiveDir",
+            "Identity",
+            "ModifiedTime",
+            "CreatedTime",
+            "AccessedTime",
+            "DefiningProjectFullPath",
+            "DefiningProjectDirectory",
+            "DefiningProjectName",
+            "DefiningProjectExtension",
+        };
+
+        private readonly Dictionary<string, string> _metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        public ArgsTaskItem(string itemSpec)
+        {
+            ItemSpec = itemSpec;
+        }
+
+        public string ItemSpec { get; set; }
+
+        // Implementation notes that we should include the built-in metadata names as well as our custom ones.
+        public ICollection MetadataNames => _metadata.Keys.Concat(WellKnownItemSpecMetadataNames).ToImmutableArray();
+
+        // Implementation notes that we should include the built-in metadata names as well as our custom ones.
+        public int MetadataCount => _metadata.Count + WellKnownItemSpecMetadataNames.Length;
+
+        public IDictionary CloneCustomMetadata()
+        {
+            return _metadata.ToImmutableDictionary();
+        }
+
+        public void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            var destinationMetadataNames = destinationItem.MetadataNames.OfType<string>();
+            var metadataNamesToCopy = _metadata.Keys.Intersect(destinationMetadataNames, StringComparer.OrdinalIgnoreCase).ToArray();
+
+            foreach (var metadataName in metadataNamesToCopy)
+            {
+                var metadataValue = _metadata[metadataName];
+                destinationItem.SetMetadata(metadataName, metadataValue);
+            }
+        }
+
+        public string GetMetadata(string metadataName)
+        {
+            return _metadata[metadataName];
+        }
+
+        public void RemoveMetadata(string metadataName)
+        {
+            _metadata.Remove(metadataName);
+        }
+
+        public void SetMetadata(string metadataName, string metadataValue)
+        {
+            _metadata[metadataName] = metadataValue;
+        }
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/ArgsTaskItem.cs
+++ b/src/Compilers/Core/MSBuildTask/ArgsTaskItem.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 {
     internal sealed class ArgsTaskItem : ITaskItem
     {
-        // This list is taken from src/Shared/Modifiers.cs in the dotnet/msbuild repo.
+        // This list is taken from https://github.com/dotnet/msbuild/blob/291a8108761ed347562228f2f8f25477996a5a93/src/Shared/Modifiers.cs#L36-L70
         private static readonly string[] WellKnownItemSpecMetadataNames =
-        {
+        [
             "FullPath",
             "RootDir",
             "Filename",
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             "DefiningProjectDirectory",
             "DefiningProjectName",
             "DefiningProjectExtension",
-        };
+        ];
 
         private readonly Dictionary<string, string> _metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -56,9 +56,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         public void CopyMetadataTo(ITaskItem destinationItem)
         {
             // Implementation notes that we should not overwrite existing metadata on the destination.
-            var sourceMetadataNames = MetadataNames.OfType<string>();
             var destinationMetadataNames = destinationItem.MetadataNames.OfType<string>();
-            var metadataNamesToCopy = sourceMetadataNames.Except(destinationMetadataNames, StringComparer.OrdinalIgnoreCase).ToArray();
+            var metadataNamesToCopy = _metadata.Keys.Except(destinationMetadataNames, StringComparer.OrdinalIgnoreCase).ToArray();
 
             foreach (var metadataName in metadataNamesToCopy)
             {

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             var items = new ITaskItem[commandLineArgs.Count];
             for (var i = 0; i < commandLineArgs.Count; i++)
             {
-                items[i] = new TaskItem(commandLineArgs[i]);
+                items[i] = new ArgsTaskItem(commandLineArgs[i]);
             }
 
             return items;

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -192,6 +192,19 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        [WorkItem(72014, "https://github.com/dotnet/roslyn/issues/72014")]
+        public void DefineConstantsWithEscaping()
+        {
+            var vbc = new Vbc();
+            vbc.DefineConstants = "CONFIG=\"DEBUG\"";
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            var responseFileContents = vbc.GenerateResponseFileContents();
+            var argTaskItems = vbc.GenerateCommandLineArgsTaskItems(responseFileContents);
+            var defineTaskItem = Assert.Single(argTaskItems, item => item.ItemSpec.StartsWith("/define:"));
+            Assert.Equal("/define:\"CONFIG=\\\"DEBUG\\\"\"", defineTaskItem.ItemSpec);
+        }
+
+        [Fact]
         public void Features()
         {
             Action<string> test = (s) =>


### PR DESCRIPTION
The TaskItem implementation from MSBuild treats the ItemSpec as file path and tries to normalize the path separators. When running on non-windows machines this means changing '\\' to '/'.  However this breaks how double quotes are escaped in the compiler args. By using our own implementation of TaskItem we can use the compiler args as the ItemSpec without any modification.

Resolves https://github.com/dotnet/roslyn/issues/72014