### PR TITLE
Revert "Update formatOnType handler to support formatting on NewLine"

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -44,12 +44,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             if (document is null)
                 return null;
 
-            if (string.IsNullOrEmpty(request.Character))
+            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+
+            if (string.IsNullOrEmpty(request.Character) || SyntaxFacts.IsNewLine(request.Character[0]))
             {
                 return [];
             }
-
-            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
 
             var formattingService = document.Project.Services.GetRequiredService<ISyntaxFormattingService>();
             var documentSyntax = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
@@ -70,37 +70,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             if (textChanges.IsEmpty)
             {
                 return [];
-            }
-
-            if (SyntaxFacts.IsNewLine(request.Character[0]))
-            {
-                // When formatting after a newline is pressed, the cursor line will be all whitespace
-                // and we do not want to remove the indentation from it.
-                //
-                // Take the following example of pressing enter after an opening brace.
-                //
-                // ```
-                //    public void M() {||}
-                // ```
-                //
-                // The editor moves the cursor to the next line and uses it's languageconfig to add
-                // the appropriate level of indentation.
-                //
-                // ```
-                //     public void M() {
-                //         ||
-                //     }
-                // ```
-                //
-                // At this point `formatOnType` is called. The formatting service will generate two
-                // text changes. The first moves the opening brace to a new line with proper
-                // indentation. The second removes the whitespace from the cursor line and rewrites
-                // the indentation prior to the closing brace.
-                // 
-                // Letting the second change go through would be a bad experience for the user as they
-                // will now be responsible for adding back the proper indentation.
-
-                textChanges = textChanges.WhereAsArray(static (change, position) => !change.Span.Contains(position), position);
             }
 
             return [.. textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, documentSyntax.Text))];

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.CodeAnalysis;
+#nullable disable
+
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,107 +24,74 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Formatting
         public async Task TestFormatDocumentOnTypeAsync(bool mutatingLspWorkspace)
         {
             var markup =
-                """
-                class A
-                {
-                    void M()
-                    {
-                        if (true)
-                            {{|type:|}
-                    }
-                }
-                """;
+@"class A
+{
+    void M()
+    {
+        if (true)
+            {{|type:|}
+    }
+}";
             var expected =
-                """
-                class A
-                {
-                    void M()
-                    {
-                        if (true)
-                        {
-                    }
-                }
-                """;
+@"class A
+{
+    void M()
+    {
+        if (true)
+        {
+    }
+}";
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
             var characterTyped = ";";
             var locationTyped = testLspServer.GetLocations("type").Single();
-            await AssertFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, expected);
+            var documentText = await testLspServer.GetDocumentTextAsync(locationTyped.Uri);
+
+            var results = await RunFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped);
+            var actualText = ApplyTextEdits(results, documentText);
+            Assert.Equal(expected, actualText);
         }
 
         [Theory, CombinatorialData]
         public async Task TestFormatDocumentOnType_UseTabsAsync(bool mutatingLspWorkspace)
         {
             var markup =
-                """
-                class A
-                {
-                	void M()
-                	{
-                		if (true)
-                			{{|type:|}
-                	}
-                }
-                """;
+@"class A
+{
+	void M()
+	{
+		if (true)
+			{{|type:|}
+	}
+}";
             var expected =
-                """
-                class A
-                {
-                	void M()
-                	{
-                		if (true)
-                		{
-                	}
-                }
-                """;
+@"class A
+{
+	void M()
+	{
+		if (true)
+		{
+	}
+}";
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
             var characterTyped = ";";
             var locationTyped = testLspServer.GetLocations("type").Single();
-            await AssertFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, expected, insertSpaces: false, tabSize: 4);
+            var documentText = await testLspServer.GetDocumentTextAsync(locationTyped.Uri);
+
+            var results = await RunFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, insertSpaces: false, tabSize: 4);
+            var actualText = ApplyTextEdits(results, documentText);
+            Assert.Equal(expected, actualText);
         }
 
-        [Theory, CombinatorialData]
-        public async Task TestFormatDocumentOnType_NewLine(bool mutatingLspWorkspace)
-        {
-            var markup =
-                """
-                class A
-                {
-                    void M() {
-                        {|type:|}
-                    }
-                }
-                """;
-            var expected =
-                """
-                class A
-                {
-                    void M()
-                    {
-                        
-                    }
-                }
-                """;
-            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
-            var characterTyped = "\n";
-            var locationTyped = testLspServer.GetLocations("type").Single();
-            await AssertFormatDocumentOnTypeAsync(testLspServer, characterTyped, locationTyped, expected);
-        }
-
-        private static async Task AssertFormatDocumentOnTypeAsync(
+        private static async Task<LSP.TextEdit[]> RunFormatDocumentOnTypeAsync(
             TestLspServer testLspServer,
             string characterTyped,
             LSP.Location locationTyped,
-            [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string expectedText,
             bool insertSpaces = true,
             int tabSize = 4)
         {
-            var documentText = await testLspServer.GetDocumentTextAsync(locationTyped.Uri);
-            var results = await testLspServer.ExecuteRequestAsync<LSP.DocumentOnTypeFormattingParams, LSP.TextEdit[]>(
-                LSP.Methods.TextDocumentOnTypeFormattingName,
-                CreateDocumentOnTypeFormattingParams(characterTyped, locationTyped, insertSpaces, tabSize),
-                CancellationToken.None);
-            var actualText = ApplyTextEdits(results, documentText);
-            Assert.Equal(expectedText, actualText);
+            return await testLspServer.ExecuteRequestAsync<LSP.DocumentOnTypeFormattingParams, LSP.TextEdit[]>(LSP.Methods.TextDocumentOnTypeFormattingName,
+                CreateDocumentOnTypeFormattingParams(
+                    characterTyped, locationTyped, insertSpaces, tabSize), CancellationToken.None);
         }
 
         private static LSP.DocumentOnTypeFormattingParams CreateDocumentOnTypeFormattingParams(


### PR DESCRIPTION
Reverts dotnet/roslyn#76876. Allocations regression testing