### PR TITLE
Fill some gaps in the LSP

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 cancellationToken).ConfigureAwait(false);
         }
 
-        public static async Task<LSP.CompletionList?> GetCompletionListAsync(
+        public static async Task<LSP.VSInternalCompletionList?> GetCompletionListAsync(
             Document document,
             int position,
             LSP.CompletionContext? completionContext,

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
 
         public static string[] DefaultCommitCharactersArray { get; } = CreateCommitCharacterArrayFromRules(CompletionItemRules.Default);
 
-        public static async Task<LSP.CompletionList> ConvertToLspCompletionListAsync(
+        public static async Task<LSP.VSInternalCompletionList> ConvertToLspCompletionListAsync(
             Document document,
             CompletionCapabilityHelper capabilityHelper,
             CompletionList list,

--- a/src/LanguageServer/Protocol/Protocol/Internal/Diagnostics/VSInternalDiagnosticRegistrationOptions.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Diagnostics/VSInternalDiagnosticRegistrationOptions.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="VSInternalDiagnosticRegistrationOptions.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Roslyn.LanguageServer.Protocol
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Diagnostic registration options.
+    /// </summary>
+    internal record class VSInternalDiagnosticRegistrationOptions : VSInternalDiagnosticOptions, ITextDocumentRegistrationOptions, IStaticRegistrationOptions
+    {
+        /// <summary>
+        /// Gets or sets the document filters for this registration option.
+        /// </summary>
+        [JsonPropertyName("documentSelector")]
+        public DocumentFilter[]? DocumentSelector { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id used to register the request.  The id can be used to deregister the request again.
+        /// </summary>
+        [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Id { get; set; }
+    }
+}

--- a/src/LanguageServer/Protocol/Protocol/Internal/Diagnostics/VSInternalDiagnosticRegistrationOptions.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Diagnostics/VSInternalDiagnosticRegistrationOptions.cs
@@ -1,6 +1,6 @@
-﻿// <copyright file="VSInternalDiagnosticRegistrationOptions.cs" company="Microsoft">
-// Copyright (c) Microsoft. All rights reserved.
-// </copyright>
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Roslyn.LanguageServer.Protocol
 {

--- a/src/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionRegistrationOptions.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionRegistrationOptions.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.LanguageServer.Protocol
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Class representing the registration options for inline completion support.
+    ///
+    /// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#inlineCompletionRegistrationOptions">Language Server Protocol specification</see> for additional information.
+    /// </summary>
+    internal class VSInternalInlineCompletionRegistrationOptions : VSInternalInlineCompletionOptions, ITextDocumentRegistrationOptions, IStaticRegistrationOptions
+    {
+        /// <summary>
+        /// Gets or sets the document filters for this registration option.
+        /// </summary>
+        [JsonPropertyName("documentSelector")]
+        public DocumentFilter[]? DocumentSelector
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the id used to register the request.  The id can be used to deregister the request again.
+        /// </summary>
+        [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Id
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/Cohost/Handlers/Completion.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Handlers/Completion.cs
@@ -24,7 +24,7 @@ internal static class Completion
     private static CompletionListCache GetCache()
         => s_completionListCache ??= InterlockedOperations.Initialize(ref s_completionListCache, () => new());
 
-    public static async Task<LSP.CompletionList?> GetCompletionListAsync(
+    public static async Task<LSP.VSInternalCompletionList?> GetCompletionListAsync(
         Document document,
         LinePosition linePosition,
         LSP.CompletionContext? completionContext,


### PR DESCRIPTION
I'm porting Razor to use the Roslyn protocol assembly, and hit a couple of missing types and annoyances.