### PR TITLE
Revert "Initial work to collapse comments at the end of a block"

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure;
 
 [Trait(Traits.Feature, Traits.Features.Outlining)]
-public sealed class BlockSyntaxStructureTests : AbstractCSharpSyntaxNodeStructureTests<BlockSyntax>
+public class BlockSyntaxStructureTests : AbstractCSharpSyntaxNodeStructureTests<BlockSyntax>
 {
     internal override AbstractSyntaxStructureProvider CreateProvider() => new BlockSyntaxStructureProvider();
 
@@ -464,13 +464,12 @@ public sealed class BlockSyntaxStructureTests : AbstractCSharpSyntaxNodeStructur
 
                 {|hint:static void Goo(){|textspan:
                 {$$
-                   {|hint2:{|textspan2:// comment|}|}
+                   // ...
                 }|}|}
                 """;
 
         await VerifyBlockSpansAsync(code,
-            Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
-            Region("textspan2", "hint2", "// comment ...", autoCollapse: true));
+            Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/68513")]
@@ -481,17 +480,16 @@ public sealed class BlockSyntaxStructureTests : AbstractCSharpSyntaxNodeStructur
             {
                 void M()
                 {
-                    {|hint1:static void Goo(){|textspan1:
+                    {|hint:static void Goo(){|textspan:
                     {$$
-                       {|hint2:{|textspan2:// comment|}|}
+                       // ...
                     }|}|}
                 }
             }
             """;
 
         await VerifyBlockSpansAsync(code,
-            Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: false),
-            Region("textspan2", "hint2", "// comment ...", autoCollapse: true));
+            Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/68513")]
@@ -504,7 +502,7 @@ public sealed class BlockSyntaxStructureTests : AbstractCSharpSyntaxNodeStructur
                 {
                     {|hint:static void Goo(){|textspan:
                     {$$
-                       {|hint2:{|textspan2:// comment|}|}
+                       // ...
                     }|}|}
                 }
             }
@@ -513,7 +511,6 @@ public sealed class BlockSyntaxStructureTests : AbstractCSharpSyntaxNodeStructur
         await VerifyBlockSpansAsync(code, GetDefaultOptions() with
         {
             CollapseLocalFunctionsWhenCollapsingToDefinitions = true,
-        }, Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
-           Region("textspan2", "hint2", "// comment ...", autoCollapse: true));
+        }, Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
     }
 }

--- a/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
@@ -187,14 +187,14 @@ internal static class CSharpStructureHelpers
                 else if (trivia is not SyntaxTrivia(
                     SyntaxKind.WhitespaceTrivia or SyntaxKind.EndOfLineTrivia or SyntaxKind.EndOfFileToken))
                 {
-                    CompleteSingleLineCommentGroup(spans);
+                    completeSingleLineCommentGroup(spans);
                 }
             }
 
-            CompleteSingleLineCommentGroup(spans);
+            completeSingleLineCommentGroup(spans);
             return;
 
-            void CompleteSingleLineCommentGroup(ArrayBuilder<BlockSpan> spans)
+            void completeSingleLineCommentGroup(ArrayBuilder<BlockSpan> spans)
             {
                 if (startComment != null)
                 {

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -142,9 +142,6 @@ internal sealed class BlockSyntaxStructureProvider : AbstractSyntaxNodeStructure
                     type: type));
             }
         }
-
-        // Add any leading comments before the end of the block
-        CSharpStructureHelpers.CollectCommentBlockSpans(node.CloseBraceToken.LeadingTrivia, spans);
     }
 
     private static bool IsNonBlockStatement(SyntaxNode node)

--- a/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
 
-internal sealed class TypeDeclarationStructureProvider : AbstractSyntaxNodeStructureProvider<TypeDeclarationSyntax>
+internal class TypeDeclarationStructureProvider : AbstractSyntaxNodeStructureProvider<TypeDeclarationSyntax>
 {
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,


### PR DESCRIPTION
Reverts dotnet/roslyn#76865. Allocations regression testing