### PR TITLE
Nullable analysis: avoid tracking object creation for reference type without initializer

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -1061,5 +1061,33 @@ class C
             var containingTypes = exprs.SelectAsArray(e => model.GetSymbolInfo(e).Symbol.ContainingSymbol).ToTestDisplayStrings();
             Assert.Equal(new[] { "A", "B", "B", "A", "B", "B" }, containingTypes);
         }
+
+        [ConditionalFact(typeof(IsRelease))]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/76568")]
+        public void NullableAnalysis_ObjectCreationExpression()
+        {
+            const int n = 200000;
+            var builder = new StringBuilder();
+            builder.AppendLine("""
+                #nullable enable
+                class A { }
+                class B
+                {
+                    static void Main()
+                    {
+                        A a;
+                """);
+            for (int i = 0; i < n; i++)
+            {
+                builder.AppendLine("        a = new A();");
+            }
+            builder.AppendLine("""
+                    }
+                }
+                """);
+            var source = builder.ToString();
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Nullable analysis was creating a `LocalState` slot for each `new()` expression. In a method with many `new()` expressions, the result is large `BitVector` for the `LocalState`, and since the `LocalState` is cloned before each statement, if there are many statements, a large block is copied many times.

The fix here is to avoid creating a slot for `new()` unnecessarily, specifically when the target type is a reference type and there is no object initializer, since there should be no references to the fields of the `new()` instance.

A more general alternative, to avoid generating a large `LocalState` block, might be to free-up and re-use slots when the corresponding expression or local is no longer in scope. That would be a much more significant change though.

Fixes #76568