### PR TITLE
Enable tests in VMR

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -142,8 +142,8 @@
     -->
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Client.Implementation" Version="17.10.72-preview" />
     <PackageVersion Include="NuGet.ProjectModel" Version="6.8.0-rc.112" />
-    <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(_MicrosoftTestPlatformVersion)" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(_MicrosoftTestPlatformVersion)" />
+    <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="9.0.0-preview.25064.4" />
 
     <!--

--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -12,7 +12,6 @@
     <ILAsmPackageVersion>9.0.0-rc.2.24462.10</ILAsmPackageVersion>
     <ILDAsmPackageVersion>6.0.0-rtm.21518.12</ILDAsmPackageVersion>
     <MicrosoftILVerificationVersion>7.0.0-alpha.1.22060.1</MicrosoftILVerificationVersion>
-    <_MicrosoftTestPlatformVersion>17.5.0</_MicrosoftTestPlatformVersion>
     <!--
       VS .NET Runtime
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -107,4 +107,12 @@
     <!-- Prohibit the usage of .NET Standard 1.x dependencies. -->
     <FlagNetStandard1XDependencies Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</FlagNetStandard1XDependencies>
   </PropertyGroup>
+  <PropertyGroup>
+    <!--
+      Test SDK should match the version of TestPlatform packages required by this repo and defined
+      in Directory.Packages.props - Microsoft.TestPlatform.TranslationLayer and Microsoft.TestPlatform.ObjectModel.
+      This version needs to match the Test SDK version consumed by Arcade.
+    -->
+    <MicrosoftNETTestSdkVersion>17.5.0</MicrosoftNETTestSdkVersion>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76960

Roslyn tests are failing in VMR with mismatched package version errors, i.e.:
```
C:\git\dotnet\src\roslyn\src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj : error NU1109: Detected package downgrade: Microsoft.TestPlatform.ObjectModel from 17.12.0 to centrally defined 17.5.0. Update the centrally managed package version to a higher version.  [C:\git\dotnet\src\roslyn\Roslyn.sln]
C:\git\dotnet\src\roslyn\src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj : error NU1109:  Microsoft.CodeAnalysis.UnitTests -> Microsoft.NET.Test.Sdk 17.12.0 -> Microsoft.TestPlatform.TestHost 17.12.0 -> Microsoft.TestPlatform.ObjectModel (>= 17.12.0)  [C:\git\dotnet\src\roslyn\Roslyn.sln]
C:\git\dotnet\src\roslyn\src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj : error NU1109:  Microsoft.CodeAnalysis.UnitTests -> Microsoft.TestPlatform.ObjectModel (>= 17.5.0) [C:\git\dotnet\src\roslyn\Roslyn.sln]
```

The fix is to explicitly set the version of `Microsoft.NET.Test.Sdk` that is consumed by arcade version that Roslyn uses.