### PR TITLE
Don't realize the SourceText in SyntaxTree.OverlapsHiddenPosition if not needed

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
@@ -17,7 +17,7 @@ internal static partial class SyntaxTreeExtensions
 {
     public static bool OverlapsHiddenPosition([NotNullWhen(returnValue: true)] this SyntaxTree? tree, TextSpan span, CancellationToken cancellationToken)
     {
-        if (tree == null)
+        if (tree == null || tree.GetLineMappings(cancellationToken).IsEmpty())
         {
             return false;
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
@@ -17,6 +17,8 @@ internal static partial class SyntaxTreeExtensions
 {
     public static bool OverlapsHiddenPosition([NotNullWhen(returnValue: true)] this SyntaxTree? tree, TextSpan span, CancellationToken cancellationToken)
     {
+        // Short-circuit if there are no line mappings to avoid potentially realizing the source text.
+        // All lines are visible if there are no line mappings.
         if (tree == null || tree.GetLineMappings(cancellationToken).IsEmpty())
         {
             return false;


### PR DESCRIPTION
This shows up in override completion commit in the speedometer profiles as 12.5% of allocations and 11.6% of CPU under CommitManager.TryCommit. We can avoid needing the SourceText in this method if the line mappings in the tree are empty. With this change, OverlapsHiddenRegion no longer appears in either allocations or cpu usage during override completion commit. I've also verified that these costs associated with creating this sourcetext weren't incurred elsewhere (at least under CommitManager.TryCommit)

PR test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/613641

*** Old Allocations ***
![image](https://github.com/user-attachments/assets/fd52f1f3-60e2-432e-9e4a-b0b62626b055)

*** New Allocations ***
![image](https://github.com/user-attachments/assets/c7dabbfd-21ff-468d-8d9b-432de870578a)

*** Old CPU ***
![image](https://github.com/user-attachments/assets/dc7db449-9de4-40b5-a303-952a6d0a5059)

*** New CPU ***
![image](https://github.com/user-attachments/assets/de87c7ae-bd71-436d-9003-90bb22628380)

