### PR TITLE
Fix fast up to date check with ServiceHub projects

### DIFF
--- a/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
+++ b/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <!-- The 9.0 Arcade targets we are consuming don't have Sets specified for the items, and don't include all items correctly. This overrides
+       those targets so they don't interfere. These two empty targets can be deleted when we've removed the support from Arcade in favor of
+       built-in support in the VS SDK, and we are consuming that support in this repo. -->
+
+  <Target Name="CollectVsixUpToDateCheckInput">
+  </Target>
+
+  <Target Name="CollectVsixUpToDateCheckBuilt">
+  </Target>
+
+  <!-- The targets below are being added to the VS SDK; in the mean time we have a copy here. This can be removed when we moved this repo forward
+       to consume those targets. -->
+
+  <PropertyGroup>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);AddUpToDateCheckVSIXSourceItems</CollectUpToDateCheckInputDesignTimeDependsOn>
+  </PropertyGroup>
+
+  <Target Name="AddUpToDateCheckVSIXSourceItems" DependsOnTargets="GetVsixSourceItems">
+    <ItemGroup>
+      <UpToDateCheckInput Include="@(VSIXSourceItem)" Set="VSIX" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Add the UpToDateCheckOutput to the VSIX being produced; we'll do this outside of any target since we know it without further calcuation -->
+  <ItemGroup Condition="'$(CreateVsixContainer)' != 'false'">
+    <UpToDateCheckOutput Include="$(TargetVsixContainer)" Set="VSIX" />
+  </ItemGroup>
+</Project>

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -165,6 +165,7 @@
   
   <PropertyGroup>
     <CreateVsixContainerDependsOn>$(CreateVsixContainerDependsOn);PublishProjectReferencesForVsixCreation</CreateVsixContainerDependsOn>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);AddUpToDateCheckItemsForPublishProjectReferences</CollectUpToDateCheckInputDesignTimeDependsOn>
   </PropertyGroup>
 
   <Target Name="PublishProjectReferencesForVsixCreation">
@@ -177,5 +178,23 @@
              Properties="%(_ProjectsToPublish.SetConfiguration);%(_ProjectsToPublish.SetPlatform);%(_ProjectsToPublish.SetTargetFramework)"
              Targets="PublishVsixItems"
              RebaseOutputs="true" />
+  </Target>
+
+  <Target Name="AddUpToDateCheckItemsForPublishProjectReferences">
+    <ItemGroup>
+      <_ProjectsToPublishForUpToDateCheck Include="@(ProjectReference)" Condition="$([MSBuild]::ValueOrDefault('%(ProjectReference.IncludeOutputGroupsInVSIX)', '').Contains('PublishedProjectOutputGroup'))"/>
+    </ItemGroup>
+    <MSBuild Projects="@(_ProjectsToPublishForUpToDateCheck)"
+           BuildInParallel="$(BuildInParallel)"
+           Properties="%(_ProjectsToPublish.SetConfiguration);%(_ProjectsToPublish.SetPlatform);%(_ProjectsToPublish.SetTargetFramework)"
+           Targets="PublishItemsOutputGroup"
+           RebaseOutputs="true"
+           ContinueOnError="$(ContinueOnError)">
+      <Output TaskParameter="TargetOutputs" ItemName="_PublishUpToDateInputs" />
+    </MSBuild>
+
+    <ItemGroup>
+      <UpToDateCheckInput Include="@(_PublishUpToDateInputs)" Set="VSIX" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -147,6 +147,10 @@
   <!-- Workaround to fix https://github.com/dotnet/msbuild/issues/10306 -->
   <Target Name="ExtensionJsonOutputGroupFixed" Returns="@(ExtensionJsonOutputGroupOutput)" DependsOnTargets="PrepareResources;ExtensionJsonOutputGroup" />
 
+  <!-- Import workarounds for the fast up to date check, but only if VsSdkTargetsImported is set which is set in the VS SDK targets themselves;
+       if we don't have that condition, we might try to include it when we don't have some targets we depend on, and things will break -->
+  <Import Project="VisualStudio.FastUpToDateCheckWorkarounds.targets" Condition="'$(VsSdkTargetsImported)' == 'true'"/>
+
   <!--
     Workaround for missing dependency publishing feature in the VS SDK.
     

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(RepositoryEngineeringDir)targets\Services.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Roslyn.VisualStudio.Setup</RootNamespace>


### PR DESCRIPTION
This fixes the fast-up-to-date check with ServiceHub projects. High level there were a few problems:

1. The arcade targets try to provide up-to-date check items, but we're consuming older targets with some issues. This copies in the version which is in the VS SDK itself so we can deprecate the Arcade versions.
2. The ServiceHub setup projects consume the published output of other projects, but won't necessarily trigger the publish itself. This can mean the setup projects are considered "up to date" even if a publish would produce new binaries.

You will see overbuilding with this change due to https://github.com/dotnet/roslyn/issues/77039.