### PR TITLE
Collection expressions: add `params` cases to tests for invalid builder methods

### DIFF
--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -18860,7 +18860,9 @@ partial class Program
                         MyCollection<string> x = [];
                         MyCollection<int> y = [1, 2, 3];
                         MyCollection<object> z = new();
+                        y = Params(4, 5);
                     }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
                 }
                 """;
             comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
@@ -18870,7 +18872,13 @@ partial class Program
                 Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[]").WithArguments("MyCollectionBuilder").WithLocation(6, 34),
                 // (7,31): warning CS0612: 'MyCollectionBuilder' is obsolete
                 //         MyCollection<int> y = [1, 2, 3];
-                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[1, 2, 3]").WithArguments("MyCollectionBuilder").WithLocation(7, 31));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[1, 2, 3]").WithArguments("MyCollectionBuilder").WithLocation(7, 31),
+                // (9,13): warning CS0612: 'MyCollectionBuilder' is obsolete
+                //         y = Params(4, 5);
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "Params(4, 5)").WithArguments("MyCollectionBuilder").WithLocation(9, 13),
+                // (11,38): warning CS0612: 'MyCollectionBuilder' is obsolete
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "params MyCollection<T> c").WithArguments("MyCollectionBuilder").WithLocation(11, 38));
         }
 
         [Fact]
@@ -18902,7 +18910,9 @@ partial class Program
                         MyCollection<string> x = [];
                         MyCollection<int> y = [1, 2, 3];
                         MyCollection<object> z = new();
+                        y = Params(4, 5);
                     }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
                 }
                 """;
             var comp = CreateCompilation(new[] { sourceA, sourceB }, targetFramework: TargetFramework.Net80);
@@ -18915,7 +18925,13 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "[]").WithArguments("MyCollectionBuilder", "message 2").WithLocation(6, 34),
                 // 1.cs(7,31): error CS0619: 'MyCollectionBuilder' is obsolete: 'message 2'
                 //         MyCollection<int> y = [1, 2, 3];
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "[1, 2, 3]").WithArguments("MyCollectionBuilder", "message 2").WithLocation(7, 31));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "[1, 2, 3]").WithArguments("MyCollectionBuilder", "message 2").WithLocation(7, 31),
+                // 1.cs(9,13): error CS0619: 'MyCollectionBuilder' is obsolete: 'message 2'
+                //         y = Params(4, 5);
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Params(4, 5)").WithArguments("MyCollectionBuilder", "message 2").WithLocation(9, 13),
+                // 1.cs(11,38): error CS0619: 'MyCollectionBuilder' is obsolete: 'message 2'
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "params MyCollection<T> c").WithArguments("MyCollectionBuilder", "message 2").WithLocation(11, 38));
         }
 
         [CombinatorialData]
@@ -18951,7 +18967,9 @@ partial class Program
                         MyCollection<string> x = [];
                         MyCollection<int> y = [1, 2, 3];
                         MyCollection<object> z = new();
+                        y = Params(4, 5);
                     }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
                 }
                 """;
             comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
@@ -18961,7 +18979,13 @@ partial class Program
                 Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)").WithLocation(6, 34),
                 // (7,31): warning CS0612: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' is obsolete
                 //         MyCollection<int> y = [1, 2, 3];
-                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[1, 2, 3]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)").WithLocation(7, 31));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[1, 2, 3]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)").WithLocation(7, 31),
+                // (9,13): warning CS0612: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' is obsolete
+                //         y = Params(4, 5);
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "Params(4, 5)").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)").WithLocation(9, 13),
+                // (11,38): warning CS0612: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' is obsolete
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "params MyCollection<T> c").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)").WithLocation(11, 38));
         }
 
         [CombinatorialData]
@@ -18997,7 +19021,9 @@ partial class Program
                         MyCollection<string> x = [];
                         MyCollection<int> y = [1, 2, 3];
                         MyCollection<object> z = new();
+                        y = Params(4, 5);
                     }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
                 }
                 """;
             comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
@@ -19007,7 +19033,13 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "[]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "message 4").WithLocation(6, 34),
                 // (7,31): error CS0619: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' is obsolete: 'message 4'
                 //         MyCollection<int> y = [1, 2, 3];
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "[1, 2, 3]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "message 4").WithLocation(7, 31));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "[1, 2, 3]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "message 4").WithLocation(7, 31),
+                // (9,13): error CS0619: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' is obsolete: 'message 4'
+                //         y = Params(4, 5);
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Params(4, 5)").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "message 4").WithLocation(9, 13),
+                // (11,38): error CS0619: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' is obsolete: 'message 4'
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "params MyCollection<T> c").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "message 4").WithLocation(11, 38));
         }
 
         [Fact]
@@ -19040,7 +19072,9 @@ partial class Program
                         MyCollection<string> x = [];
                         MyCollection<int> y = [1, 2, 3];
                         MyCollection<object> z = new();
+                        y = Params(4, 5);
                     }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
                 }
                 """;
             var comp = CreateCompilation(new[] { sourceA, sourceB }, targetFramework: TargetFramework.Net80);
@@ -19051,6 +19085,12 @@ partial class Program
                 // 1.cs(7,31): error CS8901: 'MyCollectionBuilder.Create<int>(ReadOnlySpan<int>)' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
                 //         MyCollection<int> y = [1, 2, 3];
                 Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, "[1, 2, 3]").WithArguments("MyCollectionBuilder.Create<int>(System.ReadOnlySpan<int>)").WithLocation(7, 31),
+                // 1.cs(9,13): error CS8901: 'MyCollectionBuilder.Create<int>(ReadOnlySpan<int>)' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
+                //         y = Params(4, 5);
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, "Params(4, 5)").WithArguments("MyCollectionBuilder.Create<int>(System.ReadOnlySpan<int>)").WithLocation(9, 13),
+                // 1.cs(11,38): error CS8901: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, "params MyCollection<T> c").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)").WithLocation(11, 38),
                 // 0.cs(14,6): error CS8895: Methods attributed with 'UnmanagedCallersOnly' cannot have generic type parameters and cannot be declared in a generic type.
                 //     [UnmanagedCallersOnly]
                 Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodOrTypeCannotBeGeneric, "UnmanagedCallersOnly").WithLocation(14, 6),
@@ -19097,12 +19137,13 @@ partial class Program
                     }
                 }
                 """;
-            CompileAndVerify(
+            var verifier = CompileAndVerify(
                 new[] { sourceB1, s_collectionExtensions },
                 references: new[] { refA },
                 targetFramework: TargetFramework.Net80,
                 verify: Verification.FailsPEVerify,
                 expectedOutput: IncludeExpectedOutput("[], [1, 2, 3], "));
+            verifier.VerifyDiagnostics();
 
             string sourceB2 = """
                 #pragma warning disable 219
@@ -19120,6 +19161,49 @@ partial class Program
                 // (6,32): error CS0453: The type 'int?' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)'
                 //         MyCollection<int?> x = [4, null];
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[4, null]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "int?").WithLocation(6, 32));
+
+            string sourceB3 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params(4, 5).Report();
+                    }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) where T : struct => c;
+                }
+                """;
+            verifier = CompileAndVerify(
+                [sourceB3, s_collectionExtensions],
+                references: new[] { refA },
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[4, 5], "));
+            verifier.VerifyDiagnostics();
+
+            string sourceB4 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params<object>(4, 5);
+                    }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            comp = CreateCompilation(sourceB4, references: new[] { refA }, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,9): error CS0453: The type 'object' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)'
+                //         Params<object>(4, 5);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Params<object>(4, 5)").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "object").WithLocation(5, 9),
+                // (7,28): error CS0310: 'T' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "Params").WithArguments("MyCollection<T>", "T", "T").WithLocation(7, 28),
+                // (7,38): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "params MyCollection<T> c").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(7, 38),
+                // (7,61): error CS0310: 'T' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "c").WithArguments("MyCollection<T>", "T", "T").WithLocation(7, 61));
         }
 
         [CombinatorialData]
@@ -19160,12 +19244,13 @@ partial class Program
                     }
                 }
                 """;
-            CompileAndVerify(
+            var verifier = CompileAndVerify(
                 new[] { sourceB1, s_collectionExtensions },
                 references: new[] { refA },
                 targetFramework: TargetFramework.Net80,
                 verify: Verification.FailsPEVerify,
                 expectedOutput: IncludeExpectedOutput("[], [1, 2, 3], "));
+            verifier.VerifyDiagnostics();
 
             string sourceB2 = """
                 #pragma warning disable 219
@@ -19183,6 +19268,43 @@ partial class Program
                 // (6,32): error CS0453: The type 'int?' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)'
                 //         MyCollection<int?> x = [4, null];
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[4, null]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "int?").WithLocation(6, 32));
+
+            string sourceB3 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params(4, 5).Report();
+                    }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) where T : struct => c;
+                }
+                """;
+            verifier = CompileAndVerify(
+                [sourceB3, s_collectionExtensions],
+                references: new[] { refA },
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[4, 5], "));
+            verifier.VerifyDiagnostics();
+
+            string sourceB4 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params<object>(4, 5);
+                    }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            comp = CreateCompilation(sourceB4, references: new[] { refA }, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,9): error CS0453: The type 'object' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)'
+                //         Params<object>(4, 5);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Params<object>(4, 5)").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "object").WithLocation(5, 9),
+                // (7,38): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "params MyCollection<T> c").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(7, 38));
         }
 
         [Fact]
@@ -19207,7 +19329,8 @@ partial class Program
                         => default;
                 }
                 """;
-            string sourceB = """
+
+            string sourceB1 = """
                 #pragma warning disable 219
                 class Program
                 {
@@ -19219,11 +19342,50 @@ partial class Program
                     }
                 }
                 """;
-            var comp = CreateCompilation(new[] { sourceA, sourceB }, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(new[] { sourceA, sourceB1 }, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
                 // 1.cs(7,22): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
                 //         MyCollection<int> y = [1, 2, 3];
                 Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("MyCollection<T>", "T", "int").WithLocation(7, 22),
+                // 0.cs(15,35): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //     public static MyCollection<T> Create<T>(ReadOnlySpan<T> items)
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "Create").WithArguments("MyCollection<T>", "T", "T").WithLocation(15, 35));
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints<int>([1]);
+                        NoConstraints<object>([2]);
+                        StructConstraint<int>([3]);
+                        ClassConstraint<object>([4]);
+                    }
+                    static MyCollection<T> NoConstraints<T>(params MyCollection<T> c) => c;
+                    static MyCollection<T> StructConstraint<T>(params MyCollection<T> c) where T : struct => c;
+                    static MyCollection<T> ClassConstraint<T>(params MyCollection<T> c) where T : class => c;
+                }
+                """;
+            comp = CreateCompilation(new[] { sourceA, sourceB2 }, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // 1.cs(5,9): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //         NoConstraints<int>([1]);
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "NoConstraints<int>").WithArguments("MyCollection<T>", "T", "int").WithLocation(5, 9),
+                // 1.cs(7,9): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //         StructConstraint<int>([3]);
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "StructConstraint<int>").WithArguments("MyCollection<T>", "T", "int").WithLocation(7, 9),
+                // 1.cs(10,28): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //     static MyCollection<T> NoConstraints<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "NoConstraints").WithArguments("MyCollection<T>", "T", "T").WithLocation(10, 28),
+                // 1.cs(10,68): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //     static MyCollection<T> NoConstraints<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "c").WithArguments("MyCollection<T>", "T", "T").WithLocation(10, 68),
+                // 1.cs(11,28): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //     static MyCollection<T> StructConstraint<T>(params MyCollection<T> c) where T : struct => c;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "StructConstraint").WithArguments("MyCollection<T>", "T", "T").WithLocation(11, 28),
+                // 1.cs(11,71): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
+                //     static MyCollection<T> StructConstraint<T>(params MyCollection<T> c) where T : struct => c;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "c").WithArguments("MyCollection<T>", "T", "T").WithLocation(11, 71),
                 // 0.cs(15,35): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyCollection<T>'
                 //     public static MyCollection<T> Create<T>(ReadOnlySpan<T> items)
                 Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "Create").WithArguments("MyCollection<T>", "T", "T").WithLocation(15, 35));
@@ -19769,7 +19931,9 @@ partial class Program
                         MyCollection<int> x = [];
                         MyCollection<string> y = [null];
                         MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
+                        x = Params(1, 2);
                     }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
                 }
                 """;
             var comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
@@ -19782,7 +19946,13 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "[null]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(7, 34),
                 // (8,54): error CS9041: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
                 //         MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
-                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Create<object>").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(8, 54));
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Create<object>").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(8, 54),
+                // (9,13): error CS9041: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         x = Params(1, 2);
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Params(1, 2)").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(9, 13),
+                // (11,38): error CS9041: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "params MyCollection<T> c").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(11, 38));
         }
 
         [Fact]
@@ -19826,7 +19996,9 @@ partial class Program
                         MyCollection<int> x = [];
                         MyCollection<string> y = [null];
                         MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
+                        x = Params(1, 2);
                     }
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
                 }
                 """;
             var comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
@@ -19842,7 +20014,13 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "MyCollectionBuilder").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(8, 34),
                 // (8,54): error CS9041: 'MyCollectionBuilder' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
                 //         MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
-                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Create<object>").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(8, 54));
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Create<object>").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(8, 54),
+                // (9,13): error CS9041: 'MyCollectionBuilder' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         x = Params(1, 2);
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Params(1, 2)").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(9, 13),
+                // (11,38): error CS9041: 'MyCollectionBuilder' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "params MyCollection<T> c").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(11, 38));
         }
 
         [Fact]


### PR DESCRIPTION
Add `params` cases to existing tests for invalid *collection builder* methods, since error reporting for collection builder methods may be affected by changes for *collection arguments* (see https://github.com/dotnet/roslyn/pull/76998).

This is a test-only change.