### PR TITLE
Update PR val pipeline to restore internal tools in build (match main)

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -215,16 +215,6 @@ extends:
             useGlobalJson: true
             workingDirectory: '$(Build.SourcesDirectory)'
 
-        # Needed to restore the Microsoft.DevDiv.Optimization.Data.PowerShell package
-        - task: NuGetCommand@2
-          displayName: Restore internal tools
-          inputs:
-            command: restore
-            feedsToUse: config
-            restoreSolution: 'eng\common\internal\Tools.csproj'
-            nugetConfigPath: 'NuGet.config'
-            restoreDirectory: '$(Build.SourcesDirectory)\.packages'
-
         - task: MicroBuildSigningPlugin@4
           inputs:
             signType: $(SignType)


### PR DESCRIPTION
restore internal tools was moved out of yaml in official build, also needs to happen with PR val build
See https://github.com/dotnet/roslyn/pull/76911

pr val build (just needs to get past build step) - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10928060&view=logs&j=d8f66498-7756-5707-3b43-f2312930a35f&t=bf681905-b801-52f4-803f-be09a0d10104