### PR TITLE
Allow Semantic Search query function to take symbol parameter

### DIFF
--- a/src/Features/CSharpTest/SemanticSearch/CSharpSemanticSearchServiceTests.cs
+++ b/src/Features/CSharpTest/SemanticSearch/CSharpSemanticSearchServiceTests.cs
@@ -3,10 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
@@ -42,24 +45,31 @@ public sealed class CSharpSemanticSearchServiceTests
     private static string Inspect(UserCodeExceptionInfo info, string query)
         => $"{info.ProjectDisplayName}: {info.Span} '{InspectLine(info.Span.Start, query)}': {info.TypeName.JoinText()}: '{info.Message}'";
 
-    [ConditionalFact(typeof(CoreClrOnly))]
-    public async Task SimpleQuery()
-    {
-        using var workspace = TestWorkspace.Create("""
-            <Workspace>
-                <Project Language="C#" CommonReferences="true">
-                    <Document FilePath="File1.cs">
-                        namespace N
+    private static string DefaultWorkspaceXml => """
+        <Workspace>
+            <Project Language="C#" CommonReferences="true">
+                <Document FilePath="File1.cs">
+                    using System;
+
+                    namespace N
+                    {
+                        public class C
                         {
-                            public partial class C
-                            {
-                                public void VisibleMethod() { }
-                            }
+                            public int F = 1;
+                            public void VisibleMethod(int param) { }
+                            public int P { get; }
+                            public event Action E;
                         }
-                    </Document>
-                </Project>
-            </Workspace>
-            """, composition: FeaturesTestCompositions.Features);
+                    }
+                </Document>
+            </Project>
+        </Workspace>
+        """;
+
+    [ConditionalFact(typeof(CoreClrOnly))]
+    public async Task CompilationQuery()
+    {
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
 
         var solution = workspace.CurrentSolution;
 
@@ -84,19 +94,182 @@ public sealed class CSharpSemanticSearchServiceTests
     }
 
     [ConditionalFact(typeof(CoreClrOnly))]
+    public async Task NamespaceQuery()
+    {
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
+
+        var solution = workspace.CurrentSolution;
+
+        var service = solution.Services.GetRequiredLanguageService<ISemanticSearchService>(LanguageNames.CSharp);
+
+        var query = """
+        static IEnumerable<ISymbol> Find(INamespaceSymbol n)
+        {
+            return n.GetMembers("C");
+        }
+        """;
+
+        var results = new List<DefinitionItem>();
+        var observer = new MockSemanticSearchResultsObserver() { OnDefinitionFoundImpl = results.Add };
+        var traceSource = new TraceSource("test");
+
+        var options = workspace.GlobalOptions.GetClassificationOptionsProvider();
+        var result = await service.ExecuteQueryAsync(solution, query, s_referenceAssembliesDir, observer, options, traceSource, CancellationToken.None);
+
+        Assert.Null(result.ErrorMessage);
+        AssertEx.Equal(["class C"], results.Select(Inspect));
+    }
+
+    [ConditionalFact(typeof(CoreClrOnly))]
+    public async Task NamedTypeQuery()
+    {
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
+
+        var solution = workspace.CurrentSolution;
+
+        var service = solution.Services.GetRequiredLanguageService<ISemanticSearchService>(LanguageNames.CSharp);
+
+        var query = """
+        static IEnumerable<ISymbol> Find(INamedTypeSymbol type)
+        {
+            return type.GetMembers("F");
+        }
+        """;
+
+        var results = new List<DefinitionItem>();
+        var observer = new MockSemanticSearchResultsObserver() { OnDefinitionFoundImpl = results.Add };
+        var traceSource = new TraceSource("test");
+
+        var options = workspace.GlobalOptions.GetClassificationOptionsProvider();
+        var result = await service.ExecuteQueryAsync(solution, query, s_referenceAssembliesDir, observer, options, traceSource, CancellationToken.None);
+
+        Assert.Null(result.ErrorMessage);
+        AssertEx.Equal(["int C.F"], results.Select(Inspect));
+    }
+
+    [ConditionalFact(typeof(CoreClrOnly))]
+    public async Task MethodQuery()
+    {
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
+
+        var solution = workspace.CurrentSolution;
+
+        var service = solution.Services.GetRequiredLanguageService<ISemanticSearchService>(LanguageNames.CSharp);
+
+        var query = """
+        static IEnumerable<ISymbol> Find(IMethodSymbol method)
+        {
+            return [method];
+        }
+        """;
+
+        var results = new List<DefinitionItem>();
+        var observer = new MockSemanticSearchResultsObserver() { OnDefinitionFoundImpl = results.Add };
+        var traceSource = new TraceSource("test");
+
+        var options = workspace.GlobalOptions.GetClassificationOptionsProvider();
+        var result = await service.ExecuteQueryAsync(solution, query, s_referenceAssembliesDir, observer, options, traceSource, CancellationToken.None);
+
+        Assert.Null(result.ErrorMessage);
+        AssertEx.Equal(
+        [
+            "C.C()",
+            "int C.P.get",
+            "void C.E.add",
+            "void C.E.remove",
+            "void C.VisibleMethod(int)",
+        ], results.Select(Inspect).OrderBy(s => s));
+    }
+
+    [ConditionalFact(typeof(CoreClrOnly))]
+    public async Task FieldQuery()
+    {
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
+
+        var solution = workspace.CurrentSolution;
+
+        var service = solution.Services.GetRequiredLanguageService<ISemanticSearchService>(LanguageNames.CSharp);
+
+        var query = """
+        static IEnumerable<ISymbol> Find(IFieldSymbol field)
+        {
+            return [field];
+        }
+        """;
+
+        var results = new List<DefinitionItem>();
+        var observer = new MockSemanticSearchResultsObserver() { OnDefinitionFoundImpl = results.Add };
+        var traceSource = new TraceSource("test");
+
+        var options = workspace.GlobalOptions.GetClassificationOptionsProvider();
+        var result = await service.ExecuteQueryAsync(solution, query, s_referenceAssembliesDir, observer, options, traceSource, CancellationToken.None);
+
+        Assert.Null(result.ErrorMessage);
+        AssertEx.Equal(
+        [
+            "int C.F",
+            "readonly int C.P.field",
+        ], results.Select(Inspect).OrderBy(s => s));
+    }
+
+    [ConditionalFact(typeof(CoreClrOnly))]
+    public async Task PropertyQuery()
+    {
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
+
+        var solution = workspace.CurrentSolution;
+
+        var service = solution.Services.GetRequiredLanguageService<ISemanticSearchService>(LanguageNames.CSharp);
+
+        var query = """
+        static IEnumerable<ISymbol> Find(IPropertySymbol prop)
+        {
+            return [prop];
+        }
+        """;
+
+        var results = new List<DefinitionItem>();
+        var observer = new MockSemanticSearchResultsObserver() { OnDefinitionFoundImpl = results.Add };
+        var traceSource = new TraceSource("test");
+
+        var options = workspace.GlobalOptions.GetClassificationOptionsProvider();
+        var result = await service.ExecuteQueryAsync(solution, query, s_referenceAssembliesDir, observer, options, traceSource, CancellationToken.None);
+
+        Assert.Null(result.ErrorMessage);
+        AssertEx.Equal(["int C.P { get; }"], results.Select(Inspect));
+    }
+
+    [ConditionalFact(typeof(CoreClrOnly))]
+    public async Task EventQuery()
+    {
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
+
+        var solution = workspace.CurrentSolution;
+
+        var service = solution.Services.GetRequiredLanguageService<ISemanticSearchService>(LanguageNames.CSharp);
+
+        var query = """
+        static IEnumerable<ISymbol> Find(IEventSymbol e)
+        {
+            return [e];
+        }
+        """;
+
+        var results = new List<DefinitionItem>();
+        var observer = new MockSemanticSearchResultsObserver() { OnDefinitionFoundImpl = results.Add };
+        var traceSource = new TraceSource("test");
+
+        var options = workspace.GlobalOptions.GetClassificationOptionsProvider();
+        var result = await service.ExecuteQueryAsync(solution, query, s_referenceAssembliesDir, observer, options, traceSource, CancellationToken.None);
+
+        Assert.Null(result.ErrorMessage);
+        AssertEx.Equal(["event Action C.E"], results.Select(Inspect));
+    }
+
+    [ConditionalFact(typeof(CoreClrOnly))]
     public async Task ForcedCancellation()
     {
-        using var workspace = TestWorkspace.Create("""
-            <Workspace>
-                <Project Language="C#" CommonReferences="true">
-                    <Document FilePath="File1.cs">
-                        public class C
-                        {
-                        }
-                    </Document>
-                </Project>
-            </Workspace>
-            """, composition: FeaturesTestCompositions.Features);
+        using var workspace = TestWorkspace.Create(DefaultWorkspaceXml, composition: FeaturesTestCompositions.Features);
 
         var solution = workspace.CurrentSolution;
 
@@ -105,7 +278,7 @@ public sealed class CSharpSemanticSearchServiceTests
         var query = """
         static IEnumerable<ISymbol> Find(Compilation compilation)
         {
-            yield return compilation.GlobalNamespace.GetMembers("C").First();
+            yield return compilation.GlobalNamespace.GetMembers("N").First();
 
             while (true)
             {
@@ -127,7 +300,7 @@ public sealed class CSharpSemanticSearchServiceTests
         var traceSource = new TraceSource("test");
         var options = workspace.GlobalOptions.GetClassificationOptionsProvider();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
+        await Assert.ThrowsAsync<TaskCanceledException>(
             () => service.ExecuteQueryAsync(solution, query, s_referenceAssembliesDir, observer, options, traceSource, cancellationSource.Token));
 
         Assert.Empty(exceptions);
@@ -237,10 +410,11 @@ public sealed class CSharpSemanticSearchServiceTests
 
         var exception = exceptions.Single();
         AssertEx.Equal($"CSharpAssembly1: [190..190) 'var x = s.ToString();': NullReferenceException: '{expectedMessage}'", Inspect(exception, query));
+
         AssertEx.Equal(
             $"   at Program.<<Main>$>g__F|0_1(ISymbol s) in {FeaturesResources.Query}:line 11" + Environment.NewLine +
             $"   at Program.<>c.<<Main>$>b__0_2(ISymbol x) in {FeaturesResources.Query}:line 5" + Environment.NewLine +
-            $"   at System.Linq.Enumerable.ArraySelectIterator`2.MoveNext()" + Environment.NewLine,
-            exception.StackTrace.JoinText());
+            $"   at <Select Iterator>()" + Environment.NewLine,
+            Regex.Replace(exception.StackTrace.JoinText(), @"System\.Linq\.Enumerable\..*\.MoveNext", "<Select Iterator>"));
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -3153,14 +3153,20 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Semantic_search_query_failed_to_compile" xml:space="preserve">
     <value>Semantic search query failed to compile</value>
   </data>
-  <data name="The_query_does_not_specify_0_method_or_top_level_function" xml:space="preserve">
-    <value>The query does not specify '{0}' method or top-level function</value>
+  <data name="The_query_does_not_specify_0_top_level_function" xml:space="preserve">
+    <value>The query does not specify '{0}' top-level function</value>
   </data>
   <data name="Method_0_must_be_static_and_non_generic" xml:space="preserve">
     <value>Method '{0}' must be static and non-generic</value>
   </data>
-  <data name="Method_0_must_have_a_single_parameter_of_type_1_and_return_2" xml:space="preserve">
-    <value>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</value>
+  <data name="The_query_specifies_multiple_top_level_functions_1" xml:space="preserve">
+    <value>The query specifies multiple top-level functions '{1}'</value>
+  </data>
+  <data name="Top_level_function_0_must_have_a_single_parameter" xml:space="preserve">
+    <value>Top-level function '{0}' must have a single parameter</value>
+  </data>
+  <data name="Type_0_is_not_among_supported_types_1" xml:space="preserve">
+    <value>Type '{0}' is not among supported types: {1}</value>
   </data>
   <data name="Unable_to_load_type_0_1" xml:space="preserve">
     <value>Unable to load type '{0}': '{1}'</value>

--- a/src/Features/Core/Portable/SemanticSearch/AbstractSemanticSearchService.cs
+++ b/src/Features/Core/Portable/SemanticSearch/AbstractSemanticSearchService.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -26,9 +27,11 @@ using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -48,12 +51,17 @@ internal abstract partial class AbstractSemanticSearchService : ISemanticSearchS
             => IntPtr.Zero;
     }
 
-    private static readonly FindReferencesSearchOptions s_findReferencesSearchOptions = new()
-    {
-        DisplayAllDefinitions = true,
-    };
-
-    private const int StackDisplayDepthLimit = 32;
+    /// <summary>
+    /// Mapping from the parameter type of the <c>Find</c> method to the <see cref="QueryKind"/> value.
+    /// </summary>
+    private static readonly ImmutableDictionary<Type, QueryKind> s_queryKindByParameterType = ImmutableDictionary<Type, QueryKind>.Empty
+        .Add(typeof(Compilation), QueryKind.Compilation)
+        .Add(typeof(INamespaceSymbol), QueryKind.Namespace)
+        .Add(typeof(INamedTypeSymbol), QueryKind.NamedType)
+        .Add(typeof(IMethodSymbol), QueryKind.Method)
+        .Add(typeof(IFieldSymbol), QueryKind.Field)
+        .Add(typeof(IPropertySymbol), QueryKind.Property)
+        .Add(typeof(IEventSymbol), QueryKind.Event);
 
     protected abstract Compilation CreateCompilation(SourceText query, IEnumerable<MetadataReference> references, SolutionServices services, out SyntaxTree queryTree, CancellationToken cancellationToken);
 
@@ -134,87 +142,26 @@ internal abstract partial class AbstractSemanticSearchService : ISemanticSearchS
                 Contract.ThrowIfNull(moduleCancellationTokenField);
                 moduleCancellationTokenField.SetValue(null, cancellationToken);
 
-                if (!TryGetFindMethod(queryAssembly, out var findMethod, out var errorMessage, out var errorMessageArgs))
+                if (!TryGetFindMethod(queryAssembly, out var findMethod, out var queryKind, out var errorMessage, out var errorMessageArgs))
                 {
                     traceSource.TraceInformation($"Semantic search failed: {errorMessage}");
                     return CreateResult(errorMessage, errorMessageArgs);
                 }
 
-                var executionTimeStopWatch = new Stopwatch();
-
-                foreach (var project in solution.Projects)
+                var invocationContext = new QueryExecutionContext(queryText, findMethod, observer, classificationOptions, traceSource);
+                try
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    await invocationContext.InvokeAsync(solution, queryKind, cancellationToken).ConfigureAwait(false);
 
-                    var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    try
+                    if (invocationContext.TerminatedWithException)
                     {
-                        executionTimeStopWatch.Start();
-
-                        try
-                        {
-                            var symbols = (IEnumerable<ISymbol?>?)findMethod.Invoke(null, [compilation]) ?? [];
-
-                            foreach (var symbol in symbols)
-                            {
-                                cancellationToken.ThrowIfCancellationRequested();
-
-                                if (symbol != null)
-                                {
-                                    executionTimeStopWatch.Stop();
-
-                                    try
-                                    {
-                                        var definitionItem = await symbol.ToClassifiedDefinitionItemAsync(
-                                            classificationOptions, solution, s_findReferencesSearchOptions, isPrimary: true, includeHiddenLocations: false, cancellationToken).ConfigureAwait(false);
-
-                                        await observer.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
-                                    }
-                                    catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
-                                    {
-                                        // skip symbol
-                                    }
-
-                                    executionTimeStopWatch.Start();
-                                }
-                            }
-                        }
-                        finally
-                        {
-                            executionTimeStopWatch.Stop();
-                            executionTime = executionTimeStopWatch.Elapsed;
-                        }
-                    }
-                    catch (Exception e) when (e is not OperationCanceledException)
-                    {
-                        // exception from user code
-
-                        if (e is TargetInvocationException { InnerException: { } innerException })
-                        {
-                            e = innerException;
-                        }
-
-                        var (projectName, projectFlavor) = project.State.NameAndFlavor;
-                        projectName ??= project.Name;
-                        var projectDisplay = string.IsNullOrEmpty(projectFlavor) ? projectName : $"{projectName} ({projectFlavor})";
-
-                        FormatStackTrace(e, queryAssembly, out var position, out var stackTraceTaggedText);
-                        var span = queryText.Lines.GetTextSpan(new LinePositionSpan(position, position));
-
-                        var exceptionNameTaggedText = GetExceptionTypeTaggedText(e, compilation);
-
-                        await observer.OnUserCodeExceptionAsync(new UserCodeExceptionInfo(projectDisplay, e.Message, exceptionNameTaggedText, stackTraceTaggedText, span), cancellationToken).ConfigureAwait(false);
-
-                        traceSource.TraceInformation($"Semantic query execution failed due to user code exception: {e}");
                         return CreateResult(FeaturesResources.Semantic_search_query_terminated_with_exception);
                     }
-
-                    // complete project progress item:
-                    remainingProgressItemCount--;
-                    await observer.ItemsCompletedAsync(1, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    executionTime = new TimeSpan(invocationContext.ExecutionTime);
+                    remainingProgressItemCount -= invocationContext.ProcessedProjectCount;
                 }
             }
             finally
@@ -239,96 +186,12 @@ internal abstract partial class AbstractSemanticSearchService : ISemanticSearchS
         }
     }
 
-    private static ImmutableArray<TaggedText> GetExceptionTypeTaggedText(Exception e, Compilation compilation)
-        => e.GetType().FullName is { } exceptionTypeName
-           ? compilation.GetTypeByMetadataName(exceptionTypeName) is { } exceptionTypeSymbol
-                ? exceptionTypeSymbol.ToDisplayParts(SymbolDisplayFormat.MinimallyQualifiedFormat).ToTaggedText()
-                : [new TaggedText(WellKnownTags.Class, exceptionTypeName)]
-           : [new TaggedText(WellKnownTags.Class, nameof(Exception))];
-
-    private static void FormatStackTrace(Exception e, Assembly queryAssembly, out LinePosition position, out ImmutableArray<TaggedText> formattedTrace)
+    private static bool TryGetFindMethod(Assembly queryAssembly, [NotNullWhen(true)] out MethodInfo? method, out QueryKind queryKind, out string? error, out string[]? errorMessageArgs)
     {
-        position = default;
-
-        try
-        {
-            var trace = new StackTrace(e, fNeedFileInfo: true);
-            var frames = trace.GetFrames();
-            var displayFrames = frames;
-            var skippedFrameCount = 0;
-
-            try
-            {
-                var hostAssembly = typeof(AbstractSemanticSearchService).Assembly;
-                var displayFramesEnd = frames.Length;
-                var foundPosition = false;
-                for (var i = 0; i < frames.Length; i++)
-                {
-                    var frame = frames[i];
-
-                    if (frame.GetMethod() is { } method)
-                    {
-                        var frameAssembly = method.DeclaringType?.Assembly;
-                        if (frameAssembly == hostAssembly)
-                        {
-                            displayFramesEnd = i;
-                            break;
-                        }
-
-                        if (!foundPosition &&
-                            frameAssembly == queryAssembly &&
-                            frame.GetFileName() is { } fileName &&
-                            frame.GetFileLineNumber() is > 0 and var line &&
-                            frame.GetFileColumnNumber() is > 0 and var column)
-                        {
-                            position = new LinePosition(line - 1, column - 1);
-                            foundPosition = true;
-                        }
-                    }
-                }
-
-                // display last StackDisplayDepthLimit frames preceding the host frame:
-                skippedFrameCount = Math.Max(0, displayFramesEnd - StackDisplayDepthLimit);
-                displayFrames = frames[skippedFrameCount..displayFramesEnd];
-            }
-            catch
-            {
-                // nop
-            }
-
-            formattedTrace =
-            [
-                new TaggedText(tag: TextTags.Text, (skippedFrameCount > 0 ? "   ..." + Environment.NewLine : "") + GetStackTraceText(displayFrames))
-            ];
-        }
-        catch
-        {
-            formattedTrace = [];
-        }
-    }
-
-    private static string GetStackTraceText(IEnumerable<StackFrame> frames)
-    {
-#if NET8_0_OR_GREATER
-        return new StackTrace(frames).ToString();
-#else
-        var builder = new StringBuilder();
-        foreach (var frame in frames)
-        {
-            builder.Append(new StackTrace(frame).ToString());
-        }
-
-        return builder.ToString();
-#endif
-    }
-
-    private static bool TryGetFindMethod(Assembly queryAssembly, [NotNullWhen(true)] out MethodInfo? method, out string? error, out string[]? errorMessageArgs)
-    {
-        // TODO: Use Compilation APIs to find the method
-
         method = null;
         error = null;
         errorMessageArgs = null;
+        queryKind = default;
 
         Type? program;
         try
@@ -346,45 +209,23 @@ internal abstract partial class AbstractSemanticSearchService : ISemanticSearchS
         {
             try
             {
-                method = GetFindMethod(program, allowLocalFunction: true, ref error);
+                (method, queryKind) = GetFindMethod(program, ref error);
             }
             catch
             {
             }
-
-            if (method != null)
-            {
-                return true;
-            }
         }
 
-        Type[] types;
-        try
+        if (method != null)
         {
-            types = queryAssembly.GetTypes();
-        }
-        catch (TypeLoadException e)
-        {
-            error = FeaturesResources.Unable_to_load_type_0_1;
-            errorMessageArgs = [e.TypeName, e.Message];
-            method = null;
-            return false;
+            return true;
         }
 
-        foreach (var type in types)
-        {
-            method = GetFindMethod(type, allowLocalFunction: false, ref error);
-            if (method != null)
-            {
-                return true;
-            }
-        }
-
-        error ??= string.Format(FeaturesResources.The_query_does_not_specify_0_method_or_top_level_function, SemanticSearchUtilities.FindMethodName);
+        error ??= string.Format(FeaturesResources.The_query_does_not_specify_0_top_level_function, SemanticSearchUtilities.FindMethodName);
         return false;
     }
 
-    private static MethodInfo? GetFindMethod(Type type, bool allowLocalFunction, ref string? error)
+    private static (MethodInfo? method, QueryKind queryKind) GetFindMethod(Type type, ref string? error)
     {
         try
         {
@@ -392,8 +233,7 @@ internal abstract partial class AbstractSemanticSearchService : ISemanticSearchS
 
             foreach (var candidate in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
             {
-                if (candidate.Name == SemanticSearchUtilities.FindMethodName ||
-                    allowLocalFunction && candidate.Name.StartsWith($"<{WellKnownMemberNames.TopLevelStatementsEntryPointMethodName}>g__{SemanticSearchUtilities.FindMethodName}|"))
+                if (candidate.Name.StartsWith($"<{WellKnownMemberNames.TopLevelStatementsEntryPointMethodName}>g__{SemanticSearchUtilities.FindMethodName}|"))
                 {
                     candidates.Add(candidate);
                 }
@@ -401,35 +241,45 @@ internal abstract partial class AbstractSemanticSearchService : ISemanticSearchS
 
             if (candidates is [])
             {
-                error = string.Format(FeaturesResources.The_query_does_not_specify_0_method_or_top_level_function, SemanticSearchUtilities.FindMethodName);
-                return null;
+                error = string.Format(FeaturesResources.The_query_does_not_specify_0_top_level_function, SemanticSearchUtilities.FindMethodName);
+                return default;
             }
 
             candidates.RemoveAll(candidate => candidate.IsGenericMethod || !candidate.IsStatic);
             if (candidates is [])
             {
                 error = string.Format(FeaturesResources.Method_0_must_be_static_and_non_generic, SemanticSearchUtilities.FindMethodName);
-                return null;
+                return default;
             }
 
-            candidates.RemoveAll(candidate => !(
-                typeof(IEnumerable<ISymbol>).IsAssignableFrom(candidate.ReturnType) &&
-                candidate.GetParameters() is [{ ParameterType: var paramType }] &&
-                typeof(Compilation).IsAssignableFrom(paramType)));
-
-            if (candidates is [])
+            if (candidates is not [var method])
             {
-                error = string.Format(FeaturesResources.Method_0_must_have_a_single_parameter_of_type_1_and_return_2, SemanticSearchUtilities.FindMethodName, nameof(Compilation));
-                return null;
+                error = string.Format(FeaturesResources.The_query_specifies_multiple_top_level_functions_1, SemanticSearchUtilities.FindMethodName);
+                return default;
             }
 
-            Debug.Assert(candidates.Count == 1);
-            return candidates[0];
+            if (method.GetParameters() is not [var parameter])
+            {
+                error = string.Format(FeaturesResources.The_query_specifies_multiple_top_level_functions_1, SemanticSearchUtilities.FindMethodName);
+                return default;
+            }
+
+            if (!s_queryKindByParameterType.TryGetValue(parameter.ParameterType, out var entity))
+            {
+                error = string.Format(
+                    FeaturesResources.Type_0_is_not_among_supported_types_1,
+                    SemanticSearchUtilities.FindMethodName,
+                    string.Join(", ", s_queryKindByParameterType.Keys.Select(t => $"'{t.Name}'")));
+
+                return default;
+            }
+
+            return (method, entity);
         }
         catch (Exception e)
         {
             error = e.Message;
-            return null;
+            return default;
         }
     }
 }

--- a/src/Features/Core/Portable/SemanticSearch/QueryExecutionContext.cs
+++ b/src/Features/Core/Portable/SemanticSearch/QueryExecutionContext.cs
@@ -1,0 +1,289 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Tags;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.SemanticSearch;
+
+internal sealed class QueryExecutionContext(
+    SourceText queryText,
+    MethodInfo method,
+    ISemanticSearchResultsObserver resultsObserver,
+    OptionsProvider<ClassificationOptions> classificationOptions,
+    TraceSource traceSource)
+{
+    private static readonly FindReferencesSearchOptions s_findReferencesSearchOptions = new()
+    {
+        DisplayAllDefinitions = true,
+    };
+
+    private const int StackDisplayDepthLimit = 32;
+
+    private long _executionTime;
+    private int _processedProjectCount;
+    public bool TerminatedWithException { get; private set; }
+
+    public long ExecutionTime => _executionTime;
+    public int ProcessedProjectCount => _processedProjectCount;
+
+    public async Task InvokeAsync(Solution solution, QueryKind targetEntity, CancellationToken cancellationToken)
+    {
+        // Invoke query on projects and types in parallel and on members serially.
+        // Cancel execution if the query throws an exception.
+
+        using var symbolEnumerationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        try
+        {
+            await Parallel.ForEachAsync(solution.Projects, symbolEnumerationCancellationSource.Token, async (project, cancellationToken) =>
+            {
+                try
+                {
+                    var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                    if (compilation == null)
+                    {
+                        return;
+                    }
+
+                    // only search source symbols:
+                    var rootNamespace = compilation.Assembly.GlobalNamespace;
+
+                    switch (targetEntity)
+                    {
+                        case QueryKind.Compilation:
+                            await InvokeAsync(project, compilation, entity: compilation, symbolEnumerationCancellationSource, cancellationToken).ConfigureAwait(false);
+                            break;
+
+                        case QueryKind.Namespace:
+                            await Parallel.ForEachAsync(rootNamespace.GetAllNamespaces(cancellationToken), cancellationToken, async (namespaceSymbol, cancellationToken) =>
+                            {
+                                await InvokeAsync(project, compilation, entity: namespaceSymbol, symbolEnumerationCancellationSource, cancellationToken).ConfigureAwait(false);
+                            }).ConfigureAwait(false);
+                            break;
+
+                        case QueryKind.NamedType:
+                        case QueryKind.Field:
+                        case QueryKind.Method:
+                        case QueryKind.Property:
+                        case QueryKind.Event:
+
+                            var kind = GetSymbolKind(targetEntity);
+
+                            await Parallel.ForEachAsync(rootNamespace.GetAllTypes(cancellationToken), async (type, cancellationToken) =>
+                            {
+                                if (kind == SymbolKind.NamedType)
+                                {
+                                    await InvokeAsync(project, compilation, entity: type, symbolEnumerationCancellationSource, cancellationToken).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    foreach (var member in type.GetMembers())
+                                    {
+                                        if (member.Kind == kind)
+                                        {
+                                            await InvokeAsync(project, compilation, entity: member, symbolEnumerationCancellationSource, cancellationToken).ConfigureAwait(false);
+                                        }
+                                    }
+                                }
+                            }).ConfigureAwait(false);
+                            break;
+                    }
+                }
+                finally
+                {
+                    // complete project progress item:
+                    Interlocked.Increment(ref _processedProjectCount);
+                    await resultsObserver.ItemsCompletedAsync(1, cancellationToken).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (symbolEnumerationCancellationSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // enumeration terminated due to exception in user code
+        }
+    }
+
+    private async ValueTask InvokeAsync(Project project, Compilation compilation, object entity, CancellationTokenSource symbolEnumerationCancellationSource, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var executionTime = TimeSpan.Zero;
+
+        try
+        {
+            var executionStart = Stopwatch.GetTimestamp();
+
+            try
+            {
+                var symbols = (IEnumerable<ISymbol?>?)method.Invoke(null, [entity]) ?? [];
+
+                foreach (var symbol in symbols)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (symbol != null)
+                    {
+                        executionTime += Stopwatch.GetElapsedTime(executionStart);
+
+                        try
+                        {
+                            var definitionItem = await symbol.ToClassifiedDefinitionItemAsync(
+                                classificationOptions, project.Solution, s_findReferencesSearchOptions, isPrimary: true, includeHiddenLocations: false, cancellationToken).ConfigureAwait(false);
+
+                            await resultsObserver.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
+                        {
+                            // skip symbol
+                        }
+
+                        executionStart = Stopwatch.GetTimestamp();
+                    }
+                }
+            }
+            finally
+            {
+                executionTime += Stopwatch.GetElapsedTime(executionStart);
+            }
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            // exception from user code
+            TerminatedWithException = true;
+
+            if (e is TargetInvocationException { InnerException: { } innerException })
+            {
+                e = innerException;
+            }
+
+            var (projectName, projectFlavor) = project.State.NameAndFlavor;
+            projectName ??= project.Name;
+            var projectDisplay = string.IsNullOrEmpty(projectFlavor) ? projectName : $"{projectName} ({projectFlavor})";
+
+            Contract.ThrowIfNull(method.DeclaringType);
+            FormatStackTrace(e, method.DeclaringType.Assembly, out var position, out var stackTraceTaggedText);
+            var span = queryText.Lines.GetTextSpan(new LinePositionSpan(position, position));
+
+            var exceptionNameTaggedText = GetExceptionTypeTaggedText(e, compilation);
+
+            await resultsObserver.OnUserCodeExceptionAsync(new UserCodeExceptionInfo(projectDisplay, e.Message, exceptionNameTaggedText, stackTraceTaggedText, span), cancellationToken).ConfigureAwait(false);
+
+            traceSource.TraceInformation($"Semantic query execution failed due to user code exception: {e}");
+
+            symbolEnumerationCancellationSource.Cancel();
+        }
+
+        Interlocked.Add(ref _executionTime, executionTime.Ticks);
+    }
+
+    private static SymbolKind GetSymbolKind(QueryKind targetEntity)
+        => targetEntity switch
+        {
+            QueryKind.Field => SymbolKind.Field,
+            QueryKind.Method => SymbolKind.Method,
+            QueryKind.Property => SymbolKind.Property,
+            QueryKind.Event => SymbolKind.Event,
+            QueryKind.NamedType => SymbolKind.NamedType,
+            QueryKind.Namespace => SymbolKind.Namespace,
+            _ => default
+        };
+
+    private static ImmutableArray<TaggedText> GetExceptionTypeTaggedText(Exception e, Compilation compilation)
+        => e.GetType().FullName is { } exceptionTypeName
+           ? compilation.GetTypeByMetadataName(exceptionTypeName) is { } exceptionTypeSymbol
+                ? exceptionTypeSymbol.ToDisplayParts(SymbolDisplayFormat.MinimallyQualifiedFormat).ToTaggedText()
+                : [new TaggedText(WellKnownTags.Class, exceptionTypeName)]
+           : [new TaggedText(WellKnownTags.Class, nameof(Exception))];
+
+    private static void FormatStackTrace(Exception e, Assembly queryAssembly, out LinePosition position, out ImmutableArray<TaggedText> formattedTrace)
+    {
+        position = default;
+
+        try
+        {
+            var trace = new StackTrace(e, fNeedFileInfo: true);
+            var frames = trace.GetFrames();
+            var displayFrames = frames;
+            var skippedFrameCount = 0;
+
+            try
+            {
+                var hostAssembly = typeof(AbstractSemanticSearchService).Assembly;
+                var displayFramesEnd = frames.Length;
+                var foundPosition = false;
+                for (var i = 0; i < frames.Length; i++)
+                {
+                    var frame = frames[i];
+
+                    if (frame.GetMethod() is { } method)
+                    {
+                        var frameAssembly = method.DeclaringType?.Assembly;
+                        if (frameAssembly == hostAssembly)
+                        {
+                            displayFramesEnd = i;
+                            break;
+                        }
+
+                        if (!foundPosition &&
+                            frameAssembly == queryAssembly &&
+                            frame.GetFileName() is { } fileName &&
+                            frame.GetFileLineNumber() is > 0 and var line &&
+                            frame.GetFileColumnNumber() is > 0 and var column)
+                        {
+                            position = new LinePosition(line - 1, column - 1);
+                            foundPosition = true;
+                        }
+                    }
+                }
+
+                // display last StackDisplayDepthLimit frames preceding the host frame:
+                skippedFrameCount = Math.Max(0, displayFramesEnd - StackDisplayDepthLimit);
+                displayFrames = frames[skippedFrameCount..displayFramesEnd];
+            }
+            catch
+            {
+                // nop
+            }
+
+            formattedTrace =
+            [
+                new TaggedText(tag: TextTags.Text, (skippedFrameCount > 0 ? "   ..." + Environment.NewLine : "") + GetStackTraceText(displayFrames))
+            ];
+        }
+        catch
+        {
+            formattedTrace = [];
+        }
+    }
+
+    private static string GetStackTraceText(IEnumerable<StackFrame> frames)
+    {
+#if NET8_0_OR_GREATER
+        return new StackTrace(frames).ToString();
+#else
+        var builder = new StringBuilder();
+        foreach (var frame in frames)
+        {
+            builder.Append(new StackTrace(frame).ToString());
+        }
+
+        return builder.ToString();
+#endif
+    }
+}
+#endif

--- a/src/Features/Core/Portable/SemanticSearch/QueryKind.cs
+++ b/src/Features/Core/Portable/SemanticSearch/QueryKind.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#if NET6_0_OR_GREATER
+
+namespace Microsoft.CodeAnalysis.SemanticSearch;
+
+internal enum QueryKind
+{
+    Compilation,
+    Namespace,
+    NamedType,
+    Method,
+    Field,
+    Property,
+    Event
+}
+#endif

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -1100,11 +1100,6 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Metoda {0} musí být statická a neobecná.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">Metoda {0} musí mít jeden parametr typu {1} a musí vracet {2}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Různé soubory</target>
@@ -2705,9 +2700,14 @@ Pozitivní kontrolní výrazy zpětného vyhledávání s nulovou délkou se obv
         <target state="translated">Sestavení analyzátoru {0} odkazuje na verzi {1} kompilátoru, která je novější než aktuálně spuštěná verze {2}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">Dotaz neurčuje metodu {0} nebo funkci nejvyšší úrovně.</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Pozitivní kontrolní výrazy zpětného vyhledávání s nulovou délkou se obv
         <target state="translated">Příliš mnoho znaků )</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Čárka na konci není povolená</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -1100,11 +1100,6 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Die Methode „{0}“ muss statisch und nicht generisch sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">Die Methode „{0}“ muss einen einzelnen Parameter vom Typ „{1}“ aufweisen und „{2}“ zurückgeben.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Sonstige Dateien</target>
@@ -2705,9 +2700,14 @@ Positive Lookbehindassertionen mit Nullbreite werden normalerweise am Anfang reg
         <target state="translated">Die Analyzerassembly „{0}“ verweist auf Version „{1}“ des Compilers, die neuer ist als die aktuell ausgeführte Version „{2}“.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">Die Abfrage gibt weder die Methode „{0}“ noch die Funktion der obersten Ebene an.</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Positive Lookbehindassertionen mit Nullbreite werden normalerweise am Anfang reg
         <target state="translated">Zu viele )-Zeichen.</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Ein nachgestelltes Komma ist unzulässig</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -1100,11 +1100,6 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">El método "{0}" debe ser estático y no genérico</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">El método "{0}" debe tener un único parámetro de tipo "{1}" y devolver "{2}"</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Archivos varios</target>
@@ -2705,9 +2700,14 @@ Las aserciones de búsqueda retrasada (lookbehind) positivas de ancho cero se us
         <target state="translated">El ensamblado del analizador ”{0}” hace referencia a la versión ”{1}” del compilador, que es más reciente que la versión "{2}" que se está ejecutando actualmente.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">La consulta no especifica "{0}" método o función de nivel superior</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Las aserciones de búsqueda retrasada (lookbehind) positivas de ancho cero se us
         <target state="translated">Demasiados )</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Coma final no permitida</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -1100,11 +1100,6 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">La méthode « {0} » doit être statique et non générique</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">Le « {0} » de méthode doit avoir un seul paramètre de type « {1} » et « {2} » de retour</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Fichiers divers</target>
@@ -2705,9 +2700,14 @@ Les assertions arrière positives de largeur nulle sont généralement utilisée
         <target state="translated">L'assembly d'analyseur '{0}' fait référence à la version '{1}' du compilateur, qui est plus récente que la version en cours d'exécution '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">La requête ne spécifie pas « {0} » méthode ou fonction de niveau supérieur</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Les assertions arrière positives de largeur nulle sont généralement utilisée
         <target state="translated">Trop de )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Virgule de fin non autorisée</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -1100,11 +1100,6 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Il metodo '{0}' deve essere statico e non generico</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">Il metodo '{0}' deve avere un singolo parametro di tipo '{1}' e restituire '{2}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">File esterni</target>
@@ -2705,9 +2700,14 @@ Le asserzioni lookbehind positive di larghezza zero vengono usate in genere all'
         <target state="translated">L'assembly dell'analizzatore '{0}' fa riferimento alla versione '{1}' del compilatore, che è più recente della versione attualmente in esecuzione '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">La query non specifica il metodo '{0}' o la funzione di primo livello</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Le asserzioni lookbehind positive di larghezza zero vengono usate in genere all'
         <target state="translated">Troppe parentesi di chiusura</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Virgola finale non consentita</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -1100,11 +1100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">メソッド '{0}' は静的かつ非ジェネリックである必要があります</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">メソッド '{0}' では、型が '{1}' のパラメーターを 1 つ設定し、'{2}' を返す必要があります</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">その他のファイル</target>
@@ -2705,9 +2700,14 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">アナライザー アセンブリ '{0}' は、コンパイラのバージョン '{1}' を参照しています。これは、現在実行中のバージョン '{2}' よりも新しいバージョンです。</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">クエリで、'{0}' メソッドまたは上位レベルの関数が指定されていません</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">) が多すぎます</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">末尾にコンマは使用できない</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -1100,11 +1100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">메서드 '{0}'은(는) 정적이어야 하며 제네릭이 아니어야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">메서드 '{0}'은(는) '{1}' 형식의 단일 매개 변수가 있어야 하며 '{2}'을(를) 반환해야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">기타 파일</target>
@@ -2705,9 +2700,14 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">분석기 어셈블리 '{0}'은(는) 컴파일러의 '{1}' 버전을 참조하며, 이 버전은 현재 실행 중인 버전 '{2}'보다 최신 버전입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">쿼리가 '{0}' 메서드 또는 최상위 함수를 지정하지 않습니다.</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">)가 너무 많습니다.</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">후행 쉼표는 허용되지 않습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -1100,11 +1100,6 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Metoda „{0}” musi być statyczna i nieogólna</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">Metoda „{0}” musi mieć jeden parametr typu „{1}” i zwracać wartość „{2}”</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Różne pliki</target>
@@ -2705,9 +2700,14 @@ Pozytywne asercje wsteczne o zerowej szerokości są zwykle używane na początk
         <target state="translated">Zestaw analizatora „{0}” odwołuje się do wersji „{1}” kompilatora, która jest nowsza niż obecnie uruchomiona wersja „{2}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">Zapytanie nie określa metody „{0}” ani funkcji najwyższego poziomu</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Pozytywne asercje wsteczne o zerowej szerokości są zwykle używane na początk
         <target state="translated">Zbyt wiele znaków )</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Końcowy przecinek jest niedozwolony.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -1100,11 +1100,6 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">O método '{0}' deve ser estático e não genérico</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">O método '{0}' deve ter um único parâmetro do tipo '{1}' e retornar '{2}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Arquivos Diversos</target>
@@ -2705,9 +2700,14 @@ As declarações de lookbehind positivas de largura zero normalmente são usadas
         <target state="translated">O assembly do analisador '{0}' referencia a versão '{1}' do compilador, que é mais recente que a versão em execução no momento '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">A consulta não especifica o método '{0}' ou a função de nível superior</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ As declarações de lookbehind positivas de largura zero normalmente são usadas
         <target state="translated">Muitos )'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Vírgula à direita não permitida</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -1100,11 +1100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Метод "{0}" должен быть статическим и неуниверсалным</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">Метод "{0}" должен иметь один параметр типа "{1}" и возвращать "{2}"</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Прочие файлы</target>
@@ -2705,9 +2700,14 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Сборка анализатора "{0}" ссылается на версию "{1}" компилятора, являющуюся более новой, чем версия "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">В запросе не указан метод "{0}" или функция верхнего уровня</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">Слишком много закрывающих круглых скобок</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Завершающая запятая не разрешена</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -1100,11 +1100,6 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">'{0}' yönteminin statik olması ve genel olmaması gerekir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">'{0}' yönteminin '{1}' türünde tek bir parametre olması ve '{2}' değerini döndürmesi gerekir</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">Diğer Dosyalar</target>
@@ -2705,9 +2700,14 @@ Sıfır genişlikli pozitif geri yönlü onaylamalar genellikle normal ifadeleri
         <target state="translated">'{0}' çözümleyici bütünleştirilmiş kodu, derleyicinin şu anda çalışan '{2}' sürümünden daha yeni olan '{1}' sürümüne başvurur.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">Sorgu '{0}' yöntemini veya üst düzey işlev belirtmiyor</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Sıfır genişlikli pozitif geri yönlü onaylamalar genellikle normal ifadeleri
         <target state="translated">Çok fazla)'s</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">Sona eklenen virgüle izin verilmiyor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -1100,11 +1100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">方法“{0}”必须是静态的和非泛型的</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">方法“{0}”必须具有类型“{1}”的单个参数并返回“{2}”</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">杂项文件</target>
@@ -2705,9 +2700,14 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">分析器程序集“{0}”引用了编译器的版本“{1}”，该版本高于当前正在运行的版本“{2}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">查询未指定方法“{0}”或顶级函数</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">")" 太多</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">不允许使用尾随逗号</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -1100,11 +1100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">方法 '{0}' 必須是靜態和非泛型</target>
         <note />
       </trans-unit>
-      <trans-unit id="Method_0_must_have_a_single_parameter_of_type_1_and_return_2">
-        <source>Method '{0}' must have a single parameter of type '{1}' and return '{2}'</source>
-        <target state="translated">方法 '{0}' 必須具有類型為 '{1}' 的單一參數，並傳回 '{2}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Miscellaneous_Files">
         <source>Miscellaneous Files</source>
         <target state="translated">其他檔案</target>
@@ -2705,9 +2700,14 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">分析程式組件 '{0}' 參考編譯器的版本 '{1}' ，比目前執行的版本 '{2}' 還要新。</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_query_does_not_specify_0_method_or_top_level_function">
-        <source>The query does not specify '{0}' method or top-level function</source>
-        <target state="translated">查詢未指定 '{0}' 方法或頂層函式</target>
+      <trans-unit id="The_query_does_not_specify_0_top_level_function">
+        <source>The query does not specify '{0}' top-level function</source>
+        <target state="new">The query does not specify '{0}' top-level function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_query_specifies_multiple_top_level_functions_1">
+        <source>The query specifies multiple top-level functions '{1}'</source>
+        <target state="new">The query specifies multiple top-level functions '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="The_selection_contains_a_local_function_call_without_its_declaration">
@@ -2750,9 +2750,19 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="translated">太多 )</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: )</note>
       </trans-unit>
+      <trans-unit id="Top_level_function_0_must_have_a_single_parameter">
+        <source>Top-level function '{0}' must have a single parameter</source>
+        <target state="new">Top-level function '{0}' must have a single parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trailing_comma_not_allowed">
         <source>Trailing comma not allowed</source>
         <target state="translated">尾端不得為逗號</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Type_0_is_not_among_supported_types_1">
+        <source>Type '{0}' is not among supported types: {1}</source>
+        <target state="new">Type '{0}' is not among supported types: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Types_colon">

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
@@ -1177,6 +1177,7 @@ Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.get_GetEnumeratorMethod
 Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.get_IsAsynchronous
 Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.get_MoveNextMethod
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation
+Microsoft.CodeAnalysis.CSharp.InterceptableLocation.Equals(Microsoft.CodeAnalysis.CSharp.InterceptableLocation)
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation.Equals(System.Object)
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation.GetDisplayLocation
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation.GetHashCode


### PR DESCRIPTION
Semantic Search currently requires Find method to have a parameter of type `Compilation`. 

Add support for more parameter types:
- `INamespaceSymbol`
- `INamedTypeSymbol`
- `IMethodSymbol`
- `IFieldSymbol`
- `IPropertySymbol`
- `IEventSymbol`

Such method is called on all namespaces, named types, methods, fields, properties and events, respectively.
This makes it much easier to search for specific members.

Changes the search to run in parallel on projects and types.

![Methods](https://github.com/user-attachments/assets/bd4be344-c332-45a1-b8d7-025abcaa6e39)



