### PR TITLE
Consume mibc data from VSCode profiling runs in official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -16,6 +16,11 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+  pipelines:
+    - pipeline: profilingInputs
+      source: dotnet-vscode-csharp-profiling
+      branch: main
+      trigger: none
 
 parameters:
 - name: IbcDrop
@@ -89,6 +94,9 @@ variables:
   - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
     - name: enableSourceIndex
       value: true
+  - name: VSCodeOptimizationDataRoot
+    value: $(Pipeline.Workspace)/profilingInputs/merged mibc
+
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -273,6 +281,10 @@ extends:
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
           condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
 
+        - download: profilingInputs
+          artifact: merged mibc
+          displayName: Download VSCode optimization inputs
+
         - task: PowerShell@2
           displayName: Build
           inputs:
@@ -294,6 +306,7 @@ extends:
                        -officialVisualStudioDropAccessToken $(_DevDivDropAccessToken)
                        /p:RepositoryName=$(Build.Repository.Name)
                        /p:VisualStudioDropName=$(VisualStudio.DropName)
+                       /p:VSCodeOptimizationDataRoot="$(VSCodeOptimizationDataRoot)"
                        /p:DotNetSignType=$(SignType)
                        /p:DotnetPublishUsingPipelines=true
                        /p:IgnoreIbcMergeErrors=true

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -54,6 +54,7 @@
     <RuntimeIdentifiers Condition="'$(TargetRid)' == '' and '$(BaseOS)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
+
   </PropertyGroup>
 
   <!-- When we are packing each RID, we set PackRuntimeIdentifier; by default this will also get passed to the builds of all ResolveProjectReferences
@@ -63,6 +64,18 @@
       <GlobalPropertiesToRemove>PackRuntimeIdentifier</GlobalPropertiesToRemove>
     </ProjectReference>
   </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <!-- Include MIBC data if available.  This is produced by a separate profiling pipeline for the C# extension, and injected in official builds -->
+    <PublishReadyToRunPgoFiles Condition="'$(VSCodeOptimizationDataRoot)'!=''" Include="$(VSCodeOptimizationDataRoot)\*.mibc" />
+  </ItemGroup>
+
+  <Target Name="SetCrossgen2ExtraArgs" BeforeTargets="ResolveReadyToRunCompilers" Condition="'$(PublishReadyToRun)' == 'true'">
+    <PropertyGroup>
+      <!-- Define extra crossgen2 args.  This must be done in a target as TargetName isn't available in evaluation -->
+      <PublishReadyToRunCrossgen2ExtraArgs>$(PublishReadyToRunCrossgen2ExtraArgs);--opt-cross-module:*;--non-local-generics-module:"$(TargetName)"</PublishReadyToRunCrossgen2ExtraArgs>
+    </PropertyGroup>
+  </Target>
 
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Workspaces\MSBuild\Core\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj" />


### PR DESCRIPTION
Should help resolve https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2283633/
 
We now produce mibc profiling data for the C# extension in a dnceng/internal pipeline that runs every night.  This updates Roslyn to consume pass the mibc to crossgen when building the language server.  This is adapted from similar support in devkit.

Test build - https://dnceng.visualstudio.com/internal/_build/results?buildId=2635982&view=results

Crossgen successfully runs in CI:
![image](https://github.com/user-attachments/assets/e04dcdb1-0a91-416c-9968-65375ad8b0df)

![image](https://github.com/user-attachments/assets/7a84174c-1f3f-4200-ae65-e565b892816c)

