### PR TITLE
Add ability to rewrite symbol references in BoundTreeRewriter.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -893,7 +893,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return statement;
             }
 
-            return new BoundBlock(statement.Syntax, locals, localFunctions, hasUnsafeModifier: false, instrumentation: null,
+            return new BoundBlock(statement.Syntax, locals, ImmutableArray<MethodSymbol>.CastUp(localFunctions), hasUnsafeModifier: false, instrumentation: null,
                                   ImmutableArray.Create(statement))
             { WasCompilerGenerated = true };
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -2223,7 +2223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.AddRange(boundLambda.Diagnostics);
 
             CheckParameterModifierMismatchMethodConversion(syntax, boundLambda.Symbol, destination, invokedAsExtensionMethod: false, diagnostics);
-            CheckLambdaConversion(boundLambda.Symbol, destination, diagnostics);
+            CheckLambdaConversion((LambdaSymbol)boundLambda.Symbol, destination, diagnostics);
             return new BoundConversion(
                 syntax,
                 boundLambda,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5395,7 +5395,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!hasErrors)
                 {
                     CheckParameterModifierMismatchMethodConversion(unboundLambda.Syntax, boundLambda.Symbol, type, invokedAsExtensionMethod: false, diagnostics);
-                    CheckLambdaConversion(boundLambda.Symbol, type, diagnostics);
+                    CheckLambdaConversion((LambdaSymbol)boundLambda.Symbol, type, diagnostics);
                 }
 
                 // Just stuff the bound lambda into the delegate creation expression. When we lower the lambda to

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1911,7 +1911,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundBlock(
                 node,
                 locals,
-                GetDeclaredLocalFunctionsForScope(node),
+                ImmutableArray<MethodSymbol>.CastUp(GetDeclaredLocalFunctionsForScope(node)),
                 hasUnsafeModifier: node.Parent?.Kind() == SyntaxKind.UnsafeStatement,
                 instrumentation: null,
                 boundStatements);

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -308,7 +308,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
-            var localFunction = node.Symbol;
+            var localFunction = (LocalFunctionSymbol)node.Symbol;
             var analysis = new RefSafetyAnalysis(_compilation, localFunction, _inUnsafeRegion || localFunction.IsUnsafe, _useUpdatedEscapeRules, _diagnostics);
             analysis.Visit(node.BlockBody);
             analysis.Visit(node.ExpressionBody);

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 syntax: node,
                 expression: boundSwitchGoverningExpression,
                 innerLocals: locals,
-                innerLocalFunctions: functions,
+                innerLocalFunctions: ImmutableArray<MethodSymbol>.CastUp(functions),
                 switchSections: switchSections,
                 defaultLabel: defaultLabel,
                 breakLabel: this.BreakLabel,

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1037,7 +1037,7 @@
   -->
   <Node Name="BoundBlock" Base="BoundStatementList">
     <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
-    <Field Name="LocalFunctions" Type="ImmutableArray&lt;LocalFunctionSymbol&gt;"/>
+    <Field Name="LocalFunctions" Type="ImmutableArray&lt;MethodSymbol&gt;"/>
     <Field Name="HasUnsafeModifier" Type="bool" Null="NotApplicable"/>
     
     <!-- Optional block-level instrumentation info -->
@@ -1178,7 +1178,7 @@
 
     <!-- Locals declared immediately within the switch block. -->
     <Field Name="InnerLocals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
-    <Field Name="InnerLocalFunctions" Type="ImmutableArray&lt;LocalFunctionSymbol&gt;"/>
+    <Field Name="InnerLocalFunctions" Type="ImmutableArray&lt;MethodSymbol&gt;"/>
     <Field Name="SwitchSections" Type="ImmutableArray&lt;BoundSwitchSection&gt;"/>
     <Field Name="ReachabilityDecisionDag" Type="BoundDecisionDag" Null="disallow" SkipInVisitor="true"/>
     <Field Name="DefaultLabel" Type="BoundSwitchLabel?"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1121,7 +1121,8 @@
     void Foo() { }
   -->
   <Node Name="BoundLocalFunctionStatement" Base="BoundStatement">
-    <Field Name="Symbol" Type="LocalFunctionSymbol"/>
+    <!-- Must be a LocalFunctionSymbol until the node reaches LocalRewriter -->
+    <Field Name="Symbol" Type="MethodSymbol"/>
     <Field Name="BlockBody" Type="BoundBlock?"/>
     <Field Name="ExpressionBody" Type="BoundBlock?"/>
   </Node>
@@ -1165,11 +1166,11 @@
   </Node>
 
   <Node Name="BoundBreakStatement" Base="BoundStatement">
-    <Field Name="Label" Type="GeneratedLabelSymbol" />
+    <Field Name="Label" Type="LabelSymbol" />
   </Node>
 
   <Node Name="BoundContinueStatement" Base="BoundStatement">
-    <Field Name="Label" Type="GeneratedLabelSymbol" />
+    <Field Name="Label" Type="LabelSymbol" />
   </Node>
 
   <Node Name="BoundSwitchStatement" Base="BoundStatement">
@@ -1181,7 +1182,7 @@
     <Field Name="SwitchSections" Type="ImmutableArray&lt;BoundSwitchSection&gt;"/>
     <Field Name="ReachabilityDecisionDag" Type="BoundDecisionDag" Null="disallow" SkipInVisitor="true"/>
     <Field Name="DefaultLabel" Type="BoundSwitchLabel?"/>
-    <Field Name="BreakLabel" Type="GeneratedLabelSymbol"/>
+    <Field Name="BreakLabel" Type="LabelSymbol"/>
   </Node>
 
   <!-- Part of a lowered integral switch statement. This evaluates Value, and then branches
@@ -1219,8 +1220,8 @@
   </Node>
 
   <AbstractNode Name="BoundLoopStatement" Base="BoundStatement">
-    <Field Name="BreakLabel" Type="GeneratedLabelSymbol"/>
-    <Field Name="ContinueLabel" Type="GeneratedLabelSymbol"/>
+    <Field Name="BreakLabel" Type="LabelSymbol"/>
+    <Field Name="ContinueLabel" Type="LabelSymbol"/>
   </AbstractNode>
 
   <AbstractNode Name="BoundConditionalLoopStatement" Base="BoundLoopStatement">
@@ -2287,8 +2288,9 @@
 
   <Node Name="BoundLambda" Base="BoundExpression">
     <Field Name="UnboundLambda" Type="UnboundLambda" Null="disallow" SkipInVisitor="true"/>
+    <!-- Must be a LambdaSymbol until the node reaches LocalRewriter -->
     <!-- LambdaSymbol may differ from Binder.MemberSymbol after rewriting. -->
-    <Field Name="Symbol" Type="LambdaSymbol" Null="disallow"/>
+    <Field Name="Symbol" Type="MethodSymbol" Null="disallow"/>
     <Field Name="Type" Type="TypeSymbol?" Override="true"/>
     <Field Name="Body" Type="BoundBlock"/>
     <Field Name="Diagnostics" Type="ReadOnlyBindingDiagnostic&lt;AssemblySymbol&gt;"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
@@ -192,6 +192,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return builder is null ? symbols : builder.ToImmutableAndFree();
         }
+
+        protected virtual ImmutableArray<LocalSymbol> VisitLocals(ImmutableArray<LocalSymbol> locals) => locals;
+
+        protected virtual ImmutableArray<MethodSymbol> VisitDeclaredLocalFunctions(ImmutableArray<MethodSymbol> localFunctions) => localFunctions;
     }
 
     internal abstract class BoundTreeRewriterWithStackGuard : BoundTreeRewriter

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -58,6 +59,138 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return list;
+        }
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected virtual AliasSymbol? VisitAliasSymbol(AliasSymbol? symbol) => symbol;
+
+        protected virtual DiscardSymbol VisitDiscardSymbol(DiscardSymbol symbol)
+        {
+            Debug.Assert(symbol is not null);
+            return symbol;
+        }
+
+        protected virtual EventSymbol VisitEventSymbol(EventSymbol symbol)
+        {
+            Debug.Assert(symbol is not null);
+            return symbol;
+        }
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected virtual LabelSymbol? VisitLabelSymbol(LabelSymbol? symbol) => symbol;
+
+        protected virtual LocalSymbol VisitLocalSymbol(LocalSymbol symbol)
+        {
+            Debug.Assert(symbol is not null);
+            return symbol;
+        }
+
+        protected virtual NamespaceSymbol VisitNamespaceSymbol(NamespaceSymbol symbol)
+        {
+            Debug.Assert(symbol is not null);
+            return symbol;
+        }
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected virtual RangeVariableSymbol? VisitRangeVariableSymbol(RangeVariableSymbol? symbol) => symbol;
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected virtual FieldSymbol? VisitFieldSymbol(FieldSymbol? symbol) => symbol;
+
+        protected virtual ParameterSymbol VisitParameterSymbol(ParameterSymbol symbol)
+        {
+            Debug.Assert(symbol is not null);
+            return symbol;
+        }
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected virtual PropertySymbol? VisitPropertySymbol(PropertySymbol? symbol) => symbol;
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected virtual MethodSymbol? VisitMethodSymbol(MethodSymbol? symbol) => symbol;
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected Symbol? VisitSymbol(Symbol? symbol)
+        {
+            if (symbol is null)
+            {
+                return null;
+            }
+
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Alias:
+                    return VisitAliasSymbol((AliasSymbol)symbol);
+                case SymbolKind.Discard:
+                    return VisitDiscardSymbol((DiscardSymbol)symbol);
+                case SymbolKind.Event:
+                    return VisitEventSymbol((EventSymbol)symbol);
+                case SymbolKind.Label:
+                    return VisitLabelSymbol((LabelSymbol)symbol);
+                case SymbolKind.Local:
+                    return VisitLocalSymbol((LocalSymbol)symbol);
+                case SymbolKind.Namespace:
+                    return VisitNamespaceSymbol((NamespaceSymbol)symbol);
+                case SymbolKind.RangeVariable:
+                    return VisitRangeVariableSymbol((RangeVariableSymbol)symbol);
+                case SymbolKind.Field:
+                    return VisitFieldSymbol((FieldSymbol)symbol);
+                case SymbolKind.Parameter:
+                    return VisitParameterSymbol((ParameterSymbol)symbol);
+                case SymbolKind.Property:
+                    return VisitPropertySymbol((PropertySymbol)symbol);
+                case SymbolKind.Method:
+                    return VisitMethodSymbol((MethodSymbol)symbol);
+
+                default:
+                    if (symbol is TypeSymbol type)
+                    {
+                        return VisitType(type);
+                    }
+
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
+            }
+        }
+
+        [return: NotNullIfNotNull(nameof(symbol))]
+        protected FunctionTypeSymbol? VisitFunctionTypeSymbol(FunctionTypeSymbol? symbol)
+        {
+            return (FunctionTypeSymbol?)VisitType(symbol);
+        }
+
+        protected ImmutableArray<T> VisitSymbols<T>(ImmutableArray<T> symbols) where T : Symbol?
+        {
+            if (symbols.IsDefault)
+            {
+                return symbols;
+            }
+
+            ArrayBuilder<T>? builder = null;
+
+            for (int i = 0; i < symbols.Length; i++)
+            {
+                T symbol = symbols[i];
+
+                var newSymbol = (T?)VisitSymbol(symbol);
+                if (newSymbol != (object?)symbol)
+                {
+                    Debug.Assert(newSymbol is not null);
+
+                    if (builder is null)
+                    {
+                        builder = ArrayBuilder<T>.GetInstance(symbols.Length);
+                        builder.AddRange(symbols, i);
+                    }
+
+                    builder.Add(newSymbol);
+                }
+                else if (builder is not null)
+                {
+                    builder.Add(symbol);
+                }
+            }
+
+            return builder is null ? symbols : builder.ToImmutableAndFree();
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -653,7 +653,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal partial class BoundBlock
     {
         public BoundBlock(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundStatement> statements, bool hasErrors = false)
-            : this(syntax, locals, ImmutableArray<LocalFunctionSymbol>.Empty, hasUnsafeModifier: false, instrumentation: null, statements, hasErrors)
+            : this(syntax, locals, ImmutableArray<MethodSymbol>.Empty, hasUnsafeModifier: false, instrumentation: null, statements, hasErrors)
         {
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -819,7 +819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 refKind == CodeAnalysis.RefKind.None &&
                 _returnInferenceCache!.TryGetValue(cacheKey, out BoundLambda? returnInferenceLambda) &&
                 GetLambdaExpressionBody(returnInferenceLambda.Body) is BoundExpression expression &&
-                (lambdaSymbol = returnInferenceLambda.Symbol).RefKind == refKind &&
+                (lambdaSymbol = (LambdaSymbol)returnInferenceLambda.Symbol).RefKind == refKind &&
                 (object)LambdaSymbol.InferenceFailureReturnType != lambdaSymbol.ReturnType &&
                 lambdaSymbol.ReturnTypeWithAnnotations.Equals(returnType, TypeCompareKind.ConsiderEverything))
             {
@@ -1273,7 +1273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // If multiple candidates have the same number of diagnostics, order them by delegate type name.
                     // It's not great, but it should be stable.
                     return minDiagnosticsGroup
-                        .OrderBy(lambda => GetLambdaSortString(lambda.Value.Symbol))
+                        .OrderBy(lambda => GetLambdaSortString((LambdaSymbol)lambda.Value.Symbol))
                         .FirstOrDefault()
                         .Value;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // transition the state of captured variables if the variables have state changes
             // across all branches leaving the local function
 
-            var localFunctionState = GetOrCreateLocalFuncUsages(localFuncSymbol);
+            var localFunctionState = GetOrCreateLocalFuncUsages((LocalFunctionSymbol)localFuncSymbol);
             var savedLocalFunctionState = LocalFunctionStart(localFunctionState);
 
             var oldPending2 = SavePending();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2181,7 +2181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (stmt is BoundLocalFunctionStatement localFunctionStatement)
                     {
                         // Mark attribute arguments as used.
-                        VisitAttributes(localFunctionStatement.Symbol.BindMethodAttributes());
+                        VisitAttributes(((LocalFunctionSymbol)localFunctionStatement.Symbol).BindMethodAttributes());
 
                         VisitAlways(stmt);
                     }
@@ -2425,7 +2425,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.CurrentSymbol = node.Symbol;
 
             // Mark attribute arguments as used.
-            VisitAttributes(node.Symbol.BindMethodAttributes());
+            VisitAttributes(((LambdaSymbol)node.Symbol).BindMethodAttributes());
 
             var oldPending = SavePending(); // we do not support branches into a lambda
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2329,7 +2329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void ReportUnusedVariables(ImmutableArray<LocalFunctionSymbol> locals)
+        private void ReportUnusedVariables(ImmutableArray<MethodSymbol> locals)
         {
             foreach (var symbol in locals)
             {
@@ -2337,7 +2337,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void ReportIfUnused(LocalFunctionSymbol symbol)
+        private void ReportIfUnused(MethodSymbol symbol)
         {
             if (!_usedLocalFunctions.Contains(symbol))
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.AddRange(statements, n - 1);
                 builder.Add(AppendImplicitReturn((BoundBlock)statements[n - 1], method));
 
-                return body.Update(body.Locals, ImmutableArray<LocalFunctionSymbol>.Empty, body.HasUnsafeModifier, body.Instrumentation, builder.ToImmutableAndFree());
+                return body.Update(body.Locals, ImmutableArray<MethodSymbol>.Empty, body.HasUnsafeModifier, body.Instrumentation, builder.ToImmutableAndFree());
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3161,7 +3161,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // In the first pass of the nullable walker, existence of usages here means that a call site has been visited.
                         // In subsequent nullable walker passes, the starting state is preserved from previous passes.
                         // In any case, existence of usages means that we have a good starting state.
-                        if (localFuncs[i] is { } localFunc && HasLocalFuncUsagesCreated(localFunc.Symbol))
+                        if (localFuncs[i] is { } localFunc && HasLocalFuncUsagesCreated((LocalFunctionSymbol)localFunc.Symbol))
                         {
                             localFuncs[i] = null;
                             unvisitedLocalFuncs--;
@@ -3209,7 +3209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
-            var localFunc = node.Symbol;
+            var localFunc = (LocalFunctionSymbol)node.Symbol;
 
             // Usages state is created when we visit the function's call site or its body.
             // In the first pass of the nullable walker, existence of usages here means that a call site has been visited.
@@ -8734,7 +8734,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void ReportNullabilityMismatchWithTargetDelegate(Location location, NamedTypeSymbol delegateType, BoundLambda lambda)
         {
             MethodSymbol? targetInvokeMethod = delegateType.DelegateInvokeMethod;
-            LambdaSymbol sourceMethod = lambda.Symbol;
+            LambdaSymbol sourceMethod = (LambdaSymbol)lambda.Symbol;
             UnboundLambda unboundLambda = lambda.UnboundLambda;
 
             if (targetInvokeMethod is null ||
@@ -9779,7 +9779,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!lambda.IsSuppressed)
                 {
-                    ReportNullabilityMismatchWithTargetDelegate(lambda.Symbol.DiagnosticLocation, delegateType, lambda);
+                    ReportNullabilityMismatchWithTargetDelegate(((LambdaSymbol)lambda.Symbol).DiagnosticLocation, delegateType, lambda);
                 }
 
                 return null;

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3504,7 +3504,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundLocalFunctionStatement : BoundStatement
     {
-        public BoundLocalFunctionStatement(SyntaxNode syntax, LocalFunctionSymbol symbol, BoundBlock? blockBody, BoundBlock? expressionBody, bool hasErrors = false)
+        public BoundLocalFunctionStatement(SyntaxNode syntax, MethodSymbol symbol, BoundBlock? blockBody, BoundBlock? expressionBody, bool hasErrors = false)
             : base(BoundKind.LocalFunctionStatement, syntax, hasErrors || blockBody.HasErrors() || expressionBody.HasErrors())
         {
 
@@ -3515,14 +3515,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ExpressionBody = expressionBody;
         }
 
-        public LocalFunctionSymbol Symbol { get; }
+        public MethodSymbol Symbol { get; }
         public BoundBlock? BlockBody { get; }
         public BoundBlock? ExpressionBody { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitLocalFunctionStatement(this);
 
-        public BoundLocalFunctionStatement Update(LocalFunctionSymbol symbol, BoundBlock? blockBody, BoundBlock? expressionBody)
+        public BoundLocalFunctionStatement Update(MethodSymbol symbol, BoundBlock? blockBody, BoundBlock? expressionBody)
         {
             if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(symbol, this.Symbol) || blockBody != this.BlockBody || expressionBody != this.ExpressionBody)
             {
@@ -3694,7 +3694,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundBreakStatement : BoundStatement
     {
-        public BoundBreakStatement(SyntaxNode syntax, GeneratedLabelSymbol label, bool hasErrors)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, bool hasErrors)
             : base(BoundKind.BreakStatement, syntax, hasErrors)
         {
 
@@ -3703,7 +3703,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Label = label;
         }
 
-        public BoundBreakStatement(SyntaxNode syntax, GeneratedLabelSymbol label)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label)
             : base(BoundKind.BreakStatement, syntax)
         {
 
@@ -3712,12 +3712,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Label = label;
         }
 
-        public GeneratedLabelSymbol Label { get; }
+        public LabelSymbol Label { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitBreakStatement(this);
 
-        public BoundBreakStatement Update(GeneratedLabelSymbol label)
+        public BoundBreakStatement Update(LabelSymbol label)
         {
             if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label))
             {
@@ -3731,7 +3731,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundContinueStatement : BoundStatement
     {
-        public BoundContinueStatement(SyntaxNode syntax, GeneratedLabelSymbol label, bool hasErrors)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, bool hasErrors)
             : base(BoundKind.ContinueStatement, syntax, hasErrors)
         {
 
@@ -3740,7 +3740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Label = label;
         }
 
-        public BoundContinueStatement(SyntaxNode syntax, GeneratedLabelSymbol label)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label)
             : base(BoundKind.ContinueStatement, syntax)
         {
 
@@ -3749,12 +3749,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Label = label;
         }
 
-        public GeneratedLabelSymbol Label { get; }
+        public LabelSymbol Label { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitContinueStatement(this);
 
-        public BoundContinueStatement Update(GeneratedLabelSymbol label)
+        public BoundContinueStatement Update(LabelSymbol label)
         {
             if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label))
             {
@@ -3768,7 +3768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundSwitchStatement : BoundStatement
     {
-        public BoundSwitchStatement(SyntaxNode syntax, BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, GeneratedLabelSymbol breakLabel, bool hasErrors = false)
+        public BoundSwitchStatement(SyntaxNode syntax, BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, LabelSymbol breakLabel, bool hasErrors = false)
             : base(BoundKind.SwitchStatement, syntax, hasErrors || expression.HasErrors() || switchSections.HasErrors() || reachabilityDecisionDag.HasErrors() || defaultLabel.HasErrors())
         {
 
@@ -3794,12 +3794,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public ImmutableArray<BoundSwitchSection> SwitchSections { get; }
         public BoundDecisionDag ReachabilityDecisionDag { get; }
         public BoundSwitchLabel? DefaultLabel { get; }
-        public GeneratedLabelSymbol BreakLabel { get; }
+        public LabelSymbol BreakLabel { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitSwitchStatement(this);
 
-        public BoundSwitchStatement Update(BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, GeneratedLabelSymbol breakLabel)
+        public BoundSwitchStatement Update(BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, LabelSymbol breakLabel)
         {
             if (expression != this.Expression || innerLocals != this.InnerLocals || innerLocalFunctions != this.InnerLocalFunctions || switchSections != this.SwitchSections || reachabilityDecisionDag != this.ReachabilityDecisionDag || defaultLabel != this.DefaultLabel || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel))
             {
@@ -3882,7 +3882,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal abstract partial class BoundLoopStatement : BoundStatement
     {
-        protected BoundLoopStatement(BoundKind kind, SyntaxNode syntax, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel, bool hasErrors)
+        protected BoundLoopStatement(BoundKind kind, SyntaxNode syntax, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors)
             : base(kind, syntax, hasErrors)
         {
 
@@ -3893,7 +3893,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ContinueLabel = continueLabel;
         }
 
-        protected BoundLoopStatement(BoundKind kind, SyntaxNode syntax, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel)
+        protected BoundLoopStatement(BoundKind kind, SyntaxNode syntax, LabelSymbol breakLabel, LabelSymbol continueLabel)
             : base(kind, syntax)
         {
 
@@ -3904,13 +3904,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ContinueLabel = continueLabel;
         }
 
-        public GeneratedLabelSymbol BreakLabel { get; }
-        public GeneratedLabelSymbol ContinueLabel { get; }
+        public LabelSymbol BreakLabel { get; }
+        public LabelSymbol ContinueLabel { get; }
     }
 
     internal abstract partial class BoundConditionalLoopStatement : BoundLoopStatement
     {
-        protected BoundConditionalLoopStatement(BoundKind kind, SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel, bool hasErrors = false)
+        protected BoundConditionalLoopStatement(BoundKind kind, SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors = false)
             : base(kind, syntax, breakLabel, continueLabel, hasErrors)
         {
 
@@ -3932,7 +3932,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundDoStatement : BoundConditionalLoopStatement
     {
-        public BoundDoStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel, bool hasErrors = false)
+        public BoundDoStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors = false)
             : base(BoundKind.DoStatement, syntax, locals, condition, body, breakLabel, continueLabel, hasErrors || condition.HasErrors() || body.HasErrors())
         {
 
@@ -3948,7 +3948,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitDoStatement(this);
 
-        public BoundDoStatement Update(ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel)
+        public BoundDoStatement Update(ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel)
         {
             if (locals != this.Locals || condition != this.Condition || body != this.Body || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(continueLabel, this.ContinueLabel))
             {
@@ -3962,7 +3962,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundWhileStatement : BoundConditionalLoopStatement
     {
-        public BoundWhileStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel, bool hasErrors = false)
+        public BoundWhileStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors = false)
             : base(BoundKind.WhileStatement, syntax, locals, condition, body, breakLabel, continueLabel, hasErrors || condition.HasErrors() || body.HasErrors())
         {
 
@@ -3978,7 +3978,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitWhileStatement(this);
 
-        public BoundWhileStatement Update(ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel)
+        public BoundWhileStatement Update(ImmutableArray<LocalSymbol> locals, BoundExpression condition, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel)
         {
             if (locals != this.Locals || condition != this.Condition || body != this.Body || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(continueLabel, this.ContinueLabel))
             {
@@ -3992,7 +3992,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundForStatement : BoundLoopStatement
     {
-        public BoundForStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> outerLocals, BoundStatement? initializer, ImmutableArray<LocalSymbol> innerLocals, BoundExpression? condition, BoundStatement? increment, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel, bool hasErrors = false)
+        public BoundForStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> outerLocals, BoundStatement? initializer, ImmutableArray<LocalSymbol> innerLocals, BoundExpression? condition, BoundStatement? increment, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors = false)
             : base(BoundKind.ForStatement, syntax, breakLabel, continueLabel, hasErrors || initializer.HasErrors() || condition.HasErrors() || increment.HasErrors() || body.HasErrors())
         {
 
@@ -4020,7 +4020,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitForStatement(this);
 
-        public BoundForStatement Update(ImmutableArray<LocalSymbol> outerLocals, BoundStatement? initializer, ImmutableArray<LocalSymbol> innerLocals, BoundExpression? condition, BoundStatement? increment, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel)
+        public BoundForStatement Update(ImmutableArray<LocalSymbol> outerLocals, BoundStatement? initializer, ImmutableArray<LocalSymbol> innerLocals, BoundExpression? condition, BoundStatement? increment, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel)
         {
             if (outerLocals != this.OuterLocals || initializer != this.Initializer || innerLocals != this.InnerLocals || condition != this.Condition || increment != this.Increment || body != this.Body || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(continueLabel, this.ContinueLabel))
             {
@@ -4034,7 +4034,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundForEachStatement : BoundLoopStatement
     {
-        public BoundForEachStatement(SyntaxNode syntax, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel, bool hasErrors = false)
+        public BoundForEachStatement(SyntaxNode syntax, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors = false)
             : base(BoundKind.ForEachStatement, syntax, breakLabel, continueLabel, hasErrors || elementPlaceholder.HasErrors() || elementConversion.HasErrors() || iterationVariableType.HasErrors() || iterationErrorExpressionOpt.HasErrors() || expression.HasErrors() || deconstructionOpt.HasErrors() || awaitOpt.HasErrors() || body.HasErrors())
         {
 
@@ -4071,7 +4071,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitForEachStatement(this);
 
-        public BoundForEachStatement Update(ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, GeneratedLabelSymbol breakLabel, GeneratedLabelSymbol continueLabel)
+        public BoundForEachStatement Update(ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel)
         {
             if (enumeratorInfoOpt != this.EnumeratorInfoOpt || elementPlaceholder != this.ElementPlaceholder || elementConversion != this.ElementConversion || iterationVariableType != this.IterationVariableType || iterationVariables != this.IterationVariables || iterationErrorExpressionOpt != this.IterationErrorExpressionOpt || expression != this.Expression || deconstructionOpt != this.DeconstructionOpt || awaitOpt != this.AwaitOpt || body != this.Body || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(continueLabel, this.ContinueLabel))
             {
@@ -7590,7 +7590,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundLambda : BoundExpression
     {
-        public BoundLambda(SyntaxNode syntax, UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type, bool hasErrors = false)
+        public BoundLambda(SyntaxNode syntax, UnboundLambda unboundLambda, MethodSymbol symbol, BoundBlock body, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type, bool hasErrors = false)
             : base(BoundKind.Lambda, syntax, type, hasErrors || unboundLambda.HasErrors() || body.HasErrors())
         {
 
@@ -7607,7 +7607,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public UnboundLambda UnboundLambda { get; }
-        public LambdaSymbol Symbol { get; }
+        public MethodSymbol Symbol { get; }
         public new TypeSymbol? Type => base.Type;
         public BoundBlock Body { get; }
         public ReadOnlyBindingDiagnostic<AssemblySymbol> Diagnostics { get; }
@@ -7616,7 +7616,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitLambda(this);
 
-        public BoundLambda Update(UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type)
+        public BoundLambda Update(UnboundLambda unboundLambda, MethodSymbol symbol, BoundBlock body, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type)
         {
             if (unboundLambda != this.UnboundLambda || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(symbol, this.Symbol) || body != this.Body || diagnostics != this.Diagnostics || binder != this.Binder || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
@@ -10836,17 +10836,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitFieldEqualsValue(BoundFieldEqualsValue node)
         {
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(node.Field, node.Locals, value);
+            FieldSymbol field = this.VisitFieldSymbol(node.Field);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(field, locals, value);
         }
         public override BoundNode? VisitPropertyEqualsValue(BoundPropertyEqualsValue node)
         {
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(node.Property, node.Locals, value);
+            PropertySymbol property = this.VisitPropertySymbol(node.Property);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(property, locals, value);
         }
         public override BoundNode? VisitParameterEqualsValue(BoundParameterEqualsValue node)
         {
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(node.Parameter, node.Locals, value);
+            ParameterSymbol parameter = this.VisitParameterSymbol(node.Parameter);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(parameter, locals, value);
         }
         public override BoundNode? VisitGlobalStatementInitializer(BoundGlobalStatementInitializer node)
         {
@@ -10867,7 +10873,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.VariableSymbol, node.IsDiscardExpression, type);
+            Symbol? variableSymbol = this.VisitSymbol(node.VariableSymbol);
+            return node.Update(variableSymbol, node.IsDiscardExpression, type);
         }
         public override BoundNode? VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node)
         {
@@ -10934,7 +10941,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             ImmutableArray<BoundExpression> childBoundNodes = this.VisitList(node.ChildBoundNodes);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.ResultKind, node.Symbols, childBoundNodes, type);
+            ImmutableArray<Symbol?> symbols = this.VisitSymbols<Symbol?>(node.Symbols);
+            return node.Update(node.ResultKind, symbols, childBoundNodes, type);
         }
         public override BoundNode? VisitBadStatement(BoundBadStatement node)
         {
@@ -10951,7 +10959,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression? boundContainingTypeOpt = (BoundTypeExpression?)this.Visit(node.BoundContainingTypeOpt);
             ImmutableArray<BoundExpression> boundDimensionsOpt = this.VisitList(node.BoundDimensionsOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.AliasOpt, boundContainingTypeOpt, boundDimensionsOpt, node.TypeWithAnnotations, type);
+            AliasSymbol? aliasOpt = this.VisitAliasSymbol(node.AliasOpt);
+            return node.Update(aliasOpt, boundContainingTypeOpt, boundDimensionsOpt, node.TypeWithAnnotations, type);
         }
         public override BoundNode? VisitTypeOrValueExpression(BoundTypeOrValueExpression node)
         {
@@ -10961,14 +10970,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitNamespaceExpression(BoundNamespaceExpression node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.NamespaceSymbol, node.AliasOpt);
+            NamespaceSymbol namespaceSymbol = this.VisitNamespaceSymbol(node.NamespaceSymbol);
+            AliasSymbol? aliasOpt = this.VisitAliasSymbol(node.AliasOpt);
+            return node.Update(namespaceSymbol, aliasOpt);
         }
         public override BoundNode? VisitUnaryOperator(BoundUnaryOperator node)
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, constrainedToTypeOpt, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, type);
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
+            return node.Update(node.OperatorKind, operand, node.ConstantValueOpt, methodOpt, constrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt, type);
         }
         public override BoundNode? VisitIncrementOperator(BoundIncrementOperator node)
         {
@@ -10979,7 +10992,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? resultConversion = node.ResultConversion;
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.OperatorKind, operand, node.MethodOpt, constrainedToTypeOpt, operandPlaceholder, operandConversion, resultPlaceholder, resultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, type);
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
+            return node.Update(node.OperatorKind, operand, methodOpt, constrainedToTypeOpt, operandPlaceholder, operandConversion, resultPlaceholder, resultConversion, node.ResultKind, originalUserDefinedOperatorsOpt, type);
         }
         public override BoundNode? VisitAddressOfOperator(BoundAddressOfOperator node)
         {
@@ -10997,7 +11012,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.TargetMethod, constrainedToTypeOpt, type);
+            MethodSymbol targetMethod = this.VisitMethodSymbol(node.TargetMethod);
+            return node.Update(targetMethod, constrainedToTypeOpt, type);
         }
         public override BoundNode? VisitPointerIndirectionOperator(BoundPointerIndirectionOperator node)
         {
@@ -11023,7 +11039,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(operand, node.GetTypeFromHandle, type);
+            MethodSymbol? getTypeFromHandle = this.VisitMethodSymbol(node.GetTypeFromHandle);
+            return node.Update(operand, getTypeFromHandle, type);
         }
         public override BoundNode? VisitMakeRefOperator(BoundMakeRefOperator node)
         {
@@ -11041,14 +11058,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(operand, node.MethodOpt, type);
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
+            return node.Update(operand, methodOpt, type);
         }
         public override BoundNode? VisitRangeExpression(BoundRangeExpression node)
         {
             BoundExpression? leftOperandOpt = (BoundExpression?)this.Visit(node.LeftOperandOpt);
             BoundExpression? rightOperandOpt = (BoundExpression?)this.Visit(node.RightOperandOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(leftOperandOpt, rightOperandOpt, node.MethodOpt, type);
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
+            return node.Update(leftOperandOpt, rightOperandOpt, methodOpt, type);
         }
         public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
         {
@@ -11070,7 +11089,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.OperatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, constrainedToTypeOpt, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, left, right, type);
+            MethodSymbol logicalOperator = this.VisitMethodSymbol(node.LogicalOperator);
+            MethodSymbol trueOperator = this.VisitMethodSymbol(node.TrueOperator);
+            MethodSymbol falseOperator = this.VisitMethodSymbol(node.FalseOperator);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
+            return node.Update(node.OperatorKind, logicalOperator, trueOperator, falseOperator, constrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt, left, right, type);
         }
         public override BoundNode? VisitCompoundAssignmentOperator(BoundCompoundAssignmentOperator node)
         {
@@ -11081,7 +11104,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundValuePlaceholder? finalPlaceholder = node.FinalPlaceholder;
             BoundExpression? finalConversion = node.FinalConversion;
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Operator, left, right, leftPlaceholder, leftConversion, finalPlaceholder, finalConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, type);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
+            return node.Update(node.Operator, left, right, leftPlaceholder, leftConversion, finalPlaceholder, finalConversion, node.ResultKind, originalUserDefinedOperatorsOpt, type);
         }
         public override BoundNode? VisitAssignmentOperator(BoundAssignmentOperator node)
         {
@@ -11153,7 +11177,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder = (BoundAwaitableValuePlaceholder?)this.Visit(node.AwaitableInstancePlaceholder);
             BoundExpression? getAwaiter = (BoundExpression?)this.Visit(node.GetAwaiter);
-            return node.Update(awaitableInstancePlaceholder, node.IsDynamic, getAwaiter, node.IsCompleted, node.GetResult);
+            PropertySymbol? isCompleted = this.VisitPropertySymbol(node.IsCompleted);
+            MethodSymbol? getResult = this.VisitMethodSymbol(node.GetResult);
+            return node.Update(awaitableInstancePlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult);
         }
         public override BoundNode? VisitAwaitExpression(BoundAwaitExpression node)
         {
@@ -11166,7 +11192,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundTypeExpression sourceType = (BoundTypeExpression)this.Visit(node.SourceType);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(sourceType, node.GetTypeFromHandle, type);
+            MethodSymbol? getTypeFromHandle = this.VisitMethodSymbol(node.GetTypeFromHandle);
+            return node.Update(sourceType, getTypeFromHandle, type);
         }
         public override BoundNode? VisitBlockInstrumentation(BoundBlockInstrumentation node)
         {
@@ -11177,17 +11204,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitMethodDefIndex(BoundMethodDefIndex node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Method, type);
+            MethodSymbol method = this.VisitMethodSymbol(node.Method);
+            return node.Update(method, type);
         }
         public override BoundNode? VisitLocalId(BoundLocalId node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Local, node.HoistedField, type);
+            LocalSymbol local = this.VisitLocalSymbol(node.Local);
+            FieldSymbol? hoistedField = this.VisitFieldSymbol(node.HoistedField);
+            return node.Update(local, hoistedField, type);
         }
         public override BoundNode? VisitParameterId(BoundParameterId node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Parameter, node.HoistedField, type);
+            ParameterSymbol parameter = this.VisitParameterSymbol(node.Parameter);
+            FieldSymbol? hoistedField = this.VisitFieldSymbol(node.HoistedField);
+            return node.Update(parameter, hoistedField, type);
         }
         public override BoundNode? VisitStateMachineInstanceId(BoundStateMachineInstanceId node)
         {
@@ -11232,12 +11264,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitMethodInfo(BoundMethodInfo node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Method, node.GetMethodFromHandle, type);
+            MethodSymbol method = this.VisitMethodSymbol(node.Method);
+            MethodSymbol? getMethodFromHandle = this.VisitMethodSymbol(node.GetMethodFromHandle);
+            return node.Update(method, getMethodFromHandle, type);
         }
         public override BoundNode? VisitFieldInfo(BoundFieldInfo node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Field, node.GetFieldFromHandle, type);
+            FieldSymbol field = this.VisitFieldSymbol(node.Field);
+            MethodSymbol? getFieldFromHandle = this.VisitMethodSymbol(node.GetFieldFromHandle);
+            return node.Update(field, getFieldFromHandle, type);
         }
         public override BoundNode? VisitDefaultLiteral(BoundDefaultLiteral node)
         {
@@ -11276,13 +11312,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, node.OriginalUserDefinedConversionsOpt, type);
+            ImmutableArray<MethodSymbol> originalUserDefinedConversionsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedConversionsOpt);
+            return node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, originalUserDefinedConversionsOpt, type);
         }
         public override BoundNode? VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(operand, node.ConversionMethod, type);
+            MethodSymbol conversionMethod = this.VisitMethodSymbol(node.ConversionMethod);
+            return node.Update(operand, conversionMethod, type);
         }
         public override BoundNode? VisitArgList(BoundArgList node)
         {
@@ -11302,7 +11340,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             TypeSymbol? elementPointerType = this.VisitType(node.ElementPointerType);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(elementPointerType, elementPointerPlaceholder, elementPointerConversion, expression, node.GetPinnableOpt, type);
+            MethodSymbol? getPinnableOpt = this.VisitMethodSymbol(node.GetPinnableOpt);
+            return node.Update(elementPointerType, elementPointerPlaceholder, elementPointerConversion, expression, getPinnableOpt, type);
         }
         public override BoundNode? VisitSequencePoint(BoundSequencePoint node)
         {
@@ -11321,24 +11360,29 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundBlockInstrumentation? instrumentation = (BoundBlockInstrumentation?)this.Visit(node.Instrumentation);
             ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
-            return node.Update(node.Locals, node.LocalFunctions, node.HasUnsafeModifier, instrumentation, statements);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            ImmutableArray<LocalFunctionSymbol> localFunctions = this.VisitSymbols<LocalFunctionSymbol>(node.LocalFunctions);
+            return node.Update(locals, localFunctions, node.HasUnsafeModifier, instrumentation, statements);
         }
         public override BoundNode? VisitScope(BoundScope node)
         {
             ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
-            return node.Update(node.Locals, statements);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, statements);
         }
         public override BoundNode? VisitStateMachineScope(BoundStateMachineScope node)
         {
             BoundStatement statement = (BoundStatement)this.Visit(node.Statement);
-            return node.Update(node.Fields, statement);
+            ImmutableArray<StateMachineFieldSymbol> fields = this.VisitSymbols<StateMachineFieldSymbol>(node.Fields);
+            return node.Update(fields, statement);
         }
         public override BoundNode? VisitLocalDeclaration(BoundLocalDeclaration node)
         {
             BoundTypeExpression? declaredTypeOpt = (BoundTypeExpression?)this.Visit(node.DeclaredTypeOpt);
             BoundExpression? initializerOpt = (BoundExpression?)this.Visit(node.InitializerOpt);
             ImmutableArray<BoundExpression> argumentsOpt = this.VisitList(node.ArgumentsOpt);
-            return node.Update(node.LocalSymbol, declaredTypeOpt, initializerOpt, argumentsOpt, node.InferredType);
+            LocalSymbol localSymbol = this.VisitLocalSymbol(node.LocalSymbol);
+            return node.Update(localSymbol, declaredTypeOpt, initializerOpt, argumentsOpt, node.InferredType);
         }
         public override BoundNode? VisitMultipleLocalDeclarations(BoundMultipleLocalDeclarations node)
         {
@@ -11355,7 +11399,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
             BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
-            return node.Update(node.Symbol, blockBody, expressionBody);
+            MethodSymbol symbol = this.VisitMethodSymbol(node.Symbol);
+            return node.Update(symbol, blockBody, expressionBody);
         }
         public override BoundNode? VisitNoOpStatement(BoundNoOpStatement node) => node;
         public override BoundNode? VisitReturnStatement(BoundReturnStatement node)
@@ -11387,12 +11432,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> switchSections = this.VisitList(node.SwitchSections);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             BoundSwitchLabel? defaultLabel = (BoundSwitchLabel?)this.Visit(node.DefaultLabel);
-            return node.Update(expression, node.InnerLocals, node.InnerLocalFunctions, switchSections, reachabilityDecisionDag, defaultLabel, node.BreakLabel);
+            ImmutableArray<LocalSymbol> innerLocals = this.VisitSymbols<LocalSymbol>(node.InnerLocals);
+            ImmutableArray<LocalFunctionSymbol> innerLocalFunctions = this.VisitSymbols<LocalFunctionSymbol>(node.InnerLocalFunctions);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
+            return node.Update(expression, innerLocals, innerLocalFunctions, switchSections, reachabilityDecisionDag, defaultLabel, breakLabel);
         }
         public override BoundNode? VisitSwitchDispatch(BoundSwitchDispatch node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            return node.Update(expression, node.Cases, node.DefaultLabel, node.LengthBasedStringSwitchDataOpt);
+            LabelSymbol defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
+            return node.Update(expression, node.Cases, defaultLabel, node.LengthBasedStringSwitchDataOpt);
         }
         public override BoundNode? VisitIfStatement(BoundIfStatement node)
         {
@@ -11405,13 +11454,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.Locals, condition, body, node.BreakLabel, node.ContinueLabel);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
+            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
+            return node.Update(locals, condition, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitWhileStatement(BoundWhileStatement node)
         {
             BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.Locals, condition, body, node.BreakLabel, node.ContinueLabel);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
+            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
+            return node.Update(locals, condition, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitForStatement(BoundForStatement node)
         {
@@ -11419,7 +11474,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? condition = (BoundExpression?)this.Visit(node.Condition);
             BoundStatement? increment = (BoundStatement?)this.Visit(node.Increment);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.OuterLocals, initializer, node.InnerLocals, condition, increment, body, node.BreakLabel, node.ContinueLabel);
+            ImmutableArray<LocalSymbol> outerLocals = this.VisitSymbols<LocalSymbol>(node.OuterLocals);
+            ImmutableArray<LocalSymbol> innerLocals = this.VisitSymbols<LocalSymbol>(node.InnerLocals);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
+            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
+            return node.Update(outerLocals, initializer, innerLocals, condition, increment, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitForEachStatement(BoundForEachStatement node)
         {
@@ -11431,7 +11490,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundForEachDeconstructStep? deconstructionOpt = (BoundForEachDeconstructStep?)this.Visit(node.DeconstructionOpt);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.EnumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, node.IterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, node.BreakLabel, node.ContinueLabel);
+            ImmutableArray<LocalSymbol> iterationVariables = this.VisitSymbols<LocalSymbol>(node.IterationVariables);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
+            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
+            return node.Update(node.EnumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitForEachDeconstructStep(BoundForEachDeconstructStep node)
         {
@@ -11445,13 +11507,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? expressionOpt = (BoundExpression?)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
-            return node.Update(node.Locals, declarationsOpt, expressionOpt, body, awaitOpt, node.PatternDisposeInfoOpt);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, declarationsOpt, expressionOpt, body, awaitOpt, node.PatternDisposeInfoOpt);
         }
         public override BoundNode? VisitFixedStatement(BoundFixedStatement node)
         {
             BoundMultipleLocalDeclarations declarations = (BoundMultipleLocalDeclarations)this.Visit(node.Declarations);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.Locals, declarations, body);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, declarations, body);
         }
         public override BoundNode? VisitLockStatement(BoundLockStatement node)
         {
@@ -11464,7 +11528,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundBlock tryBlock = (BoundBlock)this.Visit(node.TryBlock);
             ImmutableArray<BoundCatchBlock> catchBlocks = this.VisitList(node.CatchBlocks);
             BoundBlock? finallyBlockOpt = (BoundBlock?)this.Visit(node.FinallyBlockOpt);
-            return node.Update(tryBlock, catchBlocks, finallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler);
+            LabelSymbol? finallyLabelOpt = this.VisitLabelSymbol(node.FinallyLabelOpt);
+            return node.Update(tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, node.PreferFaultHandler);
         }
         public override BoundNode? VisitCatchBlock(BoundCatchBlock node)
         {
@@ -11473,7 +11538,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? exceptionFilterOpt = (BoundExpression?)this.Visit(node.ExceptionFilterOpt);
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             TypeSymbol? exceptionTypeOpt = this.VisitType(node.ExceptionTypeOpt);
-            return node.Update(node.Locals, exceptionSourceOpt, exceptionTypeOpt, exceptionFilterPrologueOpt, exceptionFilterOpt, body, node.IsSynthesizedAsyncCatchAll);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, exceptionSourceOpt, exceptionTypeOpt, exceptionFilterPrologueOpt, exceptionFilterOpt, body, node.IsSynthesizedAsyncCatchAll);
         }
         public override BoundNode? VisitLiteral(BoundLiteral node)
         {
@@ -11508,40 +11574,47 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitLocal(BoundLocal node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type);
+            LocalSymbol localSymbol = this.VisitLocalSymbol(node.LocalSymbol);
+            return node.Update(localSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type);
         }
         public override BoundNode? VisitPseudoVariable(BoundPseudoVariable node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.LocalSymbol, node.EmitExpressions, type);
+            LocalSymbol localSymbol = this.VisitLocalSymbol(node.LocalSymbol);
+            return node.Update(localSymbol, node.EmitExpressions, type);
         }
         public override BoundNode? VisitRangeVariable(BoundRangeVariable node)
         {
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.RangeVariableSymbol, value, type);
+            RangeVariableSymbol rangeVariableSymbol = this.VisitRangeVariableSymbol(node.RangeVariableSymbol);
+            return node.Update(rangeVariableSymbol, value, type);
         }
         public override BoundNode? VisitParameter(BoundParameter node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.ParameterSymbol, type);
+            ParameterSymbol parameterSymbol = this.VisitParameterSymbol(node.ParameterSymbol);
+            return node.Update(parameterSymbol, type);
         }
         public override BoundNode? VisitLabelStatement(BoundLabelStatement node) => node;
         public override BoundNode? VisitGotoStatement(BoundGotoStatement node)
         {
             BoundExpression? caseExpressionOpt = (BoundExpression?)this.Visit(node.CaseExpressionOpt);
             BoundLabel? labelExpressionOpt = (BoundLabel?)this.Visit(node.LabelExpressionOpt);
-            return node.Update(node.Label, caseExpressionOpt, labelExpressionOpt);
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label, caseExpressionOpt, labelExpressionOpt);
         }
         public override BoundNode? VisitLabeledStatement(BoundLabeledStatement node)
         {
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.Label, body);
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label, body);
         }
         public override BoundNode? VisitLabel(BoundLabel node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Label, type);
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label, type);
         }
         public override BoundNode? VisitStatementList(BoundStatementList node)
         {
@@ -11551,14 +11624,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitConditionalGoto(BoundConditionalGoto node)
         {
             BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            return node.Update(condition, node.JumpIfTrue, node.Label);
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(condition, node.JumpIfTrue, label);
         }
         public override BoundNode? VisitSwitchExpressionArm(BoundSwitchExpressionArm node)
         {
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundExpression? whenClause = (BoundExpression?)this.Visit(node.WhenClause);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(node.Locals, pattern, whenClause, value, node.Label);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(locals, pattern, whenClause, value, label);
         }
         public override BoundNode? VisitUnconvertedSwitchExpression(BoundUnconvertedSwitchExpression node)
         {
@@ -11566,7 +11642,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchExpressionArm> switchArms = this.VisitList(node.SwitchArms);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
+            LabelSymbol? defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
+            return node.Update(expression, switchArms, reachabilityDecisionDag, defaultLabel, node.ReportedNotExhaustive, type);
         }
         public override BoundNode? VisitConvertedSwitchExpression(BoundConvertedSwitchExpression node)
         {
@@ -11575,7 +11652,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? naturalTypeOpt = this.VisitType(node.NaturalTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
+            LabelSymbol? defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
+            return node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, defaultLabel, node.ReportedNotExhaustive, type);
         }
         public override BoundNode? VisitDecisionDag(BoundDecisionDag node)
         {
@@ -11638,7 +11716,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(node.DeconstructMethod, input);
+            MethodSymbol deconstructMethod = this.VisitMethodSymbol(node.DeconstructMethod);
+            return node.Update(deconstructMethod, input);
         }
         public override BoundNode? VisitDagTypeEvaluation(BoundDagTypeEvaluation node)
         {
@@ -11649,17 +11728,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(node.Field, input);
+            FieldSymbol field = this.VisitFieldSymbol(node.Field);
+            return node.Update(field, input);
         }
         public override BoundNode? VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(node.Property, node.IsLengthOrCount, input);
+            PropertySymbol property = this.VisitPropertySymbol(node.Property);
+            return node.Update(property, node.IsLengthOrCount, input);
         }
         public override BoundNode? VisitDagIndexEvaluation(BoundDagIndexEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(node.Property, node.Index, input);
+            PropertySymbol property = this.VisitPropertySymbol(node.Property);
+            return node.Update(property, node.Index, input);
         }
         public override BoundNode? VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node)
         {
@@ -11691,13 +11773,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             ImmutableArray<BoundSwitchLabel> switchLabels = this.VisitList(node.SwitchLabels);
             ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
-            return node.Update(node.Locals, switchLabels, statements);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, switchLabels, statements);
         }
         public override BoundNode? VisitSwitchLabel(BoundSwitchLabel node)
         {
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundExpression? whenClause = (BoundExpression?)this.Visit(node.WhenClause);
-            return node.Update(node.Label, pattern, whenClause);
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label, pattern, whenClause);
         }
         public override BoundNode? VisitSequencePointExpression(BoundSequencePointExpression node)
         {
@@ -11710,14 +11794,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Locals, sideEffects, value, type);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, sideEffects, value, type);
         }
         public override BoundNode? VisitSpillSequence(BoundSpillSequence node)
         {
             ImmutableArray<BoundStatement> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Locals, sideEffects, value, type);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, sideEffects, value, type);
         }
         public override BoundNode? VisitDynamicMemberAccess(BoundDynamicMemberAccess node)
         {
@@ -11730,7 +11816,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, type);
+            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
+            return node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableMethods, expression, arguments, type);
         }
         public override BoundNode? VisitConditionalAccess(BoundConditionalAccess node)
         {
@@ -11745,7 +11832,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
             BoundExpression? whenNullOpt = (BoundExpression?)this.Visit(node.WhenNullOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, node.ForceCopyOfNullableValueType, type);
+            MethodSymbol? hasValueMethodOpt = this.VisitMethodSymbol(node.HasValueMethodOpt);
+            return node.Update(receiver, hasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, node.ForceCopyOfNullableValueType, type);
         }
         public override BoundNode? VisitConditionalReceiver(BoundConditionalReceiver node)
         {
@@ -11763,34 +11851,42 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, node.LookupSymbolOpt, node.LookupError, node.Flags, node.FunctionType, receiverOpt, node.ResultKind);
+            ImmutableArray<MethodSymbol> methods = this.VisitSymbols<MethodSymbol>(node.Methods);
+            Symbol? lookupSymbolOpt = this.VisitSymbol(node.LookupSymbolOpt);
+            FunctionTypeSymbol? functionType = this.VisitFunctionTypeSymbol(node.FunctionType);
+            return node.Update(node.TypeArgumentsOpt, node.Name, methods, lookupSymbolOpt, node.LookupError, node.Flags, functionType, receiverOpt, node.ResultKind);
         }
         public override BoundNode? VisitPropertyGroup(BoundPropertyGroup node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Properties, receiverOpt, node.ResultKind);
+            ImmutableArray<PropertySymbol> properties = this.VisitSymbols<PropertySymbol>(node.Properties);
+            return node.Update(properties, receiverOpt, node.ResultKind);
         }
         public override BoundNode? VisitCall(BoundCall node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, node.OriginalMethodsOpt, type);
+            MethodSymbol method = this.VisitMethodSymbol(node.Method);
+            ImmutableArray<MethodSymbol> originalMethodsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalMethodsOpt);
+            return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, originalMethodsOpt, type);
         }
         public override BoundNode? VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, type);
+            EventSymbol @event = this.VisitEventSymbol(node.Event);
+            return node.Update(@event, node.IsAddition, node.IsDynamic, receiverOpt, argument, type);
         }
         public override BoundNode? VisitAttribute(BoundAttribute node)
         {
             ImmutableArray<BoundExpression> constructorArguments = this.VisitList(node.ConstructorArguments);
             ImmutableArray<BoundAssignmentOperator> namedArguments = this.VisitList(node.NamedArguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, node.ConstructorDefaultArguments, namedArguments, node.ResultKind, type);
+            MethodSymbol? constructor = this.VisitMethodSymbol(node.Constructor);
+            return node.Update(constructor, constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, node.ConstructorDefaultArguments, namedArguments, node.ResultKind, type);
         }
         public override BoundNode? VisitUnconvertedObjectCreationExpression(BoundUnconvertedObjectCreationExpression node)
         {
@@ -11803,7 +11899,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase? initializerExpressionOpt = (BoundObjectInitializerExpressionBase?)this.Visit(node.InitializerExpressionOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ConstantValueOpt, initializerExpressionOpt, node.WasTargetTyped, type);
+            MethodSymbol constructor = this.VisitMethodSymbol(node.Constructor);
+            ImmutableArray<MethodSymbol> constructorsGroup = this.VisitSymbols<MethodSymbol>(node.ConstructorsGroup);
+            return node.Update(constructor, constructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ConstantValueOpt, initializerExpressionOpt, node.WasTargetTyped, type);
         }
         public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
         {
@@ -11820,7 +11918,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundUnconvertedCollectionExpression unconvertedCollectionExpression = node.UnconvertedCollectionExpression;
             ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, node.CollectionBuilderMethod, collectionBuilderInvocationPlaceholder, collectionBuilderInvocationConversion, node.WasTargetTyped, unconvertedCollectionExpression, elements, type);
+            MethodSymbol? collectionBuilderMethod = this.VisitMethodSymbol(node.CollectionBuilderMethod);
+            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderInvocationPlaceholder, collectionBuilderInvocationConversion, node.WasTargetTyped, unconvertedCollectionExpression, elements, type);
         }
         public override BoundNode? VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node)
         {
@@ -11855,7 +11954,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase? initializerExpressionOpt = (BoundObjectInitializerExpressionBase?)this.Visit(node.InitializerExpressionOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, node.WasTargetTyped, type);
+            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
+            return node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, applicableMethods, node.WasTargetTyped, type);
         }
         public override BoundNode? VisitNoPiaObjectCreationExpression(BoundNoPiaObjectCreationExpression node)
         {
@@ -11875,7 +11975,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? receiverType = this.VisitType(node.ReceiverType);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, node.AccessorKind, receiverType, type);
+            Symbol? memberSymbol = this.VisitSymbol(node.MemberSymbol);
+            return node.Update(memberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, node.AccessorKind, receiverType, type);
         }
         public override BoundNode? VisitDynamicObjectInitializerMember(BoundDynamicObjectInitializerMember node)
         {
@@ -11895,14 +11996,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundExpression? implicitReceiverOpt = (BoundExpression?)this.Visit(node.ImplicitReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.InvokedAsExtensionMethod, node.ResultKind, type);
+            MethodSymbol addMethod = this.VisitMethodSymbol(node.AddMethod);
+            return node.Update(addMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.InvokedAsExtensionMethod, node.ResultKind, type);
         }
         public override BoundNode? VisitDynamicCollectionElementInitializer(BoundDynamicCollectionElementInitializer node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.ApplicableMethods, expression, arguments, type);
+            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
+            return node.Update(applicableMethods, expression, arguments, type);
         }
         public override BoundNode? VisitImplicitReceiver(BoundImplicitReceiver node)
         {
@@ -11914,12 +12017,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = this.VisitList(node.Declarations);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Constructor, arguments, declarations, type);
+            MethodSymbol constructor = this.VisitMethodSymbol(node.Constructor);
+            return node.Update(constructor, arguments, declarations, type);
         }
         public override BoundNode? VisitAnonymousPropertyDeclaration(BoundAnonymousPropertyDeclaration node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Property, type);
+            PropertySymbol property = this.VisitPropertySymbol(node.Property);
+            return node.Update(property, type);
         }
         public override BoundNode? VisitNewT(BoundNewT node)
         {
@@ -11931,7 +12036,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(argument, node.MethodOpt, node.IsExtensionMethod, node.WasTargetTyped, type);
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
+            return node.Update(argument, methodOpt, node.IsExtensionMethod, node.WasTargetTyped, type);
         }
         public override BoundNode? VisitArrayCreation(BoundArrayCreation node)
         {
@@ -11966,31 +12072,37 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, type);
+            FieldSymbol fieldSymbol = this.VisitFieldSymbol(node.FieldSymbol);
+            return node.Update(receiverOpt, fieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, type);
         }
         public override BoundNode? VisitHoistedFieldAccess(BoundHoistedFieldAccess node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.FieldSymbol, type);
+            FieldSymbol fieldSymbol = this.VisitFieldSymbol(node.FieldSymbol);
+            return node.Update(fieldSymbol, type);
         }
         public override BoundNode? VisitPropertyAccess(BoundPropertyAccess node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, node.PropertySymbol, node.AutoPropertyAccessorKind, node.ResultKind, type);
+            PropertySymbol propertySymbol = this.VisitPropertySymbol(node.PropertySymbol);
+            return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, propertySymbol, node.AutoPropertyAccessorKind, node.ResultKind, type);
         }
         public override BoundNode? VisitEventAccess(BoundEventAccess node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, type);
+            EventSymbol eventSymbol = this.VisitEventSymbol(node.EventSymbol);
+            return node.Update(receiverOpt, eventSymbol, node.IsUsableAsField, node.ResultKind, type);
         }
         public override BoundNode? VisitIndexerAccess(BoundIndexerAccess node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.AccessorKind, node.ArgsToParamsOpt, node.DefaultArguments, node.OriginalIndexersOpt, type);
+            PropertySymbol indexer = this.VisitPropertySymbol(node.Indexer);
+            ImmutableArray<PropertySymbol> originalIndexersOpt = this.VisitSymbols<PropertySymbol>(node.OriginalIndexersOpt);
+            return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.AccessorKind, node.ArgsToParamsOpt, node.DefaultArguments, originalIndexersOpt, type);
         }
         public override BoundNode? VisitImplicitIndexerAccess(BoundImplicitIndexerAccess node)
         {
@@ -12015,19 +12127,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiver, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, type);
+            ImmutableArray<PropertySymbol> applicableIndexers = this.VisitSymbols<PropertySymbol>(node.ApplicableIndexers);
+            return node.Update(receiver, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableIndexers, type);
         }
         public override BoundNode? VisitLambda(BoundLambda node)
         {
             UnboundLambda unboundLambda = node.UnboundLambda;
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, type);
+            MethodSymbol symbol = this.VisitMethodSymbol(node.Symbol);
+            return node.Update(unboundLambda, symbol, body, node.Diagnostics, node.Binder, type);
         }
         public override BoundNode? VisitUnboundLambda(UnboundLambda node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.Data, node.FunctionType, node.WithDependencies);
+            FunctionTypeSymbol? functionType = this.VisitFunctionTypeSymbol(node.FunctionType);
+            return node.Update(node.Data, functionType, node.WithDependencies);
         }
         public override BoundNode? VisitQueryClause(BoundQueryClause node)
         {
@@ -12036,7 +12151,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? cast = node.Cast;
             BoundExpression? unoptimizedForm = node.UnoptimizedForm;
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(value, node.DefinedSymbol, operation, cast, node.Binder, unoptimizedForm, type);
+            RangeVariableSymbol? definedSymbol = this.VisitRangeVariableSymbol(node.DefinedSymbol);
+            return node.Update(value, definedSymbol, operation, cast, node.Binder, unoptimizedForm, type);
         }
         public override BoundNode? VisitTypeOrInstanceInitializers(BoundTypeOrInstanceInitializers node)
         {
@@ -12085,7 +12201,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(expression, pattern, node.IsNegated, reachabilityDecisionDag, node.WhenTrueLabel, node.WhenFalseLabel, type);
+            LabelSymbol whenTrueLabel = this.VisitLabelSymbol(node.WhenTrueLabel);
+            LabelSymbol whenFalseLabel = this.VisitLabelSymbol(node.WhenFalseLabel);
+            return node.Update(expression, pattern, node.IsNegated, reachabilityDecisionDag, whenTrueLabel, whenFalseLabel, type);
         }
         public override BoundNode? VisitConstantPattern(BoundConstantPattern node)
         {
@@ -12106,7 +12224,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            return node.Update(declaredType, node.IsVar, node.Variable, variableAccess, inputType, narrowedType);
+            Symbol? variable = this.VisitSymbol(node.Variable);
+            return node.Update(declaredType, node.IsVar, variable, variableAccess, inputType, narrowedType);
         }
         public override BoundNode? VisitRecursivePattern(BoundRecursivePattern node)
         {
@@ -12116,7 +12235,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            return node.Update(declaredType, node.DeconstructMethod, deconstruction, properties, node.IsExplicitNotNullTest, node.Variable, variableAccess, inputType, narrowedType);
+            MethodSymbol? deconstructMethod = this.VisitMethodSymbol(node.DeconstructMethod);
+            Symbol? variable = this.VisitSymbol(node.Variable);
+            return node.Update(declaredType, deconstructMethod, deconstruction, properties, node.IsExplicitNotNullTest, variable, variableAccess, inputType, narrowedType);
         }
         public override BoundNode? VisitListPattern(BoundListPattern node)
         {
@@ -12128,7 +12249,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            return node.Update(subpatterns, node.HasSlice, lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, node.Variable, variableAccess, inputType, narrowedType);
+            Symbol? variable = this.VisitSymbol(node.Variable);
+            return node.Update(subpatterns, node.HasSlice, lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, variable, variableAccess, inputType, narrowedType);
         }
         public override BoundNode? VisitSlicePattern(BoundSlicePattern node)
         {
@@ -12145,12 +12267,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundPositionalSubpattern> subpatterns = this.VisitList(node.Subpatterns);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            return node.Update(node.GetLengthMethod, node.GetItemMethod, subpatterns, inputType, narrowedType);
+            MethodSymbol getLengthMethod = this.VisitMethodSymbol(node.GetLengthMethod);
+            MethodSymbol getItemMethod = this.VisitMethodSymbol(node.GetItemMethod);
+            return node.Update(getLengthMethod, getItemMethod, subpatterns, inputType, narrowedType);
         }
         public override BoundNode? VisitPositionalSubpattern(BoundPositionalSubpattern node)
         {
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
-            return node.Update(node.Symbol, pattern);
+            Symbol? symbol = this.VisitSymbol(node.Symbol);
+            return node.Update(symbol, pattern);
         }
         public override BoundNode? VisitPropertySubpattern(BoundPropertySubpattern node)
         {
@@ -12162,7 +12287,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundPropertySubpatternMember? receiver = (BoundPropertySubpatternMember?)this.Visit(node.Receiver);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiver, node.Symbol, type);
+            Symbol? symbol = this.VisitSymbol(node.Symbol);
+            return node.Update(receiver, symbol, type);
         }
         public override BoundNode? VisitTypePattern(BoundTypePattern node)
         {
@@ -12208,18 +12334,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.VariableSymbol, receiverOpt);
+            Symbol variableSymbol = this.VisitSymbol(node.VariableSymbol);
+            return node.Update(variableSymbol, receiverOpt);
         }
         public override BoundNode? VisitDeconstructionVariablePendingInference(DeconstructionVariablePendingInference node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.VariableSymbol, receiverOpt);
+            Symbol variableSymbol = this.VisitSymbol(node.VariableSymbol);
+            return node.Update(variableSymbol, receiverOpt);
         }
         public override BoundNode? VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.VariableSymbol, node.IsDiscardExpression);
+            Symbol? variableSymbol = this.VisitSymbol(node.VariableSymbol);
+            return node.Update(variableSymbol, node.IsDiscardExpression);
         }
         public override BoundNode? VisitNonConstructorMethodBody(BoundNonConstructorMethodBody node)
         {
@@ -12232,7 +12361,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement? initializer = (BoundStatement?)this.Visit(node.Initializer);
             BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
             BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
-            return node.Update(node.Locals, initializer, blockBody, expressionBody);
+            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            return node.Update(locals, initializer, blockBody, expressionBody);
         }
         public override BoundNode? VisitExpressionWithNullability(BoundExpressionWithNullability node)
         {
@@ -12245,7 +12375,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundObjectInitializerExpressionBase initializerExpression = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpression);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(receiver, node.CloneMethod, initializerExpression, type);
+            MethodSymbol? cloneMethod = this.VisitMethodSymbol(node.CloneMethod);
+            return node.Update(receiver, cloneMethod, initializerExpression, type);
         }
     }
 
@@ -13419,7 +13550,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
-            LocalFunctionSymbol symbol = GetUpdatedSymbol(node, node.Symbol);
+            MethodSymbol symbol = GetUpdatedSymbol(node, node.Symbol);
             BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
             BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
             return node.Update(symbol, blockBody, expressionBody);
@@ -14576,7 +14707,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLambda(BoundLambda node)
         {
-            LambdaSymbol symbol = GetUpdatedSymbol(node, node.Symbol);
+            MethodSymbol symbol = GetUpdatedSymbol(node, node.Symbol);
             UnboundLambda unboundLambda = node.UnboundLambda;
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             BoundLambda updatedNode;

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3302,7 +3302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundBlock : BoundStatementList
     {
-        public BoundBlock(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, ImmutableArray<LocalFunctionSymbol> localFunctions, bool hasUnsafeModifier, BoundBlockInstrumentation? instrumentation, ImmutableArray<BoundStatement> statements, bool hasErrors = false)
+        public BoundBlock(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, ImmutableArray<MethodSymbol> localFunctions, bool hasUnsafeModifier, BoundBlockInstrumentation? instrumentation, ImmutableArray<BoundStatement> statements, bool hasErrors = false)
             : base(BoundKind.Block, syntax, statements, hasErrors || instrumentation.HasErrors() || statements.HasErrors())
         {
 
@@ -3317,14 +3317,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public ImmutableArray<LocalSymbol> Locals { get; }
-        public ImmutableArray<LocalFunctionSymbol> LocalFunctions { get; }
+        public ImmutableArray<MethodSymbol> LocalFunctions { get; }
         public bool HasUnsafeModifier { get; }
         public BoundBlockInstrumentation? Instrumentation { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitBlock(this);
 
-        public BoundBlock Update(ImmutableArray<LocalSymbol> locals, ImmutableArray<LocalFunctionSymbol> localFunctions, bool hasUnsafeModifier, BoundBlockInstrumentation? instrumentation, ImmutableArray<BoundStatement> statements)
+        public BoundBlock Update(ImmutableArray<LocalSymbol> locals, ImmutableArray<MethodSymbol> localFunctions, bool hasUnsafeModifier, BoundBlockInstrumentation? instrumentation, ImmutableArray<BoundStatement> statements)
         {
             if (locals != this.Locals || localFunctions != this.LocalFunctions || hasUnsafeModifier != this.HasUnsafeModifier || instrumentation != this.Instrumentation || statements != this.Statements)
             {
@@ -3768,7 +3768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundSwitchStatement : BoundStatement
     {
-        public BoundSwitchStatement(SyntaxNode syntax, BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, LabelSymbol breakLabel, bool hasErrors = false)
+        public BoundSwitchStatement(SyntaxNode syntax, BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<MethodSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, LabelSymbol breakLabel, bool hasErrors = false)
             : base(BoundKind.SwitchStatement, syntax, hasErrors || expression.HasErrors() || switchSections.HasErrors() || reachabilityDecisionDag.HasErrors() || defaultLabel.HasErrors())
         {
 
@@ -3790,7 +3790,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundExpression Expression { get; }
         public ImmutableArray<LocalSymbol> InnerLocals { get; }
-        public ImmutableArray<LocalFunctionSymbol> InnerLocalFunctions { get; }
+        public ImmutableArray<MethodSymbol> InnerLocalFunctions { get; }
         public ImmutableArray<BoundSwitchSection> SwitchSections { get; }
         public BoundDecisionDag ReachabilityDecisionDag { get; }
         public BoundSwitchLabel? DefaultLabel { get; }
@@ -3799,7 +3799,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitSwitchStatement(this);
 
-        public BoundSwitchStatement Update(BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, LabelSymbol breakLabel)
+        public BoundSwitchStatement Update(BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<MethodSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag reachabilityDecisionDag, BoundSwitchLabel? defaultLabel, LabelSymbol breakLabel)
         {
             if (expression != this.Expression || innerLocals != this.InnerLocals || innerLocalFunctions != this.InnerLocalFunctions || switchSections != this.SwitchSections || reachabilityDecisionDag != this.ReachabilityDecisionDag || defaultLabel != this.DefaultLabel || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel))
             {
@@ -10835,23 +10835,23 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode? VisitFieldEqualsValue(BoundFieldEqualsValue node)
         {
-            BoundExpression value = (BoundExpression)this.Visit(node.Value);
             FieldSymbol field = this.VisitFieldSymbol(node.Field);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
             return node.Update(field, locals, value);
         }
         public override BoundNode? VisitPropertyEqualsValue(BoundPropertyEqualsValue node)
         {
-            BoundExpression value = (BoundExpression)this.Visit(node.Value);
             PropertySymbol property = this.VisitPropertySymbol(node.Property);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
             return node.Update(property, locals, value);
         }
         public override BoundNode? VisitParameterEqualsValue(BoundParameterEqualsValue node)
         {
-            BoundExpression value = (BoundExpression)this.Visit(node.Value);
             ParameterSymbol parameter = this.VisitParameterSymbol(node.Parameter);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
             return node.Update(parameter, locals, value);
         }
         public override BoundNode? VisitGlobalStatementInitializer(BoundGlobalStatementInitializer node)
@@ -10872,8 +10872,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             Symbol? variableSymbol = this.VisitSymbol(node.VariableSymbol);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(variableSymbol, node.IsDiscardExpression, type);
         }
         public override BoundNode? VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node)
@@ -10939,9 +10939,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitBadExpression(BoundBadExpression node)
         {
+            ImmutableArray<Symbol?> symbols = this.VisitSymbols<Symbol?>(node.Symbols);
             ImmutableArray<BoundExpression> childBoundNodes = this.VisitList(node.ChildBoundNodes);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<Symbol?> symbols = this.VisitSymbols<Symbol?>(node.Symbols);
             return node.Update(node.ResultKind, symbols, childBoundNodes, type);
         }
         public override BoundNode? VisitBadStatement(BoundBadStatement node)
@@ -10956,10 +10956,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitTypeExpression(BoundTypeExpression node)
         {
+            AliasSymbol? aliasOpt = this.VisitAliasSymbol(node.AliasOpt);
             BoundTypeExpression? boundContainingTypeOpt = (BoundTypeExpression?)this.Visit(node.BoundContainingTypeOpt);
             ImmutableArray<BoundExpression> boundDimensionsOpt = this.VisitList(node.BoundDimensionsOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            AliasSymbol? aliasOpt = this.VisitAliasSymbol(node.AliasOpt);
             return node.Update(aliasOpt, boundContainingTypeOpt, boundDimensionsOpt, node.TypeWithAnnotations, type);
         }
         public override BoundNode? VisitTypeOrValueExpression(BoundTypeOrValueExpression node)
@@ -10969,22 +10969,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitNamespaceExpression(BoundNamespaceExpression node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             NamespaceSymbol namespaceSymbol = this.VisitNamespaceSymbol(node.NamespaceSymbol);
             AliasSymbol? aliasOpt = this.VisitAliasSymbol(node.AliasOpt);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(namespaceSymbol, aliasOpt);
         }
         public override BoundNode? VisitUnaryOperator(BoundUnaryOperator node)
         {
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
-            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
             return node.Update(node.OperatorKind, operand, node.ConstantValueOpt, methodOpt, constrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt, type);
         }
         public override BoundNode? VisitIncrementOperator(BoundIncrementOperator node)
         {
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundValuePlaceholder? operandPlaceholder = node.OperandPlaceholder;
             BoundExpression? operandConversion = node.OperandConversion;
@@ -10992,8 +10994,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? resultConversion = node.ResultConversion;
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
-            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
             return node.Update(node.OperatorKind, operand, methodOpt, constrainedToTypeOpt, operandPlaceholder, operandConversion, resultPlaceholder, resultConversion, node.ResultKind, originalUserDefinedOperatorsOpt, type);
         }
         public override BoundNode? VisitAddressOfOperator(BoundAddressOfOperator node)
@@ -11010,9 +11010,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitFunctionPointerLoad(BoundFunctionPointerLoad node)
         {
+            MethodSymbol targetMethod = this.VisitMethodSymbol(node.TargetMethod);
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol targetMethod = this.VisitMethodSymbol(node.TargetMethod);
             return node.Update(targetMethod, constrainedToTypeOpt, type);
         }
         public override BoundNode? VisitPointerIndirectionOperator(BoundPointerIndirectionOperator node)
@@ -11037,9 +11037,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitRefTypeOperator(BoundRefTypeOperator node)
         {
+            MethodSymbol? getTypeFromHandle = this.VisitMethodSymbol(node.GetTypeFromHandle);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? getTypeFromHandle = this.VisitMethodSymbol(node.GetTypeFromHandle);
             return node.Update(operand, getTypeFromHandle, type);
         }
         public override BoundNode? VisitMakeRefOperator(BoundMakeRefOperator node)
@@ -11056,17 +11056,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitFromEndIndexExpression(BoundFromEndIndexExpression node)
         {
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
             return node.Update(operand, methodOpt, type);
         }
         public override BoundNode? VisitRangeExpression(BoundRangeExpression node)
         {
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
             BoundExpression? leftOperandOpt = (BoundExpression?)this.Visit(node.LeftOperandOpt);
             BoundExpression? rightOperandOpt = (BoundExpression?)this.Visit(node.RightOperandOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
             return node.Update(leftOperandOpt, rightOperandOpt, methodOpt, type);
         }
         public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
@@ -11085,18 +11085,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
         {
-            BoundExpression left = (BoundExpression)this.Visit(node.Left);
-            BoundExpression right = (BoundExpression)this.Visit(node.Right);
-            TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
-            TypeSymbol? type = this.VisitType(node.Type);
             MethodSymbol logicalOperator = this.VisitMethodSymbol(node.LogicalOperator);
             MethodSymbol trueOperator = this.VisitMethodSymbol(node.TrueOperator);
             MethodSymbol falseOperator = this.VisitMethodSymbol(node.FalseOperator);
             ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
+            BoundExpression left = (BoundExpression)this.Visit(node.Left);
+            BoundExpression right = (BoundExpression)this.Visit(node.Right);
+            TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(node.OperatorKind, logicalOperator, trueOperator, falseOperator, constrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt, left, right, type);
         }
         public override BoundNode? VisitCompoundAssignmentOperator(BoundCompoundAssignmentOperator node)
         {
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
             BoundExpression left = (BoundExpression)this.Visit(node.Left);
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundValuePlaceholder? leftPlaceholder = node.LeftPlaceholder;
@@ -11104,7 +11105,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundValuePlaceholder? finalPlaceholder = node.FinalPlaceholder;
             BoundExpression? finalConversion = node.FinalConversion;
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
             return node.Update(node.Operator, left, right, leftPlaceholder, leftConversion, finalPlaceholder, finalConversion, node.ResultKind, originalUserDefinedOperatorsOpt, type);
         }
         public override BoundNode? VisitAssignmentOperator(BoundAssignmentOperator node)
@@ -11175,10 +11175,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitAwaitableInfo(BoundAwaitableInfo node)
         {
-            BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder = (BoundAwaitableValuePlaceholder?)this.Visit(node.AwaitableInstancePlaceholder);
-            BoundExpression? getAwaiter = (BoundExpression?)this.Visit(node.GetAwaiter);
             PropertySymbol? isCompleted = this.VisitPropertySymbol(node.IsCompleted);
             MethodSymbol? getResult = this.VisitMethodSymbol(node.GetResult);
+            BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder = (BoundAwaitableValuePlaceholder?)this.Visit(node.AwaitableInstancePlaceholder);
+            BoundExpression? getAwaiter = (BoundExpression?)this.Visit(node.GetAwaiter);
             return node.Update(awaitableInstancePlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult);
         }
         public override BoundNode? VisitAwaitExpression(BoundAwaitExpression node)
@@ -11190,9 +11190,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitTypeOfOperator(BoundTypeOfOperator node)
         {
+            MethodSymbol? getTypeFromHandle = this.VisitMethodSymbol(node.GetTypeFromHandle);
             BoundTypeExpression sourceType = (BoundTypeExpression)this.Visit(node.SourceType);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? getTypeFromHandle = this.VisitMethodSymbol(node.GetTypeFromHandle);
             return node.Update(sourceType, getTypeFromHandle, type);
         }
         public override BoundNode? VisitBlockInstrumentation(BoundBlockInstrumentation node)
@@ -11203,22 +11203,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitMethodDefIndex(BoundMethodDefIndex node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             MethodSymbol method = this.VisitMethodSymbol(node.Method);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(method, type);
         }
         public override BoundNode? VisitLocalId(BoundLocalId node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             LocalSymbol local = this.VisitLocalSymbol(node.Local);
             FieldSymbol? hoistedField = this.VisitFieldSymbol(node.HoistedField);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(local, hoistedField, type);
         }
         public override BoundNode? VisitParameterId(BoundParameterId node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             ParameterSymbol parameter = this.VisitParameterSymbol(node.Parameter);
             FieldSymbol? hoistedField = this.VisitFieldSymbol(node.HoistedField);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(parameter, hoistedField, type);
         }
         public override BoundNode? VisitStateMachineInstanceId(BoundStateMachineInstanceId node)
@@ -11263,16 +11263,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitMethodInfo(BoundMethodInfo node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             MethodSymbol method = this.VisitMethodSymbol(node.Method);
             MethodSymbol? getMethodFromHandle = this.VisitMethodSymbol(node.GetMethodFromHandle);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(method, getMethodFromHandle, type);
         }
         public override BoundNode? VisitFieldInfo(BoundFieldInfo node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             FieldSymbol field = this.VisitFieldSymbol(node.Field);
             MethodSymbol? getFieldFromHandle = this.VisitMethodSymbol(node.GetFieldFromHandle);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(field, getFieldFromHandle, type);
         }
         public override BoundNode? VisitDefaultLiteral(BoundDefaultLiteral node)
@@ -11310,16 +11310,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitConversion(BoundConversion node)
         {
+            ImmutableArray<MethodSymbol> originalUserDefinedConversionsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedConversionsOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<MethodSymbol> originalUserDefinedConversionsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedConversionsOpt);
             return node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, originalUserDefinedConversionsOpt, type);
         }
         public override BoundNode? VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
         {
+            MethodSymbol conversionMethod = this.VisitMethodSymbol(node.ConversionMethod);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol conversionMethod = this.VisitMethodSymbol(node.ConversionMethod);
             return node.Update(operand, conversionMethod, type);
         }
         public override BoundNode? VisitArgList(BoundArgList node)
@@ -11335,12 +11335,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitFixedLocalCollectionInitializer(BoundFixedLocalCollectionInitializer node)
         {
+            MethodSymbol? getPinnableOpt = this.VisitMethodSymbol(node.GetPinnableOpt);
             BoundValuePlaceholder? elementPointerPlaceholder = node.ElementPointerPlaceholder;
             BoundExpression? elementPointerConversion = node.ElementPointerConversion;
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             TypeSymbol? elementPointerType = this.VisitType(node.ElementPointerType);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? getPinnableOpt = this.VisitMethodSymbol(node.GetPinnableOpt);
             return node.Update(elementPointerType, elementPointerPlaceholder, elementPointerConversion, expression, getPinnableOpt, type);
         }
         public override BoundNode? VisitSequencePoint(BoundSequencePoint node)
@@ -11358,30 +11358,30 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitStepThroughSequencePoint(BoundStepThroughSequencePoint node) => node;
         public override BoundNode? VisitBlock(BoundBlock node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
+            ImmutableArray<MethodSymbol> localFunctions = this.VisitDeclaredLocalFunctions(node.LocalFunctions);
             BoundBlockInstrumentation? instrumentation = (BoundBlockInstrumentation?)this.Visit(node.Instrumentation);
             ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
-            ImmutableArray<LocalFunctionSymbol> localFunctions = this.VisitSymbols<LocalFunctionSymbol>(node.LocalFunctions);
             return node.Update(locals, localFunctions, node.HasUnsafeModifier, instrumentation, statements);
         }
         public override BoundNode? VisitScope(BoundScope node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, statements);
         }
         public override BoundNode? VisitStateMachineScope(BoundStateMachineScope node)
         {
-            BoundStatement statement = (BoundStatement)this.Visit(node.Statement);
             ImmutableArray<StateMachineFieldSymbol> fields = this.VisitSymbols<StateMachineFieldSymbol>(node.Fields);
+            BoundStatement statement = (BoundStatement)this.Visit(node.Statement);
             return node.Update(fields, statement);
         }
         public override BoundNode? VisitLocalDeclaration(BoundLocalDeclaration node)
         {
+            LocalSymbol localSymbol = this.VisitLocalSymbol(node.LocalSymbol);
             BoundTypeExpression? declaredTypeOpt = (BoundTypeExpression?)this.Visit(node.DeclaredTypeOpt);
             BoundExpression? initializerOpt = (BoundExpression?)this.Visit(node.InitializerOpt);
             ImmutableArray<BoundExpression> argumentsOpt = this.VisitList(node.ArgumentsOpt);
-            LocalSymbol localSymbol = this.VisitLocalSymbol(node.LocalSymbol);
             return node.Update(localSymbol, declaredTypeOpt, initializerOpt, argumentsOpt, node.InferredType);
         }
         public override BoundNode? VisitMultipleLocalDeclarations(BoundMultipleLocalDeclarations node)
@@ -11397,9 +11397,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
+            MethodSymbol symbol = this.VisitMethodSymbol(node.Symbol);
             BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
             BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
-            MethodSymbol symbol = this.VisitMethodSymbol(node.Symbol);
             return node.Update(symbol, blockBody, expressionBody);
         }
         public override BoundNode? VisitNoOpStatement(BoundNoOpStatement node) => node;
@@ -11424,23 +11424,31 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             return node.Update(expression);
         }
-        public override BoundNode? VisitBreakStatement(BoundBreakStatement node) => node;
-        public override BoundNode? VisitContinueStatement(BoundContinueStatement node) => node;
+        public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
+        {
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label);
+        }
+        public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
+        {
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label);
+        }
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
+            ImmutableArray<LocalSymbol> innerLocals = this.VisitLocals(node.InnerLocals);
+            ImmutableArray<MethodSymbol> innerLocalFunctions = this.VisitDeclaredLocalFunctions(node.InnerLocalFunctions);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundSwitchSection> switchSections = this.VisitList(node.SwitchSections);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             BoundSwitchLabel? defaultLabel = (BoundSwitchLabel?)this.Visit(node.DefaultLabel);
-            ImmutableArray<LocalSymbol> innerLocals = this.VisitSymbols<LocalSymbol>(node.InnerLocals);
-            ImmutableArray<LocalFunctionSymbol> innerLocalFunctions = this.VisitSymbols<LocalFunctionSymbol>(node.InnerLocalFunctions);
-            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
             return node.Update(expression, innerLocals, innerLocalFunctions, switchSections, reachabilityDecisionDag, defaultLabel, breakLabel);
         }
         public override BoundNode? VisitSwitchDispatch(BoundSwitchDispatch node)
         {
-            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             LabelSymbol defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
+            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             return node.Update(expression, node.Cases, defaultLabel, node.LengthBasedStringSwitchDataOpt);
         }
         public override BoundNode? VisitIfStatement(BoundIfStatement node)
@@ -11452,36 +11460,39 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDoStatement(BoundDoStatement node)
         {
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
             LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
+            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
             return node.Update(locals, condition, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitWhileStatement(BoundWhileStatement node)
         {
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
             LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
+            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
             return node.Update(locals, condition, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitForStatement(BoundForStatement node)
         {
+            ImmutableArray<LocalSymbol> outerLocals = this.VisitLocals(node.OuterLocals);
+            ImmutableArray<LocalSymbol> innerLocals = this.VisitLocals(node.InnerLocals);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
+            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
             BoundStatement? initializer = (BoundStatement?)this.Visit(node.Initializer);
             BoundExpression? condition = (BoundExpression?)this.Visit(node.Condition);
             BoundStatement? increment = (BoundStatement?)this.Visit(node.Increment);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            ImmutableArray<LocalSymbol> outerLocals = this.VisitSymbols<LocalSymbol>(node.OuterLocals);
-            ImmutableArray<LocalSymbol> innerLocals = this.VisitSymbols<LocalSymbol>(node.InnerLocals);
-            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
-            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
             return node.Update(outerLocals, initializer, innerLocals, condition, increment, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitForEachStatement(BoundForEachStatement node)
         {
+            ImmutableArray<LocalSymbol> iterationVariables = this.VisitLocals(node.IterationVariables);
+            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
+            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
             BoundValuePlaceholder? elementPlaceholder = node.ElementPlaceholder;
             BoundExpression? elementConversion = node.ElementConversion;
             BoundTypeExpression iterationVariableType = (BoundTypeExpression)this.Visit(node.IterationVariableType);
@@ -11490,9 +11501,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundForEachDeconstructStep? deconstructionOpt = (BoundForEachDeconstructStep?)this.Visit(node.DeconstructionOpt);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            ImmutableArray<LocalSymbol> iterationVariables = this.VisitSymbols<LocalSymbol>(node.IterationVariables);
-            LabelSymbol breakLabel = this.VisitLabelSymbol(node.BreakLabel);
-            LabelSymbol continueLabel = this.VisitLabelSymbol(node.ContinueLabel);
             return node.Update(node.EnumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, breakLabel, continueLabel);
         }
         public override BoundNode? VisitForEachDeconstructStep(BoundForEachDeconstructStep node)
@@ -11503,18 +11511,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitUsingStatement(BoundUsingStatement node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             BoundMultipleLocalDeclarations? declarationsOpt = (BoundMultipleLocalDeclarations?)this.Visit(node.DeclarationsOpt);
             BoundExpression? expressionOpt = (BoundExpression?)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, declarationsOpt, expressionOpt, body, awaitOpt, node.PatternDisposeInfoOpt);
         }
         public override BoundNode? VisitFixedStatement(BoundFixedStatement node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             BoundMultipleLocalDeclarations declarations = (BoundMultipleLocalDeclarations)this.Visit(node.Declarations);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, declarations, body);
         }
         public override BoundNode? VisitLockStatement(BoundLockStatement node)
@@ -11525,20 +11533,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitTryStatement(BoundTryStatement node)
         {
+            LabelSymbol? finallyLabelOpt = this.VisitLabelSymbol(node.FinallyLabelOpt);
             BoundBlock tryBlock = (BoundBlock)this.Visit(node.TryBlock);
             ImmutableArray<BoundCatchBlock> catchBlocks = this.VisitList(node.CatchBlocks);
             BoundBlock? finallyBlockOpt = (BoundBlock?)this.Visit(node.FinallyBlockOpt);
-            LabelSymbol? finallyLabelOpt = this.VisitLabelSymbol(node.FinallyLabelOpt);
             return node.Update(tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, node.PreferFaultHandler);
         }
         public override BoundNode? VisitCatchBlock(BoundCatchBlock node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             BoundExpression? exceptionSourceOpt = (BoundExpression?)this.Visit(node.ExceptionSourceOpt);
             BoundStatementList? exceptionFilterPrologueOpt = (BoundStatementList?)this.Visit(node.ExceptionFilterPrologueOpt);
             BoundExpression? exceptionFilterOpt = (BoundExpression?)this.Visit(node.ExceptionFilterOpt);
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             TypeSymbol? exceptionTypeOpt = this.VisitType(node.ExceptionTypeOpt);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, exceptionSourceOpt, exceptionTypeOpt, exceptionFilterPrologueOpt, exceptionFilterOpt, body, node.IsSynthesizedAsyncCatchAll);
         }
         public override BoundNode? VisitLiteral(BoundLiteral node)
@@ -11573,47 +11581,51 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitLocal(BoundLocal node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             LocalSymbol localSymbol = this.VisitLocalSymbol(node.LocalSymbol);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(localSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type);
         }
         public override BoundNode? VisitPseudoVariable(BoundPseudoVariable node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             LocalSymbol localSymbol = this.VisitLocalSymbol(node.LocalSymbol);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(localSymbol, node.EmitExpressions, type);
         }
         public override BoundNode? VisitRangeVariable(BoundRangeVariable node)
         {
+            RangeVariableSymbol rangeVariableSymbol = this.VisitRangeVariableSymbol(node.RangeVariableSymbol);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol? type = this.VisitType(node.Type);
-            RangeVariableSymbol rangeVariableSymbol = this.VisitRangeVariableSymbol(node.RangeVariableSymbol);
             return node.Update(rangeVariableSymbol, value, type);
         }
         public override BoundNode? VisitParameter(BoundParameter node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             ParameterSymbol parameterSymbol = this.VisitParameterSymbol(node.ParameterSymbol);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(parameterSymbol, type);
         }
-        public override BoundNode? VisitLabelStatement(BoundLabelStatement node) => node;
+        public override BoundNode? VisitLabelStatement(BoundLabelStatement node)
+        {
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label);
+        }
         public override BoundNode? VisitGotoStatement(BoundGotoStatement node)
         {
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
             BoundExpression? caseExpressionOpt = (BoundExpression?)this.Visit(node.CaseExpressionOpt);
             BoundLabel? labelExpressionOpt = (BoundLabel?)this.Visit(node.LabelExpressionOpt);
-            LabelSymbol label = this.VisitLabelSymbol(node.Label);
             return node.Update(label, caseExpressionOpt, labelExpressionOpt);
         }
         public override BoundNode? VisitLabeledStatement(BoundLabeledStatement node)
         {
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
             return node.Update(label, body);
         }
         public override BoundNode? VisitLabel(BoundLabel node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(label, type);
         }
         public override BoundNode? VisitStatementList(BoundStatementList node)
@@ -11623,36 +11635,36 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitConditionalGoto(BoundConditionalGoto node)
         {
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
             return node.Update(condition, node.JumpIfTrue, label);
         }
         public override BoundNode? VisitSwitchExpressionArm(BoundSwitchExpressionArm node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundExpression? whenClause = (BoundExpression?)this.Visit(node.WhenClause);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
-            LabelSymbol label = this.VisitLabelSymbol(node.Label);
             return node.Update(locals, pattern, whenClause, value, label);
         }
         public override BoundNode? VisitUnconvertedSwitchExpression(BoundUnconvertedSwitchExpression node)
         {
+            LabelSymbol? defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundSwitchExpressionArm> switchArms = this.VisitList(node.SwitchArms);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? type = this.VisitType(node.Type);
-            LabelSymbol? defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
             return node.Update(expression, switchArms, reachabilityDecisionDag, defaultLabel, node.ReportedNotExhaustive, type);
         }
         public override BoundNode? VisitConvertedSwitchExpression(BoundConvertedSwitchExpression node)
         {
+            LabelSymbol? defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundSwitchExpressionArm> switchArms = this.VisitList(node.SwitchArms);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? naturalTypeOpt = this.VisitType(node.NaturalTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            LabelSymbol? defaultLabel = this.VisitLabelSymbol(node.DefaultLabel);
             return node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, defaultLabel, node.ReportedNotExhaustive, type);
         }
         public override BoundNode? VisitDecisionDag(BoundDecisionDag node)
@@ -11680,7 +11692,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDecisionDagNode? whenFalse = (BoundDecisionDagNode?)this.Visit(node.WhenFalse);
             return node.Update(node.Bindings, whenExpression, whenTrue, whenFalse);
         }
-        public override BoundNode? VisitLeafDecisionDagNode(BoundLeafDecisionDagNode node) => node;
+        public override BoundNode? VisitLeafDecisionDagNode(BoundLeafDecisionDagNode node)
+        {
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
+            return node.Update(label);
+        }
         public override BoundNode? VisitDagTemp(BoundDagTemp node)
         {
             BoundDagEvaluation? source = (BoundDagEvaluation?)this.Visit(node.Source);
@@ -11715,8 +11731,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
         {
-            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             MethodSymbol deconstructMethod = this.VisitMethodSymbol(node.DeconstructMethod);
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             return node.Update(deconstructMethod, input);
         }
         public override BoundNode? VisitDagTypeEvaluation(BoundDagTypeEvaluation node)
@@ -11727,20 +11743,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
         {
-            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             FieldSymbol field = this.VisitFieldSymbol(node.Field);
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             return node.Update(field, input);
         }
         public override BoundNode? VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
         {
-            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             PropertySymbol property = this.VisitPropertySymbol(node.Property);
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             return node.Update(property, node.IsLengthOrCount, input);
         }
         public override BoundNode? VisitDagIndexEvaluation(BoundDagIndexEvaluation node)
         {
-            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             PropertySymbol property = this.VisitPropertySymbol(node.Property);
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             return node.Update(property, node.Index, input);
         }
         public override BoundNode? VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node)
@@ -11771,16 +11787,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitSwitchSection(BoundSwitchSection node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             ImmutableArray<BoundSwitchLabel> switchLabels = this.VisitList(node.SwitchLabels);
             ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, switchLabels, statements);
         }
         public override BoundNode? VisitSwitchLabel(BoundSwitchLabel node)
         {
+            LabelSymbol label = this.VisitLabelSymbol(node.Label);
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundExpression? whenClause = (BoundExpression?)this.Visit(node.WhenClause);
-            LabelSymbol label = this.VisitLabelSymbol(node.Label);
             return node.Update(label, pattern, whenClause);
         }
         public override BoundNode? VisitSequencePointExpression(BoundSequencePointExpression node)
@@ -11791,18 +11807,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitSequence(BoundSequence node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             ImmutableArray<BoundExpression> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, sideEffects, value, type);
         }
         public override BoundNode? VisitSpillSequence(BoundSpillSequence node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             ImmutableArray<BoundStatement> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, sideEffects, value, type);
         }
         public override BoundNode? VisitDynamicMemberAccess(BoundDynamicMemberAccess node)
@@ -11813,10 +11829,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDynamicInvocation(BoundDynamicInvocation node)
         {
+            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
             return node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableMethods, expression, arguments, type);
         }
         public override BoundNode? VisitConditionalAccess(BoundConditionalAccess node)
@@ -11828,11 +11844,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
         {
+            MethodSymbol? hasValueMethodOpt = this.VisitMethodSymbol(node.HasValueMethodOpt);
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundExpression whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
             BoundExpression? whenNullOpt = (BoundExpression?)this.Visit(node.WhenNullOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? hasValueMethodOpt = this.VisitMethodSymbol(node.HasValueMethodOpt);
             return node.Update(receiver, hasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, node.ForceCopyOfNullableValueType, type);
         }
         public override BoundNode? VisitConditionalReceiver(BoundConditionalReceiver node)
@@ -11849,43 +11865,43 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitMethodGroup(BoundMethodGroup node)
         {
-            BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
-            TypeSymbol? type = this.VisitType(node.Type);
             ImmutableArray<MethodSymbol> methods = this.VisitSymbols<MethodSymbol>(node.Methods);
             Symbol? lookupSymbolOpt = this.VisitSymbol(node.LookupSymbolOpt);
             FunctionTypeSymbol? functionType = this.VisitFunctionTypeSymbol(node.FunctionType);
+            BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(node.TypeArgumentsOpt, node.Name, methods, lookupSymbolOpt, node.LookupError, node.Flags, functionType, receiverOpt, node.ResultKind);
         }
         public override BoundNode? VisitPropertyGroup(BoundPropertyGroup node)
         {
+            ImmutableArray<PropertySymbol> properties = this.VisitSymbols<PropertySymbol>(node.Properties);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<PropertySymbol> properties = this.VisitSymbols<PropertySymbol>(node.Properties);
             return node.Update(properties, receiverOpt, node.ResultKind);
         }
         public override BoundNode? VisitCall(BoundCall node)
         {
+            MethodSymbol method = this.VisitMethodSymbol(node.Method);
+            ImmutableArray<MethodSymbol> originalMethodsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalMethodsOpt);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol method = this.VisitMethodSymbol(node.Method);
-            ImmutableArray<MethodSymbol> originalMethodsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalMethodsOpt);
             return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, originalMethodsOpt, type);
         }
         public override BoundNode? VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
+            EventSymbol @event = this.VisitEventSymbol(node.Event);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             TypeSymbol? type = this.VisitType(node.Type);
-            EventSymbol @event = this.VisitEventSymbol(node.Event);
             return node.Update(@event, node.IsAddition, node.IsDynamic, receiverOpt, argument, type);
         }
         public override BoundNode? VisitAttribute(BoundAttribute node)
         {
+            MethodSymbol? constructor = this.VisitMethodSymbol(node.Constructor);
             ImmutableArray<BoundExpression> constructorArguments = this.VisitList(node.ConstructorArguments);
             ImmutableArray<BoundAssignmentOperator> namedArguments = this.VisitList(node.NamedArguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? constructor = this.VisitMethodSymbol(node.Constructor);
             return node.Update(constructor, constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, node.ConstructorDefaultArguments, namedArguments, node.ResultKind, type);
         }
         public override BoundNode? VisitUnconvertedObjectCreationExpression(BoundUnconvertedObjectCreationExpression node)
@@ -11896,11 +11912,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitObjectCreationExpression(BoundObjectCreationExpression node)
         {
+            MethodSymbol constructor = this.VisitMethodSymbol(node.Constructor);
+            ImmutableArray<MethodSymbol> constructorsGroup = this.VisitSymbols<MethodSymbol>(node.ConstructorsGroup);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase? initializerExpressionOpt = (BoundObjectInitializerExpressionBase?)this.Visit(node.InitializerExpressionOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol constructor = this.VisitMethodSymbol(node.Constructor);
-            ImmutableArray<MethodSymbol> constructorsGroup = this.VisitSymbols<MethodSymbol>(node.ConstructorsGroup);
             return node.Update(constructor, constructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ConstantValueOpt, initializerExpressionOpt, node.WasTargetTyped, type);
         }
         public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
@@ -11911,6 +11927,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
+            MethodSymbol? collectionBuilderMethod = this.VisitMethodSymbol(node.CollectionBuilderMethod);
             BoundObjectOrCollectionValuePlaceholder? placeholder = node.Placeholder;
             BoundExpression? collectionCreation = node.CollectionCreation;
             BoundValuePlaceholder? collectionBuilderInvocationPlaceholder = node.CollectionBuilderInvocationPlaceholder;
@@ -11918,7 +11935,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundUnconvertedCollectionExpression unconvertedCollectionExpression = node.UnconvertedCollectionExpression;
             ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? collectionBuilderMethod = this.VisitMethodSymbol(node.CollectionBuilderMethod);
             return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderInvocationPlaceholder, collectionBuilderInvocationConversion, node.WasTargetTyped, unconvertedCollectionExpression, elements, type);
         }
         public override BoundNode? VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node)
@@ -11951,10 +11967,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)
         {
+            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase? initializerExpressionOpt = (BoundObjectInitializerExpressionBase?)this.Visit(node.InitializerExpressionOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
             return node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, applicableMethods, node.WasTargetTyped, type);
         }
         public override BoundNode? VisitNoPiaObjectCreationExpression(BoundNoPiaObjectCreationExpression node)
@@ -11972,10 +11988,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitObjectInitializerMember(BoundObjectInitializerMember node)
         {
+            Symbol? memberSymbol = this.VisitSymbol(node.MemberSymbol);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? receiverType = this.VisitType(node.ReceiverType);
             TypeSymbol? type = this.VisitType(node.Type);
-            Symbol? memberSymbol = this.VisitSymbol(node.MemberSymbol);
             return node.Update(memberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, node.AccessorKind, receiverType, type);
         }
         public override BoundNode? VisitDynamicObjectInitializerMember(BoundDynamicObjectInitializerMember node)
@@ -11993,18 +12009,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitCollectionElementInitializer(BoundCollectionElementInitializer node)
         {
+            MethodSymbol addMethod = this.VisitMethodSymbol(node.AddMethod);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundExpression? implicitReceiverOpt = (BoundExpression?)this.Visit(node.ImplicitReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol addMethod = this.VisitMethodSymbol(node.AddMethod);
             return node.Update(addMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.InvokedAsExtensionMethod, node.ResultKind, type);
         }
         public override BoundNode? VisitDynamicCollectionElementInitializer(BoundDynamicCollectionElementInitializer node)
         {
+            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<MethodSymbol> applicableMethods = this.VisitSymbols<MethodSymbol>(node.ApplicableMethods);
             return node.Update(applicableMethods, expression, arguments, type);
         }
         public override BoundNode? VisitImplicitReceiver(BoundImplicitReceiver node)
@@ -12014,16 +12030,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitAnonymousObjectCreationExpression(BoundAnonymousObjectCreationExpression node)
         {
+            MethodSymbol constructor = this.VisitMethodSymbol(node.Constructor);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = this.VisitList(node.Declarations);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol constructor = this.VisitMethodSymbol(node.Constructor);
             return node.Update(constructor, arguments, declarations, type);
         }
         public override BoundNode? VisitAnonymousPropertyDeclaration(BoundAnonymousPropertyDeclaration node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             PropertySymbol property = this.VisitPropertySymbol(node.Property);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(property, type);
         }
         public override BoundNode? VisitNewT(BoundNewT node)
@@ -12034,9 +12050,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
         {
+            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? methodOpt = this.VisitMethodSymbol(node.MethodOpt);
             return node.Update(argument, methodOpt, node.IsExtensionMethod, node.WasTargetTyped, type);
         }
         public override BoundNode? VisitArrayCreation(BoundArrayCreation node)
@@ -12070,38 +12086,38 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitFieldAccess(BoundFieldAccess node)
         {
+            FieldSymbol fieldSymbol = this.VisitFieldSymbol(node.FieldSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            FieldSymbol fieldSymbol = this.VisitFieldSymbol(node.FieldSymbol);
             return node.Update(receiverOpt, fieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, type);
         }
         public override BoundNode? VisitHoistedFieldAccess(BoundHoistedFieldAccess node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             FieldSymbol fieldSymbol = this.VisitFieldSymbol(node.FieldSymbol);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(fieldSymbol, type);
         }
         public override BoundNode? VisitPropertyAccess(BoundPropertyAccess node)
         {
+            PropertySymbol propertySymbol = this.VisitPropertySymbol(node.PropertySymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            PropertySymbol propertySymbol = this.VisitPropertySymbol(node.PropertySymbol);
             return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, propertySymbol, node.AutoPropertyAccessorKind, node.ResultKind, type);
         }
         public override BoundNode? VisitEventAccess(BoundEventAccess node)
         {
+            EventSymbol eventSymbol = this.VisitEventSymbol(node.EventSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            EventSymbol eventSymbol = this.VisitEventSymbol(node.EventSymbol);
             return node.Update(receiverOpt, eventSymbol, node.IsUsableAsField, node.ResultKind, type);
         }
         public override BoundNode? VisitIndexerAccess(BoundIndexerAccess node)
         {
+            PropertySymbol indexer = this.VisitPropertySymbol(node.Indexer);
+            ImmutableArray<PropertySymbol> originalIndexersOpt = this.VisitSymbols<PropertySymbol>(node.OriginalIndexersOpt);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            PropertySymbol indexer = this.VisitPropertySymbol(node.Indexer);
-            ImmutableArray<PropertySymbol> originalIndexersOpt = this.VisitSymbols<PropertySymbol>(node.OriginalIndexersOpt);
             return node.Update(receiverOpt, node.InitialBindingReceiverIsSubjectToCloning, indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.AccessorKind, node.ArgsToParamsOpt, node.DefaultArguments, originalIndexersOpt, type);
         }
         public override BoundNode? VisitImplicitIndexerAccess(BoundImplicitIndexerAccess node)
@@ -12124,34 +12140,34 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
         {
+            ImmutableArray<PropertySymbol> applicableIndexers = this.VisitSymbols<PropertySymbol>(node.ApplicableIndexers);
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol? type = this.VisitType(node.Type);
-            ImmutableArray<PropertySymbol> applicableIndexers = this.VisitSymbols<PropertySymbol>(node.ApplicableIndexers);
             return node.Update(receiver, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableIndexers, type);
         }
         public override BoundNode? VisitLambda(BoundLambda node)
         {
+            MethodSymbol symbol = this.VisitMethodSymbol(node.Symbol);
             UnboundLambda unboundLambda = node.UnboundLambda;
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol symbol = this.VisitMethodSymbol(node.Symbol);
             return node.Update(unboundLambda, symbol, body, node.Diagnostics, node.Binder, type);
         }
         public override BoundNode? VisitUnboundLambda(UnboundLambda node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             FunctionTypeSymbol? functionType = this.VisitFunctionTypeSymbol(node.FunctionType);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(node.Data, functionType, node.WithDependencies);
         }
         public override BoundNode? VisitQueryClause(BoundQueryClause node)
         {
+            RangeVariableSymbol? definedSymbol = this.VisitRangeVariableSymbol(node.DefinedSymbol);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundExpression? operation = node.Operation;
             BoundExpression? cast = node.Cast;
             BoundExpression? unoptimizedForm = node.UnoptimizedForm;
             TypeSymbol? type = this.VisitType(node.Type);
-            RangeVariableSymbol? definedSymbol = this.VisitRangeVariableSymbol(node.DefinedSymbol);
             return node.Update(value, definedSymbol, operation, cast, node.Binder, unoptimizedForm, type);
         }
         public override BoundNode? VisitTypeOrInstanceInitializers(BoundTypeOrInstanceInitializers node)
@@ -12197,12 +12213,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitIsPatternExpression(BoundIsPatternExpression node)
         {
+            LabelSymbol whenTrueLabel = this.VisitLabelSymbol(node.WhenTrueLabel);
+            LabelSymbol whenFalseLabel = this.VisitLabelSymbol(node.WhenFalseLabel);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? type = this.VisitType(node.Type);
-            LabelSymbol whenTrueLabel = this.VisitLabelSymbol(node.WhenTrueLabel);
-            LabelSymbol whenFalseLabel = this.VisitLabelSymbol(node.WhenFalseLabel);
             return node.Update(expression, pattern, node.IsNegated, reachabilityDecisionDag, whenTrueLabel, whenFalseLabel, type);
         }
         public override BoundNode? VisitConstantPattern(BoundConstantPattern node)
@@ -12220,27 +12236,28 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitDeclarationPattern(BoundDeclarationPattern node)
         {
+            Symbol? variable = this.VisitSymbol(node.Variable);
             BoundTypeExpression declaredType = (BoundTypeExpression)this.Visit(node.DeclaredType);
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            Symbol? variable = this.VisitSymbol(node.Variable);
             return node.Update(declaredType, node.IsVar, variable, variableAccess, inputType, narrowedType);
         }
         public override BoundNode? VisitRecursivePattern(BoundRecursivePattern node)
         {
+            MethodSymbol? deconstructMethod = this.VisitMethodSymbol(node.DeconstructMethod);
+            Symbol? variable = this.VisitSymbol(node.Variable);
             BoundTypeExpression? declaredType = (BoundTypeExpression?)this.Visit(node.DeclaredType);
             ImmutableArray<BoundPositionalSubpattern> deconstruction = this.VisitList(node.Deconstruction);
             ImmutableArray<BoundPropertySubpattern> properties = this.VisitList(node.Properties);
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            MethodSymbol? deconstructMethod = this.VisitMethodSymbol(node.DeconstructMethod);
-            Symbol? variable = this.VisitSymbol(node.Variable);
             return node.Update(declaredType, deconstructMethod, deconstruction, properties, node.IsExplicitNotNullTest, variable, variableAccess, inputType, narrowedType);
         }
         public override BoundNode? VisitListPattern(BoundListPattern node)
         {
+            Symbol? variable = this.VisitSymbol(node.Variable);
             ImmutableArray<BoundPattern> subpatterns = this.VisitList(node.Subpatterns);
             BoundExpression? lengthAccess = node.LengthAccess;
             BoundExpression? indexerAccess = node.IndexerAccess;
@@ -12249,7 +12266,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            Symbol? variable = this.VisitSymbol(node.Variable);
             return node.Update(subpatterns, node.HasSlice, lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, variable, variableAccess, inputType, narrowedType);
         }
         public override BoundNode? VisitSlicePattern(BoundSlicePattern node)
@@ -12264,17 +12280,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitITuplePattern(BoundITuplePattern node)
         {
+            MethodSymbol getLengthMethod = this.VisitMethodSymbol(node.GetLengthMethod);
+            MethodSymbol getItemMethod = this.VisitMethodSymbol(node.GetItemMethod);
             ImmutableArray<BoundPositionalSubpattern> subpatterns = this.VisitList(node.Subpatterns);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            MethodSymbol getLengthMethod = this.VisitMethodSymbol(node.GetLengthMethod);
-            MethodSymbol getItemMethod = this.VisitMethodSymbol(node.GetItemMethod);
             return node.Update(getLengthMethod, getItemMethod, subpatterns, inputType, narrowedType);
         }
         public override BoundNode? VisitPositionalSubpattern(BoundPositionalSubpattern node)
         {
-            BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             Symbol? symbol = this.VisitSymbol(node.Symbol);
+            BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             return node.Update(symbol, pattern);
         }
         public override BoundNode? VisitPropertySubpattern(BoundPropertySubpattern node)
@@ -12285,9 +12301,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitPropertySubpatternMember(BoundPropertySubpatternMember node)
         {
+            Symbol? symbol = this.VisitSymbol(node.Symbol);
             BoundPropertySubpatternMember? receiver = (BoundPropertySubpatternMember?)this.Visit(node.Receiver);
             TypeSymbol? type = this.VisitType(node.Type);
-            Symbol? symbol = this.VisitSymbol(node.Symbol);
             return node.Update(receiver, symbol, type);
         }
         public override BoundNode? VisitTypePattern(BoundTypePattern node)
@@ -12332,22 +12348,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitOutVariablePendingInference(OutVariablePendingInference node)
         {
+            Symbol variableSymbol = this.VisitSymbol(node.VariableSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            Symbol variableSymbol = this.VisitSymbol(node.VariableSymbol);
             return node.Update(variableSymbol, receiverOpt);
         }
         public override BoundNode? VisitDeconstructionVariablePendingInference(DeconstructionVariablePendingInference node)
         {
+            Symbol variableSymbol = this.VisitSymbol(node.VariableSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            Symbol variableSymbol = this.VisitSymbol(node.VariableSymbol);
             return node.Update(variableSymbol, receiverOpt);
         }
         public override BoundNode? VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
-            TypeSymbol? type = this.VisitType(node.Type);
             Symbol? variableSymbol = this.VisitSymbol(node.VariableSymbol);
+            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(variableSymbol, node.IsDiscardExpression);
         }
         public override BoundNode? VisitNonConstructorMethodBody(BoundNonConstructorMethodBody node)
@@ -12358,10 +12374,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitConstructorMethodBody(BoundConstructorMethodBody node)
         {
+            ImmutableArray<LocalSymbol> locals = this.VisitLocals(node.Locals);
             BoundStatement? initializer = (BoundStatement?)this.Visit(node.Initializer);
             BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
             BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
-            ImmutableArray<LocalSymbol> locals = this.VisitSymbols<LocalSymbol>(node.Locals);
             return node.Update(locals, initializer, blockBody, expressionBody);
         }
         public override BoundNode? VisitExpressionWithNullability(BoundExpressionWithNullability node)
@@ -12372,10 +12388,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitWithExpression(BoundWithExpression node)
         {
+            MethodSymbol? cloneMethod = this.VisitMethodSymbol(node.CloneMethod);
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundObjectInitializerExpressionBase initializerExpression = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpression);
             TypeSymbol? type = this.VisitType(node.Type);
-            MethodSymbol? cloneMethod = this.VisitMethodSymbol(node.CloneMethod);
             return node.Update(receiver, cloneMethod, initializerExpression, type);
         }
     }
@@ -13519,7 +13535,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitBlock(BoundBlock node)
         {
             ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
-            ImmutableArray<LocalFunctionSymbol> localFunctions = GetUpdatedArray(node, node.LocalFunctions);
+            ImmutableArray<MethodSymbol> localFunctions = GetUpdatedArray(node, node.LocalFunctions);
             BoundBlockInstrumentation? instrumentation = (BoundBlockInstrumentation?)this.Visit(node.Instrumentation);
             ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
             return node.Update(locals, localFunctions, node.HasUnsafeModifier, instrumentation, statements);
@@ -13559,7 +13575,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
             ImmutableArray<LocalSymbol> innerLocals = GetUpdatedArray(node, node.InnerLocals);
-            ImmutableArray<LocalFunctionSymbol> innerLocalFunctions = GetUpdatedArray(node, node.InnerLocalFunctions);
+            ImmutableArray<MethodSymbol> innerLocalFunctions = GetUpdatedArray(node, node.InnerLocalFunctions);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundSwitchSection> switchSections = this.VisitList(node.SwitchSections);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;

--- a/src/Compilers/CSharp/Portable/Lowering/BoundTreeToDifferentEnclosingContextRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/BoundTreeToDifferentEnclosingContextRewriter.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// a bound node rewriter that rewrites types properly (which in some cases the automatically-generated
+    /// base class does not).  This is used in the lambda rewriter, the iterator rewriter, and the async rewriter.
+    /// </summary>
+    internal abstract class BoundTreeToDifferentEnclosingContextRewriter : BoundTreeRewriterWithStackGuard
+    {
+        // A mapping from every local variable to its replacement local variable.  Local variables are replaced when
+        // their types change due to being inside of a generic method.  Otherwise we reuse the original local (even
+        // though its containing method is not correct because the code is moved into another method)
+        private readonly Dictionary<LocalSymbol, LocalSymbol> localMap = new Dictionary<LocalSymbol, LocalSymbol>();
+
+        // A mapping for types in the original method to types in its replacement.  This is mainly necessary
+        // when the original method was generic, as type parameters in the original method are mapping into
+        // type parameters of the resulting class.
+        protected abstract TypeMap TypeMap { get; }
+
+        protected abstract MethodSymbol CurrentMethod { get; }
+
+        public override BoundNode DefaultVisit(BoundNode node)
+        {
+            Debug.Fail($"Override the visitor for {node.Kind}");
+            return base.DefaultVisit(node);
+        }
+
+        protected void RewriteLocals(ImmutableArray<LocalSymbol> locals, ArrayBuilder<LocalSymbol> newLocals)
+        {
+            foreach (var local in locals)
+            {
+                if (TryRewriteLocal(local, out LocalSymbol? newLocal))
+                {
+                    newLocals.Add(newLocal);
+                }
+            }
+        }
+
+        protected virtual bool TryRewriteLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? newLocal)
+        {
+            if (localMap.TryGetValue(local, out newLocal))
+            {
+                return true;
+            }
+
+            var newType = VisitType(local.Type);
+            if (TypeSymbol.Equals(newType, local.Type, TypeCompareKind.ConsiderEverything2))
+            {
+                newLocal = local;
+            }
+            else
+            {
+                newLocal = new TypeSubstitutedLocalSymbol(local, TypeWithAnnotations.Create(newType), CurrentMethod);
+                localMap.Add(local, newLocal);
+            }
+
+            return true;
+        }
+
+        protected sealed override ImmutableArray<LocalSymbol> VisitLocals(ImmutableArray<LocalSymbol> locals)
+        {
+            if (locals.IsEmpty) return locals;
+            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
+            RewriteLocals(locals, newLocals);
+            return newLocals.ToImmutableAndFree();
+        }
+
+        protected sealed override LocalSymbol VisitLocalSymbol(LocalSymbol local)
+        {
+            if (!TryRewriteLocal(local, out var newLocal))
+            {
+                throw ExceptionUtilities.UnexpectedValue(local);
+            }
+
+            return newLocal;
+        }
+
+        protected bool TryGetRewrittenLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? localToUse)
+        {
+            return localMap.TryGetValue(local, out localToUse);
+        }
+
+        public override BoundNode VisitBlock(BoundBlock node)
+            => VisitBlock(node, removeInstrumentation: false);
+
+        protected BoundBlock VisitBlock(BoundBlock node, bool removeInstrumentation)
+        {
+            // Note: Instrumentation variable is intentionally not rewritten. It should never be lifted.
+
+            var newLocals = this.VisitLocals(node.Locals);
+            var newLocalFunctions = this.VisitDeclaredLocalFunctions(node.LocalFunctions);
+            var newStatements = VisitList(node.Statements);
+            var newInstrumentation = removeInstrumentation ? null : (BoundBlockInstrumentation?)Visit(node.Instrumentation);
+            return node.Update(newLocals, newLocalFunctions, node.HasUnsafeModifier, newInstrumentation, newStatements);
+        }
+
+        [return: NotNullIfNotNull(nameof(type))]
+        public sealed override TypeSymbol? VisitType(TypeSymbol? type)
+        {
+            return TypeMap.SubstituteType(type).Type;
+        }
+
+        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        {
+            // Local rewriter should have already rewritten interpolated strings into their final form of calls and gotos
+            Debug.Assert(node.InterpolatedStringHandlerData is null);
+
+            return node.Update(
+                node.OperatorKind,
+                node.ConstantValueOpt,
+                VisitMethodSymbol(node.Method),
+                VisitType(node.ConstrainedToType),
+                node.ResultKind,
+                (BoundExpression)Visit(node.Left),
+                (BoundExpression)Visit(node.Right),
+                VisitType(node.Type));
+        }
+
+        public override BoundNode? VisitConversion(BoundConversion node)
+        {
+            var conversion = node.Conversion;
+
+            if (conversion.Method is not null)
+            {
+                conversion = conversion.SetConversionMethod(VisitMethodSymbol(conversion.Method));
+            }
+
+            return node.Update(
+                (BoundExpression)Visit(node.Operand),
+                conversion,
+                node.IsBaseConversion,
+                node.Checked,
+                node.ExplicitCastInCode,
+                node.ConstantValueOpt,
+                node.ConversionGroupOpt,
+                VisitType(node.Type));
+        }
+
+        [return: NotNullIfNotNull(nameof(method))]
+        protected override MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
+        {
+            if (method is null)
+            {
+                return null;
+            }
+
+            if (method.ContainingType.IsAnonymousType)
+            {
+                //  Method of an anonymous type
+                var newType = (NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly();
+                if (ReferenceEquals(newType, method.ContainingType))
+                {
+                    //  Anonymous type symbol was not rewritten
+                    return method;
+                }
+
+                //  get a new method by name
+                foreach (var member in newType.GetMembers(method.Name))
+                {
+                    if (member.Kind == SymbolKind.Method)
+                    {
+                        return (MethodSymbol)member;
+                    }
+                }
+
+                throw ExceptionUtilities.Unreachable();
+            }
+            else
+            {
+                //  Method of a regular type
+                return ((MethodSymbol)method.OriginalDefinition)
+                    .AsMember((NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly())
+                    .ConstructIfGeneric(TypeMap.SubstituteTypes(method.TypeArgumentsWithAnnotations));
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
@@ -768,7 +768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         LocalSymbol localToUse;
-                        if (!localMap.TryGetValue(local, out localToUse))
+                        if (!TryGetRewrittenLocal(local, out localToUse))
                         {
                             localToUse = local;
                         }
@@ -1198,17 +1198,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitScope(BoundScope node)
         {
             Debug.Assert(!node.Locals.IsEmpty);
-            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
-            RewriteLocals(node.Locals, newLocals);
+            var newLocals = VisitLocals(node.Locals);
 
             var statements = VisitList(node.Statements);
-            if (newLocals.Count == 0)
+            if (newLocals.Length == 0)
             {
-                newLocals.Free();
                 return new BoundStatementList(node.Syntax, statements);
             }
 
-            return node.Update(newLocals.ToImmutableAndFree(), statements);
+            return node.Update(newLocals, statements);
         }
 
         public override BoundNode VisitCatchBlock(BoundCatchBlock node)

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var outerLocalFunction = _staticLocalOrAnonymousFunction;
             if (node.Symbol.IsStatic)
             {
-                _staticLocalOrAnonymousFunction = node.Symbol;
+                _staticLocalOrAnonymousFunction = (SourceMethodSymbol)node.Symbol;
             }
             var result = base.VisitLocalFunctionStatement(node);
             _staticLocalOrAnonymousFunction = outerLocalFunction;
@@ -639,7 +639,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var outerLocalFunction = _staticLocalOrAnonymousFunction;
             if (node.Symbol.IsStatic)
             {
-                _staticLocalOrAnonymousFunction = node.Symbol;
+                _staticLocalOrAnonymousFunction = (SourceMethodSymbol)node.Symbol;
             }
             var result = base.VisitLambda(node);
             _staticLocalOrAnonymousFunction = outerLocalFunction;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                static bool hasReturnTypeOrParameter(LocalFunctionSymbol localFunction, Func<TypeWithAnnotations, bool> predicate) =>
+                static bool hasReturnTypeOrParameter(MethodSymbol localFunction, Func<TypeWithAnnotations, bool> predicate) =>
                     predicate(localFunction.ReturnTypeWithAnnotations) || localFunction.ParameterTypesWithAnnotations.Any(predicate);
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -141,8 +141,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<LocalSymbol> iterationVariables,
             BoundForEachDeconstructStep? deconstruction,
             BoundAwaitableInfo? awaitableInfo,
-            GeneratedLabelSymbol breakLabel,
-            GeneratedLabelSymbol continueLabel,
+            LabelSymbol breakLabel,
+            LabelSymbol continueLabel,
             BoundStatement rewrittenBody)
         {
             var forEachSyntax = (CSharpSyntaxNode)node.Syntax;
@@ -898,8 +898,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? elementConversion,
             ImmutableArray<LocalSymbol> iterationVariables,
             BoundForEachDeconstructStep? deconstruction,
-            GeneratedLabelSymbol breakLabel,
-            GeneratedLabelSymbol continueLabel,
+            LabelSymbol breakLabel,
+            LabelSymbol continueLabel,
             BoundStatement rewrittenBody)
         {
             Debug.Assert(collectionExpression.Type is { TypeKind: TypeKind.Array });
@@ -1047,8 +1047,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? elementConversion,
             ImmutableArray<LocalSymbol> iterationVariables,
             BoundForEachDeconstructStep? deconstruction,
-            GeneratedLabelSymbol breakLabel,
-            GeneratedLabelSymbol continueLabel,
+            LabelSymbol breakLabel,
+            LabelSymbol continueLabel,
             BoundStatement rewrittenBody)
         {
             Debug.Assert(collectionExpression.Type is { TypeKind: TypeKind.Array });
@@ -1158,7 +1158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // int p_dimension = a.GetLowerBound(dimension);
                 BoundStatement positionVarDecl = MakeLocalDeclaration(forEachSyntax, positionVar[dimension], currentDimensionLowerBound);
 
-                GeneratedLabelSymbol breakLabelInner = dimension == 0 // outermost for-loop
+                LabelSymbol breakLabelInner = dimension == 0 // outermost for-loop
                     ? breakLabel // i.e. the one that break statements will jump to
                     : new GeneratedLabelSymbol("break"); // Should not affect emitted code since unused
 
@@ -1178,7 +1178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundStatement positionIncrement = MakePositionIncrement(forEachSyntax, boundPositionVar[dimension], intType);
 
                 BoundStatement body;
-                GeneratedLabelSymbol continueLabelInner;
+                LabelSymbol continueLabelInner;
 
                 if (forLoop == null)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -602,8 +602,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? elementConversion,
             ImmutableArray<LocalSymbol> iterationVariables,
             BoundForEachDeconstructStep? deconstructionOpt,
-            GeneratedLabelSymbol breakLabel,
-            GeneratedLabelSymbol continueLabel,
+            LabelSymbol breakLabel,
+            LabelSymbol continueLabel,
             BoundStatement rewrittenBody)
         {
             NamedTypeSymbol? collectionType = (NamedTypeSymbol?)collectionExpression.Type;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForStatement.cs
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? rewrittenCondition,
             BoundStatement? rewrittenIncrement,
             BoundStatement rewrittenBody,
-            GeneratedLabelSymbol breakLabel,
-            GeneratedLabelSymbol continueLabel,
+            LabelSymbol breakLabel,
+            LabelSymbol continueLabel,
             bool hasErrors)
         {
             Debug.Assert(original.Kind is BoundKind.ForStatement or BoundKind.ForEachStatement or BoundKind.CollectionExpressionSpreadElement);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_WhileStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_WhileStatement.cs
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode loop,
             BoundExpression rewrittenCondition,
             BoundStatement rewrittenBody,
-            GeneratedLabelSymbol breakLabel,
-            GeneratedLabelSymbol continueLabel,
+            LabelSymbol breakLabel,
+            LabelSymbol continueLabel,
             bool hasErrors)
         {
             Debug.Assert(loop.Kind is BoundKind.WhileStatement or BoundKind.ForEachStatement or BoundKind.CollectionExpressionSpreadElement);
@@ -108,8 +108,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<LocalSymbol> locals,
             BoundExpression rewrittenCondition,
             BoundStatement rewrittenBody,
-            GeneratedLabelSymbol breakLabel,
-            GeneratedLabelSymbol continueLabel,
+            LabelSymbol breakLabel,
+            LabelSymbol continueLabel,
             bool hasErrors)
         {
             if (locals.IsEmpty)

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -613,7 +613,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         [return: NotNullIfNotNull(nameof(method))]
-        protected MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
+        protected new MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
         {
             if (method is null)
             {
@@ -651,7 +651,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         [return: NotNullIfNotNull(nameof(property))]
-        private PropertySymbol? VisitPropertySymbol(PropertySymbol? property)
+        private new PropertySymbol? VisitPropertySymbol(PropertySymbol? property)
         {
             if (property is null)
             {
@@ -685,7 +685,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable();
         }
 
-        private FieldSymbol VisitFieldSymbol(FieldSymbol field)
+        private new FieldSymbol VisitFieldSymbol(FieldSymbol field)
         {
             //  Property of a regular type
             return ((FieldSymbol)field.OriginalDefinition)

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -13,11 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    /// <summary>
-    /// a bound node rewriter that rewrites types properly (which in some cases the automatically-generated
-    /// base class does not).  This is used in the lambda rewriter, the iterator rewriter, and the async rewriter.
-    /// </summary>
-    internal abstract partial class MethodToClassRewriter : BoundTreeRewriterWithStackGuard
+    internal abstract partial class MethodToClassRewriter : BoundTreeToDifferentEnclosingContextRewriter
     {
         // For each captured variable, information about its replacement.  May be populated lazily (that is, not all
         // upfront) by subclasses.  Specifically, the async rewriter produces captured symbols for temps, including
@@ -27,20 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // created in the first pass.
         protected Dictionary<Symbol, CapturedSymbolReplacement> proxies = new Dictionary<Symbol, CapturedSymbolReplacement>();
 
-        // A mapping from every local variable to its replacement local variable.  Local variables are replaced when
-        // their types change due to being inside of a generic method.  Otherwise we reuse the original local (even
-        // though its containing method is not correct because the code is moved into another method)
-        protected readonly Dictionary<LocalSymbol, LocalSymbol> localMap = new Dictionary<LocalSymbol, LocalSymbol>();
-
-        // A mapping for types in the original method to types in its replacement.  This is mainly necessary
-        // when the original method was generic, as type parameters in the original method are mapping into
-        // type parameters of the resulting class.
-        protected abstract TypeMap TypeMap { get; }
-
         // Subclasses override this method to fetch a frame pointer.
         protected abstract BoundExpression FramePointer(SyntaxNode syntax, NamedTypeSymbol frameClass);
-
-        protected abstract MethodSymbol CurrentMethod { get; }
 
         // Containing type for any synthesized members.
         protected abstract NamedTypeSymbol ContainingType { get; }
@@ -65,30 +49,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this._placeholderMap = new Dictionary<BoundValuePlaceholderBase, BoundExpression>();
         }
 
-        public override BoundNode DefaultVisit(BoundNode node)
-        {
-            Debug.Fail($"Override the visitor for {node.Kind}");
-            return base.DefaultVisit(node);
-        }
-
         /// <summary>
         /// Returns true if the specified local/parameter needs to be hoisted to a field.
         /// Variable may be hoisted even if it is not captured, to improve debugging experience.
         /// </summary>
         protected abstract bool NeedsProxy(Symbol localOrParameter);
 
-        protected void RewriteLocals(ImmutableArray<LocalSymbol> locals, ArrayBuilder<LocalSymbol> newLocals)
-        {
-            foreach (var local in locals)
-            {
-                if (TryRewriteLocal(local, out LocalSymbol? newLocal))
-                {
-                    newLocals.Add(newLocal);
-                }
-            }
-        }
-
-        protected bool TryRewriteLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? newLocal)
+        protected sealed override bool TryRewriteLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? newLocal)
         {
             if (NeedsProxy(local))
             {
@@ -97,126 +64,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            if (localMap.TryGetValue(local, out newLocal))
-            {
-                return true;
-            }
-
-            var newType = VisitType(local.Type);
-            if (TypeSymbol.Equals(newType, local.Type, TypeCompareKind.ConsiderEverything2))
-            {
-                newLocal = local;
-            }
-            else
-            {
-                newLocal = new TypeSubstitutedLocalSymbol(local, TypeWithAnnotations.Create(newType), CurrentMethod);
-                localMap.Add(local, newLocal);
-            }
-
-            return true;
-        }
-
-        private ImmutableArray<LocalSymbol> RewriteLocals(ImmutableArray<LocalSymbol> locals)
-        {
-            if (locals.IsEmpty) return locals;
-            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
-            RewriteLocals(locals, newLocals);
-            return newLocals.ToImmutableAndFree();
-        }
-
-        public override BoundNode VisitCatchBlock(BoundCatchBlock node)
-        {
-            if (!node.Locals.IsDefaultOrEmpty)
-            {
-                // Yield/await aren't supported in catch block atm, but we need to rewrite the type 
-                // of the variables owned by the catch block. Note that one of these variables might be a closure frame reference.
-                var newLocals = RewriteLocals(node.Locals);
-
-                return node.Update(
-                    newLocals,
-                    (BoundExpression?)this.Visit(node.ExceptionSourceOpt),
-                    this.VisitType(node.ExceptionTypeOpt),
-                    (BoundStatementList?)this.Visit(node.ExceptionFilterPrologueOpt),
-                    (BoundExpression?)this.Visit(node.ExceptionFilterOpt),
-                    (BoundBlock?)this.Visit(node.Body)!,
-                    node.IsSynthesizedAsyncCatchAll);
-            }
-
-            return base.VisitCatchBlock(node)!;
-        }
-
-        public override BoundNode VisitBlock(BoundBlock node)
-            => VisitBlock(node, removeInstrumentation: false);
-
-        protected BoundBlock VisitBlock(BoundBlock node, bool removeInstrumentation)
-        {
-            // Note: Instrumentation variable is intentionally not rewritten. It should never be lifted.
-
-            var newLocals = RewriteLocals(node.Locals);
-            var newLocalFunctions = node.LocalFunctions;
-            var newStatements = VisitList(node.Statements);
-            var newInstrumentation = removeInstrumentation ? null : (BoundBlockInstrumentation?)Visit(node.Instrumentation);
-            return node.Update(newLocals, newLocalFunctions, node.HasUnsafeModifier, newInstrumentation, newStatements);
+            return base.TryRewriteLocal(local, out newLocal);
         }
 
         public abstract override BoundNode VisitScope(BoundScope node);
 
-        public override BoundNode VisitSequence(BoundSequence node)
-        {
-            var newLocals = RewriteLocals(node.Locals);
-            var newSideEffects = VisitList<BoundExpression>(node.SideEffects);
-            var newValue = (BoundExpression)this.Visit(node.Value);
-            var newType = this.VisitType(node.Type);
-            return node.Update(newLocals, newSideEffects, newValue, newType);
-        }
-
         public override BoundNode VisitForStatement(BoundForStatement node)
         {
-            var newOuterLocals = RewriteLocals(node.OuterLocals);
-            var initializer = (BoundStatement?)this.Visit(node.Initializer);
-            var newInnerLocals = RewriteLocals(node.InnerLocals);
-            var condition = (BoundExpression?)this.Visit(node.Condition);
-            var increment = (BoundStatement?)this.Visit(node.Increment);
-            var body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newOuterLocals, initializer, newInnerLocals, condition, increment, body, node.BreakLabel, node.ContinueLabel);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitDoStatement(BoundDoStatement node)
         {
-            var newLocals = RewriteLocals(node.Locals);
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newLocals, condition, body, node.BreakLabel, node.ContinueLabel);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitWhileStatement(BoundWhileStatement node)
         {
-            var newLocals = RewriteLocals(node.Locals);
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newLocals, condition, body, node.BreakLabel, node.ContinueLabel);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitUsingStatement(BoundUsingStatement node)
         {
-            var newLocals = RewriteLocals(node.Locals);
-            var declarations = (BoundMultipleLocalDeclarations?)this.Visit(node.DeclarationsOpt);
-            var expression = (BoundExpression?)this.Visit(node.ExpressionOpt);
-            var body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newLocals, declarations, expression, body, node.AwaitOpt, node.PatternDisposeInfoOpt);
-        }
-
-        [return: NotNullIfNotNull(nameof(type))]
-        public sealed override TypeSymbol? VisitType(TypeSymbol? type)
-        {
-            return TypeMap.SubstituteType(type).Type;
-        }
-
-        public override BoundNode VisitMethodInfo(BoundMethodInfo node)
-        {
-            var rewrittenMethod = VisitMethodSymbol(node.Method);
-            // No need to rewrite the node's type, because it is always System.Reflection.MethodInfo
-            return node.Update(rewrittenMethod, node.GetMethodFromHandle, node.Type);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)
@@ -261,64 +131,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 node.ResultKind,
                 rewrittenType);
         }
-
-        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
-        {
-            // Local rewriter should have already rewritten interpolated strings into their final form of calls and gotos
-            Debug.Assert(node.InterpolatedStringHandlerData is null);
-
-            return node.Update(
-                node.OperatorKind,
-                node.ConstantValueOpt,
-                VisitMethodSymbol(node.Method),
-                VisitType(node.ConstrainedToType),
-                node.ResultKind,
-                (BoundExpression)Visit(node.Left),
-                (BoundExpression)Visit(node.Right),
-                VisitType(node.Type));
-        }
-
-        public override BoundNode VisitUnaryOperator(BoundUnaryOperator node)
-            => node.Update(
-                node.OperatorKind,
-                (BoundExpression)Visit(node.Operand),
-                node.ConstantValueOpt,
-                VisitMethodSymbol(node.MethodOpt),
-                VisitType(node.ConstrainedToTypeOpt),
-                node.ResultKind,
-                VisitType(node.Type));
-
-        public override BoundNode? VisitConversion(BoundConversion node)
-        {
-            var conversion = node.Conversion;
-
-            if (conversion.Method is not null)
-            {
-                conversion = conversion.SetConversionMethod(VisitMethodSymbol(conversion.Method));
-            }
-
-            return node.Update(
-                (BoundExpression)Visit(node.Operand),
-                conversion,
-                node.IsBaseConversion,
-                node.Checked,
-                node.ExplicitCastInCode,
-                node.ConstantValueOpt,
-                node.ConversionGroupOpt,
-                VisitType(node.Type));
-        }
-
-        public override BoundNode? VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
-            => node.Update(
-                node.OperatorKind,
-                VisitMethodSymbol(node.LogicalOperator),
-                VisitMethodSymbol(node.TrueOperator),
-                VisitMethodSymbol(node.FalseOperator),
-                VisitType(node.ConstrainedToTypeOpt),
-                node.ResultKind,
-                (BoundExpression)Visit(node.Left),
-                (BoundExpression)Visit(node.Right),
-                VisitType(node.Type));
 
         private MethodSymbol GetMethodWrapperForBaseNonVirtualCall(MethodSymbol methodBeingCalled, SyntaxNode syntax)
         {
@@ -411,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // if a local needs a proxy it should have been allocated by its declaration node.
             Debug.Assert(!NeedsProxy(node.LocalSymbol));
 
-            return VisitUnhoistedLocal(node);
+            return base.VisitLocal(node)!;
         }
 
         public override BoundNode? VisitLocalId(BoundLocalId node)
@@ -440,16 +252,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             field = null;
             return false;
-        }
-
-        private BoundNode VisitUnhoistedLocal(BoundLocal node)
-        {
-            if (this.localMap.TryGetValue(node.LocalSymbol, out LocalSymbol? replacementLocal))
-            {
-                return new BoundLocal(node.Syntax, replacementLocal, node.ConstantValueOpt, replacementLocal.Type, node.HasErrors);
-            }
-
-            return base.VisitLocal(node)!;
         }
 
         public override BoundNode VisitAwaitableInfo(BoundAwaitableInfo node)
@@ -558,29 +360,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(receiverOpt, fieldSymbol, node.ConstantValueOpt, node.ResultKind, type);
         }
 
-        public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
-        {
-            var rewritten = (BoundObjectCreationExpression?)base.VisitObjectCreationExpression(node);
-            Debug.Assert(rewritten != null);
-            if (!TypeSymbol.Equals(rewritten.Type, node.Type, TypeCompareKind.ConsiderEverything2) && (object)node.Constructor != null)
-            {
-                MethodSymbol ctor = VisitMethodSymbol(node.Constructor);
-                rewritten = rewritten.Update(
-                    ctor,
-                    rewritten.Arguments,
-                    rewritten.ArgumentNamesOpt,
-                    rewritten.ArgumentRefKindsOpt,
-                    rewritten.Expanded,
-                    rewritten.ArgsToParamsOpt,
-                    rewritten.DefaultArguments,
-                    rewritten.ConstantValueOpt,
-                    rewritten.InitializerExpressionOpt,
-                    rewritten.Type);
-            }
-
-            return rewritten;
-        }
-
         public override BoundNode VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
         {
             BoundExpression originalArgument = node.Argument;
@@ -596,58 +375,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             method = VisitMethodSymbol(method);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(rewrittenArgument, method, node.IsExtensionMethod, node.WasTargetTyped, type);
-        }
-
-        public override BoundNode VisitFunctionPointerLoad(BoundFunctionPointerLoad node)
-        {
-            return node.Update(VisitMethodSymbol(node.TargetMethod), VisitType(node.ConstrainedToTypeOpt), VisitType(node.Type));
-        }
-
-        public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
-        {
-            var receiver = (BoundExpression)this.Visit(node.Receiver);
-            var whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
-            var whenNullOpt = (BoundExpression?)this.Visit(node.WhenNullOpt);
-            TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(receiver, VisitMethodSymbol(node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, node.ForceCopyOfNullableValueType, type);
-        }
-
-        [return: NotNullIfNotNull(nameof(method))]
-        protected new MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
-        {
-            if (method is null)
-            {
-                return null;
-            }
-
-            if (method.ContainingType.IsAnonymousType)
-            {
-                //  Method of an anonymous type
-                var newType = (NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly();
-                if (ReferenceEquals(newType, method.ContainingType))
-                {
-                    //  Anonymous type symbol was not rewritten
-                    return method;
-                }
-
-                //  get a new method by name
-                foreach (var member in newType.GetMembers(method.Name))
-                {
-                    if (member.Kind == SymbolKind.Method)
-                    {
-                        return (MethodSymbol)member;
-                    }
-                }
-
-                throw ExceptionUtilities.Unreachable();
-            }
-            else
-            {
-                //  Method of a regular type
-                return ((MethodSymbol)method.OriginalDefinition)
-                    .AsMember((NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly())
-                    .ConstructIfGeneric(TypeMap.SubstituteTypes(method.TypeArgumentsWithAnnotations));
-            }
         }
 
         [return: NotNullIfNotNull(nameof(property))]
@@ -712,14 +439,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return node.Update(member, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, node.AccessorKind, receiverType, type);
-        }
-
-        public override BoundNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
-        {
-            BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
-            MethodSymbol method = VisitMethodSymbol(node.ConversionMethod);
-            TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(operand, method, type);
         }
 
         private static bool BaseReferenceInReceiverWasRewritten([NotNullWhen(true)] BoundExpression? originalReceiver, [NotNullWhen(true)] BoundExpression? rewrittenReceiver)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -480,6 +480,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundBlock Block(ImmutableArray<LocalSymbol> locals, ImmutableArray<LocalFunctionSymbol> localFunctions, ImmutableArray<BoundStatement> statements)
         {
+            return Block(locals, ImmutableArray<MethodSymbol>.CastUp(localFunctions), statements);
+        }
+
+        public BoundBlock Block(ImmutableArray<LocalSymbol> locals, ImmutableArray<MethodSymbol> localFunctions, ImmutableArray<BoundStatement> statements)
+        {
             return new BoundBlock(Syntax, locals, localFunctions, hasUnsafeModifier: false, instrumentation: null, statements) { WasCompilerGenerated = true };
         }
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -769,6 +769,16 @@ namespace BoundTreeGenerator
             return AllFields(node).Where(field => TypeIsSymbol(field) || (IsImmutableArray(field.Type, out var elementType) && TypeIsSymbol(elementType)));
         }
 
+        private IEnumerable<Field> AllNonTypeSymbolOrNonTypeSymbolListFields(TreeType node)
+        {
+            return AllFields(node).Where(field => IsNonTypeSymbolOrNonTypeSymbolListField(field));
+        }
+
+        private bool IsNonTypeSymbolOrNonTypeSymbolListField(Field field)
+        {
+            return TypeIsNonTypeSymbol(field) || (IsImmutableArray(field.Type, out var elementType) && TypeIsNonTypeSymbol(elementType));
+        }
+
         private NullHandling FieldNullHandling(TreeType node, string fieldName)
         {
             Field f = GetField(node, fieldName);
@@ -1043,6 +1053,9 @@ namespace BoundTreeGenerator
 
         private static bool TypeIsSymbol(Field field) => TypeIsSymbol(field.Type);
         private static bool TypeIsSymbol(string type) => type.TrimEnd('?').EndsWith("Symbol");
+
+        private static bool TypeIsNonTypeSymbol(Field field) => TypeIsNonTypeSymbol(field.Type);
+        private static bool TypeIsNonTypeSymbol(string type) => TypeIsSymbol(type) && type.TrimEnd('?') != "TypeSymbol";
 
         private string StripBound(string name)
         {
@@ -1371,20 +1384,43 @@ namespace BoundTreeGenerator
                             WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: true));
                             Brace();
                             bool hadField = false;
+
                             foreach (Field field in AllNodeOrNodeListFields(node))
                             {
                                 hadField = true;
                                 WriteNodeVisitCall(field);
                             }
+
                             foreach (Field field in AllTypeFields(node))
                             {
                                 hadField = true;
                                 WriteLine("TypeSymbol? {0} = this.VisitType(node.{1});", ToCamelCase(field.Name), field.Name);
                             }
+
+                            foreach (var field in AllNonTypeSymbolOrNonTypeSymbolListFields(node))
+                            {
+                                hadField = true;
+
+                                if (!IsImmutableArray(field.Type, out string elementType))
+                                {
+                                    WriteLine($"{field.Type} {ToCamelCase(field.Name)} = this.Visit{field.Type.TrimEnd('?')}(node.{field.Name});");
+                                }
+                                else
+                                {
+                                    WriteLine($"{field.Type} {ToCamelCase(field.Name)} = this.VisitSymbols<{elementType}>(node.{field.Name});");
+                                }
+                            }
+
                             if (hadField)
                             {
                                 Write("return node.Update");
-                                ParenList(AllSpecifiableFields(node), field => IsDerivedOrListOfDerived("BoundNode", field.Type) || TypeIsTypeSymbol(field) ? ToCamelCase(field.Name) : string.Format("node.{0}", field.Name));
+                                ParenList(
+                                    AllSpecifiableFields(node),
+                                    field => IsDerivedOrListOfDerived("BoundNode", field.Type) ||
+                                             TypeIsTypeSymbol(field) ||
+                                             IsNonTypeSymbolOrNonTypeSymbolListField(field) ?
+                                                 ToCamelCase(field.Name) :
+                                                 string.Format("node.{0}", field.Name));
                                 WriteLine(";");
                             }
                             else


### PR DESCRIPTION
This is a cherry-pick of two previously merged PRs (#73825 and #73886).