### PR TITLE
Add an option to ignore aliases when moving using directives outside a namespace

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
@@ -13,8 +13,9 @@ using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.Simplification;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Simplification;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
@@ -24,9 +25,10 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 
 namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives;
+
+using static SyntaxFactory;
 
 /// <summary>
 /// Implements a code fix for all misplaced using statements.
@@ -149,7 +151,7 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
 
         var newCompilationUnit = placement == AddImportPlacement.InsideNamespace
             ? MoveUsingsInsideNamespace(compilationUnitWithoutHeader)
-            : MoveUsingsOutsideNamespaces(compilationUnitWithoutHeader);
+            : MoveUsingsOutsideNamespaces(compilationUnitWithoutHeader, ignoringAliases: placement == AddImportPlacement.OutsideNamespaceIgnoringAliases);
 
         // Re-attach the header now that using have been moved and LeadingTrivia is no longer being altered.
         var newCompilationUnitWithHeader = AddFileHeader(newCompilationUnit, fileHeader);
@@ -213,11 +215,13 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
         return compilationUnitWithoutBlankLine.ReplaceNode(namespaceDeclaration, namespaceDeclarationWithUsings);
     }
 
-    private static CompilationUnitSyntax MoveUsingsOutsideNamespaces(CompilationUnitSyntax compilationUnit)
+    private static CompilationUnitSyntax MoveUsingsOutsideNamespaces(
+        CompilationUnitSyntax compilationUnit, bool ignoringAliases)
     {
         var namespaceDeclarations = compilationUnit.Members.OfType<BaseNamespaceDeclarationSyntax>();
         var namespaceDeclarationMap = namespaceDeclarations.ToDictionary(
-            namespaceDeclaration => namespaceDeclaration, RemoveUsingsFromNamespace);
+            namespaceDeclaration => namespaceDeclaration,
+            namespaceDeclaration => RemoveUsingsFromNamespace(namespaceDeclaration, ignoringAliases));
 
         // Replace the namespace declarations in the compilation with the ones without using directives.
         var compilationUnitWithReplacedNamespaces = compilationUnit.ReplaceNodes(
@@ -247,23 +251,33 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
     }
 
     private static (BaseNamespaceDeclarationSyntax namespaceWithoutUsings, ImmutableArray<UsingDirectiveSyntax> usingsFromNamespace) RemoveUsingsFromNamespace(
-        BaseNamespaceDeclarationSyntax usingContainer)
+        BaseNamespaceDeclarationSyntax usingContainer, bool ignoringAliases)
     {
         var namespaceDeclarations = usingContainer.Members.OfType<BaseNamespaceDeclarationSyntax>();
         var namespaceDeclarationMap = namespaceDeclarations.ToDictionary(
-            namespaceDeclaration => namespaceDeclaration, namespaceDeclaration => RemoveUsingsFromNamespace(namespaceDeclaration));
+            namespaceDeclaration => namespaceDeclaration,
+            namespaceDeclaration => RemoveUsingsFromNamespace(namespaceDeclaration, ignoringAliases));
 
         // Get the using directives from the namespaces.
         var usingsFromNamespaces = namespaceDeclarationMap.Values.SelectMany(result => result.usingsFromNamespace);
-        var allUsings = usingContainer.Usings.AsEnumerable().Concat(usingsFromNamespaces).ToImmutableArray();
+        var usings = ignoringAliases
+            ? usingContainer.Usings.Where(u => u.Alias is null)
+            : usingContainer.Usings;
+        var allUsings = usings.Concat(usingsFromNamespaces).ToImmutableArray();
 
         // Replace the namespace declarations in the compilation with the ones without using directives.
         var namespaceDeclarationWithReplacedNamespaces = usingContainer.ReplaceNodes(
             namespaceDeclarations, (node, _) => namespaceDeclarationMap[node].namespaceWithoutUsings);
 
         // Remove usings and fix leading trivia for namespace declaration.
-        var namespaceDeclarationWithoutUsings = namespaceDeclarationWithReplacedNamespaces.WithUsings(default);
-        var namespaceDeclarationWithoutBlankLine = RemoveLeadingBlankLinesFromFirstMember(namespaceDeclarationWithoutUsings);
+        var namespaceDeclarationWithoutUsings = namespaceDeclarationWithReplacedNamespaces
+            .WithUsings(ignoringAliases
+                ? List(namespaceDeclarationWithReplacedNamespaces.Usings.Where(u => u.Alias != null))
+                : default);
+
+        var namespaceDeclarationWithoutBlankLine = namespaceDeclarationWithoutUsings.Usings.Count == 0
+            ? RemoveLeadingBlankLinesFromFirstMember(namespaceDeclarationWithoutUsings)
+            : namespaceDeclarationWithoutUsings;
 
         return (namespaceDeclarationWithoutBlankLine, allUsings);
     }
@@ -372,7 +386,7 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
         var placement = styleOption.Value;
         var preferPreservation = styleOption.Notification == NotificationOption2.None;
 
-        if (preferPreservation || placement == AddImportPlacement.OutsideNamespace)
+        if (preferPreservation || placement != AddImportPlacement.InsideNamespace)
             return (placement, preferPreservation);
 
         // Determine if we can safely apply the InsideNamespace preference.

--- a/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
+++ b/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -19,13 +20,9 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MisplacedUsingDirectives;
 
-public class MisplacedUsingDirectivesTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor
+public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
+    : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor(logger)
 {
-    public MisplacedUsingDirectivesTests(ITestOutputHelper logger)
-      : base(logger)
-    {
-    }
-
     internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
         => (new MisplacedUsingDirectivesDiagnosticAnalyzer(), new MisplacedUsingDirectivesCodeFixProvider());
 
@@ -41,43 +38,54 @@ public class MisplacedUsingDirectivesTests : AbstractCSharpDiagnosticProviderBas
     internal static readonly CodeStyleOption2<AddImportPlacement> OutsideNamespaceOption =
         new(AddImportPlacement.OutsideNamespace, NotificationOption2.Error);
 
-    protected const string ClassDefinition = """
+    internal static readonly CodeStyleOption2<AddImportPlacement> OutsideNamespaceIgnoringAliasesOption =
+        new(AddImportPlacement.OutsideNamespaceIgnoringAliases, NotificationOption2.Error);
+
+    private const string ClassDefinition = """
         public class TestClass
         {
         }
         """;
 
-    protected const string StructDefinition = """
+    private const string StructDefinition = """
         public struct TestStruct
         {
         }
         """;
 
-    protected const string InterfaceDefinition = """
+    private const string InterfaceDefinition = """
         public interface TestInterface
         {
         }
         """;
 
-    protected const string EnumDefinition = """
+    private const string EnumDefinition = """
         public enum TestEnum
         {
             TestValue
         }
         """;
 
-    protected const string DelegateDefinition = @"public delegate void TestDelegate();";
+    private const string DelegateDefinition = @"public delegate void TestDelegate();";
 
     private TestParameters GetTestParameters(CodeStyleOption2<AddImportPlacement> preferredPlacementOption)
         => new(options: new OptionsCollection(GetLanguage()) { { CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, preferredPlacementOption } });
 
-    private protected Task TestDiagnosticMissingAsync(string initialMarkup, CodeStyleOption2<AddImportPlacement> preferredPlacementOption)
+    private Task TestDiagnosticMissingAsync(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
+        CodeStyleOption2<AddImportPlacement> preferredPlacementOption)
         => TestDiagnosticMissingAsync(initialMarkup, GetTestParameters(preferredPlacementOption));
 
-    private protected Task TestMissingAsync(string initialMarkup, CodeStyleOption2<AddImportPlacement> preferredPlacementOption)
+    private Task TestMissingAsync(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
+        CodeStyleOption2<AddImportPlacement> preferredPlacementOption)
         => TestMissingAsync(initialMarkup, GetTestParameters(preferredPlacementOption));
 
-    private protected Task TestInRegularAndScriptAsync(string initialMarkup, string expectedMarkup, CodeStyleOption2<AddImportPlacement> preferredPlacementOption, bool placeSystemNamespaceFirst)
+    private Task TestInRegularAndScriptAsync(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string expectedMarkup,
+        CodeStyleOption2<AddImportPlacement> preferredPlacementOption,
+        bool placeSystemNamespaceFirst)
     {
         var options = new OptionsCollection(GetLanguage())
         {
@@ -711,6 +719,98 @@ public class MisplacedUsingDirectivesTests : AbstractCSharpDiagnosticProviderBas
             """;
 
         return TestInRegularAndScriptAsync(testCode, fixedTestCode, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
+    }
+
+    #endregion
+
+    #region OutsideNamespaceIgnoringAliases
+
+    [Fact]
+    public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved()
+    {
+        var testCode = """
+            namespace TestNamespace
+            {
+                [|using System;
+                using System.Threading;|]
+                using SCG = System.Collections.Generic;
+            }
+            """;
+        var fixedTestCode = """
+            {|Warning:using System;|}
+            {|Warning:using System.Threading;|}
+
+            namespace TestNamespace
+            {
+                using SCG = System.Collections.Generic;
+            }
+            """;
+
+        return TestInRegularAndScriptAsync(testCode, fixedTestCode, OutsideNamespaceIgnoringAliasesOption, placeSystemNamespaceFirst: true);
+    }
+
+    [Fact]
+    public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved_InnerType()
+    {
+        var testCode = """
+            namespace TestNamespace
+            {
+                [|using System;
+                using System.Threading;|]
+                using SCG = System.Collections.Generic;
+
+                class C
+                {
+                }
+            }
+            """;
+        var fixedTestCode = """
+            {|Warning:using System;|}
+            {|Warning:using System.Threading;|}
+
+            namespace TestNamespace
+            {
+                using SCG = System.Collections.Generic;
+
+                class C
+                {
+                }
+            }
+            """;
+
+        return TestInRegularAndScriptAsync(testCode, fixedTestCode, OutsideNamespaceIgnoringAliasesOption, placeSystemNamespaceFirst: true);
+    }
+
+    [Fact]
+    public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved_AliasInMiddle()
+    {
+        var testCode = """
+            namespace TestNamespace
+            {
+                [|using System;|]
+                using SCG = System.Collections.Generic;
+                [|using System.Threading;|]
+
+                class C
+                {
+                }
+            }
+            """;
+        var fixedTestCode = """
+            {|Warning:using System;|}
+            {|Warning:using System.Threading;|}
+
+            namespace TestNamespace
+            {
+                using SCG = System.Collections.Generic;
+
+                class C
+                {
+                }
+            }
+            """;
+
+        return TestInRegularAndScriptAsync(testCode, fixedTestCode, OutsideNamespaceIgnoringAliasesOption, placeSystemNamespaceFirst: true);
     }
 
     #endregion

--- a/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
+++ b/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
@@ -725,7 +725,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
 
     #region OutsideNamespaceIgnoringAliases
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
     public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved()
     {
         var testCode = """
@@ -749,7 +749,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
         return TestInRegularAndScriptAsync(testCode, fixedTestCode, OutsideNamespaceIgnoringAliasesOption, placeSystemNamespaceFirst: true);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
     public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved_InnerType()
     {
         var testCode = """
@@ -781,7 +781,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
         return TestInRegularAndScriptAsync(testCode, fixedTestCode, OutsideNamespaceIgnoringAliasesOption, placeSystemNamespaceFirst: true);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
     public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved_AliasInMiddle()
     {
         var testCode = """

--- a/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
+++ b/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
@@ -787,9 +787,9 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
         var testCode = """
             namespace TestNamespace
             {
-                [|using System;|]
+                [|using System;
                 using SCG = System.Collections.Generic;
-                [|using System.Threading;|]
+                using System.Threading;|]
 
                 class C
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpCodeStyleOptions_Parsing.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpCodeStyleOptions_Parsing.cs
@@ -56,6 +56,7 @@ internal static partial class CSharpCodeStyleOptions
             {
                 "inside_namespace" => new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.InsideNamespace, notification),
                 "outside_namespace" => new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.OutsideNamespace, notification),
+                "outside_namespace_ignoring_aliases" => new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.OutsideNamespaceIgnoringAliases, notification),
                 _ => throw new NotSupportedException(),
             };
         }
@@ -70,6 +71,7 @@ internal static partial class CSharpCodeStyleOptions
         {
             AddImportPlacement.InsideNamespace => $"inside_namespace{notificationString}",
             AddImportPlacement.OutsideNamespace => $"outside_namespace{notificationString}",
+            AddImportPlacement.OutsideNamespaceIgnoringAliases => $"outside_namespace_ignoring_aliases{notificationString}",
             _ => throw new NotSupportedException(),
         };
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/AddImportPlacement.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/AddImportPlacement.cs
@@ -17,5 +17,10 @@ internal enum AddImportPlacement
     /// <summary>
     /// Place imports outside the namespace definition.
     /// </summary>
-    OutsideNamespace
+    OutsideNamespace,
+
+    /// <summary>
+    /// Place imports outside the namespace definition, ignoring import aliases (which can stay inside the namespace).
+    /// </summary>
+    OutsideNamespaceIgnoringAliases
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/43271