### PR TITLE
Fix crash in 'introduce variable' when converting an object creation expression to an implicit object creation expression

### DIFF
--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
@@ -1177,6 +1177,7 @@ Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.get_GetEnumeratorMethod
 Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.get_IsAsynchronous
 Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.get_MoveNextMethod
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation
+Microsoft.CodeAnalysis.CSharp.InterceptableLocation.Equals(Microsoft.CodeAnalysis.CSharp.InterceptableLocation)
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation.Equals(System.Object)
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation.GetDisplayLocation
 Microsoft.CodeAnalysis.CSharp.InterceptableLocation.GetHashCode


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/77276