### PR TITLE
Ensure we log exception text when an exception is given

### DIFF
--- a/src/Workspaces/MSBuild/Core/MSBuild/DiagnosticReporterLoggerProvider.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/DiagnosticReporterLoggerProvider.cs
@@ -52,6 +52,10 @@ internal class DiagnosticReporterLoggerProvider : ILoggerProvider
             if (!string.IsNullOrEmpty(categoryName))
                 message = $"[{categoryName}] {message}";
 
+            // The standard formatters don't actually include the exception, so let's include it ourselves
+            if (exception is not null)
+                message += Environment.NewLine + exception.ToString();
+
             reporter.Report(new WorkspaceDiagnostic(kind, message));
         }
     }


### PR DESCRIPTION
The formatter passed doesn't include it (despite that the exception is passed to it) so we must append it ourselves.