### PR TITLE
Exclude generated files from compilation by default

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -32,16 +32,6 @@
     <LangVersion Condition="'$(LangVersion)' == '' AND '$(_MaxSupportedLangVersion)' != ''">$(_MaxSupportedLangVersion)</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Default to excluding generated files from compilation if not explicitly set -->
-    <ExcludeGeneratedFilesFromCompilation Condition="'$(ExcludeGeneratedFilesFromCompilation)' == ''">true</ExcludeGeneratedFilesFromCompilation>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Exclude all .cs files in the generated output directory to prevent duplicate type definitions -->
-    <Compile Remove="$(CompilerGeneratedFilesOutputPath)\**\*.cs" Condition="'$(ExcludeGeneratedFilesFromCompilation)' == 'true'" />
-  </ItemGroup>
-
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
                   @(Compile);


### PR DESCRIPTION
Set ExcludeGeneratedFilesFromCompilation to true by default if not explicitly specified by updating Microsoft.CSharp.Core.targets to automatically exclude all .cs files in CompilerGeneratedFilesOutputPath.

This prevents duplicate type definitions and build errors when running dotnet build multiple times.

Fix https://github.com/dotnet/sdk/issues/47046
