### PR TITLE
Fix race during shutdown of the BuildHost server

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/Program.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Program.cs
@@ -52,7 +52,7 @@ internal static class Program
         var pipeServer = NamedPipeUtil.CreateServer(pipeName, PipeDirection.InOut);
         await pipeServer.WaitForConnectionAsync().ConfigureAwait(false);
 
-        var server = new RpcServer(sendingStream: pipeServer, receivingStream: pipeServer);
+        var server = new RpcServer(pipeServer);
 
         var targetObject = server.AddTarget(new BuildHost(logger, propertiesBuilder.ToImmutable(), binaryLogPath, server));
         Contract.ThrowIfFalse(targetObject == 0, "The first object registered should have target 0, which is assumed by the client.");

--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
@@ -389,7 +389,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
                 throw new Exception("Ownership of BuildHost pipe is incorrect.");
             }
 
-            _rpcClient = new RpcClient(sendingStream: pipeClient, receivingStream: pipeClient);
+            _rpcClient = new RpcClient(pipeClient);
             _rpcClient.Start();
             _rpcClient.Disconnected += Process_Exited;
             BuildHost = new RemoteBuildHost(_rpcClient);


### PR DESCRIPTION
Our RPC mechanism to the build host is a simple one: we send JSON payloads that are formatted as a single textual line, similar to other methods. We did the writing to the build host via a TextWriter, and called Flush() at the end to ensure that everything is written to the other end, otherwise things might deadlock if we wait for the server to reply to something that's not coming.

We recently switched the communication over to named pipes, which have a bit of a subtle problem here: with PipeStream, Flush() doesn't do anything, but it will check the pipe is still connected and throw if it's not. This had a problem during shutdown: we might write to the pipe, and the other side will see the shutdown request, respond, and close, before that Flush() call could ever happen. And once it did, we'd then throw an exception becase the other end did exactly what wanted it to!

I could special-case the handling of pipes in the RPC code, but there's no reason to allow the use of arbitrary streams here. Instead, it's best to just update the tests to also use named pipes (which means we're better testing what we're doing in real code), and it also means we can dispense of flushing entirely. Unfortunately TextWriter gives no way to disable flushing that I can see, so I also dispose of TextWriter and just write to the PipeStream directly.

Fix https://github.com/dotnet/roslyn/issues/77040