### PR TITLE
Maintain whitespace when converting to switch expression

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -246,7 +246,7 @@ internal sealed partial class ConvertSwitchStatementToExpressionCodeFixProvider
             var switchStatement = topLevel ? AddCastIfNecessary(node) : node;
 
             return SwitchExpression(
-                switchStatement.Expression.Parenthesize(),
+                switchStatement.Expression.WithTrailingTrivia().Parenthesize(),
                 Token(leading: default, SyntaxKind.SwitchKeyword, node.CloseParenToken.TrailingTrivia),
                 Token(leading: default, SyntaxKind.OpenBraceToken, node.OpenBraceToken.TrailingTrivia),
                 SeparatedList(

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -246,7 +246,7 @@ internal sealed partial class ConvertSwitchStatementToExpressionCodeFixProvider
             var switchStatement = topLevel ? AddCastIfNecessary(node) : node;
 
             return SwitchExpression(
-                switchStatement.Expression.WithTrailingTrivia().Parenthesize(),
+                switchStatement.Expression.WithoutTrailingTrivia().Parenthesize(),
                 Token(leading: default, SyntaxKind.SwitchKeyword, node.CloseParenToken.TrailingTrivia),
                 Token(leading: default, SyntaxKind.OpenBraceToken, node.OpenBraceToken.TrailingTrivia),
                 SeparatedList(

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2587,4 +2587,44 @@ public class ConvertSwitchStatementToExpressionTests
             LanguageVersion = LanguageVersion.CSharp9,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77081")]
+    public async Task VerifyTupleSwitch()
+    {
+        await VerifyCS.VerifyCodeFixAsync(
+            """
+            class Program
+            {
+                bool M(int i, string j)
+                {
+                    [|switch|] (i, j)
+                    {
+                    case (0, _):
+                        return true;
+
+                    case (_, null):
+                        return true;
+
+                    default:
+                        return false;
+                    }
+                }
+            }
+            """,
+            """
+            class Program
+            {
+                bool M(int i, string j)
+                {
+                    return (i, j) switch
+                    {
+                        (0, _) => true,
+                        (_, null) => true,
+                        _ => false,
+                    };
+                }
+            }
+            """);
+    }
+
 }

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2626,4 +2626,3 @@ public class ConvertSwitchStatementToExpressionTests
             }
             """);
     }
-}

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2589,7 +2589,7 @@ public class ConvertSwitchStatementToExpressionTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77081")]
-    public async Task VerifyTupleSwitch()
+    public async Task TestTupleSwitch()
     {
         await VerifyCS.VerifyCodeFixAsync(
             """

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2626,5 +2626,4 @@ public class ConvertSwitchStatementToExpressionTests
             }
             """);
     }
-
 }

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2626,3 +2626,4 @@ public class ConvertSwitchStatementToExpressionTests
             }
             """);
     }
+}


### PR DESCRIPTION
Fixes #77081