### PR TITLE
Return the absolute glob paths in ProjectFileInfo

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
@@ -305,6 +305,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [InlineData("/a/../b/../c/file.cs", "/c/file.cs")]
         [InlineData("/../../c/file.cs", "/c/file.cs")]
         [InlineData("/a/../b/./././../c/file.cs", "/c/file.cs")]
+        [InlineData("/tmp/../.config/../.roslyn/**/*.cs", "/.roslyn/**/*.cs")]
         // not absolute paths
         [InlineData("a/b/c", "a/b/c")]
         [InlineData("./a/b/c", "./a/b/c")]

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -10,8 +10,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
-using Microsoft.Build.Globbing;
-using Microsoft.Build.Globbing.Extensions;
 using Roslyn.Utilities;
 using MSB = Microsoft.Build;
 
@@ -207,7 +205,10 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             static FileGlobs GetFileGlobs(GlobResult g)
             {
-                return new FileGlobs([.. g.IncludeGlobs], [.. g.Excludes], [.. g.Removes]);
+                return new FileGlobs(
+                    Includes: [.. g.IncludeGlobs.Select(PathUtilities.ExpandAbsolutePathWithRelativeParts)],
+                    Excludes: [.. g.Excludes.Select(PathUtilities.ExpandAbsolutePathWithRelativeParts)],
+                    Removes: [.. g.Removes.Select(PathUtilities.ExpandAbsolutePathWithRelativeParts)]);
             }
         }
 


### PR DESCRIPTION
MSBuild will return globs with relative paths. These globs do not work properly with M.E.FileSystemGlobbing. This PR ensures we return the absolute paths for globs.

Resolves #76959