### PR TITLE
Fix workspace command execution

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -27,6 +27,7 @@ internal abstract class AbstractLanguageServer<TRequestContext>
     /// </summary>
     private readonly Lazy<IRequestExecutionQueue<TRequestContext>> _queue;
     private readonly Lazy<ILspServices> _lspServices;
+    private readonly Lazy<AbstractHandlerProvider> _handlerProvider;
 
     public bool IsInitialized { get; private set; }
 
@@ -67,6 +68,13 @@ internal abstract class AbstractLanguageServer<TRequestContext>
         _jsonRpc.Disconnected += JsonRpc_Disconnected;
         _lspServices = new Lazy<ILspServices>(() => ConstructLspServices());
         _queue = new Lazy<IRequestExecutionQueue<TRequestContext>>(() => ConstructRequestExecutionQueue());
+        _handlerProvider = new Lazy<AbstractHandlerProvider>(() =>
+        {
+            var lspServices = _lspServices.Value;
+            var handlerProvider = new HandlerProvider(lspServices, TypeRefResolver);
+            SetupRequestDispatcher(handlerProvider);
+            return handlerProvider;
+        });
     }
 
     /// <summary>
@@ -89,10 +97,7 @@ internal abstract class AbstractLanguageServer<TRequestContext>
     {
         get
         {
-            var lspServices = _lspServices.Value;
-            var handlerProvider = new HandlerProvider(lspServices, TypeRefResolver);
-            SetupRequestDispatcher(handlerProvider);
-            return handlerProvider;
+            return _handlerProvider.Value;
         }
     }
 

--- a/src/LanguageServer/ProtocolUnitTests/Commands/ExecuteWorkspaceCommandTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Commands/ExecuteWorkspaceCommandTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Commands;
+public class ExecuteWorkspaceCommandTests : AbstractLanguageServerProtocolTests
+{
+    protected override TestComposition Composition => base.Composition.AddParts(
+            typeof(TestWorkspaceCommandHandler));
+
+    public ExecuteWorkspaceCommandTests(ITestOutputHelper? testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestExecuteWorkspaceCommand(bool mutatingLspWorkspace)
+    {
+        await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
+
+        var request = new ExecuteCommandParams()
+        {
+            Arguments = new object[] { JsonSerializer.Serialize(new TextDocumentIdentifier { Uri = ProtocolConversions.CreateAbsoluteUri(@"C:\someFile.cs") }) },
+            Command = TestWorkspaceCommandHandler.CommandName
+        };
+        var response = await server.ExecuteRequestAsync<ExecuteCommandParams, object>(Methods.WorkspaceExecuteCommandName, request, CancellationToken.None);
+        AssertEx.NotNull(response);
+        Assert.True((bool)response);
+
+    }
+
+    [ExportCSharpVisualBasicStatelessLspService(typeof(TestWorkspaceCommandHandler)), Shared, PartNotDiscoverable]
+    [Command(CommandName)]
+    internal class TestWorkspaceCommandHandler : AbstractExecuteWorkspaceCommandHandler
+    {
+        internal const string CommandName = nameof(TestWorkspaceCommandHandler);
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public TestWorkspaceCommandHandler()
+        {
+        }
+
+        public override string Command => CommandName;
+
+        public override bool MutatesSolutionState => false;
+
+        public override bool RequiresLSPSolution => true;
+
+        public override TextDocumentIdentifier GetTextDocumentIdentifier(ExecuteCommandParams request)
+        {
+            return JsonSerializer.Deserialize<TextDocumentIdentifier>((JsonElement)request.Arguments.First(), ProtocolConversions.LspJsonSerializerOptions)!;
+        }
+
+        public override Task<object> HandleRequestAsync(ExecuteCommandParams request, RequestContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<object>(true);
+        }
+    }
+}


### PR DESCRIPTION
Discovered in https://github.com/dotnet/roslyn/issues/76141

The other test for this was disabled (feature not currently used in vscode), so this regression slipped in.  