### PR TITLE
PERF: Reduce the number of nodes walked during import completion commit.

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Editing/ImportAdderService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Editing/ImportAdderService.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
-using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;


### PR DESCRIPTION
ImportAdderService.AddImportsAsync was previously doing a full tree walk (and realizing all the nodes in the tree) during override completion commit.

Noticed while looking at the csharp completion speedometer profile for the completion commit of override methods. Previously, this accounted for about 28% of CPU and 23% of allocations during CommitManager.TryCommit. With these changes applied, this enumeration is basically free.

*** Old CPU ***
![image](https://github.com/user-attachments/assets/8da865b6-10fc-4c24-ae08-28e707a1e1f7)

*** New CPU ***
![image](https://github.com/user-attachments/assets/867e24e7-ea44-4a9f-893b-5f190230efc3)

*** Old Allocations ***
![image](https://github.com/user-attachments/assets/bedc07af-ed9e-4411-a089-c1db0d672202)

*** New Allocations ***
![image](https://github.com/user-attachments/assets/16d287ba-25ea-45f0-83d0-46131ba5d020)