### PR TITLE
Revert "Opt in MS.CA.LS.Protocol into using optprof training data"

### DIFF
--- a/src/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -9,7 +9,6 @@
     <PackageDescription>
       .NET Compiler Platform ("Roslyn") support for Language Server Protocol.
     </PackageDescription>
-    <ApplyNgenOptimization Condition="'$(TargetFramework)' == 'netstandard2.0'">full</ApplyNgenOptimization>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">


### PR DESCRIPTION
Reverts dotnet/roslyn#76768. Testing allocations regression.