### PR TITLE
fix extra whitespace insertion for text edits

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionCapabilityHelper.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionCapabilityHelper.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
         public bool SupportsMarkdownDocumentation { get; }
         public ISet<CompletionItemKind> SupportedItemKinds { get; }
         public ISet<CompletionItemTag> SupportedItemTags { get; }
+        public ISet<InsertTextMode> SupportedInsertTextModes { get; }
 
         public CompletionCapabilityHelper(ClientCapabilities clientCapabilities)
             : this(supportsVSExtensions: clientCapabilities.HasVisualStudioLspCapability(),
@@ -45,6 +46,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             SupportDefaultCommitCharacters = completionSetting?.CompletionListSetting?.ItemDefaults?.Contains(CommitCharactersPropertyName) == true;
             SupportedItemKinds = completionSetting?.CompletionItemKind?.ValueSet?.ToSet() ?? SpecializedCollections.EmptySet<CompletionItemKind>();
             SupportedItemTags = completionSetting?.CompletionItem?.TagSupport?.ValueSet?.ToSet() ?? SpecializedCollections.EmptySet<CompletionItemTag>();
+            SupportedInsertTextModes = completionSetting?.CompletionItem?.InsertTextModeSupport?.ValueSet?.ToSet() ?? SpecializedCollections.EmptySet<InsertTextMode>();
 
             // internal VS LSP
             if (supportsVSExtensions)

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
                 ItemDefaults = new LSP.CompletionListItemDefaults
                 {
                     EditRange = capabilityHelper.SupportDefaultEditRange ? ProtocolConversions.TextSpanToRange(defaultSpan, documentText) : null,
-                    Data = capabilityHelper.SupportCompletionListData ? resolveData : null
+                    Data = capabilityHelper.SupportCompletionListData ? resolveData : null,
                 },
 
                 // VS internal
@@ -96,6 +96,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
                 SuggestionMode = isSuggestionMode,
                 Data = capabilityHelper.SupportVSInternalCompletionListData ? resolveData : null,
             };
+
+            if (capabilityHelper.SupportedInsertTextModes.Contains(LSP.InsertTextMode.AsIs))
+            {
+                // By default, all text edits we create include the appropriate whitespace, so tell the client to leave it as-is (if it supports the option).
+                completionList.ItemDefaults.InsertTextMode = LSP.InsertTextMode.AsIs;
+            }
 
             PromoteCommonCommitCharactersOntoList();
 

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -1471,6 +1471,62 @@ pub{|caret:|}class";
             Assert.Equal(new() { Start = new(2, 0), End = new(2, 8) }, results.ItemDefaults.EditRange.Value.First);
         }
 
+        [Theory, CombinatorialData]
+        public async Task TestHasInsertTextModeIfSupportedAsync(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"class A
+{
+    void M()
+    {
+        {|caret:|}
+    }
+}";
+            var capabilities = CreateCoreCompletionCapabilities();
+            capabilities.TextDocument.Completion.CompletionItem = new LSP.CompletionItemSetting
+            {
+                InsertTextModeSupport = new LSP.InsertTextModeSupportSetting { ValueSet = [LSP.InsertTextMode.AsIs] }
+            };
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, capabilities);
+            var completionParams = CreateCompletionParams(
+                testLspServer.GetLocations("caret").Single(),
+                invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+                triggerCharacter: "\0",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+            Assert.Equal(LSP.InsertTextMode.AsIs, results.ItemDefaults.InsertTextMode);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestDoesNotHaveInsertTextModeIfNotSupportedAsync(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"class A
+{
+    void M()
+    {
+        {|caret:|}
+    }
+}";
+            var capabilities = CreateCoreCompletionCapabilities();
+            capabilities.TextDocument.Completion.CompletionItem = new LSP.CompletionItemSetting
+            {
+                InsertTextModeSupport = new LSP.InsertTextModeSupportSetting { ValueSet = [] }
+            };
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, capabilities);
+            var completionParams = CreateCompletionParams(
+                testLspServer.GetLocations("caret").Single(),
+                invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+                triggerCharacter: "\0",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+            Assert.Null(results.ItemDefaults.InsertTextMode);
+        }
+
         internal static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
         {
             return testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,


### PR DESCRIPTION
fixes issue where whitespace gets added twice for completion items that have upfront text edits.