### PR TITLE
Make project id required with diagnostic requests

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -68,7 +68,7 @@ public class DiagnosticAnalyzerServiceTests
         var globalOptions = exportProvider.GetExportedValue<IGlobalOptionService>();
 
         var diagnostics = await analyzer.GetDiagnosticsForIdsAsync(
-            workspace.CurrentSolution, projectId: null, documentId: null, diagnosticIds: null, shouldIncludeAnalyzer: null, getDocuments: null,
+            workspace.CurrentSolution, projectId: workspace.CurrentSolution.ProjectIds.Single(), documentId: null, diagnosticIds: null, shouldIncludeAnalyzer: null, getDocuments: null,
             includeLocalDocumentDiagnostics: true, includeNonLocalDocumentDiagnostics: false, CancellationToken.None);
         Assert.NotEmpty(diagnostics);
     }

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
@@ -261,9 +261,13 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Next
 
                 Dim diagnosticProvider = GetDiagnosticProvider(workspace)
-                Dim actualDiagnostics = diagnosticProvider.GetDiagnosticsForIdsAsync(
-                    workspace.CurrentSolution, projectId:=Nothing, documentId:=Nothing, diagnosticIds:=Nothing, shouldIncludeAnalyzer:=Nothing,
-                    includeLocalDocumentDiagnostics:=True, includeNonLocalDocumentDiagnostics:=True, CancellationToken.None).Result
+                Dim actualDiagnostics = New List(Of DiagnosticData)
+
+                For Each project In workspace.CurrentSolution.Projects
+                    actualDiagnostics.AddRange(diagnosticProvider.GetDiagnosticsForIdsAsync(
+                        workspace.CurrentSolution, project.Id, documentId:=Nothing, diagnosticIds:=Nothing, shouldIncludeAnalyzer:=Nothing,
+                        includeLocalDocumentDiagnostics:=True, includeNonLocalDocumentDiagnostics:=True, CancellationToken.None).Result)
+                Next
 
                 If diagnostics Is Nothing Then
                     Assert.Empty(actualDiagnostics)

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -532,7 +532,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Assert.Empty(diagnostics)
 
                 diagnostics = Await diagnosticService.GetDiagnosticsForIdsAsync(
-                    project.Solution, projectId:=Nothing, documentId:=Nothing, diagnosticIds:=Nothing, shouldIncludeAnalyzer:=Nothing,
+                    project.Solution, projectId:=document.Project.Id, documentId:=Nothing, diagnosticIds:=Nothing, shouldIncludeAnalyzer:=Nothing,
                     includeLocalDocumentDiagnostics:=True, includeNonLocalDocumentDiagnostics:=True, CancellationToken.None)
                 Dim diagnostic = diagnostics.First()
                 Assert.True(diagnostic.Id = "AD0001")

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -75,7 +75,7 @@ internal interface IDiagnosticAnalyzerService
     /// project must be analyzed to get the complete set of non-local document diagnostics.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocumentIds, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken);
+    Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocumentIds, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get project diagnostics (diagnostics with no source location) of the given diagnostic ids and/or analyzers from
@@ -93,7 +93,7 @@ internal interface IDiagnosticAnalyzerService
     /// Entire project must be analyzed to get the complete set of non-local diagnostics.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken);
+    Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId projectId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken);
 
     /// <summary>
     /// Return up to date diagnostics for the given span for the document
@@ -151,7 +151,7 @@ internal static class IDiagnosticAnalyzerServiceExtensions
     }
 
     public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(
-        this IDiagnosticAnalyzerService service, Solution solution, ProjectId? projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+        this IDiagnosticAnalyzerService service, Solution solution, ProjectId projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
     {
         return service.GetDiagnosticsForIdsAsync(
             solution, projectId, documentId, diagnosticIds, shouldIncludeAnalyzer, getDocumentIds: null,

--- a/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.FixAllDiagnosticProvider.cs
+++ b/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.FixAllDiagnosticProvider.cs
@@ -12,74 +12,73 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.CodeFixes
+namespace Microsoft.CodeAnalysis.CodeFixes;
+
+internal partial class CodeFixService
 {
-    internal partial class CodeFixService
+    private sealed class FixAllDiagnosticProvider : FixAllContext.SpanBasedDiagnosticProvider
     {
-        private sealed class FixAllDiagnosticProvider : FixAllContext.SpanBasedDiagnosticProvider
+        private readonly IDiagnosticAnalyzerService _diagnosticService;
+        private readonly ImmutableHashSet<string>? _diagnosticIds;
+        private readonly bool _includeSuppressedDiagnostics;
+
+        public FixAllDiagnosticProvider(IDiagnosticAnalyzerService diagnosticService, ImmutableHashSet<string> diagnosticIds)
         {
-            private readonly IDiagnosticAnalyzerService _diagnosticService;
-            private readonly ImmutableHashSet<string>? _diagnosticIds;
-            private readonly bool _includeSuppressedDiagnostics;
+            _diagnosticService = diagnosticService;
 
-            public FixAllDiagnosticProvider(IDiagnosticAnalyzerService diagnosticService, ImmutableHashSet<string> diagnosticIds)
+            // When computing FixAll for unnecessary pragma suppression diagnostic,
+            // we need to include suppressed diagnostics, as well as reported compiler and analyzer diagnostics.
+            // A null value for '_diagnosticIds' ensures the latter.
+            if (diagnosticIds.Contains(IDEDiagnosticIds.RemoveUnnecessarySuppressionDiagnosticId))
             {
-                _diagnosticService = diagnosticService;
-
-                // When computing FixAll for unnecessary pragma suppression diagnostic,
-                // we need to include suppressed diagnostics, as well as reported compiler and analyzer diagnostics.
-                // A null value for '_diagnosticIds' ensures the latter.
-                if (diagnosticIds.Contains(IDEDiagnosticIds.RemoveUnnecessarySuppressionDiagnosticId))
-                {
-                    _diagnosticIds = null;
-                    _includeSuppressedDiagnostics = true;
-                }
-                else
-                {
-                    _diagnosticIds = diagnosticIds;
-                    _includeSuppressedDiagnostics = false;
-                }
+                _diagnosticIds = null;
+                _includeSuppressedDiagnostics = true;
             }
-
-            private ImmutableArray<DiagnosticData> Filter(ImmutableArray<DiagnosticData> diagnostics)
-                => diagnostics.WhereAsArray(d => _includeSuppressedDiagnostics || !d.IsSuppressed);
-
-            public override async Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+            else
             {
-                var solution = document.Project.Solution;
-                var diagnostics = Filter(await _diagnosticService.GetDiagnosticsForIdsAsync(
-                    solution, projectId: null, document.Id, _diagnosticIds, shouldIncludeAnalyzer: null, includeLocalDocumentDiagnostics: true, includeNonLocalDocumentDiagnostics: false, cancellationToken).ConfigureAwait(false));
-                Contract.ThrowIfFalse(diagnostics.All(d => d.DocumentId != null));
-                return await diagnostics.ToDiagnosticsAsync(document.Project, cancellationToken).ConfigureAwait(false);
+                _diagnosticIds = diagnosticIds;
+                _includeSuppressedDiagnostics = false;
             }
+        }
 
-            public override async Task<IEnumerable<Diagnostic>> GetDocumentSpanDiagnosticsAsync(Document document, TextSpan fixAllSpan, CancellationToken cancellationToken)
-            {
-                bool shouldIncludeDiagnostic(string id) => _diagnosticIds == null || _diagnosticIds.Contains(id);
-                var diagnostics = Filter(await _diagnosticService.GetDiagnosticsForSpanAsync(
-                    document, fixAllSpan, shouldIncludeDiagnostic, includeCompilerDiagnostics: true,
-                    priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
-                    DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false));
-                Contract.ThrowIfFalse(diagnostics.All(d => d.DocumentId != null));
-                return await diagnostics.ToDiagnosticsAsync(document.Project, cancellationToken).ConfigureAwait(false);
-            }
+        private ImmutableArray<DiagnosticData> Filter(ImmutableArray<DiagnosticData> diagnostics)
+            => diagnostics.WhereAsArray(d => _includeSuppressedDiagnostics || !d.IsSuppressed);
 
-            public override async Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
-            {
-                // Get all diagnostics for the entire project, including document diagnostics.
-                var diagnostics = Filter(await _diagnosticService.GetDiagnosticsForIdsAsync(
-                    project.Solution, project.Id, documentId: null, _diagnosticIds, shouldIncludeAnalyzer: null, includeLocalDocumentDiagnostics: true, includeNonLocalDocumentDiagnostics: false, cancellationToken).ConfigureAwait(false));
-                return await diagnostics.ToDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
-            }
+        public override async Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+        {
+            var solution = document.Project.Solution;
+            var diagnostics = Filter(await _diagnosticService.GetDiagnosticsForIdsAsync(
+                solution, projectId: document.Project.Id, document.Id, _diagnosticIds, shouldIncludeAnalyzer: null, includeLocalDocumentDiagnostics: true, includeNonLocalDocumentDiagnostics: false, cancellationToken).ConfigureAwait(false));
+            Contract.ThrowIfFalse(diagnostics.All(d => d.DocumentId != null));
+            return await diagnostics.ToDiagnosticsAsync(document.Project, cancellationToken).ConfigureAwait(false);
+        }
 
-            public override async Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
-            {
-                // Get all no-location diagnostics for the project, doesn't include document diagnostics.
-                var diagnostics = Filter(await _diagnosticService.GetProjectDiagnosticsForIdsAsync(
-                    project.Solution, project.Id, _diagnosticIds, shouldIncludeAnalyzer: null, includeNonLocalDocumentDiagnostics: false, cancellationToken).ConfigureAwait(false));
-                Contract.ThrowIfFalse(diagnostics.All(d => d.DocumentId == null));
-                return await diagnostics.ToDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
-            }
+        public override async Task<IEnumerable<Diagnostic>> GetDocumentSpanDiagnosticsAsync(Document document, TextSpan fixAllSpan, CancellationToken cancellationToken)
+        {
+            bool shouldIncludeDiagnostic(string id) => _diagnosticIds == null || _diagnosticIds.Contains(id);
+            var diagnostics = Filter(await _diagnosticService.GetDiagnosticsForSpanAsync(
+                document, fixAllSpan, shouldIncludeDiagnostic, includeCompilerDiagnostics: true,
+                priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
+                DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false));
+            Contract.ThrowIfFalse(diagnostics.All(d => d.DocumentId != null));
+            return await diagnostics.ToDiagnosticsAsync(document.Project, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override async Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            // Get all diagnostics for the entire project, including document diagnostics.
+            var diagnostics = Filter(await _diagnosticService.GetDiagnosticsForIdsAsync(
+                project.Solution, project.Id, documentId: null, _diagnosticIds, shouldIncludeAnalyzer: null, includeLocalDocumentDiagnostics: true, includeNonLocalDocumentDiagnostics: false, cancellationToken).ConfigureAwait(false));
+            return await diagnostics.ToDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override async Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            // Get all no-location diagnostics for the project, doesn't include document diagnostics.
+            var diagnostics = Filter(await _diagnosticService.GetProjectDiagnosticsForIdsAsync(
+                project.Solution, project.Id, _diagnosticIds, shouldIncludeAnalyzer: null, includeNonLocalDocumentDiagnostics: false, cancellationToken).ConfigureAwait(false));
+            Contract.ThrowIfFalse(diagnostics.All(d => d.DocumentId == null));
+            return await diagnostics.ToDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(
-            Workspace workspace, ProjectId? projectId, DocumentId? documentId, CancellationToken cancellationToken)
+            Workspace workspace, ProjectId projectId, DocumentId? documentId, CancellationToken cancellationToken)
         {
             var analyzer = CreateIncrementalAnalyzer(workspace);
             return analyzer.GetCachedDiagnosticsAsync(workspace.CurrentSolution, projectId, documentId, cancellationToken);
@@ -107,14 +107,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(
-            Solution solution, ProjectId? projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+            Solution solution, ProjectId projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
         {
             var analyzer = CreateIncrementalAnalyzer(solution.Workspace);
             return analyzer.GetDiagnosticsForIdsAsync(solution, projectId, documentId, diagnosticIds, shouldIncludeAnalyzer, getDocuments, includeLocalDocumentDiagnostics, includeNonLocalDocumentDiagnostics, cancellationToken);
         }
 
         public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(
-            Solution solution, ProjectId? projectId, ImmutableHashSet<string>? diagnosticIds,
+            Solution solution, ProjectId projectId, ImmutableHashSet<string>? diagnosticIds,
             Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer,
             bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
         {

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -66,8 +66,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 Project project, IReadOnlyList<DocumentId> documentIds,
                 bool includeProjectNonLocalResult, CancellationToken cancellationToken)
             {
-                // PERF: run projects in parallel rather than running CompilationWithAnalyzer with concurrency == true.
-                // We do this to not get into thread starvation causing hundreds of threads to be spawned.
                 using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var builder);
                 await this.ProduceDiagnosticsAsync(
                     project, documentIds, includeProjectNonLocalResult, builder, cancellationToken).ConfigureAwait(false);

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -59,18 +59,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // return diagnostics specific to one project or document
                 var includeProjectNonLocalResult = DocumentId == null;
                 return await ProduceProjectDiagnosticsAsync(
-                    project, project => _getDocuments(project, DocumentId), includeProjectNonLocalResult, cancellationToken).ConfigureAwait(false);
+                    project, _getDocuments(project, DocumentId), includeProjectNonLocalResult, cancellationToken).ConfigureAwait(false);
             }
 
             protected async Task<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(
-                Project project, Func<Project, IReadOnlyList<DocumentId>> getDocumentIds,
+                Project project, IReadOnlyList<DocumentId> documentIds,
                 bool includeProjectNonLocalResult, CancellationToken cancellationToken)
             {
                 // PERF: run projects in parallel rather than running CompilationWithAnalyzer with concurrency == true.
                 // We do this to not get into thread starvation causing hundreds of threads to be spawned.
                 using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var builder);
                 await this.ProduceDiagnosticsAsync(
-                    project, getDocumentIds(project), includeProjectNonLocalResult, builder, cancellationToken).ConfigureAwait(false);
+                    project, documentIds, includeProjectNonLocalResult, builder, cancellationToken).ConfigureAwait(false);
                 return builder.ToImmutableAndClear();
             }
 
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return [];
 
                 return await ProduceProjectDiagnosticsAsync(
-                    project, static _ => [], includeProjectNonLocalResult: true, cancellationToken).ConfigureAwait(false);
+                    project, documentIds: [], includeProjectNonLocalResult: true, cancellationToken).ConfigureAwait(false);
             }
 
             protected override bool ShouldIncludeDiagnostic(DiagnosticData diagnostic)

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -52,23 +52,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(CancellationToken cancellationToken)
             {
-                if (ProjectId != null)
-                {
-                    var project = Solution.GetProject(ProjectId);
-                    if (project == null)
-                        return [];
+                var project = Solution.GetProject(ProjectId);
+                if (project == null)
+                    return [];
 
-                    // return diagnostics specific to one project or document
-                    var includeProjectNonLocalResult = DocumentId == null;
-                    return await ProduceProjectDiagnosticsAsync(
-                        [project], project => _getDocuments(project, DocumentId), includeProjectNonLocalResult, cancellationToken).ConfigureAwait(false);
-                }
-
-                return await ProduceSolutionDiagnosticsAsync(Solution, cancellationToken).ConfigureAwait(false);
+                // return diagnostics specific to one project or document
+                var includeProjectNonLocalResult = DocumentId == null;
+                return await ProduceProjectDiagnosticsAsync(
+                    [project], project => _getDocuments(project, DocumentId), includeProjectNonLocalResult, cancellationToken).ConfigureAwait(false);
             }
-
-            protected Task<ImmutableArray<DiagnosticData>> ProduceSolutionDiagnosticsAsync(Solution solution, CancellationToken cancellationToken)
-                => ProduceProjectDiagnosticsAsync(solution.Projects, static project => project.DocumentIds, includeProjectNonLocalResult: true, cancellationToken);
 
             protected async Task<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(
                 IEnumerable<Project> projects, Func<Project, IReadOnlyList<DocumentId>> getDocumentIds,
@@ -212,17 +204,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             public async Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsAsync(CancellationToken cancellationToken)
             {
-                if (ProjectId != null)
-                {
-                    var project = Solution.GetProject(ProjectId);
-                    if (project is null)
-                        return [];
+                var project = Solution.GetProject(ProjectId);
+                if (project is null)
+                    return [];
 
-                    return await ProduceProjectDiagnosticsAsync(
-                        [project], static _ => [], includeProjectNonLocalResult: true, cancellationToken).ConfigureAwait(false);
-                }
-
-                return await ProduceSolutionDiagnosticsAsync(Solution, cancellationToken).ConfigureAwait(false);
+                return await ProduceProjectDiagnosticsAsync(
+                    [project], static _ => [], includeProjectNonLocalResult: true, cancellationToken).ConfigureAwait(false);
             }
 
             protected override bool ShouldIncludeDiagnostic(DiagnosticData diagnostic)

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -15,19 +15,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
     internal partial class DiagnosticIncrementalAnalyzer
     {
-        public Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, CancellationToken cancellationToken)
+        public Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Solution solution, ProjectId projectId, DocumentId? documentId, CancellationToken cancellationToken)
             => new IdeCachedDiagnosticGetter(this, solution, projectId, documentId).GetDiagnosticsAsync(cancellationToken);
 
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId projectId, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
             => new IdeLatestDiagnosticGetter(this, solution, projectId, documentId, diagnosticIds, shouldIncludeAnalyzer, getDocuments, includeLocalDocumentDiagnostics, includeNonLocalDocumentDiagnostics).GetDiagnosticsAsync(cancellationToken);
 
-        public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
+        public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId projectId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
             => new IdeLatestDiagnosticGetter(this, solution, projectId, documentId: null, diagnosticIds, shouldIncludeAnalyzer, getDocuments: null, includeLocalDocumentDiagnostics: false, includeNonLocalDocumentDiagnostics).GetProjectDiagnosticsAsync(cancellationToken);
 
         private abstract class DiagnosticGetter(
             DiagnosticIncrementalAnalyzer owner,
             Solution solution,
-            ProjectId? projectId,
+            ProjectId projectId,
             DocumentId? documentId,
             Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments,
             bool includeLocalDocumentDiagnostics,
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             protected readonly DiagnosticIncrementalAnalyzer Owner = owner;
 
             protected readonly Solution Solution = solution;
-            protected readonly ProjectId? ProjectId = projectId ?? documentId?.ProjectId;
+            protected readonly ProjectId ProjectId = projectId;
             protected readonly DocumentId? DocumentId = documentId;
             protected readonly bool IncludeLocalDocumentDiagnostics = includeLocalDocumentDiagnostics;
             protected readonly bool IncludeNonLocalDocumentDiagnostics = includeNonLocalDocumentDiagnostics;
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private sealed class IdeCachedDiagnosticGetter(
             DiagnosticIncrementalAnalyzer owner,
             Solution solution,
-            ProjectId? projectId,
+            ProjectId projectId,
             DocumentId? documentId)
             : DiagnosticGetter(
                 owner, solution, projectId, documentId, getDocuments: null,
@@ -197,13 +197,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private sealed class IdeLatestDiagnosticGetter(
             DiagnosticIncrementalAnalyzer owner,
             Solution solution,
-            ProjectId? projectId,
+            ProjectId projectId,
             DocumentId? documentId,
             ImmutableHashSet<string>? diagnosticIds,
             Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer,
             Func<Project, DocumentId?, IReadOnlyList<DocumentId>>? getDocuments,
             bool includeLocalDocumentDiagnostics,
-            bool includeNonLocalDocumentDiagnostics) : DiagnosticGetter(
+            bool includeNonLocalDocumentDiagnostics)
+            : DiagnosticGetter(
                 owner, solution, projectId, documentId, getDocuments, includeLocalDocumentDiagnostics, includeNonLocalDocumentDiagnostics)
         {
             private readonly ImmutableHashSet<string>? _diagnosticIds = diagnosticIds;

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return builder.ToImmutableAndClear();
             }
 
-            protected void InvokeCallback(ArrayBuilder<DiagnosticData> builder, ImmutableArray<DiagnosticData> diagnostics)
+            protected void AddIncludedDiagnostics(ArrayBuilder<DiagnosticData> builder, ImmutableArray<DiagnosticData> diagnostics)
             {
                 foreach (var diagnostic in diagnostics)
                 {
@@ -104,18 +104,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     {
                         if (IncludeLocalDocumentDiagnostics)
                         {
-                            InvokeCallback(builder, await GetDiagnosticsAsync(stateSet, project, documentId, AnalysisKind.Syntax, cancellationToken).ConfigureAwait(false));
-                            InvokeCallback(builder, await GetDiagnosticsAsync(stateSet, project, documentId, AnalysisKind.Semantic, cancellationToken).ConfigureAwait(false));
+                            AddIncludedDiagnostics(builder, await GetDiagnosticsAsync(stateSet, project, documentId, AnalysisKind.Syntax, cancellationToken).ConfigureAwait(false));
+                            AddIncludedDiagnostics(builder, await GetDiagnosticsAsync(stateSet, project, documentId, AnalysisKind.Semantic, cancellationToken).ConfigureAwait(false));
                         }
 
                         if (IncludeNonLocalDocumentDiagnostics)
-                            InvokeCallback(builder, await GetDiagnosticsAsync(stateSet, project, documentId, AnalysisKind.NonLocal, cancellationToken).ConfigureAwait(false));
+                            AddIncludedDiagnostics(builder, await GetDiagnosticsAsync(stateSet, project, documentId, AnalysisKind.NonLocal, cancellationToken).ConfigureAwait(false));
                     }
 
                     if (includeProjectNonLocalResult)
                     {
                         // include project diagnostics if there is no target document
-                        InvokeCallback(builder, await GetProjectStateDiagnosticsAsync(stateSet, project, documentId: null, AnalysisKind.NonLocal, cancellationToken).ConfigureAwait(false));
+                        AddIncludedDiagnostics(builder, await GetProjectStateDiagnosticsAsync(stateSet, project, documentId: null, AnalysisKind.NonLocal, cancellationToken).ConfigureAwait(false));
                     }
                 }
             }
@@ -237,18 +237,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     {
                         if (IncludeLocalDocumentDiagnostics)
                         {
-                            InvokeCallback(builder, analysisResult.GetDocumentDiagnostics(documentId, AnalysisKind.Syntax));
-                            InvokeCallback(builder, analysisResult.GetDocumentDiagnostics(documentId, AnalysisKind.Semantic));
+                            AddIncludedDiagnostics(builder, analysisResult.GetDocumentDiagnostics(documentId, AnalysisKind.Syntax));
+                            AddIncludedDiagnostics(builder, analysisResult.GetDocumentDiagnostics(documentId, AnalysisKind.Semantic));
                         }
 
                         if (IncludeNonLocalDocumentDiagnostics)
-                            InvokeCallback(builder, analysisResult.GetDocumentDiagnostics(documentId, AnalysisKind.NonLocal));
+                            AddIncludedDiagnostics(builder, analysisResult.GetDocumentDiagnostics(documentId, AnalysisKind.NonLocal));
                     }
 
                     if (includeProjectNonLocalResult)
                     {
                         // include project diagnostics if there is no target document
-                        InvokeCallback(builder, analysisResult.GetOtherDiagnostics());
+                        AddIncludedDiagnostics(builder, analysisResult.GetOtherDiagnostics());
                     }
                 }
             }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/77028

Ensures callers can't do something like pass no projectId and no documentId.  Now, you're always asking about some project, and optionally some document in that project.