### PR TITLE
Keep initializer when converting properties to field-backed properties

### DIFF
--- a/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -129,9 +129,7 @@ internal sealed class CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProv
 
         var preference = info.Options.PreferExpressionBodiedProperties.Value;
         if (preference == ExpressionBodyPreference.Never)
-        {
-            return propertyDeclaration.WithSemicolonToken(default);
-        }
+            return propertyDeclaration;
 
         // if there is a get accessors only, we can move the expression body to the property
         if (propertyDeclaration.AccessorList?.Accessors.Count == 1 &&
@@ -146,7 +144,7 @@ internal sealed class CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProv
             }
         }
 
-        return propertyDeclaration.WithSemicolonToken(default);
+        return propertyDeclaration;
     }
 
     protected override SyntaxNode GetTypeBlock(SyntaxNode syntaxNode)
@@ -168,10 +166,8 @@ internal sealed class CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProv
         // Update the getter/setter to reference the 'field' expression instead.
         var (newGetAccessor, newSetAccessor) = GetNewAccessors(info, property, FieldExpression(), cancellationToken);
 
-        // The normal helper will strip off the semicolon (as we're normally moving the initializer to a field).
-        // Don't do that here as we will keep the current initializer on the property if it is there.
-        var finalProperty = (PropertyDeclarationSyntax)CreateFinalProperty(document, property, info, newGetAccessor, newSetAccessor);
-        var finalRoot = root.ReplaceNode(property, finalProperty.WithSemicolonToken(property.SemicolonToken));
+        var finalProperty = CreateFinalProperty(document, property, info, newGetAccessor, newSetAccessor);
+        var finalRoot = root.ReplaceNode(property, finalProperty);
 
         return document.WithSyntaxRoot(finalRoot);
     }

--- a/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -168,8 +168,10 @@ internal sealed class CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProv
         // Update the getter/setter to reference the 'field' expression instead.
         var (newGetAccessor, newSetAccessor) = GetNewAccessors(info, property, FieldExpression(), cancellationToken);
 
-        var finalProperty = CreateFinalProperty(document, property, info, newGetAccessor, newSetAccessor);
-        var finalRoot = root.ReplaceNode(property, finalProperty);
+        // The normal helper will strip off the semicolon (as we're normally moving the initializer to a field).
+        // Don't do that here as we will keep the current initializer on the property if it is there.
+        var finalProperty = (PropertyDeclarationSyntax)CreateFinalProperty(document, property, info, newGetAccessor, newSetAccessor);
+        var finalRoot = root.ReplaceNode(property, finalProperty.WithSemicolonToken(property.SemicolonToken));
 
         return document.WithSyntaxRoot(finalRoot);
     }

--- a/src/Features/CSharpTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.cs
+++ b/src/Features/CSharpTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.cs
@@ -1444,4 +1444,34 @@ public sealed partial class ConvertAutoPropertyToFullPropertyTests : AbstractCSh
             """;
         await TestInRegularAndScriptAsync(text, expected, options: DoNotPreferExpressionBodiedAccessors, index: 1, parseOptions: CSharp14);
     }
+
+    [Theory]
+    [InlineData("set"), InlineData("init")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/76992")]
+    public async Task ProduceFieldBackedProperty2(string setter)
+    {
+        var text = $$"""
+            class TestClass
+            {
+                public int G[||]oo { get; {{setter}}; } = 0;
+            }
+            """;
+        var expected = $$"""
+            class TestClass
+            {
+                public int Goo
+                {
+                    get
+                    {
+                        return field;
+                    }
+                    {{setter}}
+                    {
+                        field = value;
+                    }
+                } = 0;
+            }
+            """;
+        await TestInRegularAndScriptAsync(text, expected, options: DoNotPreferExpressionBodiedAccessors, index: 1, parseOptions: CSharp14);
+    }
 }

--- a/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -99,9 +99,9 @@ internal abstract class AbstractConvertAutoPropertyToFullPropertyCodeRefactoring
         var fieldName = await GetFieldNameAsync(document, propertySymbol, cancellationToken).ConfigureAwait(false);
         var (newGetAccessor, newSetAccessor) = GetNewAccessors(info, property, fieldName, cancellationToken);
 
-        editor.ReplaceNode(
-            property,
-            CreateFinalProperty(document, property, info, newGetAccessor, newSetAccessor));
+        var finalProperty = CreateFinalProperty(
+            document, GetPropertyWithoutInitializer(property), info, newGetAccessor, newSetAccessor);
+        editor.ReplaceNode(property, finalProperty);
 
         // add backing field, plus initializer if it exists 
         var newField = CodeGenerationSymbolFactory.CreateFieldSymbol(
@@ -137,7 +137,7 @@ internal abstract class AbstractConvertAutoPropertyToFullPropertyCodeRefactoring
 
         var fullProperty = generator
             .WithAccessorDeclarations(
-                GetPropertyWithoutInitializer(property),
+                property,
                 newSetAccessor == null
                     ? [newGetAccessor]
                     : [newGetAccessor, newSetAccessor])

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -440,13 +440,15 @@ internal sealed class CSharpSyntaxGenerator : SyntaxGenerator
     public override SyntaxNode WithAccessorDeclarations(SyntaxNode declaration, IEnumerable<SyntaxNode> accessorDeclarations)
         => declaration switch
         {
-            PropertyDeclarationSyntax property => property.WithAccessorList(CreateAccessorList(property.AccessorList, accessorDeclarations))
-                              .WithExpressionBody(null)
-                              .WithSemicolonToken(default),
+            PropertyDeclarationSyntax property =>
+                property.WithAccessorList(CreateAccessorList(property.AccessorList, accessorDeclarations))
+                        .WithExpressionBody(null)
+                        .WithSemicolonToken(property.Initializer is null ? default : property.SemicolonToken),
 
-            IndexerDeclarationSyntax indexer => indexer.WithAccessorList(CreateAccessorList(indexer.AccessorList, accessorDeclarations))
-                              .WithExpressionBody(null)
-                              .WithSemicolonToken(default),
+            IndexerDeclarationSyntax indexer =>
+                indexer.WithAccessorList(CreateAccessorList(indexer.AccessorList, accessorDeclarations))
+                       .WithExpressionBody(null)
+                       .WithSemicolonToken(default),
 
             _ => declaration,
         };


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76992