### PR TITLE
Remove unneeded additional sources and ForceAzureDevCom sources switch

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -298,7 +298,6 @@ extends:
                        /p:DotnetPublishUsingPipelines=true
                        /p:IgnoreIbcMergeErrors=true
                        /p:GenerateSbom=true
-                       /p:ForceAzureComSources=true
           condition: succeeded()
 
         - template: /eng/common/templates-official/steps/generate-sbom.yml@self

--- a/eng/InternalTools.props
+++ b/eng/InternalTools.props
@@ -1,13 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
-    <PropertyGroup>
-        <RestoreSources Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'">
-          $(RestoreSources);
-          https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json;
-          https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
-        </RestoreSources>
-    </PropertyGroup>
-    
     <ItemGroup Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'">
         <!-- Add explicit top-level dependencies to override the implicit versions brought in by Microsoft.DevDiv.Optimization.Data.PowerShell -->
         <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)"/>
@@ -16,5 +8,4 @@
         <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)"/>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)"/>
     </ItemGroup>
-
 </Project>

--- a/eng/InternalTools.props
+++ b/eng/InternalTools.props
@@ -6,19 +6,6 @@
           https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json;
           https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
         </RestoreSources>
-        <RestoreSources>
-          $(RestoreSources);
-          https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
-        </RestoreSources>
-
-        <!-- Workaround for https://github.com/dotnet/dnceng/issues/4441. -->
-        <RestoreSources Condition="'$(ForceAzureComSources)' == 'true'">
-          https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
-          https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json;
-          https://pkgs.dev.azure.com/devdiv/_packaging/Engineering/nuget/v3/index.json;
-          https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
-          https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
-        </RestoreSources>
     </PropertyGroup>
     
     <ItemGroup Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'">


### PR DESCRIPTION
The forced azure-dev-com appears no longer necessary, and dotnet-core-internal tooling is already added from internal tools nuget.config