### PR TITLE
Set a RID for InteractiveHost32

### DIFF
--- a/src/Interactive/HostProcess/x86/InteractiveHost32.csproj
+++ b/src/Interactive/HostProcess/x86/InteractiveHost32.csproj
@@ -9,6 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />


### PR DESCRIPTION
The .NET SDK's RID (and PlatformTarget) inference for .NET Framework only executes on Windows. As a result, building InteractiveHost32 on non-Windows produces a differently-named NuGet package. This is causing us issues in the VMR.

Set the RID explicitly like the InteractiveHost64 process does. This ensures that the resulting package name is InteractiveHost32.x86.Symbols when built on Windows or non-Windows.

Discovered by (and fixed for) the VMR's final join job's asset resolution.