### PR TITLE
Add `HelpLinkUri` to `CodeStyleConfigFileGenerator`

### DIFF
--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -147,6 +147,12 @@ namespace CodeStyleConfigFileGenerator
 
                             result.AppendLine();
                             result.AppendLine($"# {rule.Id}: {rule.Title}");
+
+                            if (rule.HelpLinkUri is not null)
+                            {
+                                result.AppendLine($"# {rule.HelpLinkUri}");
+                            }
+
                             result.AppendLine($"dotnet_diagnostic.{rule.Id}.severity = {severityString}");
                             return true;
                         }


### PR DESCRIPTION
e.g.:

```editorconfig
# CAXXXX: Title
# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/caXXXX
dotnet_diagnostic.CAXXXX.severity = default
```