### PR TITLE
Allow expression body refactorings on non empty selections

### DIFF
--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -58,12 +58,10 @@ internal sealed class UseExpressionBodyCodeRefactoringProvider() : SyntaxEditorB
     public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
     {
         var (document, textSpan, cancellationToken) = context;
-        if (textSpan.Length > 0)
-            return;
 
         var position = textSpan.Start;
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var node = root.FindToken(position).Parent!;
+        var node = root.FindNode(textSpan);
 
         var containingLambda = node.FirstAncestorOrSelf<LambdaExpressionSyntax>();
         if (containingLambda != null &&

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
@@ -83,208 +83,264 @@ public class UseExpressionBodyForAccessorsRefactoringTests : AbstractCSharpCodeA
     public async Task TestUpdatePropertyIfPropertyWantsBlockAndAccessorWantsExpression()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            [||]return Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody2()
     {
         await TestMissingAsync(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            [||]return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return [||]Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return [||]Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody2()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return [||]Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return [||]Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return [||]Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo
-    {
-        get => Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return [||]Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get => Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferExpressionBodyForPropertyIfPropertyAndAccessorBothPreferExpressions()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return [||]Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo => [||]Bar();
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return [||]Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    int Goo { get => [||]Bar(); }
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo { get => [||]Bar(); }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo { get => [||]Bar(); }
-}",
+            """
+            class C
+            {
+                int Goo { get => [||]Bar(); }
+            }
+            """,
 
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody2()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo { get => [||]Bar(); }
-}",
+            """
+            class C
+            {
+                int Goo { get => [||]Bar(); }
+            }
+            """,
 
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedForPropertyIfUserPrefersBlockPropertiesAndHasBlockProperty()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo { get => [||]Bar(); }
-}",
+            """
+            class C
+            {
+                int Goo { get => [||]Bar(); }
+            }
+            """,
 
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferForPropertyIfPropertyPrefersBlockButCouldBecomeExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo { get => [||]Bar(); }
-}",
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo { get => [||]Bar(); }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20350")]
     public async Task TestAccessorListFormatting()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo { get => [||]Bar(); }
-}",
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo { get => [||]Bar(); }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
@@ -286,4 +286,51 @@ public class UseExpressionBodyForAccessorsRefactoringTests : AbstractCSharpCodeA
     }
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideExpressionBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return [|Bar()|];
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get => Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideExpressionBody()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return [|Bar();
+                    }
+                }|]
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
+    }
 }

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
@@ -137,4 +137,42 @@ public class UseExpressionBodyForConstructorsRefactoringTests : AbstractCSharpCo
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideExpressionBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                public C()
+                {
+                    [|Bar()|];
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public C() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideExpressionBody()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                public C()
+                {
+                    [|Bar();
+                }
+            }|]
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
 }

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
@@ -38,104 +38,133 @@ public class UseExpressionBodyForConstructorsRefactoringTests : AbstractCSharpCo
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    public C()
-    {
-        [||]Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                public C()
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public C()
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    public C() => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                public C()
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public C() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public C()
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    public C() => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public C()
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public C() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedInLambda()
     {
         await TestMissingAsync(
-@"class C
-{
-    public C()
-    {
-        return () => { [||] };
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public C()
+                {
+                    return () => { [||] };
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    public C() => [||]Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public C() => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public C() => [||]Bar();
-}",
-@"class C
-{
-    public C()
-    {
-        Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                public C() => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                public C()
+                {
+                    Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public C() => [||]Bar();
-}",
-@"class C
-{
-    public C()
-    {
-        Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                public C() => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                public C()
+                {
+                    Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
@@ -137,4 +137,42 @@ public class UseExpressionBodyForConversionOperatorsRefactoringTests : AbstractC
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideBlockBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    [|Bar()|];
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public static implicit operator bool(C c1) => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideBlockBody()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    [|Bar();
+                }
+            }|]
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
 }

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
@@ -38,104 +38,133 @@ public class UseExpressionBodyForConversionOperatorsRefactoringTests : AbstractC
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    public static implicit operator bool(C c1)
-    {
-        [||]Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static implicit operator bool(C c1)
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    public static implicit operator bool(C c1) => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public static implicit operator bool(C c1) => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static implicit operator bool(C c1)
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    public static implicit operator bool(C c1) => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public static implicit operator bool(C c1) => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedInLambda()
     {
         await TestMissingAsync(
-@"class C
-{
-    public static implicit operator bool(C c1)
-    {
-        return () => { [||] };
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    return () => { [||] };
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    public static implicit operator bool(C c1) => [||]Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public static implicit operator bool(C c1) => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static implicit operator bool(C c1) => [||]Bar();
-}",
-@"class C
-{
-    public static implicit operator bool(C c1)
-    {
-        return Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                public static implicit operator bool(C c1) => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    return Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static implicit operator bool(C c1) => [||]Bar();
-}",
-@"class C
-{
-    public static implicit operator bool(C c1)
-    {
-        return Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                public static implicit operator bool(C c1) => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                public static implicit operator bool(C c1)
+                {
+                    return Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
@@ -156,4 +156,48 @@ public class UseExpressionBodyForIndexersRefactoringTests : AbstractCSharpCodeAc
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideBlockBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                int this[int i]
+                {
+                    get
+                    {
+                        [|return Bar()|];
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int this[int i] => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideBlockBody()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                int this[int i]
+                {
+                    get
+                    {
+                        [|return Bar();
+                    }
+                }
+            }|]
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
 }

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
@@ -39,122 +39,151 @@ public class UseExpressionBodyForIndexersRefactoringTests : AbstractCSharpCodeAc
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    int this[int i]
-    {
-        get 
-        {
-            [||]return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                int this[int i]
+                {
+                    get 
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int this[int i]
-    {
-        get
-        {
-            [||]return Bar();
-        }
-    }
-}",
-@"class C
-{
-    int this[int i] => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                int this[int i]
+                {
+                    get
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int this[int i] => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int this[int i]
-    {
-        get
-        {
-            [||]return Bar();
-        }
-    }
-}",
-@"class C
-{
-    int this[int i] => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                int this[int i]
+                {
+                    get
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int this[int i] => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedInLambda()
     {
         await TestMissingAsync(
-@"class C
-{
-    Action Goo[int i]
-    {
-        get 
-        {
-            return () => { [||] };
-        }
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                Action Goo[int i]
+                {
+                    get 
+                    {
+                        return () => { [||] };
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    int this[int i] => [||]Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                int this[int i] => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int this[int i] => [||]Bar();
-}",
-@"class C
-{
-    int this[int i]
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                int this[int i] => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                int this[int i]
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20363")]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int this[int i] => [||]Bar();
-}",
-@"class C
-{
-    int this[int i]
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                int this[int i] => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                int this[int i]
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForLocalFunctionsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForLocalFunctionsRefactoringTests.cs
@@ -154,4 +154,51 @@ public class UseExpressionBodyForLocalFunctionsRefactoringTests : AbstractCSharp
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideBlockBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() 
+                    {
+                        [|Test()|];
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() => Test();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideBlockBody()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() 
+                    {
+                        [|Test();
+                    }
+                }|]
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
 }

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForLocalFunctionsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForLocalFunctionsRefactoringTests.cs
@@ -38,121 +38,147 @@ public class UseExpressionBodyForLocalFunctionsRefactoringTests : AbstractCSharp
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    void Goo()
-    {
-        void Bar() 
-        {
-            [||]Test();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() 
+                    {
+                        [||]Test();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo()
-    {
-        void Bar() 
-        {
-            [||]Test();
-        }
-    }
-}",
-@"class C
-{
-    void Goo()
-    {
-        void Bar() => Test();
-    }
-}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() 
+                    {
+                        [||]Test();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() => Test();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo()
-    {
-        void Bar() 
-        {
-            [||]Test();
-        }
-    }
-}",
-@"class C
-{
-    void Goo()
-    {
-        void Bar() => Test();
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() 
+                    {
+                        [||]Test();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() => Test();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    void Goo()
-    {
-        void Bar() => [||]Test();
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() => [||]Test();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo()
-    {
-        void Bar() => [||]Test();
-    }
-}",
-@"class C
-{
-    void Goo()
-    {
-        void Bar()
-        {
-            Test();
-        }
-    }
-}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() => [||]Test();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar()
+                    {
+                        Test();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo()
-    {
-        void Bar() => [||]Test();
-    }
-}",
-@"class C
-{
-    void Goo()
-    {
-        void Bar()
-        {
-            Test();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar() => [||]Test();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    void Bar()
+                    {
+                        Test();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
@@ -37,205 +37,260 @@ public class UseExpressionBodyForMethodsRefactoringTests : AbstractCSharpCodeAct
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    void Goo()
-    {
-        [||]Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo()
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    void Goo() => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo()
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    void Goo() => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                void Goo()
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedInLambda()
     {
         await TestMissingAsync(
-@"class C
-{
-    Action Goo()
-    {
-        return () => { [||] };
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                Action Goo()
+                {
+                    return () => { [||] };
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    void Goo() => [||]Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                void Goo() => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo() => [||]Bar();
-}",
-@"class C
-{
-    void Goo()
-    {
-        Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                void Goo() => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void Goo() => [||]Bar();
-}",
-@"class C
-{
-    void Goo()
-    {
-        Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                void Goo() => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25501")]
     public async Task TestOfferedAtStartOfMethod()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    [||]void Goo()
-    {
-        Bar();
-    }
-}",
-@"class C
-{
-    void Goo() => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                [||]void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25501")]
     public async Task TestOfferedBeforeMethodOnSameLine()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-[||]    void Goo()
-    {
-        Bar();
-    }
-}",
-@"class C
-{
-    void Goo() => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+            [||]    void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25501")]
     public async Task TestOfferedBeforeAttributes()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    [||][A]
-    void Goo()
-    {
-        Bar();
-    }
-}",
-@"class C
-{
-    [A]
-    void Goo() => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                [||][A]
+                void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                [A]
+                void Goo() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25501")]
     public async Task TestNotOfferedBeforeComments()
     {
         await TestMissingInRegularAndScriptAsync(
-@"class C
-{
-    [||]/// <summary/>
-    void Goo()
-    {
-        Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                [||]/// <summary/>
+                void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25501")]
     public async Task TestNotOfferedInComments()
     {
         await TestMissingInRegularAndScriptAsync(
-@"class C
-{
-    /// [||]<summary/>
-    void Goo()
-    {
-        Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                /// [||]<summary/>
+                void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/53532")]
     public async Task TestTriviaOnArrow1()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-        // Test
-         [||]=> Console.WriteLine();
-}",
-@"class C
-{
-    void M()
-    {
-        // Test
-        Console.WriteLine();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                void M()
+                    // Test
+                     [||]=> Console.WriteLine();
+            }
+            """,
+            """
+            class C
+            {
+                void M()
+                {
+                    // Test
+                    Console.WriteLine();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
@@ -237,4 +237,77 @@ public class UseExpressionBodyForMethodsRefactoringTests : AbstractCSharpCodeAct
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideBlockBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                void Goo()
+                {
+                    [|Bar()|];
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void Goo() => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideBlockBody()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void Goo()
+                {
+                    [|Bar();
+                }
+            }|]
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideExpressionBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                void Goo() => [|Bar()|];
+            }
+            """,
+            """
+            class C
+            {
+                void Goo()
+                {
+                    Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideExpressionBody()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void Goo() => [|Bar();
+            }|]
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
+    }
 }

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
@@ -137,4 +137,42 @@ public class UseExpressionBodyForOperatorsRefactoringTests : AbstractCSharpCodeA
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideBlockBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    [|Bar()|];
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2) => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideBlockBody()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    [|Bar();
+                }
+            }|]
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
+    }
 }

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
@@ -38,104 +38,133 @@ public class UseExpressionBodyForOperatorsRefactoringTests : AbstractCSharpCodeA
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    public static bool operator +(C c1, C c2)
-    {
-        [||]Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static bool operator +(C c1, C c2)
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    public static bool operator +(C c1, C c2) => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2) => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static bool operator +(C c1, C c2)
-    {
-        [||]Bar();
-    }
-}",
-@"class C
-{
-    public static bool operator +(C c1, C c2) => Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    [||]Bar();
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2) => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedInLambda()
     {
         await TestMissingAsync(
-@"class C
-{
-    public static bool operator +(C c1, C c2)
-    {
-        return () => { [||] };
-    }
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    return () => { [||] };
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    public static bool operator +(C c1, C c2) => [||]Bar();
-}", parameters: new TestParameters(options: UseBlockBody));
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2) => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBody));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static bool operator +(C c1, C c2) => [||]Bar();
-}",
-@"class C
-{
-    public static bool operator +(C c1, C c2)
-    {
-        return Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2) => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    return Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    public static bool operator +(C c1, C c2) => [||]Bar();
-}",
-@"class C
-{
-    public static bool operator +(C c1, C c2)
-    {
-        return Bar();
-    }
-}", parameters: new TestParameters(options: UseExpressionBody));
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2) => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                public static bool operator +(C c1, C c2)
+                {
+                    return Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBody));
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
@@ -77,236 +77,293 @@ public class UseExpressionBodyForPropertiesRefactoringTests : AbstractCSharpCode
     public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    int Goo
-    {
-        get 
-        {
-            [||]return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get 
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get 
-        {
-            [||]return Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get 
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestUpdateAccessorIfAccessWantsBlockAndPropertyWantsExpression()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get 
-        {
-            [||]return Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo
-    {
-        get => Bar();
-    }
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get 
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get => Bar();
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            [||]return Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesAndInBlockBody2()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            [||]return Bar();
-        }
-    }
-}",
-@"class C
-{
-    int Goo => Bar();
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        [||]return Bar();
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestNotOfferedInLambda()
     {
         await TestMissingAsync(
-@"class C
-{
-    Action Goo
-    {
-        get 
-        {
-            return () => { [||] };
-        }
-    }
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                Action Goo
+                {
+                    get 
+                    {
+                        return () => { [||] };
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody()
     {
         await TestMissingAsync(
-@"class C
-{
-    int Goo => [||]Bar();
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestNotOfferedIfUserPrefersBlockBodiesAndInExpressionBody2()
     {
         await TestMissingAsync(
-@"class C
-{
-    int Goo => [||]Bar();
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo => [||]Bar();
-}",
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody2()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo => [||]Bar();
-}",
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20363")]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo => [||]Bar();
-}",
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody2()
     {
         await TestInRegularAndScript1Async(
-@"class C
-{
-    int Goo => [||]Bar();
-}",
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20360")]
     public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody_CSharp6()
     {
         await TestAsync(
-@"class C
-{
-    int Goo => [||]Bar();
-}",
-@"class C
-{
-    int Goo
-    {
-        get
-        {
-            return Bar();
-        }
-    }
-}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6),
-options: UseExpressionBodyForAccessors_ExpressionBodyForProperties);
+            """
+            class C
+            {
+                int Goo => [||]Bar();
+            }
+            """,
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        return Bar();
+                    }
+                }
+            }
+            """,
+            parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6),
+            options: UseExpressionBodyForAccessors_ExpressionBodyForProperties);
     }
 
     [Fact]

--- a/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
+++ b/src/Features/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
@@ -308,4 +308,48 @@ public class UseExpressionBodyForPropertiesRefactoringTests : AbstractCSharpCode
 }", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6),
 options: UseExpressionBodyForAccessors_ExpressionBodyForProperties);
     }
+
+    [Fact]
+    public async Task TestOfferedWithSelectionInsideBlockBody()
+    {
+        await TestInRegularAndScript1Async(
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        [|return Bar()|];
+                    }
+                }
+            }
+            """,
+            """
+            class C
+            {
+                int Goo => Bar();
+            }
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
+    }
+
+    [Fact]
+    public async Task TestNotOfferedWithSelectionOutsideBlockBody()
+    {
+        await TestMissingAsync(
+            """
+            class C
+            {
+                int Goo
+                {
+                    get
+                    {
+                        [|return Bar();
+                    }
+                }
+            }|]
+            """,
+            parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
+    }
 }


### PR DESCRIPTION
Currently, all expression/body refactorings only work with an empty selection. I've started looking into https://github.com/dotnet/roslyn/issues/29495 which requests overload completion to set the selection upon commit. Upon commit (and setting the selection), it's desirable to be able to do the expression/body refactoring. This change should allow that.

1st commit == entirety of product code change.
2nd commit == new tests for each of the refactorings with selections
3rd commit == raw string changes in the modified test files