### PR TITLE
Implemented IVsEditorFactoryChooser on AbstractEditorFactory class to invoke WinForms designer editor factory directly by VS Shell

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -14,10 +14,10 @@ using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
@@ -25,18 +25,20 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.WinForms.Interfaces;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation;
 
 /// <summary>
 /// The base class of both the Roslyn editor factories.
 /// </summary>
-internal abstract class AbstractEditorFactory : IVsEditorFactory, IVsEditorFactory4, IVsEditorFactoryNotify
+internal abstract class AbstractEditorFactory : IVsEditorFactory, IVsEditorFactory4, IVsEditorFactoryNotify, IVsEditorFactoryChooser
 {
     private readonly IComponentModel _componentModel;
-    private Microsoft.VisualStudio.OLE.Interop.IServiceProvider? _oleServiceProvider;
+    private OLE.Interop.IServiceProvider? _oleServiceProvider;
     private bool _encoding;
+    private Guid WinFormsDesignerEditorFactoryGuid = new("{8b39ef50-558d-4077-a40b-128adddd2880}");
+    private bool _isWinFormsDesignerPackageLoaded;
+    private bool? _isWinFormsDesignerAsyncLoadFeatureEnabled;
 
     protected AbstractEditorFactory(IComponentModel componentModel)
         => _componentModel = componentModel;
@@ -411,6 +413,72 @@ internal abstract class AbstractEditorFactory : IVsEditorFactory, IVsEditorFacto
                 return project;
 
             return project.AddAnalyzerConfigDocument(EditorConfigFileName, text, filePath: editorConfigFile).Project;
+        }
+    }
+
+    public int ChooseEditorFactory(
+        string pszMkDocument,
+        IVsHierarchy pHier,
+        uint itemid,
+        IntPtr punkDocDataExisting,
+        ref Guid rguidLogicalView,
+        out Guid pguidEditorTypeActual,
+        out Guid pguidLogicalViewActual)
+    {
+        // Use WinForms Editor Factory directly if view type is Designer.
+        if (IsWinFormsDesignerAsyncLoadFeatureEnabled() && VSConstants.LOGVIEWID_Designer.CompareTo(rguidLogicalView) == 0)
+        {
+            EnsureWinFormsDesignerPackageLoaded();
+
+            pguidEditorTypeActual = WinFormsDesignerEditorFactoryGuid;
+            pguidLogicalViewActual = VSConstants.LOGVIEWID_Designer;
+
+            return VSConstants.S_OK;
+        }
+
+        pguidEditorTypeActual = Guid.Empty;
+        pguidLogicalViewActual = Guid.Empty;
+
+        return VSConstants.S_FALSE;
+    }
+
+    private void EnsureWinFormsDesignerPackageLoaded()
+    {
+        if (_isWinFormsDesignerPackageLoaded)
+        {
+            return;
+        }
+
+        // In ChooseEditorFactory workflow VS Shell is not automatically loading WinForms Designer Package if it's not loaded yet.
+        // This issue is under investigation. For time being, we will load it ourselves.
+        var packageManager = (IVsPackageManagerPrivate)PackageUtilities.QueryService<SVsPackageManagerPrivate>(_oleServiceProvider);
+
+        Guid WinFormsDesignerPackageGuid = new("{68939055-38E0-4d17-92CB-8909710D8178}");
+
+        packageManager.LoadPackageWithContext(
+            WinFormsDesignerPackageGuid,
+            (int)LoadPackageReasonPrivate.LR_EditorFactory,
+            WinFormsDesignerEditorFactoryGuid);
+
+        _isWinFormsDesignerPackageLoaded = true;
+    }
+
+    private bool IsWinFormsDesignerAsyncLoadFeatureEnabled()
+    {
+        return _isWinFormsDesignerAsyncLoadFeatureEnabled ??= GetWinFormsDesignerAsyncLoadFeatureFlagValue();
+
+        bool GetWinFormsDesignerAsyncLoadFeatureFlagValue()
+        {
+            try
+            {
+                var featureFlags = (IVsFeatureFlags)PackageUtilities.QueryService<SVsFeatureFlags>(_oleServiceProvider);
+                return featureFlags.IsFeatureEnabled("Winforms.AsyncDesignerLoad", defaultValue: true);
+            }
+            catch (Exception)
+            {
+                // Disable the feature in case of an exception
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Implemented [IVsEditorFactoryChooser](https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.ivseditorfactorychooser?view=visualstudiosdk-2022) interface on `AbstractEditorFactory` class. This interface provides a method `ChooseEditorFactory` which is invoked by VS Shell before `CreateEditorInstance` method is invoked.

`ChooseEditorFactory` method provides an opportunity to the current editor factory to sniff the file and return another editor factory guid if required. If an alternate editor factory guid is returned, VS Shell will invoke that editor factory directly. Else it will continue to invoke `CreateEditorInstance` method of current editor factory. We use this mechanism to check if `rguidLogicalView` is `Designer`. If it is designer, then `ChooseEditorFactory` will return editor factory guid of a new WinForms Editor Factory `WinFormsDesignerEditorFactory`. This [new editor factory](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/607115) will return an instance of `IAsyncDocView` interface which will enable it to load the designer asynchronously.  

We have safeguarded the changes behind a feature flag which will be enabled by default.

**Note**: WinForms [PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/607115) should merge before this PR.