### PR TITLE
Remove IGlobalOptionService from diagnostic service

### DIFF
--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
 using Microsoft.CodeAnalysis.EditorConfig;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using RoslynEnumerableExtensions = Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Extensions.EnumerableExtensions;
 
@@ -19,8 +20,13 @@ internal sealed class AnalyzerSettingsProvider : SettingsProviderBase<AnalyzerSe
 {
     private readonly IDiagnosticAnalyzerService _analyzerService;
 
-    public AnalyzerSettingsProvider(string fileName, AnalyzerSettingsUpdater settingsUpdater, Workspace workspace, IDiagnosticAnalyzerService analyzerService)
-        : base(fileName, settingsUpdater, workspace, analyzerService.GlobalOptions)
+    public AnalyzerSettingsProvider(
+        string fileName,
+        AnalyzerSettingsUpdater settingsUpdater,
+        Workspace workspace,
+        IDiagnosticAnalyzerService analyzerService,
+        IGlobalOptionService optionService)
+        : base(fileName, settingsUpdater, workspace, optionService)
     {
         _analyzerService = analyzerService;
         Update();

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProviderFactory.cs
@@ -5,17 +5,18 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Analyzer;
 
-internal class AnalyzerSettingsProviderFactory(Workspace workspace, IDiagnosticAnalyzerService analyzerService) : IWorkspaceSettingsProviderFactory<AnalyzerSetting>
+internal sealed class AnalyzerSettingsProviderFactory(
+    Workspace workspace,
+    IDiagnosticAnalyzerService analyzerService,
+    IGlobalOptionService globalOptionService) : IWorkspaceSettingsProviderFactory<AnalyzerSetting>
 {
-    private readonly Workspace _workspace = workspace;
-    private readonly IDiagnosticAnalyzerService _analyzerService = analyzerService;
-
     public ISettingsProvider<AnalyzerSetting> GetForFile(string filePath)
     {
-        var updater = new AnalyzerSettingsUpdater(_workspace, filePath);
-        return new AnalyzerSettingsProvider(filePath, updater, _workspace, _analyzerService);
+        var updater = new AnalyzerSettingsUpdater(workspace, filePath);
+        return new AnalyzerSettingsProvider(filePath, updater, workspace, analyzerService, globalOptionService);
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsWorkspaceServiceFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsWorkspaceServiceFactory.cs
@@ -8,16 +8,17 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Analyzer;
 
 [ExportWorkspaceServiceFactory(typeof(IWorkspaceSettingsProviderFactory<AnalyzerSetting>)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal class AnalyzerSettingsWorkspaceServiceFactory(IDiagnosticAnalyzerService analyzerService) : IWorkspaceServiceFactory
+internal sealed class AnalyzerSettingsWorkspaceServiceFactory(
+    IDiagnosticAnalyzerService analyzerService,
+    IGlobalOptionService globalOptionService) : IWorkspaceServiceFactory
 {
-    private readonly IDiagnosticAnalyzerService _analyzerService = analyzerService;
-
     public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        => new AnalyzerSettingsProviderFactory(workspaceServices.Workspace, _analyzerService);
+        => new AnalyzerSettingsProviderFactory(workspaceServices.Workspace, analyzerService, globalOptionService);
 }

--- a/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticAnalyzerService.cs
@@ -16,58 +16,49 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
+
+[Export(typeof(IDiagnosticAnalyzerService)), Shared, PartNotDiscoverable]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class MockDiagnosticAnalyzerService() : IDiagnosticAnalyzerService
 {
-    [Export(typeof(IDiagnosticAnalyzerService)), Shared, PartNotDiscoverable]
-    internal class MockDiagnosticAnalyzerService : IDiagnosticAnalyzerService
+    private readonly ArrayBuilder<(DiagnosticData Diagnostic, DiagnosticKind KindFilter)> _diagnosticsWithKindFilter = ArrayBuilder<(DiagnosticData Diagnostic, DiagnosticKind KindFilter)>.GetInstance();
+    public bool RequestedRefresh;
+
+    public void AddDiagnostic(DiagnosticData diagnostic, DiagnosticKind diagnosticKind)
+        => _diagnosticsWithKindFilter.Add((diagnostic, diagnosticKind));
+
+    public void AddDiagnostics(ImmutableArray<DiagnosticData> diagnostics, DiagnosticKind diagnosticKind)
     {
-        private readonly ArrayBuilder<(DiagnosticData Diagnostic, DiagnosticKind KindFilter)> _diagnosticsWithKindFilter;
-        public bool RequestedRefresh;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public MockDiagnosticAnalyzerService(IGlobalOptionService globalOptions)
-        {
-            GlobalOptions = globalOptions;
-            _diagnosticsWithKindFilter = ArrayBuilder<(DiagnosticData Diagnostic, DiagnosticKind KindFilter)>.GetInstance();
-        }
-
-        public void AddDiagnostic(DiagnosticData diagnostic, DiagnosticKind diagnosticKind)
-            => _diagnosticsWithKindFilter.Add((diagnostic, diagnosticKind));
-
-        public void AddDiagnostics(ImmutableArray<DiagnosticData> diagnostics, DiagnosticKind diagnosticKind)
-        {
-            foreach (var diagnostic in diagnostics)
-                AddDiagnostic(diagnostic, diagnosticKind);
-        }
-
-        public void RequestDiagnosticRefresh()
-            => RequestedRefresh = true;
-
-        public DiagnosticAnalyzerInfoCache AnalyzerInfoCache
-            => throw new NotImplementedException();
-
-        public IGlobalOptionService GlobalOptions { get; }
-
-        public bool ContainsDiagnostics(Workspace workspace, ProjectId projectId)
-            => throw new NotImplementedException();
-
-        public Task ForceAnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-
-        public Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Workspace workspace, ProjectId? projectId, DocumentId? documentId, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, ICodeActionRequestPriorityProvider priorityProvider, DiagnosticKind diagnosticKind, bool isExplicit, CancellationToken cancellationToken)
-            => Task.FromResult(_diagnosticsWithKindFilter.Where(d => diagnosticKind == d.KindFilter).Select(d => d.Diagnostic).ToImmutableArray());
-
-        public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
+        foreach (var diagnostic in diagnostics)
+            AddDiagnostic(diagnostic, diagnosticKind);
     }
+
+    public void RequestDiagnosticRefresh()
+        => RequestedRefresh = true;
+
+    public DiagnosticAnalyzerInfoCache AnalyzerInfoCache
+        => throw new NotImplementedException();
+
+    public bool ContainsDiagnostics(Workspace workspace, ProjectId projectId)
+        => throw new NotImplementedException();
+
+    public Task ForceAnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
+        => throw new NotImplementedException();
+
+    public Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Workspace workspace, ProjectId? projectId, DocumentId? documentId, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+        => throw new NotImplementedException();
+
+    public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+        => throw new NotImplementedException();
+
+    public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+        => throw new NotImplementedException();
+
+    public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, ICodeActionRequestPriorityProvider priorityProvider, DiagnosticKind diagnosticKind, bool isExplicit, CancellationToken cancellationToken)
+        => Task.FromResult(_diagnosticsWithKindFilter.Where(d => diagnosticKind == d.KindFilter).Select(d => d.Diagnostic).ToImmutableArray());
+
+    public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+        => throw new NotImplementedException();
 }

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal interface IDiagnosticAnalyzerService
 {
-    public IGlobalOptionService GlobalOptions { get; }
-
     /// <summary>
     /// Provides and caches analyzer information.
     /// </summary>

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public DiagnosticAnalyzerInfoCache AnalyzerInfoCache { get; private set; }
 
         public IAsynchronousOperationListener Listener { get; }
-        public IGlobalOptionService GlobalOptions { get; }
+        private IGlobalOptionService GlobalOptions { get; }
 
         private readonly ConditionalWeakTable<Workspace, DiagnosticIncrementalAnalyzer> _map = new();
         private readonly ConditionalWeakTable<Workspace, DiagnosticIncrementalAnalyzer>.CreateValueCallback _createIncrementalAnalyzer;

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -21,7 +21,7 @@ internal partial class DiagnosticAnalyzerService
         // subscribe to active context changed event for new workspace
         workspace.DocumentActiveContextChanged += OnDocumentActiveContextChanged;
 
-        return new DiagnosticIncrementalAnalyzer(this, workspace, AnalyzerInfoCache);
+        return new DiagnosticIncrementalAnalyzer(this, workspace, AnalyzerInfoCache, this.GlobalOptions);
     }
 
     private void OnDocumentActiveContextChanged(object? sender, DocumentActiveContextChangedEventArgs e)

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -14,82 +14,83 @@ using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
+namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2;
+
+/// <summary>
+/// Diagnostic Analyzer Engine V2
+/// 
+/// This one follows pattern compiler has set for diagnostic analyzer.
+/// </summary>
+internal partial class DiagnosticIncrementalAnalyzer
 {
-    /// <summary>
-    /// Diagnostic Analyzer Engine V2
-    /// 
-    /// This one follows pattern compiler has set for diagnostic analyzer.
-    /// </summary>
-    internal partial class DiagnosticIncrementalAnalyzer
+    private readonly DiagnosticAnalyzerTelemetry _telemetry = new();
+    private readonly StateManager _stateManager;
+    private readonly InProcOrRemoteHostAnalyzerRunner _diagnosticAnalyzerRunner;
+    private readonly IncrementalMemberEditAnalyzer _incrementalMemberEditAnalyzer = new();
+
+    internal DiagnosticAnalyzerService AnalyzerService { get; }
+    internal Workspace Workspace { get; }
+
+    [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
+    public DiagnosticIncrementalAnalyzer(
+        DiagnosticAnalyzerService analyzerService,
+        Workspace workspace,
+        DiagnosticAnalyzerInfoCache analyzerInfoCache,
+        IGlobalOptionService globalOptionService)
     {
-        private readonly DiagnosticAnalyzerTelemetry _telemetry = new();
-        private readonly StateManager _stateManager;
-        private readonly InProcOrRemoteHostAnalyzerRunner _diagnosticAnalyzerRunner;
-        private readonly IncrementalMemberEditAnalyzer _incrementalMemberEditAnalyzer = new();
+        Contract.ThrowIfNull(analyzerService);
 
-        internal DiagnosticAnalyzerService AnalyzerService { get; }
-        internal Workspace Workspace { get; }
+        AnalyzerService = analyzerService;
+        Workspace = workspace;
+        GlobalOptions = globalOptionService;
 
-        [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
-        public DiagnosticIncrementalAnalyzer(
-            DiagnosticAnalyzerService analyzerService,
-            Workspace workspace,
-            DiagnosticAnalyzerInfoCache analyzerInfoCache)
-        {
-            Contract.ThrowIfNull(analyzerService);
+        _stateManager = new StateManager(workspace, analyzerInfoCache);
+        _stateManager.ProjectAnalyzerReferenceChanged += OnProjectAnalyzerReferenceChanged;
 
-            AnalyzerService = analyzerService;
-            Workspace = workspace;
-
-            _stateManager = new StateManager(workspace, analyzerInfoCache);
-            _stateManager.ProjectAnalyzerReferenceChanged += OnProjectAnalyzerReferenceChanged;
-
-            var enabled = this.AnalyzerService.GlobalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler);
-            _diagnosticAnalyzerRunner = new InProcOrRemoteHostAnalyzerRunner(
-                enabled, analyzerInfoCache, analyzerService.Listener);
-        }
-
-        internal IGlobalOptionService GlobalOptions => AnalyzerService.GlobalOptions;
-        internal DiagnosticAnalyzerInfoCache DiagnosticAnalyzerInfoCache => _diagnosticAnalyzerRunner.AnalyzerInfoCache;
-
-        private void OnProjectAnalyzerReferenceChanged(object? sender, ProjectAnalyzerReferenceChangedEventArgs e)
-        {
-            if (e.Removed.Length == 0)
-            {
-                // nothing to refresh
-                return;
-            }
-
-            // make sure we drop cache related to the analyzers
-            foreach (var stateSet in e.Removed)
-                stateSet.OnRemoved();
-        }
-
-        public static Task<VersionStamp> GetDiagnosticVersionAsync(Project project, CancellationToken cancellationToken)
-            => project.GetDependentVersionAsync(cancellationToken);
-
-        private static DiagnosticAnalysisResult GetResultOrEmpty(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> map, DiagnosticAnalyzer analyzer, ProjectId projectId, VersionStamp version)
-        {
-            if (map.TryGetValue(analyzer, out var result))
-            {
-                return result;
-            }
-
-            return DiagnosticAnalysisResult.CreateEmpty(projectId, version);
-        }
-
-        internal async Task<IEnumerable<DiagnosticAnalyzer>> GetAnalyzersTestOnlyAsync(Project project, CancellationToken cancellationToken)
-        {
-            var analyzers = await _stateManager.GetOrCreateStateSetsAsync(project, cancellationToken).ConfigureAwait(false);
-
-            return analyzers.Select(s => s.Analyzer);
-        }
-
-        private static string GetProjectLogMessage(Project project, ImmutableArray<StateSet> stateSets)
-            => $"project: ({project.Id}), ({string.Join(Environment.NewLine, stateSets.Select(s => s.Analyzer.ToString()))})";
-
-        private static string GetOpenLogMessage(TextDocument document)
-            => $"document open: ({document.FilePath ?? document.Name})";
+        var enabled = globalOptionService.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler);
+        _diagnosticAnalyzerRunner = new InProcOrRemoteHostAnalyzerRunner(
+            enabled, analyzerInfoCache, analyzerService.Listener);
     }
+
+    internal IGlobalOptionService GlobalOptions { get; }
+    internal DiagnosticAnalyzerInfoCache DiagnosticAnalyzerInfoCache => _diagnosticAnalyzerRunner.AnalyzerInfoCache;
+
+    private void OnProjectAnalyzerReferenceChanged(object? sender, ProjectAnalyzerReferenceChangedEventArgs e)
+    {
+        if (e.Removed.Length == 0)
+        {
+            // nothing to refresh
+            return;
+        }
+
+        // make sure we drop cache related to the analyzers
+        foreach (var stateSet in e.Removed)
+            stateSet.OnRemoved();
+    }
+
+    public static Task<VersionStamp> GetDiagnosticVersionAsync(Project project, CancellationToken cancellationToken)
+        => project.GetDependentVersionAsync(cancellationToken);
+
+    private static DiagnosticAnalysisResult GetResultOrEmpty(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> map, DiagnosticAnalyzer analyzer, ProjectId projectId, VersionStamp version)
+    {
+        if (map.TryGetValue(analyzer, out var result))
+        {
+            return result;
+        }
+
+        return DiagnosticAnalysisResult.CreateEmpty(projectId, version);
+    }
+
+    internal async Task<IEnumerable<DiagnosticAnalyzer>> GetAnalyzersTestOnlyAsync(Project project, CancellationToken cancellationToken)
+    {
+        var analyzers = await _stateManager.GetOrCreateStateSetsAsync(project, cancellationToken).ConfigureAwait(false);
+
+        return analyzers.Select(s => s.Analyzer);
+    }
+
+    private static string GetProjectLogMessage(Project project, ImmutableArray<StateSet> stateSets)
+        => $"project: ({project.Id}), ({string.Join(Environment.NewLine, stateSets.Select(s => s.Analyzer.ToString()))})";
+
+    private static string GetOpenLogMessage(TextDocument document)
+        => $"document open: ({document.FilePath ?? document.Name})";
 }

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
@@ -139,8 +139,6 @@ internal partial class ContainedLanguage
         this.DataBuffer.Changed += OnDataBufferChanged;
     }
 
-    public IGlobalOptionService GlobalOptions => _diagnosticAnalyzerService.GlobalOptions;
-
     private void OnDisconnect()
     {
         this.DataBuffer.Changed -= OnDataBufferChanged;

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim threadingContext = workspace.ExportProvider.GetExport(Of IThreadingContext).Value
 
-                Dim service = New TestDiagnosticAnalyzerService(workspace.GlobalOptions)
+                Dim service = New TestDiagnosticAnalyzerService()
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
                 vsWorkspace.SetWorkspace(workspace)
                 Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
@@ -71,7 +71,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         Public Async Function TestExternalDiagnostics_SupportedDiagnosticId_Concurrent() As Task
             Using workspace = EditorTestWorkspace.CreateCSharp(String.Empty, composition:=s_composition)
                 Dim waiter = workspace.GetService(Of AsynchronousOperationListenerProvider)().GetWaiter(FeatureAttribute.ErrorList)
-                Dim service = New TestDiagnosticAnalyzerService(workspace.GlobalOptions)
+                Dim service = New TestDiagnosticAnalyzerService()
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
                 vsWorkspace.SetWorkspace(workspace)
                 Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
@@ -98,7 +98,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim threadingContext = workspace.ExportProvider.GetExport(Of IThreadingContext).Value
 
-                Dim service = New TestDiagnosticAnalyzerService(workspace.GlobalOptions)
+                Dim service = New TestDiagnosticAnalyzerService()
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
                 vsWorkspace.SetWorkspace(workspace)
                 Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
@@ -119,7 +119,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim project = workspace.CurrentSolution.Projects.First()
                 Dim diagnostic = GetDiagnosticData(project.Id)
 
-                Dim service = New TestDiagnosticAnalyzerService(workspace.GlobalOptions)
+                Dim service = New TestDiagnosticAnalyzerService()
                 Dim threadingContext = workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim testServiceBroker = workspace.ExportProvider.GetExportedValue(Of TestServiceBroker)
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
@@ -154,7 +154,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim project = workspace.CurrentSolution.Projects.First()
 
-                Dim service = New TestDiagnosticAnalyzerService(workspace.GlobalOptions)
+                Dim service = New TestDiagnosticAnalyzerService()
                 Dim threadingContext = workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim testServiceBroker = workspace.ExportProvider.GetExportedValue(Of TestServiceBroker)
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
@@ -195,7 +195,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim project = workspace.CurrentSolution.Projects.First()
                 Dim diagnostic = GetDiagnosticData(project.Id)
 
-                Dim service = New TestDiagnosticAnalyzerService(globalOptions)
+                Dim service = New TestDiagnosticAnalyzerService()
                 Dim threadingContext = workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim testServiceBroker = workspace.ExportProvider.GetExportedValue(Of TestServiceBroker)
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
@@ -300,11 +300,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
             Private ReadOnly _analyzerInfoCache As DiagnosticAnalyzerInfoCache
 
-            Public ReadOnly Property GlobalOptions As IGlobalOptionService Implements IDiagnosticAnalyzerService.GlobalOptions
-
-            Public Sub New(globalOptions As IGlobalOptionService, Optional data As ImmutableArray(Of DiagnosticData) = Nothing)
+            Public Sub New(Optional data As ImmutableArray(Of DiagnosticData) = Nothing)
                 _analyzerInfoCache = New DiagnosticAnalyzerInfoCache()
-                Me.GlobalOptions = globalOptions
             End Sub
 
             Public ReadOnly Property AnalyzerInfoCache As DiagnosticAnalyzerInfoCache Implements IDiagnosticAnalyzerService.AnalyzerInfoCache


### PR DESCRIPTION
Part of a larger effort to simplify the diagnostics subsystem we have. 