### PR TITLE
Reduce allocations in SymbolCompletionItem.GetSupportedPlatforms

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -24,7 +24,7 @@ internal static class SymbolCompletionItem
 
     private static readonly Action<ImmutableArray<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolEncoding = AddSymbolEncoding;
     private static readonly Action<ImmutableArray<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolInfo = AddSymbolInfo;
-    private static readonly char[] s_projectSeperators = [';'];
+    private const char ProjectSeperatorChar = ';';
 
     private static CompletionItem CreateWorker(
         string displayText,
@@ -236,11 +236,43 @@ internal static class SymbolCompletionItem
         {
             return new SupportedPlatformData(
                 solution,
-                invalidProjects.Split(s_projectSeperators).SelectAsArray(s => ProjectId.CreateFromSerialized(Guid.Parse(s))),
-                candidateProjects.Split(s_projectSeperators).SelectAsArray(s => ProjectId.CreateFromSerialized(Guid.Parse(s))));
+                SplitIntoProjectIds(invalidProjects),
+                SplitIntoProjectIds(candidateProjects));
         }
 
         return null;
+    }
+
+    private static ImmutableArray<ProjectId> SplitIntoProjectIds(string projectIds)
+    {
+        // Does the equivalent of string.Split, with fewer allocations
+        var start = 0;
+        var current = 0;
+        using var _ = ArrayBuilder<ProjectId>.GetInstance(out var builder);
+
+        while (current < projectIds.Length)
+        {
+            if (projectIds[current] == ProjectSeperatorChar)
+            {
+                if (start != current)
+                {
+                    var projectGuid = Guid.Parse(projectIds.Substring(start, current - start));
+                    builder.Add(ProjectId.CreateFromSerialized(projectGuid));
+                }
+
+                start = current + 1;
+            }
+
+            current++;
+        }
+
+        if (start != current)
+        {
+            var projectGuid = Guid.Parse(projectIds.Substring(start, current - start));
+            builder.Add(ProjectId.CreateFromSerialized(projectGuid));
+        }
+
+        return builder.ToImmutableAndClear();
     }
 
     public static int GetContextPosition(CompletionItem item)


### PR DESCRIPTION
This method shows up as 0.8% of VS allocations during typing in the CSharpEditingTests.ScrollingAndTyping speedometer test. These changes should cut this in under half.

This method was previously using string.Split, which allocates an int[] for processing and allocates a return array. Instead, we can roll our own here and avoid both of those allocations

Highlighted allocations from below should be removed
![image](https://github.com/user-attachments/assets/c6413b3f-c83b-48a2-a83c-00dd35093477)