### PR TITLE
Return LSP diagnostics with their reported severity.

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
@@ -213,8 +213,7 @@ internal static partial class ProtocolConversions
             // Hidden is translated in ConvertTags to pass along appropriate _ms tags
             // that will hide the item in a client that knows about those tags.
             DiagnosticSeverity.Hidden => LSP.DiagnosticSeverity.Hint,
-            // VSCode shows information diagnostics as blue squiggles, and hint diagnostics as 3 dots.  We prefer the latter rendering so we return hint diagnostics in vscode.
-            DiagnosticSeverity.Info => supportsVisualStudioExtensions ? LSP.DiagnosticSeverity.Information : LSP.DiagnosticSeverity.Hint,
+            DiagnosticSeverity.Info => LSP.DiagnosticSeverity.Information,
             DiagnosticSeverity.Warning => LSP.DiagnosticSeverity.Warning,
             DiagnosticSeverity.Error => LSP.DiagnosticSeverity.Error,
             _ => throw ExceptionUtilities.UnexpectedValue(severity),

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
@@ -107,7 +107,7 @@ internal static partial class ProtocolConversions
             Code = diagnosticData.Id,
             CodeDescription = ProtocolConversions.HelpLinkToCodeDescription(diagnosticData.GetValidHelpLinkUri()),
             Message = diagnosticData.Message,
-            Severity = ConvertDiagnosticSeverity(diagnosticData.Severity, supportsVisualStudioExtensions),
+            Severity = ConvertDiagnosticSeverity(diagnosticData.Severity),
             Tags = ConvertTags(diagnosticData, isLiveSource, potentialDuplicate),
             DiagnosticRank = ConvertRank(diagnosticData),
             Range = GetRange(diagnosticData.DataLocation)
@@ -207,7 +207,7 @@ internal static partial class ProtocolConversions
         return null;
     }
 
-    private static LSP.DiagnosticSeverity ConvertDiagnosticSeverity(DiagnosticSeverity severity, bool supportsVisualStudioExtensions)
+    private static LSP.DiagnosticSeverity ConvertDiagnosticSeverity(DiagnosticSeverity severity)
         => severity switch
         {
             // Hidden is translated in ConvertTags to pass along appropriate _ms tags

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -870,30 +870,6 @@ class C
         Assert.Equal(LSP.DiagnosticSeverity.Information, results.Single().Diagnostics.Single().Severity);
     }
 
-    [Theory, CombinatorialData]
-    public async Task TestInfoDiagnosticsAreReportedAsHintInVSCode(bool mutatingLspWorkspace)
-    {
-        var markup =
-@"class A
-{
-    public A SomeA = new A();
-}";
-        await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, mutatingLspWorkspace, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics: false);
-
-        // Calling GetTextBuffer will effectively open the file.
-        testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
-
-        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
-
-        await OpenDocumentAsync(testLspServer, document);
-
-        var results = await RunGetDocumentPullDiagnosticsAsync(
-            testLspServer, document.GetURI(), useVSDiagnostics: false);
-
-        Assert.Equal("IDE0090", results.Single().Diagnostics.Single().Code);
-        Assert.Equal(LSP.DiagnosticSeverity.Hint, results.Single().Diagnostics.Single().Severity);
-    }
-
     #endregion
 
     #region Workspace Diagnostics


### PR DESCRIPTION
For VSCode we were adjusting information diagnostics severity so that they would be reported as hints. We are moving this behavior to the client and allowing users to opt-in.

Client-side PR: https://github.com/dotnet/vscode-csharp/pull/7984

Part of https://github.com/dotnet/vscode-csharp/issues/6723