### PR TITLE
Avoid forking solution for Hot Reload when Razor's ForceRuntimeCodeGeneration feature flag is enabled

### DIFF
--- a/src/EditorFeatures/Core/Options/LegacyGlobalOptionsWorkspaceService.cs
+++ b/src/EditorFeatures/Core/Options/LegacyGlobalOptionsWorkspaceService.cs
@@ -47,6 +47,9 @@ internal sealed class LegacyGlobalOptionsWorkspaceService(IGlobalOptionService g
     public int RazorTabSize
         => _globalOptions.GetOption(RazorLineFormattingOptionsStorage.TabSize);
 
+    public bool RazorForceRuntimeCodeGeneration
+        => _globalOptions.GetOption(LegacyRazorOptions.ForceRuntimeCodeGeneration);
+
     public bool GetGenerateEqualsAndGetHashCodeFromMembersGenerateOperators(string language)
         => _globalOptions.GetOption(s_implementIEquatable, language);
 

--- a/src/Features/Core/Portable/Options/LegacyRazorOptions.cs
+++ b/src/Features/Core/Portable/Options/LegacyRazorOptions.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Options;
+
+internal static class LegacyRazorOptions
+{
+    public static readonly Option2<bool> ForceRuntimeCodeGeneration = new("razor_force_runtime_code_generation", defaultValue: false);
+}

--- a/src/Features/ExternalAccess/OmniSharp/Options/OmnisharpLegacyGlobalOptionsWorkspaceService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Options/OmnisharpLegacyGlobalOptionsWorkspaceService.cs
@@ -29,6 +29,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options
         public int RazorTabSize
             => LineFormattingOptions.Default.TabSize;
 
+        public bool RazorForceRuntimeCodeGeneration
+            => false;
+
         public bool GenerateOverrides
         {
             get => true;

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -429,5 +429,6 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_reload_changed_analyzer_references", new RoamingProfileStorage("TextEditor.Roslyn.Specific.ReloadChangedAnalyzerReferences")},
         {"dotnet_reload_changed_analyzer_references_feature_flag", new FeatureFlagStorage(@"Roslyn.ReloadChangedAnalyzerReferences")},
         {"xaml_enable_lsp_intellisense", new FeatureFlagStorage(@"Xaml.EnableLspIntelliSense")},
+        {"razor_force_runtime_code_generation", new FeatureFlagStorage("Razor.LSP.ForceRuntimeCodeGeneration")},
     };
 }

--- a/src/Workspaces/Core/Portable/Options/ILegacyGlobalOptionsWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/Options/ILegacyGlobalOptionsWorkspaceService.cs
@@ -15,6 +15,7 @@ internal interface ILegacyGlobalOptionsWorkspaceService : IWorkspaceService
 {
     public bool RazorUseTabs { get; }
     public int RazorTabSize { get; }
+    public bool RazorForceRuntimeCodeGeneration { get; }
 
     public bool GenerateOverrides { get; set; }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigData.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigData.cs
@@ -23,9 +23,16 @@ internal readonly struct AnalyzerConfigData
     /// </summary>
     public readonly ImmutableDictionary<string, ReportDiagnostic> TreeOptions;
 
-    public AnalyzerConfigData(AnalyzerConfigOptionsResult result, StructuredAnalyzerConfigOptions fallbackOptions)
+    public AnalyzerConfigData(AnalyzerConfigOptionsResult result, StructuredAnalyzerConfigOptions fallbackOptions, bool legacyOverrideSuppressRazorSourceGenerator)
     {
-        _dictionaryConfigOptions = new DictionaryAnalyzerConfigOptions(result.AnalyzerOptions);
+        var entries = result.AnalyzerOptions;
+
+        if (legacyOverrideSuppressRazorSourceGenerator)
+        {
+            entries = entries.SetItem("build_property.SuppressRazorSourceGenerator", "false");
+        }
+
+        _dictionaryConfigOptions = new DictionaryAnalyzerConfigOptions(entries);
         ConfigOptionsWithoutFallback = StructuredAnalyzerConfigOptions.Create(_dictionaryConfigOptions, StructuredAnalyzerConfigOptions.Empty);
         ConfigOptionsWithFallback = StructuredAnalyzerConfigOptions.Create(_dictionaryConfigOptions, fallbackOptions);
         TreeOptions = result.TreeOptions;


### PR DESCRIPTION
Aims to avoid overhead of a separate solution snapshot used for Hot Reload and EnC.

The feature flag is checked at two locations:
1) CompileTimeSolutionProvider, where we simply return the design time solution without updating it
2) Global editorconfig option reader in project, where we need to override the value of editorconfig option `build_property.SuppressRazorSourceGenerator` if the feature flag is enabled. The option is set in an editorconfig file included  to all Razor projects by Razor SDK and defaults to true. When the solution was transformed in CompileTimeSolutionProvider the editorconfig file was removed, which enabled the source generator. If the transformation is not performed the source generator would be disabled if we didn't override the option.


