### PR TITLE
Improve performance of SyntaxReplacer.ReplaceNode

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
@@ -6,7 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.Syntax;
+using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -192,6 +195,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     {
                         rewritten = _computeReplacementNode((TNode)node, (TNode)rewritten!);
                     }
+                }
+
+                return rewritten;
+            }
+
+            public override SyntaxList<TSyntaxNode> VisitList<TSyntaxNode>(SyntaxList<TSyntaxNode> list)
+            {
+                SyntaxList<TSyntaxNode> rewritten = list;
+
+                if (this.ShouldVisit(list.FullSpan))
+                {
+                    rewritten = base.VisitList(list);
                 }
 
                 return rewritten;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
@@ -117,7 +117,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 }
             }
 
-            [MemberNotNull(nameof(_totalSpan))]
             private void CalculateVisitationCriteria()
             {
                 _spanSet.Clear();
@@ -195,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                 if (node != null)
                 {
-                    var isReplacedNode = _nodeSet.Remove(node);
+                    bool isReplacedNode = _nodeSet.Remove(node);
 
                     if (isReplacedNode)
                     {
@@ -224,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             public override SyntaxToken VisitToken(SyntaxToken token)
             {
                 var rewritten = token;
-                var isReplacedToken = _tokenSet.Remove(token);
+                bool isReplacedToken = _tokenSet.Remove(token);
 
                 if (isReplacedToken)
                 {
@@ -252,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             public override SyntaxTrivia VisitListElement(SyntaxTrivia trivia)
             {
                 var rewritten = trivia;
-                var isReplacedTrivia = _triviaSet.Remove(trivia);
+                bool isReplacedTrivia = _triviaSet.Remove(trivia);
 
                 if (isReplacedTrivia)
                 {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
@@ -200,6 +200,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                     if (isReplacedNode)
                     {
+                        // If node is in _nodeSet, then it contributed to the calculation of _spanSet.
+                        // We are currently processing that node, so it no longer needs to contribute
+                        // to _spanSet and affect determination of inward visitation. This is done before
+                        // calling ShouldVisit to avoid walking into the node if there aren't any remaining
+                        // spans inside it representing items to replace.
                         CalculateVisitationCriteria();
                     }
 
@@ -224,6 +229,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                 if (isReplacedToken)
                 {
+                    // If token is in _tokenSet, then it contributed to the calculation of _spanSet.
+                    // We are currently processing that token, so it no longer needs to contribute
+                    // to _spanSet and affect determination of inward visitation. This is done before
+                    // calling ShouldVisit to avoid walking into the token if there aren't any remaining
+                    // spans inside it representing items to replace.
                     CalculateVisitationCriteria();
                 }
 
@@ -247,6 +257,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                 if (isReplacedTrivia)
                 {
+                    // If trivia is in _triviaSet, then it contributed to the calculation of _spanSet.
+                    // We are currently processing that trivia, so it no longer needs to contribute
+                    // to _spanSet and affect determination of inward visitation. This is done before
+                    // calling ShouldVisit to avoid walking into the trivia if there aren't any remaining
+                    // spans inside it representing items to replace.
                     CalculateVisitationCriteria();
                 }
 
@@ -278,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     return list;
                 }
 
-                var listNode = list.Node!;
+                SyntaxNode listNode = list.Node!;
                 if (!listNode.IsList)
                 {
                     if (!this.ShouldVisit(listNode.FullSpan))

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
@@ -6,10 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.Syntax;
-using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
@@ -208,6 +208,80 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return rewritten;
             }
 
+            public override SyntaxList<TSyntaxNode> VisitList<TSyntaxNode>(SyntaxList<TSyntaxNode> list)
+            {
+                // This method is a performance optimized version of CSharpSyntaxRewriter.VisitList.
+                // Optimizations include:
+                // 1: Usage of ShouldVisit to minimize nodes on which to invoke VisitListElement
+                // 2: Avoids creation of SyntaxListBuilder if no nodes are replaced
+                // 3: Avoids realization of red nodes unless VisitListElement needs to be invoked
+                // 4: Avoids creation of SyntaxList result if no nodes are replaced
+                // 5: Avoids call to SyntaxList.FullSpan in list scenario as it realizes first and last nodes in list.
+                var listCount = list.Count;
+                if (listCount == 0)
+                {
+                    return list;
+                }
+
+                var listNode = list.Node!;
+                if (!listNode.IsList)
+                {
+                    if (!this.ShouldVisit(listNode.FullSpan))
+                    {
+                        return list;
+                    }
+
+                    var visited = this.VisitListElement(listNode);
+
+                    return visited != listNode && visited != null && !visited.IsKind(SyntaxKind.None)
+                        ? new SyntaxList<TSyntaxNode>(visited)
+                        : list;
+                }
+
+                SyntaxListBuilder? alternate = null;
+                var greenList = new CodeAnalysis.Syntax.InternalSyntax.SyntaxList<GreenNode>(listNode.Green);
+                var start = list[0].FullSpan.Start;
+
+                for (var i = 0; i < listCount; i++)
+                {
+                    var green = greenList[i]!;
+                    var greenSpan = new TextSpan(start, green.FullWidth);
+
+                    if (!this.ShouldVisit(greenSpan))
+                    {
+                        alternate?.AddInternal(green);
+                    }
+                    else
+                    {
+                        var item = list[i];
+                        var visited = this.VisitListElement(item);
+
+                        if (visited != item && alternate == null)
+                        {
+                            alternate = new SyntaxListBuilder(list.Count);
+                            for (int j = 0; j < i; j++)
+                            {
+                                alternate.AddInternal(greenList[j]!);
+                            }
+                        }
+
+                        if (alternate != null && visited != null && !visited.IsKind(SyntaxKind.None))
+                        {
+                            alternate.Add(visited);
+                        }
+                    }
+
+                    start += green.FullWidth;
+                }
+
+                if (alternate != null)
+                {
+                    return (SyntaxList<TSyntaxNode>)alternate.ToList();
+                }
+
+                return list;
+            }
+
             public override SyntaxToken VisitToken(SyntaxToken token)
             {
                 var rewritten = token;


### PR DESCRIPTION
I've noticed overrides completion commit in the csharp completion speedometer profiles as indicating a large amount of time/memory spent in their ReplaceNode calls. (about 18.6% of CPU time and 24.0% of memory allocations spent within CommitManager.TryCommit are attributable to ReplaceNode calls). 

The Visit methods for Nodes/Tokens/Trivia could be changed such that if they are invoked for an item affecting _totalSpan, that once they are processed they should no longer have an effect on _totalSpan. This would allow a large pruning of the amount of tree walked due to the ShouldVisit calls. Override completion benefits in particular as it replaces a large single node in the tree (the class node) and thus wouldn't need to walk inside the class anymore.

As the images below show, this optimization reduced the CPU/allocations costs of the ReplaceNode call to basically nothing.

*** Before CPU ***
![image](https://github.com/user-attachments/assets/ca7ef876-b61d-405e-9a34-082028666eba)

*** After CPU ***
![image](https://github.com/user-attachments/assets/c8fe514f-6e0a-49a7-8328-aa31fd11a875)

*** Before Allocations ***
![image](https://github.com/user-attachments/assets/94d24450-3978-4967-afce-9ab726d6cf2a)

*** After Allocations ***
![image](https://github.com/user-attachments/assets/47110431-a394-427c-a55e-9c9a37a32a67)

