### PR TITLE
Fix issue where hitting enter before a raw-string literal was processed incorrectly

### DIFF
--- a/src/EditorFeatures/CSharp/RawStringLiteral/RawStringLiteralCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/RawStringLiteral/RawStringLiteralCommandHandler.cs
@@ -20,18 +20,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.RawStringLiteral;
 [Order(After = nameof(SplitStringLiteralCommandHandler))]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal partial class RawStringLiteralCommandHandler(
+internal sealed partial class RawStringLiteralCommandHandler(
     ITextUndoHistoryRegistry undoHistoryRegistry,
-    IGlobalOptionService globalOptions,
     IEditorOperationsFactoryService editorOperationsFactoryService,
-    EditorOptionsService editorOptionsService,
-    IIndentationManagerService indentationManager)
+    EditorOptionsService editorOptionsService)
 {
     private readonly ITextUndoHistoryRegistry _undoHistoryRegistry = undoHistoryRegistry;
-    private readonly IGlobalOptionService _globalOptions = globalOptions;
     private readonly IEditorOperationsFactoryService _editorOperationsFactoryService = editorOperationsFactoryService;
     private readonly EditorOptionsService _editorOptionsService = editorOptionsService;
-    private readonly IIndentationManagerService _indentationManager = indentationManager;
 
     public string DisplayName => CSharpEditorResources.Split_raw_string;
 }

--- a/src/EditorFeatures/CSharp/RawStringLiteral/RawStringLiteralCommandHandler_Return.cs
+++ b/src/EditorFeatures/CSharp/RawStringLiteral/RawStringLiteralCommandHandler_Return.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Utilities;
 
@@ -31,6 +30,8 @@ internal partial class RawStringLiteralCommandHandler : ICommandHandler<ReturnKe
     /// </summary>
     public bool ExecuteCommand(ReturnKeyCommandArgs args, CommandExecutionContext context)
     {
+        var cancellationToken = context.OperationContext.UserCancellationToken;
+
         var textView = args.TextView;
         var subjectBuffer = args.SubjectBuffer;
         var spans = textView.Selection.GetSnapshotSpansOnBuffer(subjectBuffer);
@@ -50,8 +51,6 @@ internal partial class RawStringLiteralCommandHandler : ICommandHandler<ReturnKe
         var currentSnapshot = subjectBuffer.CurrentSnapshot;
         if (position >= currentSnapshot.Length)
             return false;
-
-        var cancellationToken = context.OperationContext.UserCancellationToken;
 
         var document = currentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
         if (document == null)
@@ -76,6 +75,10 @@ internal partial class RawStringLiteralCommandHandler : ICommandHandler<ReturnKe
 
                 quotesAfter++;
             }
+
+            // We must have at least one following quote, as we only got into ExecuteReturnCommandBeforeQuoteCharacter
+            // if there was a quote character in front of it.
+            Debug.Assert(quotesAfter > 0);
 
             for (var i = position - 1; i >= 0; i--)
             {
@@ -108,6 +111,14 @@ internal partial class RawStringLiteralCommandHandler : ICommandHandler<ReturnKe
                 token.Parent is not ExpressionSyntax expression)
             {
                 return false;
+            }
+
+            if (!isEmpty)
+            {
+                // in the non empty case (e.g. `"""goo$$"""`) we have to make sure sure that the caret is before the
+                // final quotes, not the initial ones.
+                if (token.Span.End - quotesAfter != position)
+                    return false;
             }
 
             return MakeEdit(parsedDocument, expression, isEmpty);

--- a/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
@@ -52,15 +52,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Debugging\Resources\*.*" />
-    <Compile Remove="Diagnostics\NamingStyles\**" />
     <EmbeddedResource Include="Debugging\Resources\*.*" LogicalName="Debugging/%(FileName)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Remove="Diagnostics\NamingStyles\**" />
-    <Page Remove="Diagnostics\NamingStyles\**" />
+    <Compile Include="..\..\VisualStudio\Core\Def\CodeCleanup\AbstractCodeCleanUpFixer_Helper.cs" Link="Formatting\AbstractCodeCleanUpFixer_Helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\VisualStudio\Core\Def\CodeCleanup\AbstractCodeCleanUpFixer_Helper.cs" Link="Formatting\AbstractCodeCleanUpFixer_Helper.cs" />
+    <Folder Include="Diagnostics\NamingStyles\" />
   </ItemGroup>
   <Import Project="$(RepositoryEngineeringDir)targets\ILAsm.targets" />
 </Project>

--- a/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
@@ -52,13 +52,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Debugging\Resources\*.*" />
+    <Compile Remove="Diagnostics\NamingStyles\**" />
     <EmbeddedResource Include="Debugging\Resources\*.*" LogicalName="Debugging/%(FileName)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\VisualStudio\Core\Def\CodeCleanup\AbstractCodeCleanUpFixer_Helper.cs" Link="Formatting\AbstractCodeCleanUpFixer_Helper.cs" />
+    <EmbeddedResource Remove="Diagnostics\NamingStyles\**" />
+    <Page Remove="Diagnostics\NamingStyles\**" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Diagnostics\NamingStyles\" />
+    <Compile Include="..\..\VisualStudio\Core\Def\CodeCleanup\AbstractCodeCleanUpFixer_Helper.cs" Link="Formatting\AbstractCodeCleanUpFixer_Helper.cs" />
   </ItemGroup>
   <Import Project="$(RepositoryEngineeringDir)targets\ILAsm.targets" />
 </Project>

--- a/src/EditorFeatures/CSharpTest/RawStringLiteral/RawStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/RawStringLiteral/RawStringLiteralCommandHandlerTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RawStringLiteral;
 
 [UseExportProvider]
-public class RawStringLiteralCommandHandlerTests
+public sealed class RawStringLiteralCommandHandlerTests
 {
     internal sealed class RawStringLiteralTestState : AbstractCommandHandlerTestState
     {
@@ -517,6 +517,48 @@ public class RawStringLiteralCommandHandlerTests
             ""$$";
             """");
 
+        testState.SendReturn(handled: false);
+    }
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/76773")]
+    public void TestReturnPriorToStartingQuotes1()
+    {
+        using var testState = RawStringLiteralTestState.CreateTestState(
+            """"
+            var v = Goo($$"""
+                bar);
+                """
+            """");
+
+        // Should not handle this as we're not inside the raw string.
+        testState.SendReturn(handled: false);
+    }
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/76773")]
+    public void TestReturnPriorToStartingQuotes2()
+    {
+        using var testState = RawStringLiteralTestState.CreateTestState(
+            """"
+            var v = Goo("$$""
+                bar);
+                """
+            """");
+
+        // Should not handle this as we're not inside the raw string.
+        testState.SendReturn(handled: false);
+    }
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/76773")]
+    public void TestReturnPriorToStartingQuotes3()
+    {
+        using var testState = RawStringLiteralTestState.CreateTestState(
+            """"
+            var v = Goo(""$$"
+                bar);
+                """
+            """");
+
+        // Should not handle this as we're not inside the raw string.
         testState.SendReturn(handled: false);
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/76773