### PR TITLE
Remove out of support branches from PublishData.json

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -111,14 +111,6 @@
       "vsBranch": "rel/d15.9",
       "vsMajorVersion": 15
     },
-    "release/dev16.9-vs-deps": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d16.9",
-      "vsMajorVersion": 16
-    },
     "release/dev16.11-vs-deps": {
       "nugetKind": [
         "Shipping",
@@ -127,51 +119,6 @@
       "vsBranch": "rel/d16.11",
       "vsMajorVersion": 16,
       "insertionTitlePrefix": "[d16.11]"
-    },
-    "release/dev17.0-vs-deps": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.0",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.0]"
-    },
-    "release/dev17.2": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.2",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.2]"
-    },
-    "release/dev17.3": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.3",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.3]"
-    },
-    "release/dev17.6": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.6",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.6]"
-    },
-    "release/dev17.7": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.7",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.7]"
     },
     "release/dev17.8": {
       "nugetKind": [
@@ -182,15 +129,6 @@
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.8]"
     },
-    "release/dev17.9": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.9",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.9]"
-    },
     "release/dev17.10": {
       "nugetKind": [
         "Shipping",
@@ -199,15 +137,6 @@
       "vsBranch": "rel/d17.10",
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.10]"
-    },
-    "release/dev17.11": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.11",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.11]"
     },
     "release/dev17.12": {
       "nugetKind": [
@@ -218,15 +147,6 @@
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.12]"
     },
-    "release/dev17.12-telmet": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.12telmet",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.12]"
-    },
     "release/dev17.13": {
       "nugetKind": [
         "Shipping",
@@ -234,16 +154,7 @@
       ],
       "vsBranch": "rel/d17.13",
       "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.13 P3]"
-    },
-    "release/dev17.13-preview2.1": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.13",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.13 P2]"
+      "insertionTitlePrefix": "[d17.13]"
     },
     "release/dev17.14": {
       "nugetKind": [
@@ -274,46 +185,6 @@
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.14 P2]"
-    },
-    "dev/andrha/telemetry": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "main",
-      "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
-      "insertionTitlePrefix": "[Telemetry Validation]"
-    },
-    "dev/jorobich/pr-val-v3-publishing": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "main",
-      "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
-      "insertionTitlePrefix": "[PR Validation]"
-    },
-    "demo/razor-lexer": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "main",
-      "insertionTitlePrefix": "[Do not merge, please close me]",
-      "vsMajorVersion": 17,
-      "insertionCreateDraftPR": false
-    },
-    "features/vscode_net9": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "main",
-      "insertionTitlePrefix": "[Do not merge, please close me]",
-      "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true
     }
   }
 }


### PR DESCRIPTION
Removed one-off and out of support servicing branches from the publish data.