### PR TITLE
Fix issue in watch window completion

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
@@ -25,6 +25,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 {
     internal class CSharpDebuggerIntelliSenseContext : AbstractDebuggerIntelliSenseContext
     {
+        private const string StatementTerminator = ";";
+
         public CSharpDebuggerIntelliSenseContext(
             IWpfTextView view,
             IVsTextView vsTextView,
@@ -60,12 +62,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         {
         }
 
-        protected override int GetAdjustedContextPoint(int contextPoint, Document document)
+        protected override IProjectionBuffer GetAdjustedBuffer(int contextPoint, Document document, ITrackingSpan debuggerMappedSpan)
         {
             // Determine the position in the buffer at which to end the tracking span representing
             // the part of the imaginary buffer before the text in the view. 
             var tree = document.GetSyntaxTreeSynchronously(CancellationToken.None);
             var token = tree.FindTokenOnLeftOfPosition(contextPoint, CancellationToken.None);
+            var separatorBeforeDebuggerMappedSpan = StatementTerminator;
+            var adjustedStart = token.FullSpan.End;
 
             // Special case to handle class designer because it asks for debugger IntelliSense using
             // spans between members.
@@ -74,40 +78,43 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 token.Parent.IsKind(SyntaxKind.Block) &&
                 token.Parent.Parent is MemberDeclarationSyntax)
             {
-                return contextPoint;
+                adjustedStart = contextPoint;
             }
-
-            if (token.IsKindOrHasMatchingText(SyntaxKind.CloseBraceToken) &&
+            else if (token.IsKindOrHasMatchingText(SyntaxKind.CloseBraceToken) &&
                 token.Parent.IsKind(SyntaxKind.Block))
             {
-                return token.SpanStart;
+                adjustedStart = token.SpanStart;
+            }
+            else if (token.IsKindOrHasMatchingText(SyntaxKind.SemicolonToken) &&
+                token.Parent is StatementSyntax)
+            {
+                // If the context is at a semicolon terminated statement, then we use the start of
+                // that statement as the adjusted context position. This is to ensure the placement
+                // of debuggerMappedSpan is in the same block as token originally was. For example,
+                // 
+                // for (int i = 0; i < 10; i++)
+                //   [Console.WriteLine(i);]
+                //
+                // where [] denotes CurrentStatementSpan, should use the start of CurrentStatementSpan
+                // as the adjusted context, and should not place a semicolon before debuggerMappedSpan.
+                // Not doing either of those would place debuggerMappedSpan outside the for loop.
+                separatorBeforeDebuggerMappedSpan = string.Empty;
+                adjustedStart = token.Parent.SpanStart;
             }
 
-            return token.FullSpan.End;
-        }
+            var beforeAdjustedStart = ContextBuffer.CurrentSnapshot.CreateTrackingSpan(Span.FromBounds(0, adjustedStart), SpanTrackingMode.EdgeNegative);
+            var afterAdjustedStart = ContextBuffer.CurrentSnapshot.CreateTrackingSpanFromIndexToEnd(adjustedStart, SpanTrackingMode.EdgePositive);
 
-        protected override ITrackingSpan GetPreviousStatementBufferAndSpan(int contextPoint, Document document)
-        {
-            var previousTrackingSpan = ContextBuffer.CurrentSnapshot.CreateTrackingSpan(Span.FromBounds(0, contextPoint), SpanTrackingMode.EdgeNegative);
-
-            // terminate the previous expression/statement
-            var buffer = ProjectionBufferFactoryService.CreateProjectionBuffer(
+            return ProjectionBufferFactoryService.CreateProjectionBuffer(
                 projectionEditResolver: null,
-                sourceSpans: [previousTrackingSpan, this.StatementTerminator],
+                sourceSpans: [beforeAdjustedStart, separatorBeforeDebuggerMappedSpan, debuggerMappedSpan, StatementTerminator, afterAdjustedStart],
                 options: ProjectionBufferOptions.None,
-                contentType: this.ContentType);
-
-            return buffer.CurrentSnapshot.CreateTrackingSpan(0, buffer.CurrentSnapshot.Length, SpanTrackingMode.EdgeNegative);
+                contentType: ContentType);
         }
 
         public override bool CompletionStartsOnQuestionMark
         {
             get { return false; }
-        }
-
-        protected override string StatementTerminator
-        {
-            get { return ";"; }
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
@@ -68,6 +68,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             // the part of the imaginary buffer before the text in the view. 
             var tree = document.GetSyntaxTreeSynchronously(CancellationToken.None);
             var token = tree.FindTokenOnLeftOfPosition(contextPoint, CancellationToken.None);
+
+            // Typically, the separator between the text before adjustedStart and debuggerMappedSpan is
+            // a semicolon (StatementTerminator), unless a specific condition outlined later in the
+            // method is encountered.
             var separatorBeforeDebuggerMappedSpan = StatementTerminator;
             var adjustedStart = token.FullSpan.End;
 

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -316,6 +316,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Function
 
         <WpfFact>
+        Public Async Function SingleStatementBlock() As Task
+            Dim text = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>class Program
+{
+    static void Main()
+    {
+        for (int variable1 = 0; variable1 &lt; 10; variable1++)
+            [|Console.Write(0);|]
+        int variable2 = 0;
+    }
+}</Document>
+                           </Project>
+                       </Workspace>
+
+            Using state = TestState.CreateCSharpTestState(text, False)
+                state.SendTypeChars("variable")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertCompletionItemsContainAll("variable1", "variable2")
+            End Using
+        End Function
+
+        <WpfFact>
         Public Async Function SignatureHelpInParameterizedConstructor() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">


### PR DESCRIPTION
The issue here is when the watch window contains

for (int i = 0; i < 10; i++)
    [Console.WriteLine(i);]

where [] denotes the current statement. In that case, the adjusted context should be at the start of Console.WriteLine. Additionally, a semicolon should not be placed in the generated projection buffer before debuggerMappedSpan, as that would place debuggerMappedSpan outside the for loop.

Fixes https://github.com/dotnet/roslyn/issues/42718