### PR TITLE
Remove need to use semantics in the 'move type' code refactoring provider.

### DIFF
--- a/src/Features/CSharp/Portable/CodeRefactorings/MoveType/CSharpMoveTypeService.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/MoveType/CSharpMoveTypeService.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.MoveType;
 internal sealed class CSharpMoveTypeService() :
     AbstractMoveTypeService<CSharpMoveTypeService, BaseTypeDeclarationSyntax, BaseNamespaceDeclarationSyntax, CompilationUnitSyntax>
 {
+    protected override (string name, int arity) GetSymbolNameAndArity(BaseTypeDeclarationSyntax syntax)
+        => (syntax.Identifier.ValueText, syntax is TypeDeclarationSyntax { TypeParameterList.Parameters.Count: var arity } ? arity : 0);
+
     protected override bool IsMemberDeclaration(SyntaxNode syntaxNode)
         => syntaxNode is MemberDeclarationSyntax;
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeCodeAction.cs
@@ -20,7 +20,6 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
         private readonly State _state;
         private readonly TService _service;
         private readonly MoveTypeOperationKind _operationKind;
-        private readonly string _title;
         private readonly string _fileName;
 
         public MoveTypeCodeAction(
@@ -33,7 +32,7 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
             _service = service;
             _operationKind = operationKind;
             _fileName = fileName;
-            _title = CreateDisplayText();
+            this.Title = CreateDisplayText();
         }
 
         private string CreateDisplayText()
@@ -46,7 +45,7 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
                 _ => throw ExceptionUtilities.UnexpectedValue(_operationKind),
             };
 
-        public override string Title => _title;
+        public override string Title { get; }
 
         protected override async Task<ImmutableArray<CodeActionOperation>> ComputeOperationsAsync(
             IProgress<CodeAnalysisProgress> progress, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,8 +13,14 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
 {
     private sealed class RenameFileEditor(TService service, State state, string fileName, CancellationToken cancellationToken) : Editor(service, state, fileName, cancellationToken)
     {
-        public override Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync()
-            => Task.FromResult(RenameFileToMatchTypeName());
+        /// <summary>
+        /// Renames the file to match the type contained in it.
+        /// </summary>
+        public override async Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync()
+        {
+            var newSolution = await GetModifiedSolutionAsync().ConfigureAwait(false);
+            return [new ApplyChangesOperation(newSolution)];
+        }
 
         public override Task<Solution> GetModifiedSolutionAsync()
         {
@@ -24,18 +28,6 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
                 .WithDocumentName(SemanticDocument.Document.Id, FileName);
 
             return Task.FromResult(modifiedSolution);
-        }
-
-        /// <summary>
-        /// Renames the file to match the type contained in it.
-        /// </summary>
-        private ImmutableArray<CodeActionOperation> RenameFileToMatchTypeName()
-        {
-            var documentId = SemanticDocument.Document.Id;
-            var oldSolution = SemanticDocument.Document.Project.Solution;
-            var newSolution = oldSolution.WithDocumentName(documentId, FileName);
-
-            return [new ApplyChangesOperation(newSolution)];
         }
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
@@ -16,7 +16,6 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
 
         public TTypeDeclarationSyntax TypeNode { get; }
         public string DocumentNameWithoutExtension { get; }
-        public bool IsDocumentNameAValidIdentifier { get; }
 
         private State(SemanticDocument document, TTypeDeclarationSyntax typeNode)
         {
@@ -24,9 +23,6 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
             TypeNode = typeNode;
 
             DocumentNameWithoutExtension = Path.GetFileNameWithoutExtension(SemanticDocument.Document.Name);
-
-            var syntaxFacts = SemanticDocument.Document.GetRequiredLanguageService<ISyntaxFactsService>();
-            IsDocumentNameAValidIdentifier = syntaxFacts.IsValidIdentifier(DocumentNameWithoutExtension);
         }
 
         public static State? Generate(TService service, SemanticDocument document, TTypeDeclarationSyntax typeDeclaration)

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.IO;
-using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -18,58 +14,22 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
     {
         public SemanticDocument SemanticDocument { get; }
 
-        public TTypeDeclarationSyntax TypeNode { get; set; }
-        public string TypeName { get; set; }
-        public string DocumentNameWithoutExtension { get; set; }
-        public bool IsDocumentNameAValidIdentifier { get; set; }
+        public TTypeDeclarationSyntax TypeNode { get; }
+        public string DocumentNameWithoutExtension { get; }
+        public bool IsDocumentNameAValidIdentifier { get; }
 
-        private State(SemanticDocument document)
+        private State(SemanticDocument document, TTypeDeclarationSyntax typeNode)
         {
             SemanticDocument = document;
-        }
+            TypeNode = typeNode;
 
-        internal static State Generate(
-            SemanticDocument document, TTypeDeclarationSyntax typeDeclaration,
-            CancellationToken cancellationToken)
-        {
-            var state = new State(document);
-            if (!state.TryInitialize(typeDeclaration, cancellationToken))
-            {
-                return null;
-            }
-
-            return state;
-        }
-
-        private bool TryInitialize(
-            TTypeDeclarationSyntax typeDeclaration,
-            CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return false;
-            }
-
-            var tree = SemanticDocument.SyntaxTree;
-            var root = SemanticDocument.Root;
-            var syntaxFacts = SemanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
-
-            // compiler declared types, anonymous types, types defined in metadata should be filtered out.
-            if (SemanticDocument.SemanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken) is not INamedTypeSymbol typeSymbol ||
-                typeSymbol.Locations.Any(static loc => loc.IsInMetadata) ||
-                typeSymbol.IsAnonymousType ||
-                typeSymbol.IsImplicitlyDeclared ||
-                typeSymbol.Name == string.Empty)
-            {
-                return false;
-            }
-
-            TypeNode = typeDeclaration;
-            TypeName = typeSymbol.Name;
             DocumentNameWithoutExtension = Path.GetFileNameWithoutExtension(SemanticDocument.Document.Name);
-            IsDocumentNameAValidIdentifier = syntaxFacts.IsValidIdentifier(DocumentNameWithoutExtension);
 
-            return true;
+            var syntaxFacts = SemanticDocument.Document.GetRequiredLanguageService<ISyntaxFactsService>();
+            IsDocumentNameAValidIdentifier = syntaxFacts.IsValidIdentifier(DocumentNameWithoutExtension);
         }
+
+        public static State? Generate(TService service, SemanticDocument document, TTypeDeclarationSyntax typeDeclaration)
+            => service.GetSymbolName(typeDeclaration) is "" ? null : new State(document, typeDeclaration);
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
@@ -117,13 +117,10 @@ internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarati
         if (!AnyTopLevelTypeMatchesDocumentName(state))
         {
             foreach (var fileName in suggestedFileNames)
-            {
                 actions.Add(GetCodeAction(state, fileName, operationKind: MoveTypeOperationKind.RenameFile));
-            }
 
-            // only if the document name can be legal identifier in the language,
-            // offer to rename type with document name
-            if (state.IsDocumentNameAValidIdentifier)
+            // Only if the document name can be legal identifier in the language, offer to rename type with document name
+            if (syntaxFacts.IsValidIdentifier(state.DocumentNameWithoutExtension))
             {
                 actions.Add(GetCodeAction(
                     state, fileName: state.DocumentNameWithoutExtension,

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/MoveType/VisualBasicMoveTypeService.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/MoveType/VisualBasicMoveTypeService.vb
@@ -20,6 +20,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveType
         Public Sub New()
         End Sub
 
+        Protected Overrides Function GetSymbolNameAndArity(syntax As TypeBlockSyntax) As (name As String, arity As Integer)
+            Dim statement = syntax.BlockStatement
+            Return (statement.Identifier.ValueText, If(statement.TypeParameterList?.Parameters.Count, 0))
+        End Function
+
         Protected Overrides Function IsMemberDeclaration(syntaxNode As SyntaxNode) As Boolean
             Return TypeOf syntaxNode Is MethodBaseSyntax OrElse TypeOf syntaxNode Is MethodBlockBaseSyntax
         End Function


### PR DESCRIPTION
Extracted out all the cleanup and simplification i did in https://github.com/dotnet/roslyn/pull/77239

This allows changing 'rename type to file' (and vice versa) to operate entirely syntactically.  This is important for fix all performance. 