### PR TITLE
WIP: Switch TextDocumentState.GetTextVersionAsync to ValueTask to reduce allocations.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
@@ -90,8 +90,8 @@ public class TextDocument
     /// <summary>
     /// Gets the version of the document's text.
     /// </summary>
-    public Task<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken = default)
-        => State.GetTextVersionAsync(cancellationToken);
+    public async Task<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken = default)
+        => await State.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Fetches the current version for the document synchronously.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -123,7 +123,7 @@ internal abstract partial class TextDocumentState
         return textAndVersion.Version;
     }
 
-    public async Task<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
+    public async ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
     {
         // try fast path first
         if (TryGetTextVersion(out var version))


### PR DESCRIPTION
The task creation from calling this method accounts for 34 MB (0.2%) of allocations in the CSharpEditingTests.Completion speedometer test.

Going to run a test insertion to verify that this gets rid of the majority of these allocations before proceeding.