### PR TITLE
Ensure diagnostics refresh when source generators run in balanced mode

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md
@@ -35,7 +35,7 @@ public class C
 ***Introduced in Visual Studio 2022 version 17.10***
 
 *Conversion* of a collection expression to a `struct` or `class` that implements `System.Collections.IEnumerable` and *does not* have a strongly-typed `GetEnumerator()`
-requires the elements in the collection expression are implicitly convertible to the `object`.
+requires that the elements in the collection expression are implicitly convertible to `object`.
 Previously, the elements of a collection expression targeting an `IEnumerable` implementation were assumed to be convertible to `object`, and converted only when binding to the applicable `Add` method.
 
 This additional requirement means that collection expression conversions to `IEnumerable` implementations are treated consistently with other target types where the elements in the collection expression must be implicitly convertible to the *iteration type* of the target type.

--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -810,6 +810,12 @@ namespace Roslyn.Test.Utilities
                 await listenerProvider.GetWaiter(FeatureAttribute.DiagnosticService).ExpeditedWaitAsync();
             }
 
+            internal async Task WaitForSourceGeneratorsAsync()
+            {
+                var operations = TestWorkspace.ExportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
+                await operations.WaitAllAsync(TestWorkspace, [FeatureAttribute.Workspace, FeatureAttribute.SourceGenerators]);
+            }
+
             internal RequestExecutionQueue<RequestContext>.TestAccessor? GetQueueAccessor() => _languageServer.Value.GetTestAccessor().GetQueueAccessor();
 
             internal LspWorkspaceManager.TestAccessor GetManagerAccessor() => GetRequiredLspService<LspWorkspaceManager>().GetTestAccessor();

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -24,7 +24,7 @@ internal partial class DiagnosticAnalyzerService
     /// value if the set of analyzers changes.  In that case, a new instance will be created and will be cached for the
     /// next caller.
     /// </summary>
-    private static readonly ConditionalWeakTable<ProjectState, StrongBox<(Checksum checksum, ImmutableArray<DiagnosticAnalyzer> analyzers, CompilationWithAnalyzersPair? compilationWithAnalyzersPair)>> s_projectToCompilationWithAnalyzers = new();
+    private static readonly ConditionalWeakTable<ProjectState, StrongBox<(Checksum checksum, SourceGeneratorExecutionVersion sourceGeneratorExecution, ImmutableArray<DiagnosticAnalyzer> analyzers, CompilationWithAnalyzersPair? compilationWithAnalyzersPair)>> s_projectToCompilationWithAnalyzers = new();
 
     private static async Task<CompilationWithAnalyzersPair?> GetOrCreateCompilationWithAnalyzersAsync(
         Project project,
@@ -38,16 +38,18 @@ internal partial class DiagnosticAnalyzerService
 
         var projectState = project.State;
         var checksum = await project.GetDependentChecksumAsync(cancellationToken).ConfigureAwait(false);
+        var sourceGeneratorVersion = project.Solution.GetSourceGeneratorExecutionVersion(project.Id);
 
         // Make sure the cached pair was computed with at least the same state sets we're asking about.  if not,
         // recompute and cache with the new state sets.
         if (!s_projectToCompilationWithAnalyzers.TryGetValue(projectState, out var tupleBox) ||
             tupleBox.Value.checksum != checksum ||
+            tupleBox.Value.sourceGeneratorExecution != sourceGeneratorVersion ||
             !analyzers.IsSubsetOf(tupleBox.Value.analyzers))
         {
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
             var compilationWithAnalyzersPair = CreateCompilationWithAnalyzers(projectState, compilation);
-            tupleBox = new((checksum, analyzers, compilationWithAnalyzersPair));
+            tupleBox = new((checksum, sourceGeneratorVersion, analyzers, compilationWithAnalyzersPair));
 
 #if NET
             s_projectToCompilationWithAnalyzers.AddOrUpdate(projectState, tupleBox);

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -24,7 +24,7 @@ internal partial class DiagnosticAnalyzerService
     /// value if the set of analyzers changes.  In that case, a new instance will be created and will be cached for the
     /// next caller.
     /// </summary>
-    private static readonly ConditionalWeakTable<ProjectState, StrongBox<(Checksum checksum, SourceGeneratorExecutionVersion sourceGeneratorExecution, ImmutableArray<DiagnosticAnalyzer> analyzers, CompilationWithAnalyzersPair? compilationWithAnalyzersPair)>> s_projectToCompilationWithAnalyzers = new();
+    private static readonly ConditionalWeakTable<ProjectState, StrongBox<(Checksum checksum, ImmutableArray<DiagnosticAnalyzer> analyzers, CompilationWithAnalyzersPair? compilationWithAnalyzersPair)>> s_projectToCompilationWithAnalyzers = new();
 
     private static async Task<CompilationWithAnalyzersPair?> GetOrCreateCompilationWithAnalyzersAsync(
         Project project,
@@ -38,18 +38,16 @@ internal partial class DiagnosticAnalyzerService
 
         var projectState = project.State;
         var checksum = await project.GetDependentChecksumAsync(cancellationToken).ConfigureAwait(false);
-        var sourceGeneratorVersion = project.Solution.GetSourceGeneratorExecutionVersion(project.Id);
 
         // Make sure the cached pair was computed with at least the same state sets we're asking about.  if not,
         // recompute and cache with the new state sets.
         if (!s_projectToCompilationWithAnalyzers.TryGetValue(projectState, out var tupleBox) ||
             tupleBox.Value.checksum != checksum ||
-            tupleBox.Value.sourceGeneratorExecution != sourceGeneratorVersion ||
             !analyzers.IsSubsetOf(tupleBox.Value.analyzers))
         {
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
             var compilationWithAnalyzersPair = CreateCompilationWithAnalyzers(projectState, compilation);
-            tupleBox = new((checksum, sourceGeneratorVersion, analyzers, compilationWithAnalyzersPair));
+            tupleBox = new((checksum, analyzers, compilationWithAnalyzersPair));
 
 #if NET
             s_projectToCompilationWithAnalyzers.AddOrUpdate(projectState, tupleBox);

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticsPullCache.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticsPullCache.cs
@@ -17,6 +17,10 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
 {
     internal record struct DiagnosticsRequestState(Project Project, int GlobalStateVersion, RequestContext Context, IDiagnosticSource DiagnosticSource);
 
+    internal record struct CheapDiagnosticState(int GlobalStateVersion, SourceGeneratorExecutionVersion ExecutionVersion, VersionStamp DependentVersion);
+
+    internal record struct ExpensiveDiagnosticState(int GlobalStateVersion, SourceGeneratorExecutionVersion ExecutionVersion, Checksum DependentChecksum);
+
     /// <summary>
     /// Cache where we store the data produced by prior requests so that they can be returned if nothing of significance 
     /// changed. The <see cref="VersionStamp"/> is produced by <see cref="Project.GetDependentVersionAsync(CancellationToken)"/> while the 
@@ -24,16 +28,18 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
     /// and works well for us in the normal case.  The latter still allows us to reuse diagnostics when changes happen that
     /// update the version stamp but not the content (for example, forking LSP text).
     /// </summary>
-    private sealed class DiagnosticsPullCache(string uniqueKey) : VersionedPullCache<(int globalStateVersion, VersionStamp? dependentVersion), (int globalStateVersion, Checksum dependentChecksum), DiagnosticsRequestState, ImmutableArray<DiagnosticData>>(uniqueKey)
+    private sealed class DiagnosticsPullCache(string uniqueKey) : VersionedPullCache<CheapDiagnosticState, ExpensiveDiagnosticState, DiagnosticsRequestState, ImmutableArray<DiagnosticData>>(uniqueKey)
     {
-        public override async Task<(int globalStateVersion, VersionStamp? dependentVersion)> ComputeCheapVersionAsync(DiagnosticsRequestState state, CancellationToken cancellationToken)
+        public override async Task<CheapDiagnosticState> ComputeCheapVersionAsync(DiagnosticsRequestState state, CancellationToken cancellationToken)
         {
-            return (state.GlobalStateVersion, await state.Project.GetDependentVersionAsync(cancellationToken).ConfigureAwait(false));
+            var sgState = state.Project.Solution.GetSourceGeneratorExecutionVersion(state.Project.Id);
+            return new(state.GlobalStateVersion, sgState, await state.Project.GetDependentVersionAsync(cancellationToken).ConfigureAwait(false));
         }
 
-        public override async Task<(int globalStateVersion, Checksum dependentChecksum)> ComputeExpensiveVersionAsync(DiagnosticsRequestState state, CancellationToken cancellationToken)
+        public override async Task<ExpensiveDiagnosticState> ComputeExpensiveVersionAsync(DiagnosticsRequestState state, CancellationToken cancellationToken)
         {
-            return (state.GlobalStateVersion, await state.Project.GetDependentChecksumAsync(cancellationToken).ConfigureAwait(false));
+            var sgState = state.Project.Solution.GetSourceGeneratorExecutionVersion(state.Project.Id);
+            return new(state.GlobalStateVersion, sgState, await state.Project.GetDependentChecksumAsync(cancellationToken).ConfigureAwait(false));
         }
 
         /// <inheritdoc cref="VersionedPullCache{TCheapVersion, TExpensiveVersion, TState, TComputedData}.ComputeDataAsync(TState, CancellationToken)"/>

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -11,12 +11,14 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.TaskList;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
@@ -633,6 +635,98 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
     }
 
     [Theory, CombinatorialData]
+    internal async Task TestDocumentDiagnosticsUpdatesSourceGeneratorDiagnostics(bool useVSDiagnostics, bool mutatingLspWorkspace, SourceGeneratorExecutionPreference executionPreference)
+    {
+        var markup = """
+            public {|insert:|}class C
+            {
+                public int F => _field;
+            }
+            """;
+
+        await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(
+            markup, mutatingLspWorkspace, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics);
+
+        // Set execution mode preference.
+        var configService = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<TestWorkspaceConfigurationService>();
+        configService.Options = new WorkspaceConfigurationOptions(SourceGeneratorExecution: executionPreference);
+
+        //var globalOptionService = workspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
+        //globalOptionService.SetGlobalOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, executionPreference);
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+        // Add a generator to the solution that reports a diagnostic if the text matches original markup
+        var generator = new CallbackGenerator(onInit: (_) => { }, onExecute: context =>
+        {
+            var tree = context.Compilation.SyntaxTrees.Single();
+            var text = tree.GetText(CancellationToken.None).ToString();
+            if (text.Contains("public partial class C"))
+            {
+                context.AddSource("blah", """
+                    public partial class C
+                    {
+                        private readonly int _field = 1;
+                    }
+                    """);
+            }
+        });
+
+        testLspServer.TestWorkspace.OnAnalyzerReferenceAdded(
+            document.Project.Id,
+            new TestGeneratorReference(generator));
+        await testLspServer.WaitForSourceGeneratorsAsync();
+
+        await OpenDocumentAsync(testLspServer, document);
+
+        // First diagnostic request should report a diagnostic since the generator does not produce any source (text does not match).
+        var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI(), useVSDiagnostics);
+        var diagnostic = AssertEx.Single(results.Single().Diagnostics);
+        Assert.Equal("CS0103", diagnostic.Code);
+
+        // Update the text to include the text trigger the source generator relies on.
+        var textLocation = testLspServer.GetLocations()["insert"].Single();
+
+        var textEdit = new LSP.TextEdit { Range = textLocation.Range, NewText = "partial " };
+        if (mutatingLspWorkspace)
+        {
+            // In the mutating workspace, we just need to update the LSP text (which will flow into the workspace).
+            await testLspServer.ReplaceTextAsync(textLocation.Uri, (textEdit.Range, textEdit.NewText));
+            await WaitForWorkspaceOperationsAsync(testLspServer.TestWorkspace);
+        }
+        else
+        {
+            // In the non-mutating workspace, we need to ensure that both the workspace and LSP view of the world are updated.
+            //TODO - not needed.  Enqueuing the refresh should update the workspace solution (triggering generators to run on the fork?)
+            var workspaceText = await document.GetTextAsync(CancellationToken.None);
+            var textChange = ProtocolConversions.TextEditToTextChange(textEdit, workspaceText);
+            await testLspServer.TestWorkspace.ChangeDocumentAsync(document.Id, workspaceText.WithChanges(textChange));
+            await testLspServer.ReplaceTextAsync(textLocation.Uri, (textEdit.Range, textEdit.NewText));
+        }
+
+        await testLspServer.WaitForSourceGeneratorsAsync();
+        results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI(), useVSDiagnostics);
+
+        if (executionPreference == SourceGeneratorExecutionPreference.Automatic)
+        {
+            // In automatic mode, the diagnostic should be immediately removed as the source generator ran and produced the required field.
+            Assert.Empty(results.Single().Diagnostics!);
+        }
+        else
+        {
+            // In balanced mode, the diagnostic should remain until there is a manual source generator run that updates the sg text.
+            diagnostic = AssertEx.Single(results.Single().Diagnostics);
+            Assert.Equal("CS0103", diagnostic.Code);
+
+            testLspServer.TestWorkspace.EnqueueUpdateSourceGeneratorVersion(document.Project.Id, forceRegeneration: false);
+            await testLspServer.WaitForSourceGeneratorsAsync();
+
+            results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI(), useVSDiagnostics);
+            Assert.Empty(results.Single().Diagnostics!);
+        }
+    }
+
+    [Theory, CombinatorialData]
     public async Task TestDocumentDiagnosticsIncludesSourceGeneratorDiagnostics(bool useVSDiagnostics, bool mutatingLspWorkspace)
     {
         var markup = "// Hello, World";
@@ -641,7 +735,10 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
 
         var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
 
-        var generator = new DiagnosticProducingGenerator(context => Location.Create(context.Compilation.SyntaxTrees.Single(), new TextSpan(0, 10)));
+        var generator = new DiagnosticProducingGenerator(context =>
+        {
+            return Location.Create(context.Compilation.SyntaxTrees.Single(), new TextSpan(0, 10));
+        });
 
         testLspServer.TestWorkspace.OnAnalyzerReferenceAdded(
             document.Project.Id,

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -651,9 +651,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         var configService = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<TestWorkspaceConfigurationService>();
         configService.Options = new WorkspaceConfigurationOptions(SourceGeneratorExecution: executionPreference);
 
-        //var globalOptionService = workspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
-        //globalOptionService.SetGlobalOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, executionPreference);
-
         var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
 
         // Add a generator to the solution that reports a diagnostic if the text matches original markup
@@ -697,7 +694,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         else
         {
             // In the non-mutating workspace, we need to ensure that both the workspace and LSP view of the world are updated.
-            //TODO - not needed.  Enqueuing the refresh should update the workspace solution (triggering generators to run on the fork?)
             var workspaceText = await document.GetTextAsync(CancellationToken.None);
             var textChange = ProtocolConversions.TextEditToTextChange(textEdit, workspaceText);
             await testLspServer.TestWorkspace.ChangeDocumentAsync(document.Id, workspaceText.WithChanges(textChange));

--- a/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentTests.cs
@@ -171,7 +171,7 @@ public class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHelper) :
         // In automatic mode this should trigger generators to re-run.
         // In balanced mode generators should not re-run.
         await testLspServer.TestWorkspace.ChangeDocumentAsync(testLspServer.TestWorkspace.Documents.Single(d => !d.IsSourceGenerated).Id, SourceText.From("new text"));
-        await WaitForSourceGeneratorsAsync(testLspServer.TestWorkspace);
+        await testLspServer.WaitForSourceGeneratorsAsync();
 
         // Ask for the source generated text again.
         var secondRequest = await testLspServer.ExecuteRequestAsync<SourceGeneratorGetTextParams, SourceGeneratedDocumentText>(SourceGeneratedDocumentGetTextHandler.MethodName,
@@ -216,7 +216,7 @@ public class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHelper) :
 
         // Updating the execution version should trigger source generators to run in both automatic and balanced mode.
         testLspServer.TestWorkspace.EnqueueUpdateSourceGeneratorVersion(projectId: null, forceRegeneration: true);
-        await WaitForSourceGeneratorsAsync(testLspServer.TestWorkspace);
+        await testLspServer.WaitForSourceGeneratorsAsync();
 
         var secondRequest = await testLspServer.ExecuteRequestAsync<SourceGeneratorGetTextParams, SourceGeneratedDocumentText>(SourceGeneratedDocumentGetTextHandler.MethodName,
             new SourceGeneratorGetTextParams(new LSP.TextDocumentIdentifier { Uri = sourceGeneratorDocumentUri }, ResultId: text.ResultId), CancellationToken.None);
@@ -279,12 +279,6 @@ public class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHelper) :
 
         Assert.NotNull(secondRequest);
         Assert.Null(secondRequest.Text);
-    }
-
-    private static async Task WaitForSourceGeneratorsAsync(LspTestWorkspace workspace)
-    {
-        var operations = workspace.ExportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
-        await operations.WaitAllAsync(workspace, [FeatureAttribute.Workspace, FeatureAttribute.SourceGenerators]);
     }
 
     private async Task<TestLspServer> CreateTestLspServerWithGeneratorAsync(bool mutatingLspWorkspace, string generatedDocumentText)


### PR DESCRIPTION
Fixes an issue where diagnostics would not refresh when source generators run in balanced mode (e.g. after a save triggers sg re-run, diagnostics would not update based on the new sg contents).

checksum changes taken from https://github.com/dotnet/roslyn/pull/77273