### PR TITLE
Always specify Image width/height for glyphs sourced from IGlyphService

### DIFF
--- a/src/VisualStudio/Core/Def/CommonControls/MemberSelection.xaml
+++ b/src/VisualStudio/Core/Def/CommonControls/MemberSelection.xaml
@@ -5,10 +5,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:utilities="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Utilities" xmlns:commoncontrols="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.CommonControls"
+             xmlns:utilities="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Utilities"
+             xmlns:commoncontrols="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.CommonControls"
+             xmlns:platformimaging="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:vsutil="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
+             xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d" 
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             platformimaging:ImageThemingUtilities.ImageBackgroundColor="{DynamicResource VsColor.ToolWindowBackground}"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -18,6 +23,7 @@
             <Thickness x:Key="ButtonControlsPadding">2, 4, 4, 2</Thickness>
             <utilities:BooleanReverseConverter x:Key="BooleanReverseConverter"/>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <platformimaging:ThemedImageSourceConverter x:Uid="ThemedImageSourceConverter" x:Key="ThemedImageSourceConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -96,7 +102,19 @@
                                     <Image 
                                         x:Name="GlyphOfMember"
                                         Margin="8, 0, 5, 0"
-                                        Source="{Binding Glyph}"/>
+                                        Width="16"
+                                        Height="16">
+                                        <Image.Source>
+                                            <MultiBinding x:Uid="MultiBinding_1" Converter="{StaticResource ThemedImageSourceConverter}">
+                                                <Binding x:Uid="Binding_1" Path="Glyph" />
+                                                <Binding
+                                                    x:Uid="Binding_2"
+                                                    Path="(platformimaging:ImageThemingUtilities.ImageBackgroundColor)"
+                                                    RelativeSource="{RelativeSource Self}" />
+                                                <Binding x:Uid="Binding_3" Source="{x:Static vsutil:Boxes.BooleanTrue}" />
+                                            </MultiBinding>
+                                        </Image.Source>
+                                    </Image>
                                     <TextBlock
                                         x:Name="MemberName"
                                         Text="{Binding SymbolName}"

--- a/src/VisualStudio/Core/Def/MoveStaticMembers/StaticMemberSelection.xaml
+++ b/src/VisualStudio/Core/Def/MoveStaticMembers/StaticMemberSelection.xaml
@@ -48,7 +48,9 @@
                         <Image 
                             x:Name="GlyphOfMember"
                             Margin="8, 0, 5, 0"
-                            Source="{Binding Glyph}"/>
+                            Source="{Binding Glyph}"
+                            Width="16"
+                            Height="16"/>
                         <TextBlock
                             x:Name="MemberName"
                             Text="{Binding SymbolName}"

--- a/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
@@ -13,6 +13,7 @@
              xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:platformimaging="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:vsutil="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
              mc:Ignorable="d" 
              d:DesignHeight="380" d:DesignWidth="460"
              Height="380" Width="460"
@@ -41,6 +42,7 @@
         <vs:NegateBooleanConverter x:Key="NegateBooleanConverter"/>
         <RoutedUICommand x:Key="MoveUp" />
         <RoutedUICommand x:Key="MoveDown" />
+        <platformimaging:ThemedImageSourceConverter x:Uid="ThemedImageSourceConverter" x:Key="ThemedImageSourceConverter" />
     </Window.Resources>
     <Window.CommandBindings>
         <CommandBinding Command="{StaticResource MoveUp}" Executed="MoveUp_Click" />
@@ -95,9 +97,22 @@
                                           Focusable="False"
                                           AutomationProperties.AutomationId="{Binding SymbolName}">
                                 </CheckBox>
-                                <Image x:Uid="SelectableMemberGlyph" 
-                                       Margin="8,0,0,0"
-                                               Source="{Binding Glyph}"/>
+                                <Image
+                                    x:Uid="SelectableMemberGlyph" 
+                                    Margin="8,0,0,0"
+                                    Width="16"
+                                    Height="16">
+                                    <Image.Source>
+                                        <MultiBinding x:Uid="MultiBinding_1" Converter="{StaticResource ThemedImageSourceConverter}">
+                                            <Binding x:Uid="Binding_1" Path="Glyph" />
+                                            <Binding
+                                                    x:Uid="Binding_2"
+                                                    Path="(platformimaging:ImageThemingUtilities.ImageBackgroundColor)"
+                                                    RelativeSource="{RelativeSource Self}" />
+                                            <Binding x:Uid="Binding_3" Source="{x:Static vsutil:Boxes.BooleanTrue}" />
+                                        </MultiBinding>
+                                    </Image.Source>
+                                </Image>
                                 <TextBlock x:Uid="SelectableMemberName" 
                                                    Text="{Binding SymbolName}"/>
                             </StackPanel>

--- a/src/VisualStudio/Core/Def/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
+++ b/src/VisualStudio/Core/Def/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
@@ -3,8 +3,10 @@
     x:Name="dialog"
     x:Class="Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.MainDialog.PullMemberUpDialog"
     x:ClassModifier="internal"
+    xmlns:platformimaging="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
     xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
     xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:vsutil="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -21,7 +23,8 @@
     ShowInTaskbar="False"
     ResizeMode="CanResizeWithGrip"
     Title="{Binding ElementName=dialog, Path=PullMembersUpTitle}"
-    Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
+    Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}"
+    platformimaging:ImageThemingUtilities.ImageBackgroundColor="{StaticResource {x:Static vsshell:VsColors.ToolWindowBackgroundKey}}">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -48,6 +51,7 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
+            <platformimaging:ThemedImageSourceConverter x:Uid="ThemedImageSourceConverter" x:Key="ThemedImageSourceConverter" />
         </ResourceDictionary>
     </Window.Resources>
     <Grid Margin="12">
@@ -90,7 +94,21 @@
                             HorizontalAlignment="Stretch"
                             Focusable="False"
                             VerticalAlignment="Stretch">
-                            <Image Source="{Binding Glyph}" Margin="0, 0, 5, 0" />
+                            <Image
+                                Margin="0, 0, 5, 0"
+                                Width="16"
+                                Height="16">
+                                <Image.Source>
+                                    <MultiBinding x:Uid="MultiBinding_1" Converter="{StaticResource ThemedImageSourceConverter}">
+                                        <Binding x:Uid="Binding_1" Path="Glyph" />
+                                        <Binding
+                                            x:Uid="Binding_2"
+                                            Path="(platformimaging:ImageThemingUtilities.ImageBackgroundColor)"
+                                            RelativeSource="{RelativeSource Self}" />
+                                        <Binding x:Uid="Binding_3" Source="{x:Static vsutil:Boxes.BooleanTrue}" />
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
                             <TextBlock
                                 x:Uid="DestinationTextBlock"
                                 Text="{Binding SymbolName}"

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml
@@ -6,13 +6,18 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.ValueTracking"
              xmlns:utils="clr-namespace:Microsoft.VisualStudio.LanguageServices.Utilities"
+             xmlns:platformimaging="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:vsutil="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
              mc:Ignorable="d" 
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             platformimaging:ImageThemingUtilities.ImageBackgroundColor="{StaticResource {x:Static vsshell:VsColors.ToolWindowBackgroundKey}}"
              d:DesignHeight="450" d:DesignWidth="800"
              x:Name="control">
 
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <platformimaging:ThemedImageSourceConverter x:Uid="ThemedImageSourceConverter" x:Key="ThemedImageSourceConverter" />
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -59,7 +64,20 @@
             <TreeView.Resources>
                 <HierarchicalDataTemplate DataType="{x:Type local:TreeItemViewModel}" ItemsSource="{Binding ChildItems}">
                     <StackPanel Orientation="Horizontal">
-                        <Image Source="{Binding GlyphImage}" />
+                        <Image
+                            Width="16"
+                            Height="16">
+                            <Image.Source>
+                                <MultiBinding x:Uid="MultiBinding_1" Converter="{StaticResource ThemedImageSourceConverter}">
+                                    <Binding x:Uid="Binding_1" Path="GlyphImage" />
+                                    <Binding
+                                        x:Uid="Binding_2"
+                                        Path="(platformimaging:ImageThemingUtilities.ImageBackgroundColor)"
+                                        RelativeSource="{RelativeSource Self}" />
+                                    <Binding x:Uid="Binding_3" Source="{x:Static vsutil:Boxes.BooleanTrue}" />
+                                </MultiBinding>
+                            </Image.Source>
+                        </Image>
                         <utils:BindableTextBlock InlineCollection="{Binding Inlines}" Margin="0 0 5 0" />
                     </StackPanel>
                 </HierarchicalDataTemplate>


### PR DESCRIPTION
In VS 17.14 (and previews of 17.13, but we are reverting for P5), the editor's `IGlyphService` implementation was improved to return images from `IVsImageService2` based on the appropriate moniker. This fixes several instances of blurry 16px icons throughout the IDE.

Unfortunately, some WPF components failed to specify explicit `Image` dimensions, leading to larger than expected glyphs in the UI.

![image](https://github.com/user-attachments/assets/11b53717-4d7b-41ef-a69d-d25850829bde)


Additionally, these proper VS icons require theming, or else you can get black-on-black or other poor contrast scenarios.

These changes add explicit dimensions to `Image`s that display glyphs from `IGlyphService`. It also uses `ThemedImageSourceConverter` to theme the images correctly. Sometimes this requires setting `ImageThemingUtilities.ImageBackgroundColor`.

NOTE: `MoveStaticMembersDialog` is not themed, so I did not apply the changes necessary to theme the icon correctly.