### PR TITLE
Do not offer primary constructor parameters when offering to generate Equals/GetHashCode

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -4400,4 +4400,19 @@ DiagnosticResult.CompilerError("CS1069").WithSpan(18, 52, 18, 57).WithArguments(
             LanguageVersion = LanguageVersion.Default,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76916")]
+    public async Task TestMissingWithPrimaryConstructorAndNoFields()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C(int a)
+                {
+                    [||]
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
 }

--- a/src/Features/Core/Portable/GenerateFromMembers/GenerateFromMembersHelpers.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/GenerateFromMembersHelpers.cs
@@ -70,10 +70,10 @@ internal static class GenerateFromMembersHelpers
         };
 
     private static bool IsViableField(IFieldSymbol field)
-        => field.AssociatedSymbol == null;
+        => field is { AssociatedSymbol: null, CanBeReferencedByName: true };
 
     private static bool IsViableProperty(IPropertySymbol property)
-        => property.Parameters.IsEmpty;
+        => property is { Parameters.IsEmpty: true, CanBeReferencedByName: true };
 
     /// <summary>
     /// Returns an array of parameter symbols that correspond to selected member symbols.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76916
