### PR TITLE
Do not offer to convert typeof to nameof on a generic type

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/ConvertTypeofToNameof/CSharpConvertTypeOfToNameOfDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertTypeofToNameof/CSharpConvertTypeOfToNameOfDiagnosticAnalyzer.cs
@@ -19,9 +19,6 @@ internal sealed class CSharpConvertTypeOfToNameOfDiagnosticAnalyzer()
 {
     private static readonly string s_title = CSharpAnalyzersResources.typeof_can_be_converted_to_nameof;
 
-    protected override bool SupportsUnboundGenerics(ParseOptions options)
-        => options.LanguageVersion().IsCSharp14OrAbove();
-
     protected override bool IsValidTypeofAction(OperationAnalysisContext context)
     {
         var node = context.Operation.Syntax;

--- a/src/Analyzers/CSharp/Tests/ConvertTypeOfToNameOf/ConvertTypeOfToNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertTypeOfToNameOf/ConvertTypeOfToNameOfTests.cs
@@ -272,18 +272,6 @@ public partial class ConvertTypeOfToNameOfTests
                     }
                 }
                 """,
-            FixedCode = """
-                class Test
-                {
-                    class Goo<T> 
-                    { 
-                        void M() 
-                        {
-                            _ = nameof(Goo<>);
-                        }
-                    }
-                }
-                """,
             LanguageVersion = CSharp14,
         }.RunAsync();
     }
@@ -322,18 +310,6 @@ public partial class ConvertTypeOfToNameOfTests
                         void M() 
                         {
                             _ = [|typeof(Goo<>).Name|];
-                        }
-                    }
-                }
-                """,
-            FixedCode = """
-                class Test
-                {
-                    class Goo<T> 
-                    { 
-                        void M() 
-                        {
-                            _ = nameof(Goo<>);
                         }
                     }
                 }

--- a/src/Analyzers/CSharp/Tests/ConvertTypeOfToNameOf/ConvertTypeOfToNameOfTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertTypeOfToNameOf/ConvertTypeOfToNameOfTests.cs
@@ -267,7 +267,7 @@ public partial class ConvertTypeOfToNameOfTests
                     { 
                         void M() 
                         {
-                            _ = [|typeof(Goo<int>).Name|];
+                            _ = typeof(Goo<int>).Name;
                         }
                     }
                 }
@@ -309,7 +309,7 @@ public partial class ConvertTypeOfToNameOfTests
                     { 
                         void M() 
                         {
-                            _ = [|typeof(Goo<>).Name|];
+                            _ = typeof(Goo<>).Name;
                         }
                     }
                 }

--- a/src/Analyzers/VisualBasic/Analyzers/ConvertTypeofToNameof/VisualBasicConvertTypeOfToNameOfDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/ConvertTypeofToNameof/VisualBasicConvertTypeOfToNameOfDiagnosticAnalyzer.vb
@@ -18,10 +18,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertTypeOfToNameOf
             MyBase.New(s_title)
         End Sub
 
-        Protected Overrides Function SupportsUnboundGenerics(options As ParseOptions) As Boolean
-            Return False
-        End Function
-
         Protected Overrides Function IsValidTypeofAction(context As OperationAnalysisContext) As Boolean
             Dim node = context.Operation.Syntax
             Dim compilation = context.Compilation


### PR DESCRIPTION
Fixes issue reported by partner.

Note: nested types are fine and still can be converted (and we have tests for this).