### PR TITLE
Loosen casting requirements on switch expression conversion

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -196,7 +196,12 @@ internal sealed partial class ConvertSwitchStatementToExpressionCodeFixProvider
             {
                 var conversion = _semanticModel.Compilation.ClassifyConversion(typeInfo.Type, typeInfo.ConvertedType);
                 if (!conversion.IsIdentityOrImplicitReference())
-                    return node.Cast(typeInfo.ConvertedType);
+                {
+                    if (!conversion.IsBoxing || typeInfo.Type.IsNumericType())
+                    {
+                        return node.Cast(typeInfo.ConvertedType);
+                    }
+                }
             }
 
             return node;

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2398,6 +2398,48 @@ public class ConvertSwitchStatementToExpressionTests
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77084")]
+    public async Task TestRuntimeTypeConversion_Assignment3()
+    {
+        await VerifyCS.VerifyCodeFixAsync(
+            """
+            class Program
+            {
+                void M(string s)
+                {
+                    object result;
+
+                    [|switch|] (s)
+                    {
+                    case "a":
+                        result = 1234;
+                        break;
+                    case "b":
+                        result = 3.14;
+                        break;
+                    default:
+                        result = true;
+                        break;
+                    }
+                }
+            }
+            """,
+            """
+            class Program
+            {
+                void M(string s)
+                {
+                    object result = s switch
+                    {
+                        "a" => 1234,
+                        "b" => 3.14,
+                        _ => true,
+                    };
+                }
+            }
+            """);
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58636")]
     public async Task TestRuntimeTypeConversion_Return1()
     {
@@ -2469,6 +2511,41 @@ public class ConvertSwitchStatementToExpressionTests
                         "b" => 3.14,
                         "c" => true,
                         _ => throw new System.Exception(),
+                    };
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77084")]
+    public async Task TestRuntimeTypeConversion_Return3()
+    {
+        await VerifyCS.VerifyCodeFixAsync(
+            """
+            class Program
+            {
+                object M(string s)
+                {
+                    [|switch|] (s)
+                    {
+                    case "a":
+                        return true;
+
+                    default:
+                        return false;
+                    }
+                }
+            }
+            """,
+            """
+            class Program
+            {
+                object M(string s)
+                {
+                    return s switch
+                    {
+                        "a" => true,
+                        _ => false,
                     };
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/77084

The fix for the old issue https://github.com/dotnet/roslyn/issues/58636 was more conservative than it needed to be. This allows eg. `bool` to be returned to an `object` target in a switch expression arm without a cast.