### PR TITLE
disable the WPF ComboBox Search behavior in Rename popup

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -15,6 +15,7 @@
           ItemsSource="{Binding SuggestedNames}"
           StaysOpenOnEdit="True"
           IsEditable="True"
+          IsTextSearchEnabled="False"
           Style="{StaticResource {x:Static vsfx:VsResourceKeys.ComboBoxStyleKey}}"
           GotKeyboardFocus="ComboBox_GotKeyboardFocus"
           VirtualizingStackPanel.IsVirtualizing="True"


### PR DESCRIPTION
In Copilot Rename UI, user's input is overridden with different case if there is a match with rename suggestions

Notice: I'm typing lowercase `test`, but it's replaced with uppercase.
![smart rename combobox search before](https://github.com/user-attachments/assets/c6523908-9978-4cdd-9084-01d2d687932c)

We can avoid this by setting `ComboBox.IsTextSearchEnabled=False` on the `SmartRenameUserInputComboBox`. Now, WPF will stop overriding user's input if there is a match.

![smart rename combobox search after](https://github.com/user-attachments/assets/ec061829-88b5-457e-9e6e-9f1061ebc783)

