### PR TITLE
Provide a simple ArrayBuilder api that does not drop array builders when they have a large number of elements in them

### DIFF
--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
@@ -745,10 +745,11 @@ internal abstract class AbstractRemoveUnnecessaryInlineSuppressionsDiagnosticAna
             return false;
         }
 
-        using var pooledDeclarationNodes = SyntaxFacts.GetTopLevelAndMethodLevelMembers(root);
-        var declarationNodes = pooledDeclarationNodes.Object;
+        // Specifies false for discardLargeInstances as these objects commonly exceed the default ArrayBuilder capacity threshold.
+        using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(discardLargeInstances: false, out var declarationNodes);
+        this.SyntaxFacts.AddTopLevelAndMethodLevelMembers(root, declarationNodes);
 
-        using var _ = PooledHashSet<ISymbol>.GetInstance(out var processedPartialSymbols);
+        using var _2 = PooledHashSet<ISymbol>.GetInstance(out var processedPartialSymbols);
         if (declarationNodes.Count > 0)
         {
             foreach (var node in declarationNodes)

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -201,8 +200,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-                using var pooledMembers = syntaxFacts.GetMethodLevelMembers(root);
-                var members = pooledMembers.Object;
+
+                // Specifies false for discardLargeInstances as these objects commonly exceed the default ArrayBuilder capacity threshold.
+                using var _ = ArrayBuilder<SyntaxNode>.GetInstance(discardLargeInstances: false, out var members);
+                syntaxFacts.AddMethodLevelMembers(root, members);
 
                 var memberSpans = members.SelectAsArray(member => member.FullSpan);
                 var changedMemberId = members.IndexOf(changedMember);

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -47,8 +48,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var service = document.GetRequiredLanguageService<ISyntaxFactsService>();
                     var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-                    using var pooledMembers = service.GetMethodLevelMembers(root);
-                    var members = pooledMembers.Object;
+                    // Specifies false for discardLargeInstances as these objects commonly exceed the default ArrayBuilder capacity threshold.
+                    using var _ = ArrayBuilder<SyntaxNode>.GetInstance(discardLargeInstances: false, out var members);
+                    service.AddMethodLevelMembers(root, members);
 
                     return members.SelectAsArray(m => m.FullSpan);
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -433,6 +433,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Services\SyntaxFacts\AbstractDocumentationCommentService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\FileBannerFacts\AbstractFileBannerFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\HeaderFacts\AbstractHeaderFacts.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\SyntaxFacts\AbstractSyntaxFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\SyntaxFacts\ExternalSourceInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\SyntaxFacts\IAccessibilityFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\SyntaxFacts\IDocumentationCommentService.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/ArrayBuilder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/ArrayBuilder.cs
@@ -6,11 +6,10 @@ namespace Microsoft.CodeAnalysis.PooledObjects;
 
 internal sealed partial class ArrayBuilder<T> : IPooled
 {
+    private static readonly ObjectPool<ArrayBuilder<T>> s_keepLargeInstancesPool = CreatePool();
+
     public static PooledDisposer<ArrayBuilder<T>> GetInstance(out ArrayBuilder<T> instance)
-    {
-        instance = GetInstance();
-        return new PooledDisposer<ArrayBuilder<T>>(instance);
-    }
+        => GetInstance(discardLargeInstances: true, out instance);
 
     public static PooledDisposer<ArrayBuilder<T>> GetInstance(int capacity, out ArrayBuilder<T> instance)
     {
@@ -22,5 +21,28 @@ internal sealed partial class ArrayBuilder<T> : IPooled
     {
         instance = GetInstance(capacity, fillWithValue);
         return new PooledDisposer<ArrayBuilder<T>>(instance);
+    }
+
+    public static PooledDisposer<ArrayBuilder<T>> GetInstance(bool discardLargeInstances, out ArrayBuilder<T> instance)
+    {
+        // If we're discarding large instances (the default behavior), then just use the normal pool.  If we're not, use
+        // a specific pool so that *other* normal callers don't accidentally get it and discard it.
+        instance = discardLargeInstances ? GetInstance() : s_keepLargeInstancesPool.Allocate();
+        return new PooledDisposer<ArrayBuilder<T>>(instance, discardLargeInstances);
+    }
+
+    void IPooled.Free(bool discardLargeInstances)
+    {
+        // If we're discarding large instances, use the default behavior (which already does that).  Otherwise, always
+        // clear and free the instance back to its originating pool.
+        if (discardLargeInstances)
+        {
+            Free();
+        }
+        else
+        {
+            this.Clear();
+            _pool?.Free(this);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/IPooled.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/IPooled.cs
@@ -6,5 +6,5 @@ namespace Microsoft.CodeAnalysis.PooledObjects;
 
 internal interface IPooled
 {
-    void Free();
+    void Free(bool discardLargeInstances);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledDictionary.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledDictionary.cs
@@ -11,4 +11,8 @@ internal sealed partial class PooledDictionary<K, V> : IPooled
         instance = GetInstance();
         return new PooledDisposer<PooledDictionary<K, V>>(instance);
     }
+
+    // Nothing special to do here.
+    void IPooled.Free(bool discardLargeInstance)
+        => this.Free();
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledDisposer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledDisposer.cs
@@ -8,9 +8,9 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.PooledObjects;
 
 [NonCopyable]
-internal readonly struct PooledDisposer<TPoolable>(TPoolable instance) : IDisposable
+internal readonly struct PooledDisposer<TPoolable>(TPoolable instance, bool discardLargeInstances = true) : IDisposable
     where TPoolable : class, IPooled
 {
     void IDisposable.Dispose()
-        => instance?.Free();
+        => instance?.Free(discardLargeInstances);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledHashSet.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledHashSet.cs
@@ -13,4 +13,8 @@ internal sealed partial class PooledHashSet<T> : IPooled, IReadOnlySet<T>
         instance = GetInstance();
         return new PooledDisposer<PooledHashSet<T>>(instance);
     }
+
+    // Nothing special to do here.
+    void IPooled.Free(bool discardLargeInstance)
+        => this.Free();
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledStringBuilder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledStringBuilder.cs
@@ -8,10 +8,32 @@ namespace Microsoft.CodeAnalysis.PooledObjects;
 
 internal sealed partial class PooledStringBuilder : IPooled
 {
+    private static readonly ObjectPool<PooledStringBuilder> s_keepLargeInstancesPool = CreatePool();
+
     public static PooledDisposer<PooledStringBuilder> GetInstance(out StringBuilder instance)
+        => GetInstance(discardLargeInstances: true, out instance);
+
+    public static PooledDisposer<PooledStringBuilder> GetInstance(bool discardLargeInstances, out StringBuilder instance)
     {
-        var pooledInstance = GetInstance();
+        // If we're discarding large instances (the default behavior), then just use the normal pool.  If we're not, use
+        // a specific pool so that *other* normal callers don't accidentally get it and discard it.
+        var pooledInstance = discardLargeInstances ? GetInstance() : s_keepLargeInstancesPool.Allocate();
         instance = pooledInstance;
-        return new PooledDisposer<PooledStringBuilder>(pooledInstance);
+        return new PooledDisposer<PooledStringBuilder>(pooledInstance, discardLargeInstances);
+    }
+
+    void IPooled.Free(bool discardLargeInstances)
+    {
+        // If we're discarding large instances, use the default behavior (which already does that).  Otherwise, always
+        // clear and free the instance back to its originating pool.
+        if (discardLargeInstances)
+        {
+            Free();
+        }
+        else
+        {
+            this.Builder.Clear();
+            _pool.Free(this);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractSyntaxFacts.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.LanguageService;
+
+internal abstract class AbstractSyntaxFacts
+{
+    public void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> result)
+        => AppendMembers(root, result, topLevel: true, methodLevel: true);
+
+    public void AddTopLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> result)
+        => AppendMembers(root, result, topLevel: true, methodLevel: false);
+
+    public void AddMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> result)
+        => AppendMembers(root, result, topLevel: false, methodLevel: true);
+
+    protected abstract void AppendMembers(SyntaxNode? node, ArrayBuilder<SyntaxNode> list, bool topLevel, bool methodLevel);
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.LanguageService;
@@ -410,9 +411,12 @@ internal interface ISyntaxFacts
     SyntaxNode? ConvertToSingleLine(SyntaxNode? node, bool useElasticTrivia = false);
 
     // Violation.  This is a feature level API.
-    PooledObject<List<SyntaxNode>> GetTopLevelAndMethodLevelMembers(SyntaxNode? root);
+    void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> result);
     // Violation.  This is a feature level API.
-    PooledObject<List<SyntaxNode>> GetMethodLevelMembers(SyntaxNode? root);
+    void AddTopLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> result);
+    // Violation.  This is a feature level API.
+    void AddMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> result);
+
     SyntaxList<SyntaxNode> GetMembersOfTypeDeclaration(SyntaxNode typeDeclaration);
 
     // Violation.  This is a feature level API.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -21,14 +21,12 @@ Imports Microsoft.CodeAnalysis.Editing
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
     Friend Class VisualBasicSyntaxFacts
+        Inherits AbstractSyntaxFacts
         Implements ISyntaxFacts
 
         Private Const DoesNotExistInVBErrorMessage = "This feature does not exist in VB"
 
         Public Shared ReadOnly Property Instance As New VisualBasicSyntaxFacts
-
-        ' Specifies false for trimOnFree as these objects commonly exceed the default ObjectPool threshold
-        Private Shared ReadOnly s_syntaxNodeListPool As ObjectPool(Of List(Of SyntaxNode)) = New ObjectPool(Of List(Of SyntaxNode))(Function() New List(Of SyntaxNode), trimOnFree:=False)
 
         Protected Sub New()
         End Sub
@@ -888,24 +886,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
         End Function
 
-        Public Function GetTopLevelAndMethodLevelMembers(root As SyntaxNode) As PooledObject(Of List(Of SyntaxNode)) Implements ISyntaxFacts.GetTopLevelAndMethodLevelMembers
-            Dim pooledList = PooledObject(Of List(Of SyntaxNode)).Create(s_syntaxNodeListPool)
-            Dim list = pooledList.Object
-
-            AppendMembers(root, list, topLevel:=True, methodLevel:=True)
-
-            Return pooledList
-        End Function
-
-        Public Function GetMethodLevelMembers(root As SyntaxNode) As PooledObject(Of List(Of SyntaxNode)) Implements ISyntaxFacts.GetMethodLevelMembers
-            Dim pooledList = PooledObject(Of List(Of SyntaxNode)).Create(s_syntaxNodeListPool)
-            Dim list = pooledList.Object
-
-            AppendMembers(root, list, topLevel:=False, methodLevel:=True)
-
-            Return pooledList
-        End Function
-
         Public Function GetMembersOfTypeDeclaration(typeDeclaration As SyntaxNode) As SyntaxList(Of SyntaxNode) Implements ISyntaxFacts.GetMembersOfTypeDeclaration
             Return DirectCast(typeDeclaration, TypeBlockSyntax).Members
         End Function
@@ -1050,7 +1030,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             End If
         End Sub
 
-        Private Sub AppendMembers(node As SyntaxNode, list As List(Of SyntaxNode), topLevel As Boolean, methodLevel As Boolean)
+        Protected Overrides Sub AppendMembers(node As SyntaxNode, list As ArrayBuilder(Of SyntaxNode), topLevel As Boolean, methodLevel As Boolean)
             Debug.Assert(topLevel OrElse methodLevel)
 
             For Each member In node.GetMembers()
@@ -1997,6 +1977,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
         Public Function GetTokenOfLiteralExpression(node As SyntaxNode) As SyntaxToken Implements ISyntaxFacts.GetTokenOfLiteralExpression
             Return DirectCast(node, LiteralExpressionSyntax).Token
         End Function
+
+        Private Sub ISyntaxFacts_AddTopLevelAndMethodLevelMembers(root As SyntaxNode, result As ArrayBuilder(Of SyntaxNode)) Implements ISyntaxFacts.AddTopLevelAndMethodLevelMembers
+            AddTopLevelAndMethodLevelMembers(root, result)
+        End Sub
+
+        Private Sub ISyntaxFacts_AddTopLevelMembers(root As SyntaxNode, result As ArrayBuilder(Of SyntaxNode)) Implements ISyntaxFacts.AddTopLevelMembers
+            AddTopLevelMembers(root, result)
+        End Sub
+
+        Private Sub ISyntaxFacts_AddMethodLevelMembers(root As SyntaxNode, result As ArrayBuilder(Of SyntaxNode)) Implements ISyntaxFacts.AddMethodLevelMembers
+            AddMethodLevelMembers(root, result)
+        End Sub
 
 #End Region
 


### PR DESCRIPTION
Allows us to still use ArrayBuilder (and the api/ergonomics we like with it) while adjusting this piece of behavior in a few places where desired.