### PR TITLE
Realize less of the syntax tree during AbstractSemanticModelReuseLanguageService.GetPreviousBodyNode

### DIFF
--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -124,7 +124,14 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
                     return null;
                 }
 
-                previousNode = children[childIndex].AsNode()!;
+                var childAsNode = children[childIndex].AsNode();
+                if (childAsNode is null)
+                {
+                    Debug.Fail("Child at indicated index should be a node as there were no top level edits.");
+                    return null;
+                }
+
+                previousNode = childAsNode;
             }
 
             return previousNode;

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.SemanticModelReuse;
 
@@ -106,26 +107,44 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
         }
         else
         {
-            using var pooledCurrentMembers = this.SyntaxFacts.GetMethodLevelMembers(currentRoot);
-            var currentMembers = pooledCurrentMembers.Object;
+            // Walk up the ancestor nodes of currentBodyNode, finding child indexes up to the root.
+            using var _ = ArrayBuilder<int>.GetInstance(out var indexPath);
+            GetNodeChildIndexPathToRootReversed(currentBodyNode, indexPath);
 
-            var index = currentMembers.IndexOf(currentBodyNode);
-            if (index < 0)
+            // Then use those indexes to walk back down the previous tree to find the equivalent node.
+            var previousNode = previousRoot;
+            for (var i = indexPath.Count - 1; i >= 0; i--)
             {
-                Debug.Fail($"Unhandled member type in {nameof(GetPreviousBodyNode)}");
-                return null;
+                var childIndex = indexPath[i];
+                var children = previousNode.ChildNodesAndTokens();
+                previousNode = children[childIndex].AsNode()!;
             }
 
-            using var pooledPreviousMembers = this.SyntaxFacts.GetMethodLevelMembers(previousRoot);
-            var previousMembers = pooledPreviousMembers.Object;
+            return previousNode;
+        }
+    }
 
-            if (currentMembers.Count != previousMembers.Count)
+    private static void GetNodeChildIndexPathToRootReversed(SyntaxNode node, ArrayBuilder<int> path)
+    {
+        var current = node;
+        var parent = current.Parent;
+
+        while (parent != null)
+        {
+            var childIndex = 0;
+            foreach (var child in parent.ChildNodesAndTokens())
             {
-                Debug.Fail("Member count shouldn't have changed as there were no top level edits.");
-                return null;
+                if (child.AsNode() == current)
+                {
+                    path.Add(childIndex);
+                    break;
+                }
+
+                childIndex++;
             }
 
-            return previousMembers[index];
+            current = parent;
+            parent = current.Parent;
         }
     }
 

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -117,6 +117,13 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
             {
                 var childIndex = indexPath[i];
                 var children = previousNode.ChildNodesAndTokens();
+
+                if (children.Count <= childIndex)
+                {
+                    Debug.Fail("Member count shouldn't have changed as there were no top level edits.");
+                    return null;
+                }
+
                 previousNode = children[childIndex].AsNode()!;
             }
 


### PR DESCRIPTION
During the typing scenario in the scrolling speedometer test, about 13% of allocations in VS are under GetPreviousBodyNode, due to realizing a bunch of nodes in the syntax tree to attempt to map from a method node in one tree to the corresponding node in similarly structured tree. Instead, as we know the trees have similar structure, just walk up the ancestors in the current tree to generate a node index path, and apply that path to the previous tree to find the appropriate method node.

*** Without change ***
13% of VS allocations during typing:
![image](https://github.com/user-attachments/assets/f196c583-f95e-4bac-bfa8-3679c9c710d8)

Types allocated under GetPreviousBodyNode:
![image](https://github.com/user-attachments/assets/fba2b4be-00c1-4e93-87c7-2f5576571a5d)

*** With change ***
0.3% of VS allocations during typing:
![image](https://github.com/user-attachments/assets/12a23d1b-ea07-475f-b1b3-cded5a6de921)

Types allocated under GetPreviousBodyNode:
![image](https://github.com/user-attachments/assets/3b09ea9b-477b-4b04-9df5-a218ada437d3)