### PR TITLE
Do not build Microsoft.CodeAnalysis.ExternalAccess.Copilot during source-build

### DIFF
--- a/src/Features/ExternalAccess/Copilot/Microsoft.CodeAnalysis.ExternalAccess.Copilot.csproj
+++ b/src/Features/ExternalAccess/Copilot/Microsoft.CodeAnalysis.ExternalAccess.Copilot.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.ExternalAccess.Copilot</RootNamespace>
     <TargetFrameworks>$(NetVSShared);net472</TargetFrameworks>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
This is only used by VS, and causes errors during source-build due to it targeting net8.0.
