### PR TITLE
Always write the Api output files, even if they don't change

### DIFF
--- a/src/Tools/SemanticSearch/BuildTask/GenerateFilteredReferenceAssembliesTask.cs
+++ b/src/Tools/SemanticSearch/BuildTask/GenerateFilteredReferenceAssembliesTask.cs
@@ -149,31 +149,14 @@ public sealed class GenerateFilteredReferenceAssembliesTask : Task
         var newContent = "# Generated, do not update manually\r\n" +
             string.Join("\r\n", apis);
 
-        string currentContent;
         try
         {
-            currentContent = File.ReadAllText(outputFilePath, Encoding.UTF8);
+            File.WriteAllText(outputFilePath, newContent);
+            Log.LogMessage($"Baseline updated: '{outputFilePath}'");
         }
-        catch (Exception)
+        catch (Exception e)
         {
-            currentContent = "";
-        }
-
-        if (currentContent != newContent)
-        {
-            try
-            {
-                File.WriteAllText(outputFilePath, newContent);
-                Log.LogMessage($"Baseline updated: '{outputFilePath}'");
-            }
-            catch (Exception e)
-            {
-                Log.LogError($"Error updating baseline '{outputFilePath}': {e.Message}");
-            }
-        }
-        else
-        {
-            Log.LogMessage($"Baseline not updated '{outputFilePath}'");
+            Log.LogError($"Error updating baseline '{outputFilePath}': {e.Message}");
         }
     }
 


### PR DESCRIPTION
The calling MSBuild targets already specify inputs and outputs; skipping writing the output files if they're not changed prevents the output timestamp from being updated, so the builds always run (and then force a rebuild of our setup projects).

Fixes https://github.com/dotnet/roslyn/issues/77039