### PR TITLE
Extensions: Resolve classic and new extension methods together

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8592,6 +8592,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var extensionMethodResult = resolveOverloads(this, methodGroup, actualArguments, options, returnType, returnRefKind, in callingConvention, expression, diagnostics);
+                diagnostics.Free();
+
                 // If the search in the current scope resulted in any applicable method (regardless of whether a best
                 // applicable method could be determined) then our search is complete. Otherwise, store aside the
                 // first non-applicable result and continue searching for an applicable result.
@@ -8601,7 +8603,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     actualArguments?.Free();
                     lookupResult.Free();
                     classicExtensionLookupResult.Free();
-                    diagnostics.Free();
                     return extensionMethodResult;
                 }
                 else if (firstResult.IsEmpty)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3437,75 +3437,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                if (!argument.HasAnyErrors)
-                {
-                    var argRefKind = analyzedArguments.RefKind(arg);
-
-                    if (!Compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefReadonlyParameters))
-                    {
-                        // Disallow using `ref readonly` parameters with no or `in` argument modifier,
-                        // same as older versions of the compiler would (since they would see the parameter as `ref`).
-                        if (argRefKind is RefKind.None or RefKind.In &&
-                            getCorrespondingParameter(in result, parameters, arg).RefKind == RefKind.RefReadOnlyParameter)
-                        {
-                            var available = CheckFeatureAvailability(argument.Syntax, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
-                            Debug.Assert(!available);
-                        }
-                    }
-                    else
-                    {
-                        var argNumber = invokedAsExtensionMethod ? arg : arg + 1;
-
-                        // Warn for `ref`/`in` or None/`ref readonly` mismatch.
-                        if (argRefKind == RefKind.Ref)
-                        {
-                            if (getCorrespondingParameter(in result, parameters, arg).RefKind == RefKind.In)
-                            {
-                                Debug.Assert(argNumber > 0);
-                                // The 'ref' modifier for argument {0} corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
-                                diagnostics.Add(
-                                    ErrorCode.WRN_BadArgRef,
-                                    argument.Syntax,
-                                    argNumber);
-                            }
-                        }
-                        else if (argRefKind == RefKind.None &&
-                            getCorrespondingParameter(in result, parameters, arg).RefKind == RefKind.RefReadOnlyParameter)
-                        {
-                            if (!this.CheckValueKind(argument.Syntax, argument, BindValueKind.RefersToLocation, checkingReceiver: false, BindingDiagnosticBag.Discarded))
-                            {
-                                Debug.Assert(argNumber >= 0); // can be 0 for receiver of extension method
-                                // Argument {0} should be a variable because it is passed to a 'ref readonly' parameter
-                                diagnostics.Add(
-                                    ErrorCode.WRN_RefReadonlyNotVariable,
-                                    argument.Syntax,
-                                    argNumber);
-                            }
-                            else if (!invokedAsExtensionMethod || arg != 0)
-                            {
-                                Debug.Assert(argNumber > 0);
-                                if (this.CheckValueKind(argument.Syntax, argument, BindValueKind.Assignable, checkingReceiver: false, BindingDiagnosticBag.Discarded))
-                                {
-                                    // Argument {0} should be passed with 'ref' or 'in' keyword
-                                    diagnostics.Add(
-                                        ErrorCode.WRN_ArgExpectedRefOrIn,
-                                        argument.Syntax,
-                                        argNumber);
-                                }
-                                else
-                                {
-                                    // Argument {0} should be passed with the 'in' keyword
-                                    diagnostics.Add(
-                                        ErrorCode.WRN_ArgExpectedIn,
-                                        argument.Syntax,
-                                        argNumber);
-                                }
-                            }
-                        }
-                    }
-                }
-
                 int paramNum = result.ParameterFromArgument(arg);
+                CheckArgumentRefKind(analyzedArguments.RefKind(arg), argument, arg, parameters[paramNum], invokedAsExtensionMethod, diagnostics);
 
                 if (expanded && paramNum == parameters.Length - 1)
                 {
@@ -3936,6 +3869,76 @@ namespace Microsoft.CodeAnalysis.CSharp
                     constantValueOpt: null,
                     handlerType,
                     hasErrors || interpolatedString.HasErrors);
+            }
+        }
+
+        private void CheckArgumentRefKind(RefKind argRefKind, BoundExpression argument, int arg, ParameterSymbol parameter,
+            bool invokedAsExtensionMethod, BindingDiagnosticBag diagnostics)
+        {
+            if (argument.HasAnyErrors)
+            {
+                return;
+            }
+
+            if (!Compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefReadonlyParameters))
+            {
+                // Disallow using `ref readonly` parameters with no or `in` argument modifier,
+                // same as older versions of the compiler would (since they would see the parameter as `ref`).
+                if (argRefKind is RefKind.None or RefKind.In && parameter.RefKind == RefKind.RefReadOnlyParameter)
+                {
+                    var available = CheckFeatureAvailability(argument.Syntax, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
+                    Debug.Assert(!available);
+                }
+            }
+            else
+            {
+                var argNumber = invokedAsExtensionMethod ? arg : arg + 1;
+
+                // Warn for `ref`/`in` or None/`ref readonly` mismatch.
+                if (argRefKind == RefKind.Ref)
+                {
+                    if (parameter.RefKind == RefKind.In)
+                    {
+                        Debug.Assert(argNumber > 0);
+                        // The 'ref' modifier for argument {0} corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+                        diagnostics.Add(
+                            ErrorCode.WRN_BadArgRef,
+                            argument.Syntax,
+                            argNumber);
+                    }
+                }
+                else if (argRefKind == RefKind.None && parameter.RefKind == RefKind.RefReadOnlyParameter)
+                {
+                    if (!this.CheckValueKind(argument.Syntax, argument, BindValueKind.RefersToLocation, checkingReceiver: false, BindingDiagnosticBag.Discarded))
+                    {
+                        Debug.Assert(argNumber >= 0); // can be 0 for receiver of extension method
+                                                      // Argument {0} should be a variable because it is passed to a 'ref readonly' parameter
+                        diagnostics.Add(
+                            ErrorCode.WRN_RefReadonlyNotVariable,
+                            argument.Syntax,
+                            argNumber);
+                    }
+                    else if (!invokedAsExtensionMethod || arg != 0)
+                    {
+                        Debug.Assert(argNumber > 0);
+                        if (this.CheckValueKind(argument.Syntax, argument, BindValueKind.Assignable, checkingReceiver: false, BindingDiagnosticBag.Discarded))
+                        {
+                            // Argument {0} should be passed with 'ref' or 'in' keyword
+                            diagnostics.Add(
+                                ErrorCode.WRN_ArgExpectedRefOrIn,
+                                argument.Syntax,
+                                argNumber);
+                        }
+                        else
+                        {
+                            // Argument {0} should be passed with the 'in' keyword
+                            diagnostics.Add(
+                                ErrorCode.WRN_ArgExpectedIn,
+                                argument.Syntax,
+                                argNumber);
+                        }
+                    }
+                }
             }
         }
 #nullable disable
@@ -7990,9 +7993,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Note: we're resolving without arguments, which means we're not treating the member access as invoked
             var resolution = this.ResolveExtension(
                 syntax, name, analyzedArguments: null, receiver, typeArgumentsOpt, options: OverloadResolution.Options.None,
-                returnRefKind: default, returnType: null, ref useSiteInfo);
-
-            diagnostics.Add(syntax, useSiteInfo);
+                returnRefKind: default, returnType: null, withDependencies: diagnostics.AccumulatesDependencies);
 
             if (resolution.IsNonMethodExtensionMember(out Symbol? extensionMember))
             {
@@ -8014,6 +8015,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (extensionMember)
             {
                 case PropertySymbol propertySymbol:
+                    Debug.Assert(extensionMember.ContainingType.ExtensionParameter is not null);
+                    if (receiver is not BoundTypeExpression)
+                    {
+                        receiver = CreateConversion(receiver, extensionMember.ContainingType.ExtensionParameter.Type, diagnostics);
+                    }
+
                     return BindPropertyAccess(syntax, receiver, propertySymbol, diagnostics, LookupResultKind.Viable, hasErrors: false);
 
                 case NamedTypeSymbol namedTypeSymbol:
@@ -8322,7 +8329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(extensionMethodArguments.Names.Count == 0);
             Debug.Assert(extensionMethodArguments.RefKinds.Count == 0);
 
-            extensionMethodArguments.IsExtensionMethodInvocation = true;
+            extensionMethodArguments.IncludesReceiverAsArgument = true;
             extensionMethodArguments.Arguments.Add(receiver);
             extensionMethodArguments.Arguments.AddRange(originalArguments.Arguments);
 
@@ -8469,7 +8476,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        // PROTOTYPE revisit handling of use-site diagnostics (some are currently put in the returned MethodGroupResolution and others are collected separately)
         protected MethodGroupResolution ResolveExtension(
             SyntaxNode expression,
             string memberName,
@@ -8479,7 +8485,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             OverloadResolution.Options options,
             RefKind returnRefKind,
             TypeSymbol? returnType,
-            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
+            bool withDependencies,
             in CallingConventionInfo callingConvention = default)
         {
             Debug.Assert(left.Type is not null);
@@ -8493,151 +8499,54 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var firstResult = new MethodGroupResolution();
             AnalyzedArguments? actualArguments = null;
+            var lookupResult = LookupResult.GetInstance();
+            var classicExtensionLookupResult = LookupResult.GetInstance();
+
+            // PROTOTYPE we need to lookup on combined arity of extension declaration and extension method
+            int arity = typeArgumentsWithAnnotations.IsDefault ? 0 : typeArgumentsWithAnnotations.Length;
+            var lookupOptions = (arity == 0) ? LookupOptions.AllMethodsOnArityZero : LookupOptions.Default;
+            if (analyzedArguments is not null)
+            {
+                lookupOptions |= LookupOptions.MustBeInvocableIfMember;
+            }
+
+            var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies);
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = this.GetNewCompoundUseSiteInfo(diagnostics);
 
             foreach (var scope in new ExtensionScopes(this))
             {
-                // PROTOTYPE we are temporarily prioritizing new extension members over classic extension methods, instead of mixing them
-                if (tryResolveExtensionMember(this, expression, memberName, analyzedArguments, left, typeArgumentsWithAnnotations,
-                    options, returnRefKind, in callingConvention, returnType, ref useSiteInfo, scope,
-                    out MethodGroupResolution extensionResult))
-                {
-                    if (extensionResult.IsNonMethodExtensionMember(out _))
-                    {
-                        firstResult.Free();
-                        return extensionResult;
-                    }
-
-                    // If the search in the current scope resulted in any applicable method from an extension type
-                    // (regardless of whether a best applicable method could be determined) then our search is complete.
-                    // Otherwise, store aside the first non-applicable result and continue searching for an applicable result.
-                    if (extensionResult.HasAnyApplicableMethod)
-                    {
-                        firstResult.Free();
-                        return extensionResult;
-                    }
-                    else if (firstResult.IsEmpty)
-                    {
-                        firstResult = extensionResult;
-                    }
-                    else
-                    {
-                        // Neither the first result, nor applicable. No need to save result.
-                        extensionResult.Free();
-                    }
-                }
-
-                if (tryResolveExtensionMethod(this, expression, memberName, analyzedArguments, left, typeArgumentsWithAnnotations,
-                    options, returnRefKind, returnType, in callingConvention, ref useSiteInfo, scope,
-                    ref actualArguments, out MethodGroupResolution extensionMethodResult))
-                {
-                    // If the search in the current scope resulted in any applicable method (regardless of whether a best
-                    // applicable method could be determined) then our search is complete. Otherwise, store aside the
-                    // first non-applicable result and continue searching for an applicable result.
-                    if (extensionMethodResult.HasAnyApplicableMethod)
-                    {
-                        firstResult.Free();
-                        actualArguments?.Free();
-                        return extensionMethodResult;
-                    }
-                    else if (firstResult.IsEmpty)
-                    {
-                        firstResult = extensionMethodResult;
-                    }
-                    else
-                    {
-                        // Neither the first result, nor applicable. No need to save result.
-                        extensionMethodResult.Free();
-                    }
-                }
-            }
-
-            Debug.Assert((actualArguments == null) || !firstResult.IsEmpty);
-            actualArguments?.Free();
-
-            return firstResult;
-
-            static bool tryResolveExtensionMember(Binder binder, SyntaxNode expression, string memberName, AnalyzedArguments? analyzedArguments, BoundExpression left,
-                ImmutableArray<TypeWithAnnotations> typeArgumentsWithAnnotations, OverloadResolution.Options options, RefKind returnRefKind, in CallingConventionInfo callingConvention,
-                TypeSymbol? returnType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, ExtensionScope scope, out MethodGroupResolution extensionResult)
-            {
-                var lookupResult = LookupResult.GetInstance();
-
-                int arity = typeArgumentsWithAnnotations.IsDefault ? 0 : typeArgumentsWithAnnotations.Length;
-                var lookupOptions = (arity == 0) ? LookupOptions.AllMethodsOnArityZero : LookupOptions.Default;
-                if (analyzedArguments is not null)
-                {
-                    lookupOptions |= LookupOptions.MustBeInvocableIfMember;
-                }
+                lookupResult.Clear();
+                classicExtensionLookupResult.Clear();
 
                 scope.Binder.LookupExtensionMembersInSingleBinder(
                     lookupResult, left.Type!, memberName, arity,
-                    basesBeingResolved: null, lookupOptions, originalBinder: binder, ref useSiteInfo);
+                    basesBeingResolved: null, lookupOptions, originalBinder: this, ref useSiteInfo);
+
+                this.LookupExtensionMethods(classicExtensionLookupResult, scope, memberName, arity, ref useSiteInfo);
+                diagnostics.Add(expression, useSiteInfo);
+
+                lookupResult.MergeEqual(classicExtensionLookupResult);
 
                 if (!lookupResult.IsMultiViable)
                 {
-                    lookupResult.Free();
-                    extensionResult = default;
-                    return false;
+                    continue;
                 }
 
                 var members = ArrayBuilder<Symbol>.GetInstance();
-
-                var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: useSiteInfo.AccumulatesDependencies);
-
-                Symbol? symbol = binder.GetSymbolOrMethodOrPropertyGroupStrict(lookupResult, expression, memberName, arity, members, diagnostics, qualifierOpt: null);
+                Symbol? symbol = this.GetSymbolOrMethodOrPropertyGroupStrict(lookupResult, expression, memberName, arity, members, diagnostics, qualifierOpt: null);
                 if (symbol is not null)
                 {
+                    firstResult.Free();
+                    actualArguments?.Free();
                     lookupResult.Free();
+                    classicExtensionLookupResult.Free();
                     members.Free();
-                    extensionResult = new MethodGroupResolution(symbol, LookupResultKind.Viable, diagnostics.ToReadOnlyAndFree());
-                    return true;
-                }
-
-                if (members[0].Kind is not SymbolKind.Method)
-                {
-                    lookupResult.Free();
-                    members.Free();
-                    diagnostics.Free();
-                    extensionResult = default;
-                    return false;
+                    return new MethodGroupResolution(symbol, LookupResultKind.Viable, diagnostics.ToReadOnlyAndFree());
                 }
 
                 var methodGroup = MethodGroup.GetInstance();
-                methodGroup.PopulateWithMethods(left, members, typeArgumentsWithAnnotations, isExtensionMethodGroup: false, resultKind: lookupResult.Kind);
+                methodGroup.PopulateWithMethods(left, members, typeArgumentsWithAnnotations, resultKind: lookupResult.Kind);
                 members.Free();
-
-                if (analyzedArguments is null)
-                {
-                    lookupResult.Free();
-                    extensionResult = new MethodGroupResolution(methodGroup, diagnostics.ToReadOnlyAndFree());
-                    return true;
-                }
-
-                extensionResult = resolveOverloads(binder, methodGroup, analyzedArguments, options, returnType, returnRefKind, in callingConvention, expression, diagnostics);
-                diagnostics.Free();
-                return true;
-            }
-
-            static bool tryResolveExtensionMethod(
-                Binder binder,
-                SyntaxNode expression,
-                string methodName,
-                AnalyzedArguments? analyzedArguments,
-                BoundExpression left,
-                ImmutableArray<TypeWithAnnotations> typeArgumentsWithAnnotations,
-                OverloadResolution.Options options,
-                RefKind returnRefKind,
-                TypeSymbol? returnType,
-                in CallingConventionInfo callingConvention,
-                ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
-                ExtensionScope scope,
-                ref AnalyzedArguments? actualArguments,
-                out MethodGroupResolution result)
-            {
-                var methodGroup = MethodGroup.GetInstance();
-
-                var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: useSiteInfo.AccumulatesDependencies);
-                binder.PopulateExtensionMethodsFromSingleBinder(scope, methodGroup, expression, left, methodName, typeArgumentsWithAnnotations, diagnostics);
 
                 if (analyzedArguments == null)
                 {
@@ -8645,23 +8554,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // we can still prune the inapplicable extension methods using the receiver type
                     for (int i = methodGroup.Methods.Count - 1; i >= 0; i--)
                     {
-                        if ((object)methodGroup.Methods[i].ReduceExtensionMethod(left.Type, binder.Compilation) == null)
+                        if (methodGroup.Methods[i].IsExtensionMethod
+                            && (object)methodGroup.Methods[i].ReduceExtensionMethod(left.Type, this.Compilation) == null)
+                        {
                             methodGroup.Methods.RemoveAt(i);
+                        }
+                        // PROTOTYPE we'll want to do the same for new extension methods, once we remove the "compatible extension" logic
                     }
 
                     if (methodGroup.Methods.Count != 0)
                     {
-                        result = new MethodGroupResolution(methodGroup, diagnostics.ToReadOnlyAndFree());
-                        return true;
+                        firstResult.Free();
+                        actualArguments?.Free();
+                        lookupResult.Free();
+                        classicExtensionLookupResult.Free();
+                        return new MethodGroupResolution(methodGroup, diagnostics.ToReadOnlyAndFree());
                     }
                 }
 
                 if (methodGroup.Methods.Count == 0)
                 {
                     methodGroup.Free();
-                    diagnostics.Free();
-                    result = default;
-                    return false;
+                    continue;
                 }
 
                 if (actualArguments == null)
@@ -8672,10 +8586,36 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CombineExtensionMethodArguments(left, analyzedArguments, actualArguments);
                 }
 
-                result = resolveOverloads(binder, methodGroup, actualArguments, options, returnType, returnRefKind, in callingConvention, expression, diagnostics);
-                diagnostics.Free();
-                return true;
+                var extensionMethodResult = resolveOverloads(this, methodGroup, actualArguments, options, returnType, returnRefKind, in callingConvention, expression, diagnostics);
+                // If the search in the current scope resulted in any applicable method (regardless of whether a best
+                // applicable method could be determined) then our search is complete. Otherwise, store aside the
+                // first non-applicable result and continue searching for an applicable result.
+                if (extensionMethodResult.HasAnyApplicableMethod)
+                {
+                    firstResult.Free();
+                    actualArguments?.Free();
+                    lookupResult.Free();
+                    classicExtensionLookupResult.Free();
+                    diagnostics.Free();
+                    return extensionMethodResult;
+                }
+                else if (firstResult.IsEmpty)
+                {
+                    firstResult = extensionMethodResult;
+                }
+                else
+                {
+                    // Neither the first result, nor applicable. No need to save result.
+                    extensionMethodResult.Free();
+                }
             }
+
+            Debug.Assert((actualArguments == null) || !firstResult.IsEmpty);
+            lookupResult.Free();
+            classicExtensionLookupResult.Free();
+            diagnostics.Free();
+
+            return firstResult;
 
             static MethodGroupResolution resolveOverloads(Binder binder, MethodGroup methodGroup, AnalyzedArguments actualArguments, OverloadResolution.Options options,
                 TypeSymbol? returnType, RefKind returnRefKind, in CallingConventionInfo callingConvention, SyntaxNode expression, BindingDiagnosticBag diagnostics)
@@ -8747,7 +8687,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Symbol symbol = GetSymbolOrMethodOrPropertyGroup(lookupResult, node, rightName, arity, members, diagnostics, out wasError, qualifierOpt: null);
                 Debug.Assert((object)symbol == null);
                 Debug.Assert(members.Count > 0);
-                methodGroup.PopulateWithMethods(left, members, typeArgumentsWithAnnotations, isExtensionMethodGroup: true, lookupResult.Kind);
+                methodGroup.PopulateWithMethods(left, members, typeArgumentsWithAnnotations, lookupResult.Kind);
                 members.Free();
             }
 
@@ -10603,7 +10543,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var extensionMethodResolution = ResolveExtension(
                 expression, memberName, analyzedArguments, methodGroup.ReceiverOpt, methodGroup.TypeArgumentsOpt, options,
-                returnRefKind: returnRefKind, returnType: returnType, ref useSiteInfo,
+                returnRefKind: returnRefKind, returnType: returnType, useSiteInfo.AccumulatesDependencies,
                 in callingConvention);
             bool preferExtensionMethodResolution = false;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8522,7 +8522,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     lookupResult, left.Type!, memberName, arity,
                     basesBeingResolved: null, lookupOptions, originalBinder: this, ref useSiteInfo);
 
-                this.LookupExtensionMethods(classicExtensionLookupResult, scope, memberName, arity, ref useSiteInfo);
+                var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, useSiteInfo.AccumulatesDependencies);
+
+                CompoundUseSiteInfo<AssemblySymbol> classicExtensionUseSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+                this.LookupExtensionMethods(classicExtensionLookupResult, scope, memberName, arity, ref classicExtensionUseSiteInfo);
+                diagnostics.Add(expression, classicExtensionUseSiteInfo);
 
                 lookupResult.MergeEqual(classicExtensionLookupResult);
 
@@ -8532,7 +8536,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var members = ArrayBuilder<Symbol>.GetInstance();
-                var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, useSiteInfo.AccumulatesDependencies);
                 Symbol? symbol = this.GetSymbolOrMethodOrPropertyGroupStrict(lookupResult, expression, memberName, arity, members, diagnostics, qualifierOpt: null);
                 if (symbol is not null)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8532,6 +8532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!lookupResult.IsMultiViable)
                 {
+                    diagnostics.Free();
                     continue;
                 }
 
@@ -8578,6 +8579,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (methodGroup.Methods.Count == 0)
                 {
                     methodGroup.Free();
+                    diagnostics.Free();
                     continue;
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -2397,6 +2397,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #nullable enable
         private BoundFunctionPointerInvocation BindFunctionPointerInvocation(SyntaxNode node, BoundExpression boundExpression, AnalyzedArguments analyzedArguments, BindingDiagnosticBag diagnostics)
         {
+            // PROTOTYPE this function will probably need an adjustment to deal with static extensions 
             boundExpression = BindToNaturalType(boundExpression, diagnostics);
             RoslynDebug.Assert(boundExpression.Type is FunctionPointerTypeSymbol);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -195,7 +195,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 LookupMembersInClass(tempResult, extension, name, arity, basesBeingResolved,
                     options, originalBinder, diagnose: false, ref useSiteInfo);
 
-                // PROTOTYPE we should prefer extension members that apply to a more specific type
                 result.MergeEqual(tempResult);
                 tempResult.Clear();
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(methodName == "SelectMany");
 
             // Estimate the return type of Select's lambda argument
-            BoundExpression arg = arguments.Argument(arguments.IsExtensionMethodInvocation ? 1 : 0);
+            BoundExpression arg = arguments.Argument(arguments.IncludesReceiverAsArgument ? 1 : 0);
             TypeSymbol type = null;
             if (arg.Kind == BoundKind.UnboundLambda)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(methodName == "SelectMany");
 
             // Estimate the return type of Select's lambda argument
-            BoundExpression arg = arguments.Argument(arguments.IncludesReceiverAsArgument ? 1 : 0);
+            BoundExpression arg = arguments.Argument(arguments.IncludesReceiverAsArgument ? 1 : 0); // PROTOTYPE test this code path for new extensions
             TypeSymbol type = null;
             if (arg.Kind == BoundKind.UnboundLambda)
             {

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1500,8 +1500,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var analyzedArguments = AnalyzedArguments.GetInstance();
 
-            CompoundUseSiteInfo<AssemblySymbol> extensionUseSiteInfo = this.GetNewCompoundUseSiteInfo(diagnostics);
-
             var methodGroupResolutionResult = this.ResolveExtension(
                 collectionSyntax,
                 methodName,
@@ -1511,9 +1509,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 options: OverloadResolution.Options.None,
                 returnRefKind: default,
                 returnType: null,
-                ref extensionUseSiteInfo);
+                diagnostics.AccumulatesDependencies);
 
-            diagnostics.Add(syntax, extensionUseSiteInfo);
             diagnostics.AddRange(methodGroupResolutionResult.Diagnostics);
 
             var overloadResolutionResult = methodGroupResolutionResult.OverloadResolutionResult;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1500,6 +1500,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var analyzedArguments = AnalyzedArguments.GetInstance();
 
+            CompoundUseSiteInfo<AssemblySymbol> extensionUseSiteInfo = this.GetNewCompoundUseSiteInfo(diagnostics);
+
             var methodGroupResolutionResult = this.ResolveExtension(
                 collectionSyntax,
                 methodName,
@@ -1509,8 +1511,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 options: OverloadResolution.Options.None,
                 returnRefKind: default,
                 returnType: null,
-                diagnostics.AccumulatesDependencies);
+                ref extensionUseSiteInfo);
 
+            diagnostics.Add(syntax, extensionUseSiteInfo);
             diagnostics.AddRange(methodGroupResolutionResult.Diagnostics);
 
             var overloadResolutionResult = methodGroupResolutionResult.OverloadResolutionResult;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly ArrayBuilder<BoundExpression> Arguments;
         public readonly ArrayBuilder<(string Name, Location Location)?> Names;
         public readonly ArrayBuilder<RefKind> RefKinds;
-        public bool IsExtensionMethodInvocation;
+        public bool IncludesReceiverAsArgument;
         private ThreeState _lazyHasDynamicArgument;
 
         internal AnalyzedArguments()
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Arguments.Clear();
             this.Names.Clear();
             this.RefKinds.Clear();
-            this.IsExtensionMethodInvocation = false;
+            this.IncludesReceiverAsArgument = false;
             _lazyHasDynamicArgument = ThreeState.Unknown;
         }
 
@@ -78,9 +78,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return RefKinds.Count > 0 ? RefKinds[i] : Microsoft.CodeAnalysis.RefKind.None;
         }
 
-        public bool IsExtensionMethodThisArgument(int i)
+        public bool IsExtensionMethodReceiverArgument(int i)
         {
-            return (i == 0) && this.IsExtensionMethodInvocation;
+            return (i == 0) && this.IncludesReceiverAsArgument;
         }
 
         public bool HasDynamicArgument
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             instance.Arguments.AddRange(original.Arguments);
             instance.Names.AddRange(original.Names);
             instance.RefKinds.AddRange(original.RefKinds);
-            instance.IsExtensionMethodInvocation = original.IsExtensionMethodInvocation;
+            instance.IncludesReceiverAsArgument = original.IncludesReceiverAsArgument;
             instance._lazyHasDynamicArgument = original._lazyHasDynamicArgument;
             return instance;
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -421,6 +421,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var argsToParams = adjustArgsToParams(ArgsToParamsOpt);
             var conversions = adjustConversions(ConversionsOpt);
 
+            // We only need HasAnyRefOmittedArgument as part of overload resolution, so we don't need to adjust it post-overload resolution.
             return new MemberAnalysisResult(Kind, badArguments, argsToParams, conversions, BadParameter - 1, HasAnyRefOmittedArgument,
                 ConstraintFailureDiagnostics, DefinitionParamsElementTypeOpt, ParamsElementTypeOpt);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -432,19 +432,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return badArguments;
                 }
 
+                var result = BitVector.Create(badArguments.Capacity);
                 foreach (int setIndex in badArguments.TrueBits())
                 {
-                    if (setIndex == 0)
-                    {
-                        badArguments[setIndex] = false;
-                        continue;
-                    }
-
-                    badArguments[setIndex] = false;
-                    badArguments[setIndex - 1] = true;
+                    result[setIndex] = true;
                 }
 
-                return badArguments;
+                return result;
             }
 
             static ImmutableArray<int> adjustArgsToParams(ImmutableArray<int> argsToParams)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
@@ -8,7 +8,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -42,17 +41,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt,
             ArrayBuilder<Symbol> members,
             ImmutableArray<TypeWithAnnotations> typeArguments,
-            bool isExtensionMethodGroup,
             LookupResultKind resultKind = LookupResultKind.Viable,
             DiagnosticInfo error = null)
         {
             this.PopulateHelper(receiverOpt, resultKind, error);
-            this.IsExtensionMethodGroup = isExtensionMethodGroup;
+            this.IsExtensionMethodGroup = true;
 
             foreach (var member in members)
             {
                 this.Methods.Add((MethodSymbol)member);
-                Debug.Assert(((MethodSymbol)member).IsExtensionMethod == isExtensionMethodGroup);
+                Debug.Assert(((MethodSymbol)member).IsExtensionMethod || member.ContainingType.IsExtension);
             }
 
             if (!typeArguments.IsDefault)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Methods.Add(method);
         }
 
-        internal void PopulateWithMethods(
+        internal void PopulateWithExtensionMethods(
             BoundExpression receiverOpt,
             ArrayBuilder<Symbol> members,
             ImmutableArray<TypeWithAnnotations> typeArguments,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -581,7 +581,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt) where TMember : Symbol
         {
             // When the feature 'ImprovedOverloadCandidates' is enabled, we do not include instance members when the receiver
-            // is a type, or static members when the receiver is an instance. It does not apply when the
+            // is a type, or static members when the receiver is an instance. This does not apply when the
             // receiver is a TypeOrValueExpression, which is used to handle the receiver of a Color-Color ambiguity, where either
             // an instance or a static member would be acceptable.
             if (Binder.IsTypeOrValueExpression(receiverOpt))

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3876,11 +3876,17 @@ outerDefault:
 
             if (argumentCount == parameterCount && argToParamMap.IsDefaultOrEmpty)
             {
-                ImmutableArray<RefKind> parameterRefKinds = isNewExtensionMember ? GetParameterRefKindsIncludingReceiver(member) : member.GetParameterRefKinds();
-                if (parameterRefKinds.IsDefaultOrEmpty)
+                bool hasSomeRefKinds = !member.GetParameterRefKinds().IsDefaultOrEmpty;
+                if (member.GetIsNewExtensionMember())
+                {
+                    Debug.Assert(member.ContainingType.ExtensionParameter is not null);
+                    hasSomeRefKinds |= member.ContainingType.ExtensionParameter.RefKind != RefKind.None;
+                }
+
+                if (!hasSomeRefKinds)
                 {
                     var parameterTypes = isNewExtensionMember ? GetParameterTypesIncludingReceiver(member) : member.GetParameterTypes();
-                    return new EffectiveParameters(parameterTypes, parameterRefKinds, firstParamsElementIndex: -1);
+                    return new EffectiveParameters(parameterTypes, refKinds: default, firstParamsElementIndex: -1);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -581,7 +581,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt) where TMember : Symbol
         {
             // When the feature 'ImprovedOverloadCandidates' is enabled, we do not include instance members when the receiver
-            // is a type, or static members when the receiver is an instance. It also does not apply when the
+            // is a type, or static members when the receiver is an instance. It does not apply when the
             // receiver is a TypeOrValueExpression, which is used to handle the receiver of a Color-Color ambiguity, where either
             // an instance or a static member would be acceptable.
             if (Binder.IsTypeOrValueExpression(receiverOpt))
@@ -3869,7 +3869,7 @@ outerDefault:
             hasAnyRefOmittedArgument = false;
 
             bool isNewExtensionMember = member.GetIsNewExtensionMember();
-            ImmutableArray<ParameterSymbol> parameters = isNewExtensionMember ? GetParametersIncludingExtensionParameter(member) : member.GetParameters();
+            ImmutableArray<ParameterSymbol> parameters = isNewExtensionMember ? GetParametersIncludingReceiver(member) : member.GetParameters();
 
             // We simulate an extra parameter for vararg methods 
             int parameterCount = parameters.Length + (member.GetIsVararg() ? 1 : 0);
@@ -4030,7 +4030,7 @@ outerDefault:
             var types = ArrayBuilder<TypeWithAnnotations>.GetInstance();
             var refs = ArrayBuilder<RefKind>.GetInstance();
             bool anyRef = false;
-            var parameters = member.GetIsNewExtensionMember() ? GetParametersIncludingExtensionParameter(member) : member.GetParameters();
+            var parameters = member.GetIsNewExtensionMember() ? GetParametersIncludingReceiver(member) : member.GetParameters();
             bool hasAnyRefArg = argumentRefKinds.Any();
             hasAnyRefOmittedArgument = false;
             TypeWithAnnotations paramsIterationType = default;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3872,7 +3872,7 @@ outerDefault:
             ImmutableArray<ParameterSymbol> parameters = isNewExtensionMember ? GetParametersIncludingExtensionParameter(member) : member.GetParameters();
 
             // We simulate an extra parameter for vararg methods 
-            int parameterCount = member.GetParameterCount() + (member.GetIsVararg() ? 1 : 0);
+            int parameterCount = parameters.Length + (member.GetIsVararg() ? 1 : 0);
 
             if (argumentCount == parameterCount && argToParamMap.IsDefaultOrEmpty)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -895,7 +895,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to required formal parameter 'y'.
 
             TMember badMember = bad.Member;
-            ImmutableArray<ParameterSymbol> parameters = badMember.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingExtensionParameter(badMember) : badMember.GetParameters();
+            ImmutableArray<ParameterSymbol> parameters = badMember.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingReceiver(badMember) : badMember.GetParameters();
             int badParamIndex = bad.Result.BadParameter;
             string badParamName;
             if (badParamIndex == parameters.Length)
@@ -1115,7 +1115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // as there is no explicit call to Add method.
 
                 int argumentOffset = arguments.IncludesReceiverAsArgument ? 1 : 0;
-                var parameters = method.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingExtensionParameter(method) : method.GetParameters();
+                var parameters = method.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingReceiver(method) : method.GetParameters();
 
                 for (int i = argumentOffset; i < parameters.Length; i++)
                 {
@@ -1170,7 +1170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Early out: if the bad argument is an __arglist parameter then simply report that:
 
-            var parameters = method.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingExtensionParameter(method) : method.GetParameters();
+            var parameters = method.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingReceiver(method) : method.GetParameters();
             if (method.GetIsVararg() && parm == parameters.Length)
             {
                 // NOTE: No SymbolDistinguisher required, since one of the arguments is "__arglist".

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -895,7 +895,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to required formal parameter 'y'.
 
             TMember badMember = bad.Member;
-            ImmutableArray<ParameterSymbol> parameters = badMember.GetParameters();
+            ImmutableArray<ParameterSymbol> parameters = badMember.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingExtensionParameter(badMember) : badMember.GetParameters();
             int badParamIndex = bad.Result.BadParameter;
             string badParamName;
             if (badParamIndex == parameters.Length)
@@ -946,7 +946,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             };
 
             int argCount = arguments.Arguments.Count;
-            if (arguments.IsExtensionMethodInvocation)
+            if (arguments.IncludesReceiverAsArgument)
             {
                 argCount--;
             }
@@ -1114,8 +1114,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // ErrorCode.ERR_BadArgTypesForCollectionAdd or ErrorCode.ERR_InitializerAddHasParamModifiers
                 // as there is no explicit call to Add method.
 
-                int argumentOffset = arguments.IsExtensionMethodInvocation ? 1 : 0;
-                var parameters = method.GetParameters();
+                int argumentOffset = arguments.IncludesReceiverAsArgument ? 1 : 0;
+                var parameters = method.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingExtensionParameter(method) : method.GetParameters();
 
                 for (int i = argumentOffset; i < parameters.Length; i++)
                 {
@@ -1156,6 +1156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TMember method,
             int arg)
         {
+            // PROTOTYPE consider adjusting or removing the argument index for displaying in diagnostic
             BoundExpression argument = arguments.Argument(arg);
             if (argument.HasAnyErrors)
             {
@@ -1169,7 +1170,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Early out: if the bad argument is an __arglist parameter then simply report that:
 
-            if (method.GetIsVararg() && parm == method.GetParameterCount())
+            var parameters = method.GetIsNewExtensionMember() ? OverloadResolution.GetParametersIncludingExtensionParameter(method) : method.GetParameters();
+            if (method.GetIsVararg() && parm == parameters.Length)
             {
                 // NOTE: No SymbolDistinguisher required, since one of the arguments is "__arglist".
 
@@ -1184,12 +1186,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            ParameterSymbol parameter = method.GetParameters()[parm];
-            bool isLastParameter = method.GetParameterCount() == parm + 1; // This is used to later decide if we need to try to unwrap a params collection
+            ParameterSymbol parameter = parameters[parm];
+            bool isLastParameter = parameters.Count() == parm + 1; // This is used to later decide if we need to try to unwrap a params collection
             RefKind refArg = arguments.RefKind(arg);
             RefKind refParameter = parameter.RefKind;
 
-            if (arguments.IsExtensionMethodThisArgument(arg))
+            if (arguments.IsExtensionMethodReceiverArgument(arg))
             {
                 Debug.Assert(refArg == RefKind.None);
                 if (refParameter == RefKind.Ref || refParameter == RefKind.In)
@@ -1301,7 +1303,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(argument.Kind != BoundKind.DiscardExpression || argument.HasExpressionType());
                 Debug.Assert(argument.Display != null);
 
-                if (arguments.IsExtensionMethodThisArgument(arg))
+                if (arguments.IsExtensionMethodReceiverArgument(arg))
                 {
                     Debug.Assert((arg == 0) && (parm == arg));
                     Debug.Assert(!badArg.Result.ConversionForArg(parm).IsImplicit);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -1187,7 +1187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             ParameterSymbol parameter = parameters[parm];
-            bool isLastParameter = parameters.Count() == parm + 1; // This is used to later decide if we need to try to unwrap a params collection
+            bool isLastParameter = parameters.Length == parm + 1; // This is used to later decide if we need to try to unwrap a params collection
             RefKind refArg = arguments.RefKind(arg);
             RefKind refParameter = parameter.RefKind;
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -68,9 +68,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             // PROTOTYPE consider optimizing
             var refKinds = symbol.GetParameterRefKinds();
             var receiverRefKind = symbol.ContainingType.ExtensionParameter.RefKind;
-            if (refKinds.IsDefault && receiverRefKind == RefKind.None)
+            if (refKinds.IsDefault)
             {
-                return default;
+                return receiverRefKind == RefKind.None ? default : [receiverRefKind];
             }
 
             return [receiverRefKind, .. refKinds];

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -62,20 +62,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return [symbol.ContainingType.ExtensionParameter, .. symbol.GetParameters()];
         }
 
-        private static ImmutableArray<RefKind> GetParameterRefKindsIncludingReceiver(Symbol symbol)
-        {
-            Debug.Assert(symbol.GetIsNewExtensionMember());
-            // PROTOTYPE consider optimizing
-            var refKinds = symbol.GetParameterRefKinds();
-            var receiverRefKind = symbol.ContainingType.ExtensionParameter.RefKind;
-            if (refKinds.IsDefault)
-            {
-                return receiverRefKind == RefKind.None ? default : [receiverRefKind];
-            }
-
-            return [receiverRefKind, .. refKinds];
-        }
-
         private static ImmutableArray<TypeWithAnnotations> GetParameterTypesIncludingReceiver(Symbol symbol)
         {
             Debug.Assert(symbol.GetIsNewExtensionMember());

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal static ImmutableArray<ParameterSymbol> GetParametersIncludingExtensionParameter(Symbol symbol)
+        internal static ImmutableArray<ParameterSymbol> GetParametersIncludingReceiver(Symbol symbol)
         {
             Debug.Assert(symbol.GetIsNewExtensionMember());
             // PROTOTYPE consider optimizing
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(arguments != null);
 
             bool isNewExtensionMember = symbol.GetIsNewExtensionMember();
-            ImmutableArray<ParameterSymbol> parameters = isNewExtensionMember ? GetParametersIncludingExtensionParameter(symbol) : symbol.GetParameters();
+            ImmutableArray<ParameterSymbol> parameters = isNewExtensionMember ? GetParametersIncludingReceiver(symbol) : symbol.GetParameters();
             bool isVararg = symbol.GetIsVararg();
 
             // The easy out is that we have no named arguments and are in normal form.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4415,7 +4415,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(reinferredMethod is object);
                 if (node.ImplicitReceiverOpt != null)
                 {
-                    Debug.Assert(node.ImplicitReceiverOpt.Kind == BoundKind.ObjectOrCollectionValuePlaceholder);
+                    //Debug.Assert(node.ImplicitReceiverOpt.Kind == BoundKind.ObjectOrCollectionValuePlaceholder); // PROTOTYPE the receiver may be converted now
                     SetAnalyzedNullability(node.ImplicitReceiverOpt, new VisitResult(node.ImplicitReceiverOpt.Type, NullableAnnotation.NotAnnotated, NullableFlowState.NotNull));
                 }
                 SetUnknownResultNullability(node);

--- a/src/Compilers/CSharp/Portable/Lowering/ExtensionMethodReferenceRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ExtensionMethodReferenceRewriter.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         invokedAsExtensionMethod = true;
 
-                        // PROTOTYPE: We probably need to convert the receiver to the parameter's type here
+                        Debug.Assert(receiverOpt.Type!.Equals(method.Parameters[0].Type, TypeCompareKind.ConsiderEverything));
 
                         arguments = arguments.Insert(0, receiverOpt);
                         receiverOpt = null;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(initializer.Arguments.Any());
             Debug.Assert(rewrittenReceiver != null || _inExpressionLambda);
 
-            rewrittenReceiver = VisitExpression(initializer.ImplicitReceiverOpt); // The receiver may have a conversion for a new extension method. The relevant placeholder was already set
+            // PROTOTYPE The receiver may have a conversion (stored in ImplicitReceiverOpt) for a new extension method. We need to account for it
 
             var syntax = initializer.Syntax;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -148,6 +148,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(initializer.Arguments.Any());
             Debug.Assert(rewrittenReceiver != null || _inExpressionLambda);
 
+            rewrittenReceiver = VisitExpression(initializer.ImplicitReceiverOpt); // The receiver may have a conversion for a new extension method. The relevant placeholder was already set
+
             var syntax = initializer.Syntax;
 
             if (_allowOmissionOfConditionalCalls)

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -77,6 +77,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal static bool GetIsNewExtensionMember(this Symbol member)
+        {
+            switch (member.Kind)
+            {
+                case SymbolKind.Method:
+                case SymbolKind.Property:
+                    return member.ContainingSymbol is TypeSymbol { IsExtension: true };
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(member.Kind);
+            }
+        }
+
         /// <summary>
         /// Get the ref kinds of the parameters of a member symbol.  Should be a method, property, or event.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -204,6 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // errors relevant for extension methods
             if (IsExtensionMethod)
             {
+                // PROTOTYPE these validation rules should also be applied to extension declarations
                 var syntax = GetSyntax();
                 var parameter0Type = this.Parameters[0].TypeWithAnnotations;
                 var parameter0RefKind = this.Parameters[0].RefKind;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -2511,14 +2511,20 @@ public static class Extensions
     public void ReceiverParameter_Ref_01()
     {
         var src = """
+int i = 42;
+i.M();
+System.Console.Write(i);
+
 public static class Extensions
 {
-    extension(ref int i) { }
-    static void M(this ref int i) { }
+    extension(ref int i) 
+    {
+        public void M() { System.Console.Write(i); i = 43; }
+    }
 }
 """;
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "4243").VerifyDiagnostics();
     }
 
     [Fact]
@@ -2638,14 +2644,20 @@ public static class Extensions
     public void ReceiverParameter_RefReadonly()
     {
         var src = """
+int i = 42;
+i.M();
+
 public static class Extensions
 {
-    extension(ref readonly int i) { }
-    static void M(this ref readonly int i) { }
+    extension(ref readonly int i) 
+    {
+        public void M() { System.Console.Write(i); }
+    }
+    static void M2(this ref readonly int i) { }
 }
 """;
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
     }
 
     [Fact]
@@ -2672,7 +2684,7 @@ public static class Extensions
     public void ReceiverParameter_ArgList_01()
     {
         var src = """
-_ = object.P;
+_ = object.M();
 
 public static class Extensions
 {
@@ -2684,11 +2696,11 @@ public static class Extensions
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
-            // (1,12): error CS0117: 'object' does not contain a definition for 'P'
-            // _ = object.P;
-            Diagnostic(ErrorCode.ERR_NoSuchMember, "P").WithArguments("object", "P").WithLocation(1, 12),
+            // (1,12): error CS0117: 'object' does not contain a definition for 'M'
+            // _ = object.M();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "M").WithArguments("object", "M").WithLocation(1, 12),
             // (5,15): error CS1669: __arglist is not valid in this context
-            //     extension(__arglist) { }
+            //     extension(__arglist)
             Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(5, 15));
 
         MethodSymbol implementation = comp.GetTypeByMetadataName("Extensions").GetMembers().OfType<MethodSymbol>().Single();
@@ -3038,8 +3050,10 @@ static class Extensions
 """;
         var comp = CreateCompilation(src);
 
-        // PROTOTYPE: A similar error is expected for 'GetInt().M1()';
         comp.VerifyDiagnostics(
+            // (5,9): error CS1510: A ref or out value must be an assignable variable
+            //         GetInt().M1();
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetInt()").WithLocation(5, 9),
             // (6,9): error CS1510: A ref or out value must be an assignable variable
             //         GetInt().M2();
             Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetInt()").WithLocation(6, 9)
@@ -3075,8 +3089,10 @@ static class Extensions
 """;
         var comp = CreateCompilation(src);
 
-        // PROTOTYPE: A similar warning is expected for 'GetInt().M1()';
         comp.VerifyEmitDiagnostics(
+            // (5,9): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+            //         GetInt().M1();
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetInt()").WithArguments("0").WithLocation(5, 9),
             // (6,9): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
             //         GetInt().M2();
             Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetInt()").WithArguments("0").WithLocation(6, 9)
@@ -9498,9 +9514,32 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "M StaticType").VerifyDiagnostics();
+        comp.VerifyEmitDiagnostics(
+            // (2,32): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            // System.Console.Write($"{nameof(o.M)} ");
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "o.M").WithLocation(2, 32));
+    }
+
+    [Fact]
+    public void InstanceMethodInvocation_Nameof_ViaType()
+    {
+        var src = """
+System.Console.Write($"{nameof(E.M)} ");
+
+static class E
+{
+    extension(object)
+    {
+        public void M() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        // PROTOTYPE we'll want this to work
+        comp.VerifyEmitDiagnostics(
+            // (1,32): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            // System.Console.Write($"{nameof(E.M)} ");
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "E.M").WithLocation(1, 32));
     }
 
     [Fact]
@@ -9520,9 +9559,10 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "M").VerifyDiagnostics();
+        comp.VerifyEmitDiagnostics(
+            // (2,32): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            // System.Console.Write($"{nameof(o.M)} ");
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "o.M").WithLocation(2, 32));
     }
 
     [Fact]
@@ -9799,7 +9839,6 @@ namespace N
     [Fact]
     public void InstanceMethodInvocation_NewExtensionPriority()
     {
-        // The method from the extension declaration comes before the extension method
         var source = """
 new C().M(42);
 
@@ -9812,7 +9851,7 @@ static class E1
 {
     extension(C c)
     {
-        public void M(int i) { System.Console.Write($"E1.M({i})"); }
+        public void M(int i) => throw null;
     }
 }
 
@@ -9822,21 +9861,21 @@ static class E2
 }
 """;
         var comp = CreateCompilation(source);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "E1.M(42)");
+        comp.VerifyEmitDiagnostics(
+            // (1,9): error CS0121: The call is ambiguous between the following methods or properties: 'E1.extension(C).M(int)' and 'E2.M(C, int)'
+            // new C().M(42);
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E1.extension(C).M(int)", "E2.M(C, int)").WithLocation(1, 9));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M");
-        Assert.Equal("void E1.<>E__0.M(System.Int32 i)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
         Assert.Equal(["void C.M()", "void C.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE semantic model is undone
     }
 
     [Fact]
     public void InstanceMethodInvocation_NewExtensionPriority_02()
     {
-        // The method from the extension declaration comes before the extension method
         var source = """
 new C().M(42);
 
@@ -9849,20 +9888,21 @@ static class E
 {
     extension(C c)
     {
-        public void M(int i) { System.Console.Write($"E1.M({i})"); }
+        public void M(int i) => throw null;
     }
     public static void M(this C c, int i) => throw null;
 }
 """;
         var comp = CreateCompilation(source);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "E1.M(42)");
+        comp.VerifyEmitDiagnostics(
+            // (1,9): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(C).M(int)' and 'E.M(C, int)'
+            // new C().M(42);
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(C).M(int)", "E.M(C, int)").WithLocation(1, 9));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M");
-        Assert.Equal("void E.<>E__0.M(System.Int32 i)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
         Assert.Equal(["void C.M()", "void C.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE semantic model is undone
     }
 
@@ -10016,6 +10056,81 @@ public static class E2
     }
 
     [Fact]
+    public void InstanceMethodInvocation_ArgumentName_03()
+    {
+        var source = """
+new object().M(c: 43, b: 42);
+
+static class E
+{
+    extension(object o)
+    {
+        public void M(int b, int c) { System.Console.Write($"E.M({b}, {c})"); }
+    }
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "E.M(42, 43)").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+        Assert.Equal("void E.<>E__0.M(System.Int32 b, System.Int32 c)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void InstanceMethodInvocation_ArgumentName_04()
+    {
+        var source = """
+new object().M(o: new object());
+
+static class E
+{
+    extension(object o)
+    {
+        public void M(object o2) => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (1,16): error CS1744: Named argument 'o' specifies a parameter for which a positional argument has already been given
+            // new object().M(o: new object());
+            Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "o").WithArguments("o").WithLocation(1, 16));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+    }
+
+    [Fact]
+    public void InstanceMethodInvocation_RefKind()
+    {
+        var source = """
+int i = 42;
+int j;
+
+new object().M(ref i, out j);
+
+static class E
+{
+    extension(object o)
+    {
+        public void M(ref int b, out int c) { c = 43; System.Console.Write($"E.M({b}, {c})"); }
+    }
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "E.M(42, 43)").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+        Assert.Equal("void E.<>E__0.M(ref System.Int32 b, out System.Int32 c)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
     public void InstanceMethodInvocation_AmbiguityWithExtensionOnBaseType_PreferMoreSpecific()
     {
         var source = """
@@ -10041,12 +10156,13 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(source);
-        comp.VerifyEmitDiagnostics(
-            // (1,30): error CS0121: The call is ambiguous between the following methods or properties: 'E1.extension(Base).M(int)' and 'E2.extension(C).M(int)'
-            // System.Console.Write(new C().M(42));
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E1.extension(Base).M(int)", "E2.extension(C).M(int)").WithLocation(1, 30));
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M");
+        Assert.Equal("System.Int32 E2.<>E__0.M(System.Int32 i)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
 
         source = """
 System.Console.Write(new C().M(42));
@@ -10748,10 +10864,7 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
-
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "hi") .VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "hi").VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -10976,6 +11089,7 @@ class C : I1<int>, I2 { }
     [Fact]
     public void InstanceMethodInvocation_MultipleStageInference()
     {
+        // PROTOTYPE type inference should operate on the full list of type parameters (from extension declaration plus from method) in one go
         var src = """
 public class C
 {
@@ -11003,9 +11117,9 @@ public interface I<out T> { }
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
-            // (6,18): error CS1503: Argument 1: cannot convert from 'out object' to 'out string'
+            // (6,18): error CS1503: Argument 2: cannot convert from 'out object' to 'out string'
             //         i.M2(out o); // 1
-            Diagnostic(ErrorCode.ERR_BadArgType, "o").WithArguments("1", "out object", "out string").WithLocation(6, 18));
+            Diagnostic(ErrorCode.ERR_BadArgType, "o").WithArguments("2", "out object", "out string").WithLocation(6, 18));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
@@ -11017,7 +11131,7 @@ public interface I<out T> { }
 
         var memberAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "i.M2");
         Assert.Null(model.GetSymbolInfo(memberAccess2).Symbol);
-        Assert.Equal(["void E2.<>E__0<System.String>.M2(out System.String t)"], model.GetSymbolInfo(memberAccess2).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal([], model.GetSymbolInfo(memberAccess2).CandidateSymbols.ToTestDisplayStrings());
         Assert.Empty(model.GetMemberGroup(memberAccess2)); // PROTOTYPE semantic model is undone
     }
 
@@ -11297,9 +11411,6 @@ static class E
 """;
         var comp = CreateCompilation(src, references: [derivedRef]);
         comp.VerifyEmitDiagnostics(
-            // (1,1): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-            // new Derived().M();
-            Diagnostic(ErrorCode.ERR_NoTypeDef, "new Derived().M").WithArguments("Missing", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1),
             // (1,15): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
             // new Derived().M();
             Diagnostic(ErrorCode.ERR_NoTypeDef, "M").WithArguments("Missing", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 15),
@@ -11493,9 +11604,6 @@ static class E
 """;
         var comp = CreateCompilation(src, references: [containerRef]);
         comp.VerifyEmitDiagnostics(
-            // (1,1): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-            // Container.M();
-            Diagnostic(ErrorCode.ERR_NoTypeDef, "Container.M").WithArguments("Missing", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1),
             // (1,11): error CS0117: 'Container' does not contain a definition for 'M'
             // Container.M();
             Diagnostic(ErrorCode.ERR_NoSuchMember, "M").WithArguments("Container", "M").WithLocation(1, 11));
@@ -11576,12 +11684,15 @@ namespace N
         comp.VerifyEmitDiagnostics(
             // (3,1): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
             // Container.M();
+            Diagnostic(ErrorCode.ERR_NoTypeDef, "Container.M").WithArguments("Missing", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 1),
+            // (3,1): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            // Container.M();
             Diagnostic(ErrorCode.ERR_NoTypeDef, "Container.M").WithArguments("Missing", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 1));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "Container.M");
-        Assert.Equal("void N.E2.<>E__0<Container>.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
 
         src = """
@@ -11595,14 +11706,12 @@ static class E
     }
 }
 """;
+        // We only end up reporting the details of the use-site problems if we find an applicable extension method
         comp = CreateCompilation(src, references: [containerRef]);
         comp.VerifyEmitDiagnostics(
-                // (1,1): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                // Container.M();
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "Container.M").WithArguments("Missing", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1),
-                // (1,11): error CS0117: 'Container' does not contain a definition for 'M'
-                // Container.M();
-                Diagnostic(ErrorCode.ERR_NoSuchMember, "M").WithArguments("Container", "M").WithLocation(1, 11));
+            // (1,11): error CS0117: 'Container' does not contain a definition for 'M'
+            // Container.M();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "M").WithArguments("Container", "M").WithLocation(1, 11));
     }
 
     [Fact]
@@ -11988,7 +12097,6 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(source);
         comp.VerifyEmitDiagnostics(
             // (2,18): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
@@ -11997,20 +12105,6 @@ static class E2
             // (2,24): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
             // string x = b ? D.f : D.f;
             Diagnostic(ErrorCode.ERR_AmbigMember, "f").WithArguments("E2.extension(object).f()", "E1.extension(D).f").WithLocation(2, 24));
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
-
-        //var tree = comp.SyntaxTrees.First();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "D.f").ToArray();
-        //Assert.Equal("System.String E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[0]).Symbol.ToTestDisplayString());
-        //Assert.Equal("System.String E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[1]).Symbol.ToTestDisplayString());
-
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[0]).Type.ToTestDisplayString());
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[0]).ConvertedType.ToTestDisplayString());
-
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[1]).Type.ToTestDisplayString());
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[1]).ConvertedType.ToTestDisplayString());
     }
 
     [Fact]
@@ -12039,7 +12133,6 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(source);
         comp.VerifyEmitDiagnostics(
             // (2,25): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E.extension(D).f'
@@ -12048,22 +12141,7 @@ static class E2
             // (2,31): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E.extension(D).f'
             // System.Action x = b ? D.f : D.f;
             Diagnostic(ErrorCode.ERR_AmbigMember, "f").WithArguments("E2.extension(object).f()", "E.extension(D).f").WithLocation(2, 31)
-            //// (2,19): error CS0029: Cannot implicitly convert type 'string' to 'System.Action'
-            //// System.Action x = b ? D.f : D.f;
-            //Diagnostic(ErrorCode.ERR_NoImplicitConv, "b ? D.f : D.f").WithArguments("string", "System.Action").WithLocation(2, 19)
             );
-
-        //var tree = comp.SyntaxTrees.First();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "D.f").ToArray();
-        //Assert.Equal("System.String E.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[0]).Symbol.ToTestDisplayString());
-        //Assert.Equal("System.String E.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[1]).Symbol.ToTestDisplayString());
-
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[0]).Type.ToTestDisplayString());
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[0]).ConvertedType.ToTestDisplayString());
-
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[1]).Type.ToTestDisplayString());
-        //Assert.Equal("System.String", model.GetTypeInfo(memberAccess[1]).ConvertedType.ToTestDisplayString());
     }
 
     [Fact]
@@ -12120,19 +12198,11 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(source);
         comp.VerifyEmitDiagnostics(
             // (1,19): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
             // var x = (string)D.f;
             Diagnostic(ErrorCode.ERR_AmbigMember, "f").WithArguments("E2.extension(object).f()", "E1.extension(D).f").WithLocation(1, 19));
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
-
-        //var tree = comp.SyntaxTrees.First();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "D.f");
-        //Assert.Equal("System.String E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
     }
 
     [Fact]
@@ -12160,7 +12230,6 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(source);
         comp.VerifyEmitDiagnostics(
             // (1,26): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
@@ -12169,12 +12238,6 @@ static class E2
             // (2,21): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
             // System.Action a = D.f;
             Diagnostic(ErrorCode.ERR_AmbigMember, "f").WithArguments("E2.extension(object).f()", "E1.extension(D).f").WithLocation(2, 21));
-
-        //var tree = comp.SyntaxTrees.First();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "D.f").ToArray();
-        //Assert.Equal("System.String E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[0]).Symbol.ToTestDisplayString());
-        //Assert.Equal("System.String E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[1]).Symbol.ToTestDisplayString());
 
         // Note: a conversion to a delegate type does not provide invocation context for resolving the member access
         source = """
@@ -12412,9 +12475,93 @@ public class MyCollection : IEnumerable<int>
 }
 """;
         var comp = CreateCompilation(source);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ResolveAll_CollectionExpression_ExtensionAddMethod_RefReceiverParameter()
+    {
+        // The receiver argument gets an implicit `ref` when the parameter is `ref`
+        var source = """
+using System.Collections;
+using System.Collections.Generic;
+
+MyCollection c = [42];
+System.Console.Write(c is null);
+
+static class E
+{
+    extension(ref MyCollection c)
+    {
+        public void Add(int i) { System.Console.Write("ran "); c = null; }
+    }
+}
+
+public class MyCollection : IEnumerable<int>
+{
+    IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw null;
+    IEnumerator IEnumerable.GetEnumerator() => throw null;
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "ran True").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ResolveAll_CollectionExpression_ExtensionAddMethod_InReceiverParameter()
+    {
+        var source = """
+using System.Collections;
+using System.Collections.Generic;
+
+MyCollection c = [42];
+
+static class E
+{
+    extension(in MyCollection c)
+    {
+        public void Add(int i) { System.Console.Write("ran"); }
+    }
+}
+
+public class MyCollection : IEnumerable<int>
+{
+    IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw null;
+    IEnumerator IEnumerable.GetEnumerator() => throw null;
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ResolveAll_CollectionExpression_ExtensionAddMethod_RefParameter()
+    {
+        var source = """
+using System.Collections;
+using System.Collections.Generic;
+
+MyCollection c = [42];
+
+static class E
+{
+    extension(MyCollection c)
+    {
+        public void Add(ref int i) { System.Console.Write("ran"); }
+    }
+}
+
+public class MyCollection : IEnumerable<int>
+{
+    IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw null;
+    IEnumerator IEnumerable.GetEnumerator() => throw null;
+}
+""";
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (4,18): error CS1954: The best overloaded method match 'E.extension(MyCollection).Add(ref int)' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.
+            // MyCollection c = [42];
+            Diagnostic(ErrorCode.ERR_InitializerAddHasParamModifiers, "[42]").WithArguments("E.extension(MyCollection).Add(ref int)").WithLocation(4, 18));
     }
 
     [Fact]
@@ -12604,9 +12751,7 @@ static class E
 }
 """;
         var comp = CreateCompilation(source);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        // CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -12630,9 +12775,7 @@ static class E
 }
 """;
         var comp = CreateCompilation(source);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -13168,7 +13311,7 @@ static class E
         Assert.Equal("System.String E.<>E__0.M { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void ResolveAll_Invocation_Static_DelegateTypeParameter()
     {
         var src = """
@@ -13228,7 +13371,7 @@ static class E
         Assert.Equal("System.String E.<>E__0.M { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void ResolveAll_Invocation_Static_DelegateTypeParameter_InapplicableInstanceMember()
     {
         var src = """
@@ -13280,22 +13423,19 @@ static class E1
 
 public static class E2
 {
-    public static void Member(this object o)
-    {
-        System.Console.Write("ran");
-    }
+    public static void Member(this object o) => throw null;
 }
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
-            // (2,5): error CS1503: Argument 1: cannot convert from 'string' to 'System.Action'
+            // (2,7): error CS0229: Ambiguity between 'E2.Member(object)' and 'E1.extension(object).Member'
             // C.M(o.Member);
-            Diagnostic(ErrorCode.ERR_BadArgType, "o.Member").WithArguments("1", "string", "System.Action").WithLocation(2, 5));
+            Diagnostic(ErrorCode.ERR_AmbigMember, "Member").WithArguments("E2.Member(object)", "E1.extension(object).Member").WithLocation(2, 7));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "o.Member");
-        Assert.Equal("System.String E1.<>E__0.Member { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
         Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
@@ -13358,7 +13498,6 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
             // (1,12): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
@@ -13367,16 +13506,7 @@ static class E2
             // (1,18): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
             // bool b = D.f + D.f;
             Diagnostic(ErrorCode.ERR_AmbigMember, "f").WithArguments("E2.extension(object).f()", "E1.extension(D).f").WithLocation(1, 18)
-            //// (1,10): error CS0019: Operator '+' cannot be applied to operands of type 'C' and 'C'
-            //// bool b = D.f + D.f;
-            //Diagnostic(ErrorCode.ERR_BadBinaryOps, "D.f + D.f").WithArguments("+", "C", "C").WithLocation(1, 10)
             );
-
-        //var tree = comp.SyntaxTrees.First();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "D.f").ToArray();
-        //Assert.Equal("C E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[0]).Symbol.ToTestDisplayString());
-        //Assert.Equal("C E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess[1]).Symbol.ToTestDisplayString());
     }
 
     [Fact]
@@ -13426,28 +13556,22 @@ static class E
         public string Member => throw null;
     }
 
-    public static void Member(this object o)
-    {
-        System.Console.Write("ran");
-    }
+    public static void Member(this object o) => throw null;
 }
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
-            // (1,43): error CS0029: Cannot implicitly convert type 'string' to 'System.Action'
+            // (1,56): error CS0229: Ambiguity between 'E.Member(object)' and 'E.extension(object).Member'
             // System.Func<System.Action> lambda = () => new object().Member;
-            Diagnostic(ErrorCode.ERR_NoImplicitConv, "new object().Member").WithArguments("string", "System.Action").WithLocation(1, 43),
-            // (1,43): error CS1662: Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
-            // System.Func<System.Action> lambda = () => new object().Member;
-            Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "new object().Member").WithArguments("lambda expression").WithLocation(1, 43));
+            Diagnostic(ErrorCode.ERR_AmbigMember, "Member").WithArguments("E.Member(object)", "E.extension(object).Member").WithLocation(1, 56));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().Member");
-        Assert.Equal("System.String E.<>E__0.Member { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void ResolveAll_Lambda_Instance_MethodGroupWithMultipleOverloads()
     {
         var src = """
@@ -13497,24 +13621,12 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
             // (1,31): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(object).f'
             // var l = System.Action () => D.f;
             Diagnostic(ErrorCode.ERR_AmbigMember, "f").WithArguments("E2.extension(object).f()", "E1.extension(object).f").WithLocation(1, 31)
-            //// (1,29): error CS0029: Cannot implicitly convert type 'string' to 'System.Action'
-            //// var l = System.Action () => D.f;
-            //Diagnostic(ErrorCode.ERR_NoImplicitConv, "D.f").WithArguments("string", "System.Action").WithLocation(1, 29),
-            //// (1,29): error CS1662: Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
-            //// var l = System.Action () => D.f;
-            //Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "D.f").WithArguments("lambda expression").WithLocation(1, 29)
             );
-
-        //var tree = comp.SyntaxTrees.First();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "D.f");
-        //Assert.Equal("System.String E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
     }
 
     [Fact]
@@ -13541,24 +13653,12 @@ static class E2
     }
 }
 """;
-        // PROTOTYPE we should prefer extension members that apply to a more specific type
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
             // (1,40): error CS0229: Ambiguity between 'E2.extension(object).f()' and 'E1.extension(D).f'
             // System.Func<System.Action> l = () => D.f;
             Diagnostic(ErrorCode.ERR_AmbigMember, "f").WithArguments("E2.extension(object).f()", "E1.extension(D).f").WithLocation(1, 40)
-            //// (1,38): error CS0029: Cannot implicitly convert type 'string' to 'System.Action'
-            //// System.Func<System.Action> l = () => D.f;
-            //Diagnostic(ErrorCode.ERR_NoImplicitConv, "D.f").WithArguments("string", "System.Action").WithLocation(1, 38),
-            //// (1,38): error CS1662: Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
-            //// System.Func<System.Action> l = () => D.f;
-            //Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "D.f").WithArguments("lambda expression").WithLocation(1, 38)
             );
-
-        //var tree = comp.SyntaxTrees.First();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "D.f");
-        //Assert.Equal("System.String E1.<>E__0.f { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
     }
 
     [Fact]
@@ -13753,7 +13853,7 @@ static class E
         Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE function type")]
     public void ResolveAll_Instance_InferredVariable_InnerExtensionMethodVsOuterInvocableExtensionProperty()
     {
         var src = """
@@ -13964,7 +14064,7 @@ static class E2
         Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void ResolveAll_Instance_LocalDeclaration_InnerIrrelevantExtensionMethodVsOuterExtensionProperty()
     {
         var src = """
@@ -14005,7 +14105,7 @@ static class E
         Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void ResolveAll_Instance_LocalDeclaration_DelegateType_InnerInapplicableExtensionMethodVsOuterExtensionProperty()
     {
         var src = """
@@ -14045,7 +14145,7 @@ static class E
         Assert.Equal(["void System.Object.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void ResolveAll_Instance_LocalDeclaration_DelegateType_InnerIrrelevantExtensionMethodVsOuterExtensionProperty()
     {
         var src = """
@@ -14123,7 +14223,7 @@ static class E2
         Assert.Null(model.GetSymbolInfo(memberAccess[1]).Symbol);
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_TypeReceiver()
     {
         var source = """
@@ -14154,7 +14254,7 @@ static class E
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_InstanceReceiver()
     {
         var source = """
@@ -14189,7 +14289,7 @@ static class E
         Assert.Equal(["void C.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_TypeReceiver_Overloads()
     {
         var source = """
@@ -14224,7 +14324,7 @@ static class E
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_ValueReceiver_Overloads()
     {
         var source = """
@@ -14258,7 +14358,7 @@ static class E
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_TypeReceiver_Overloads_DifferentExtensions()
     {
         var source = """
@@ -14298,7 +14398,7 @@ static class E2
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_WrongSignature()
     {
         var source = """
@@ -14336,7 +14436,7 @@ static class E
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_TypeReceiver_ZeroArityMatchesAny()
     {
         var source = """
@@ -14370,7 +14470,7 @@ static class E
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_ValueReceiver_Overloads_OuterScope_WithInapplicableInstanceMember()
     {
         var source = """
@@ -14422,7 +14522,7 @@ static class E2
         Assert.Equal(["void C.M(System.Char c)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_TypeReceiver_Overloads_InnerScope()
     {
         var source = """
@@ -14470,7 +14570,7 @@ namespace N
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE method group conversion")]
     public void DelegateConversion_TypeReceiver_TypeArguments()
     {
         var source = """
@@ -15880,21 +15980,11 @@ class C { }
 """;
         var comp = CreateCompilation(src);
 
-        // PROTOTYPE we should prefer extension members that apply to a more specific type (ie. no error)
+        // PROTOTYPE consider improving the symbols in this error message (the ambiguity is not between those two methods)
         comp.VerifyEmitDiagnostics(
             // (1,24): error CS0229: Ambiguity between 'E1.extension(object).M()' and 'E3.extension(C).M()'
             // System.Console.Write(C.M());
             Diagnostic(ErrorCode.ERR_AmbigMember, "M").WithArguments("E1.extension(object).M()", "E3.extension(C).M()").WithLocation(1, 24));
-
-        //var tree = comp.SyntaxTrees.Single();
-        //var model = comp.GetSemanticModel(tree);
-        //var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
-        //Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-
-        //Assert.Equal(["System.Func<System.String> E2.<>E__0.M", "System.String E3.<>E__0.M()"],
-        //    model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
-
-        //Assert.Empty(model.GetMemberGroup(memberAccess));
     }
 
     [Fact]
@@ -17069,9 +17159,47 @@ static class E
 
         // PROTOTYPE confirm when spec'ing pattern-based collection initializer
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "add");
+        CompileAndVerify(comp, expectedOutput: "add").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ExtensionMemberLookup_CollectionInitializer_NoApplicableMethod_ExpressionTree()
+    {
+        var src = """
+using System.Collections;
+using System.Collections.Generic;
+
+try
+{
+    System.Linq.Expressions.Expression<System.Func<C>> e = () => new C() { 42 };
+    System.Console.Write(e);
+}
+catch (System.ArgumentException ae)
+{
+    System.Console.Write(ae.Message);
+}
+
+class C : IEnumerable<int>, IEnumerable
+{
+    IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw null;
+    IEnumerator IEnumerable.GetEnumerator() => throw null;
+    public void Add(string notApplicable) => throw null;
+}
+
+static class E
+{
+    extension(object o)
+    {
+        public void Add(int i) { System.Console.Write("add"); }
+    }
+}
+""";
+
+        // PROTOTYPE confirm when spec'ing pattern-based collection initializer
+        // PROTOTYPE expression trees
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        var expectedOutput = "Method 'Void Add(Int32)' declared on type 'E+<>E__0' cannot be called with instance of type 'C'";
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify).VerifyDiagnostics();
     }
 
     [Fact]
@@ -17293,7 +17421,7 @@ static class E1
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings()); // PROTOTYPE semantic model is undone
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE addressof")]
     public void AddressOf_Simple()
     {
         var src = """
@@ -17323,7 +17451,7 @@ static class E
         Assert.Equal("void E.<>E__0.M(System.String s, System.Object o)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE addressof")]
     public void AddressOf_AmbiguousBestMethod()
     {
         var src = """
@@ -17414,7 +17542,11 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-        CompileAndVerify(comp, expectedOutput: "Method").VerifyDiagnostics();
+        // PROTOTYPE should we allow this after all, since there's no other way to refer to new extension methods?
+        comp.VerifyEmitDiagnostics(
+            // (1,29): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            // System.Console.Write(nameof(C.Method));
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "C.Method").WithLocation(1, 29));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
@@ -17464,7 +17596,10 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-        CompileAndVerify(comp, expectedOutput: "Method").VerifyDiagnostics();
+        comp.VerifyEmitDiagnostics(
+            // (1,29): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            // System.Console.Write(nameof(C.Method));
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "C.Method").WithLocation(1, 29));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
@@ -17488,7 +17623,10 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-        CompileAndVerify(comp, expectedOutput: "M").VerifyDiagnostics();
+        comp.VerifyEmitDiagnostics(
+            // (1,32): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            // System.Console.Write($"{nameof(object.M)} ");
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "object.M").WithLocation(1, 32));
     }
 
     [Fact]
@@ -17630,8 +17768,10 @@ public class Program
 }
 """;
         var comp = CreateCompilation(source);
-        // PROTOTYPE should we produce ERR_NameofExtensionMethod (Extension method groups are not allowed as an argument to 'nameof') or something similar?
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (15,20): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            //         _ = nameof(a.Extension);
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "a.Extension").WithLocation(15, 20));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -17833,5 +17973,1402 @@ static class E
 
         var format = new SymbolDisplayFormat(parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeModifiers);
         Assert.Equal("extension(ref readonly Int32)", symbol.ToDisplayString(format));
+    }
+
+    [Fact]
+    public void Mixing()
+    {
+        var source = """
+new object().M();
+
+static class E1
+{
+    extension(object o)
+    {
+        public void M() { }
+    }
+}
+static class E2
+{
+    public static void M(this object o) { }
+}
+""";
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (1,14): error CS0121: The call is ambiguous between the following methods or properties: 'E1.extension(object).M()' and 'E2.M(object)'
+            // new object().M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E1.extension(object).M()", "E2.M(object)").WithLocation(1, 14));
+    }
+
+    [Fact]
+    public void MethodInvocation_02()
+    {
+        var source = """
+new object().M(42);
+
+static class E1
+{
+    extension(object o)
+    {
+        public void M(int i) { System.Console.Write("ran"); }
+    }
+}
+static class E2
+{
+    public static void M(this object o, string s) => throw null;
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+        Assert.Equal("void E1.<>E__0.M(System.Int32 i)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_03()
+    {
+        var source = """
+new object().M("");
+
+static class E1
+{
+    extension(object o)
+    {
+        public void M(int i) => throw null;
+    }
+}
+static class E2
+{
+    public static void M(this object o, string s) { System.Console.Write("ran"); }
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+        Assert.Equal("void System.Object.M(System.String s)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_04()
+    {
+        var source = """
+42.M();
+
+static class E1
+{
+    extension(int i)
+    {
+        public void M() { System.Console.Write("ran"); }
+    }
+}
+static class E2
+{
+    public static void M(this int? i) => throw null;
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_05()
+    {
+        var source = """
+42.M();
+
+static class E1
+{
+    extension(int? i)
+    {
+        public void M() => throw null;
+    }
+}
+static class E2
+{
+    public static void M(this int i) { System.Console.Write("ran"); }
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void System.Int32.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveLowerPriorityMembers_01()
+    {
+        var source = """
+42.M(43);
+
+static class E1
+{
+    extension(int i)
+    {
+        public void M(int j) => throw null;
+
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public void M(long l) { System.Console.Write("ran"); }
+    }
+}
+""";
+        var comp = CreateCompilation([source, OverloadResolutionPriorityAttributeDefinition]);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void E1.<>E__0.M(System.Int64 l)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveLowerPriorityMembers_02()
+    {
+        var source = """
+42.M(43);
+
+static class E1
+{
+    extension(int i)
+    {
+        public void M(int j) { System.Console.Write("ran"); }
+    }
+    extension(int i)
+    {
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public void M(long l) => throw null;
+    }
+}
+""";
+        // PROTOTYPE ORPA should look at the containing static class (rather than look at the extension declaration) as the "containing type"
+        var comp = CreateCompilation([source, OverloadResolutionPriorityAttributeDefinition]);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void E1.<>E__0.M(System.Int32 j)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveLowerPriorityMembers_03()
+    {
+        var source = """
+42.M(43);
+
+static class E1
+{
+    extension(int i)
+    {
+        public void M(int j) { System.Console.Write("ran"); }
+    }
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static void M(this int i, long l) => throw null;
+}
+""";
+        // PROTOTYPE ORPA should look at the containing static class (rather than look at the extension declaration) as the "containing type"
+        var comp = CreateCompilation([source, OverloadResolutionPriorityAttributeDefinition]);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void E1.<>E__0.M(System.Int32 j)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveLowerPriorityMembers_04()
+    {
+        var source = """
+42.M(43);
+
+static class E1
+{
+    public static void M(this int i, int j) { System.Console.Write("ran"); }
+    extension(int i)
+    {
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public void M(long l) => throw null;
+    }
+}
+""";
+        // PROTOTYPE ORPA should look at the containing static class (rather than look at the extension declaration) as the "containing type"
+        var comp = CreateCompilation([source, OverloadResolutionPriorityAttributeDefinition]);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void System.Int32.M(System.Int32 j)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveStaticInstanceMismatches_01()
+    {
+        var src = """
+using N;
+
+42.M();
+
+static class E1
+{
+    extension(object o)
+    {
+        public static void M() => throw null; // skipped
+    }
+}
+
+namespace N
+{
+    static class E2
+    {
+        extension(object o)
+        {
+            public void M() { System.Console.Write("ran"); }
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void N.E2.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveStaticInstanceMismatches_02()
+    {
+        var src = """
+using N;
+
+42.M();
+
+static class E1
+{
+    extension(object o)
+    {
+        public void M() { System.Console.Write("ran"); }
+    }
+}
+
+namespace N
+{
+    static class E2
+    {
+        extension(object o)
+        {
+            public void M() => throw null;
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using N;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1));
+        CompileAndVerify(comp, expectedOutput: "ran");
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveStaticInstanceMismatches_03()
+    {
+        var src = """
+using N;
+
+int.M();
+
+static class E1
+{
+    extension(object o)
+    {
+        public void M() => throw null;
+    }
+}
+
+namespace N
+{
+    static class E2
+    {
+        extension(object o)
+        {
+            public static void M() { System.Console.Write("ran"); }
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "int.M");
+        Assert.Equal("void N.E2.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveStaticInstanceMismatches_ColorColor_01()
+    {
+        var src = """
+using N;
+
+Color.M2(null);
+
+class Color 
+{ 
+    public static void M2(Color Color)
+    {
+        Color.M();
+    }
+}
+
+static class E1
+{
+    extension(Color)
+    {
+        public static void M() { System.Console.Write("ran"); }
+    }
+}
+
+namespace N
+{
+    static class E2
+    {
+        extension(Color c)
+        {
+            public void M() => throw null;
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using N;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1));
+
+        CompileAndVerify(comp, expectedOutput: "ran");
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "Color.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal(SymbolKind.NamedType, model.GetSymbolInfo(memberAccess.Expression).Symbol.Kind);
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveStaticInstanceMismatches_ColorColor_02()
+    {
+        var src = """
+using N;
+
+Color.M2(new Color());
+
+class Color 
+{ 
+    public static void M2(Color Color)
+    {
+        Color.M();
+    }
+}
+
+static class E1
+{
+    extension(Color c)
+    {
+        public void M() { System.Console.Write("ran"); }
+    }
+}
+
+namespace N
+{
+    static class E2
+    {
+        extension(Color)
+        {
+            public static void M() => throw null;
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using N;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1));
+        CompileAndVerify(comp, expectedOutput: "ran");
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "Color.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal(SymbolKind.Parameter, model.GetSymbolInfo(memberAccess.Expression).Symbol.Kind);
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveInaccessibleTypeArguments()
+    {
+        var src = """
+int.M(new A.C());
+
+static class E1
+{
+    extension(int)
+    {
+        public static void M<T>(I<T> x) { }
+    }
+}
+
+interface I<T> { }
+
+class A
+{
+    private class B { }
+    public class C : I<B> { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,5): error CS0122: 'E1.extension(int).M<A.B>(I<A.B>)' is inaccessible due to its protection level
+            // int.M(new A.C());
+            Diagnostic(ErrorCode.ERR_BadAccess, "M").WithArguments("E1.extension(int).M<A.B>(I<A.B>)").WithLocation(1, 5));
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveLessDerivedMembers()
+    {
+        var src = """
+"".M("");
+
+static class E
+{
+    extension(object o)
+    {
+        public void M(string s) { }
+    }
+    extension(string s)
+    {
+        public void M(object o) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,4): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(object).M(string)' and 'E.extension(string).M(object)'
+            // "".M("");
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(object).M(string)", "E.extension(string).M(object)").WithLocation(1, 4));
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveWorseMembers_01()
+    {
+        var src = """
+I<C2> i = null;
+i.M();
+
+static class E1
+{
+    extension(I<C1> i)
+    {
+        public void M() { }
+    }
+}
+static class E2
+{
+    extension(I<object> i)
+    {
+        public void M() { }
+    }
+}
+interface I<out T> { }
+class C1 { }
+class C2 : C1 { }
+""";
+        // PROTOTYPE confirm whether we want this betterness behavior (for methods and/or properties)
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "i.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveWorseMembers_02()
+    {
+        var src = """
+I<C2>.M();
+
+static class E1
+{
+    extension(I<C1>)
+    {
+        public static void M() { }
+    }
+}
+static class E2
+{
+    extension(I<object>)
+    {
+        public static void M() { }
+    }
+}
+interface I<out T> { }
+class C1 { }
+class C2 : C1 { }
+""";
+        // PROTOTYPE confirm whether we want this betterness behavior (for methods and/or properties)
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "I<C2>.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveWorseMembers_03()
+    {
+        var src = """
+42.M();
+
+static class E1
+{
+    extension<T>(T t)
+    {
+        public void M() { }
+    }
+}
+static class E2
+{
+    extension(int i)
+    {
+        public void M() { }
+    }
+}
+""";
+        // PROTOTYPE we should prefer the non-generic extension member
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,4): error CS0121: The call is ambiguous between the following methods or properties: 'E1.extension<T>(T).M()' and 'E2.extension(int).M()'
+            // 42.M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E1.extension<T>(T).M()", "E2.extension(int).M()").WithLocation(1, 4));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveWorseMembers_04()
+    {
+        var src = """
+int.M();
+
+static class E1
+{
+    extension<T>(T)
+    {
+        public static void M() { }
+    }
+}
+static class E2
+{
+    extension(int)
+    {
+        public static void M() { }
+    }
+}
+""";
+        // PROTOTYPE confirm that we should prefer the non-generic extension member when the receiver is a type
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,5): error CS0121: The call is ambiguous between the following methods or properties: 'E1.extension<T>(T).M()' and 'E2.extension(int).M()'
+            // int.M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E1.extension<T>(T).M()", "E2.extension(int).M()").WithLocation(1, 5));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "int.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveWorseMembers_05()
+    {
+        var src = """
+42.M();
+
+static class E1
+{
+    extension(int i)
+    {
+        public void M() { }
+    }
+}
+static class E2
+{
+    extension(in int i)
+    {
+        public void M() => throw null;
+    }
+}
+""";
+        // PROTOTYPE confirm whether we want this betterness behavior (for methods and/or properties)
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_RemoveWorseMembers_06()
+    {
+        var src = """
+int.M();
+
+static class E1
+{
+    extension(int)
+    {
+        public static void M() { }
+    }
+}
+static class E2
+{
+    extension(in int i)
+    {
+        public static void M() => throw null;
+    }
+}
+""";
+        // PROTOTYPE confirm whether we want this betterness behavior (for methods and/or properties)
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "int.M");
+        Assert.Equal("void E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_ByValueArgumentForRefReadonlyParameter_01()
+    {
+        var src = """
+int.M(42);
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(ref readonly int i) { System.Console.Write(i); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,7): warning CS9193: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            // int.M(42);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "42").WithArguments("1").WithLocation(1, 7));
+
+        CompileAndVerify(comp, expectedOutput: "42");
+    }
+
+    [Fact]
+    public void MethodInvocation_ByValueArgumentForRefReadonlyParameter_02()
+    {
+        var src = """
+int i = 42;
+int.M(i);
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(ref readonly int i) { System.Console.Write(i); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (2,7): warning CS9192: Argument 1 should be passed with 'ref' or 'in' keyword
+            // int.M(i);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "i").WithArguments("1").WithLocation(2, 7));
+
+        CompileAndVerify(comp, expectedOutput: "42");
+    }
+
+    [Fact]
+    public void MethodInvocation_ByValueArgumentForRefReadonlyParameter_03()
+    {
+        var src = """
+var f = (ref readonly int i) => int.M(i);
+int i = 42;
+f(ref i);
+
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(ref readonly int i) { System.Console.Write(i); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,39): warning CS9195: Argument 1 should be passed with the 'in' keyword
+            // var f = (ref readonly int i) => int.M(i);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "i").WithArguments("1").WithLocation(1, 39));
+
+        CompileAndVerify(comp, expectedOutput: "42");
+    }
+
+    [Fact]
+    public void MethodInvocation_RefArgumentForInParameter()
+    {
+        var src = """
+int i = 42;
+int.M(ref i);
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(in int i) { System.Console.Write(i); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (2,11): warning CS9191: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+            // int.M(ref i);
+            Diagnostic(ErrorCode.WRN_BadArgRef, "i").WithArguments("1").WithLocation(2, 11));
+
+        CompileAndVerify(comp, expectedOutput: "42");
+    }
+
+    [Fact]
+    public void MethodInvocation_ByValueReceiverForRefReadonlyParameter_01()
+    {
+        var src = """
+42.M();
+
+static class E
+{
+    extension(ref readonly int i)
+    {
+        public void M() { System.Console.Write(42); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,1): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+            // 42.M();
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "42").WithArguments("0").WithLocation(1, 1));
+
+        CompileAndVerify(comp, expectedOutput: "42");
+    }
+
+    [Fact]
+    public void MethodInvocation_ByValueReceiverForRefReadonlyParameter_02()
+    {
+        var src = """
+int i = 42;
+i.M();
+
+static class E
+{
+    extension(ref readonly int i)
+    {
+        public void M() { System.Console.Write(i); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MethodInvocation_ByValueReceiverForRefReadonlyParameter_03()
+    {
+        var src = """
+var f = (ref readonly int i) => i.M();
+int i = 42;
+f(ref i);
+
+static class E
+{
+    extension(ref readonly int i)
+    {
+        public void M() { System.Console.Write(i); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MethodInvocation_Params()
+    {
+        var src = """
+int.M(42, 43);
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(params int[] i) { System.Console.Write((i[0], i[1])); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "(42, 43)").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MethodInvocation_Params_02()
+    {
+        var src = """
+int.M([42, 43]);
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(params int[] i) { System.Console.Write((i[0], i[1])); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "(42, 43)").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MethodInvocation_Params_03()
+    {
+        var src = """
+int.M([42, 43]);
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(params long[] l) { System.Console.Write((l[0], l[1]));  }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "(42, 43)").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MethodInvocation_DefaultValue()
+    {
+        var src = """
+int.M();
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(int i = 42) { System.Console.Write(i); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MethodInvocation_DefaultValue_02()
+    {
+        var src = """
+42.M();
+
+static class E
+{
+    extension(int i = 0)
+    {
+        public void M(int j = 1) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (5,15): error CS9503: The receiver parameter of an extension cannot have a default value
+            //     extension(int i = 0)
+            Diagnostic(ErrorCode.ERR_ExtensionParameterDisallowsDefaultValue, "int i = 0").WithLocation(5, 15));
+    }
+
+    [Fact]
+    public void MethodInvocation_InaccessibleTypeArguments()
+    {
+        var src = """
+new A.C().M();
+
+static class E1
+{
+    extension<T>(I<T> i)
+    {
+        public static void M() { }
+    }
+}
+
+interface I<T> { }
+
+class A
+{
+    private class B { }
+    public class C : I<B> { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,11): error CS1061: 'A.C' does not contain a definition for 'M' and no accessible extension method 'M' accepting a first argument of type 'A.C' could be found (are you missing a using directive or an assembly reference?)
+            // new A.C().M();
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M").WithArguments("A.C", "M").WithLocation(1, 11));
+    }
+
+    [Fact]
+    public void PropertyAccess_InaccessibleTypeArguments()
+    {
+        var src = """
+_ = new A.C().P;
+
+static class E1
+{
+    extension<T>(I<T> i)
+    {
+        public static int P => 0;
+    }
+}
+
+interface I<T> { }
+
+class A
+{
+    private class B { }
+    public class C : I<B> { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,15): error CS1061: 'A.C' does not contain a definition for 'P' and no accessible extension method 'P' accepting a first argument of type 'A.C' could be found (are you missing a using directive or an assembly reference?)
+            // _ = new A.C().P;
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "P").WithArguments("A.C", "P").WithLocation(1, 15));
+    }
+
+    [Fact]
+    public void MethodInvocation_ReceiverConversion()
+    {
+        var src = """
+42.M();
+
+static class E
+{
+    extension(object o)
+    {
+        public void M() => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var literal = GetSyntax<LiteralExpressionSyntax>(tree, "42");
+        Assert.Equal("System.Int32", model.GetTypeInfo(literal).Type.ToTestDisplayString());
+        Assert.Equal("System.Object", model.GetTypeInfo(literal).ConvertedType.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_ReceiverConversion_ColorColor()
+    {
+        var src = """
+Color.M2(new Color(42));
+
+class Color(int i) : Base(i)
+{ 
+    public static void M2(Color Color)
+    {
+        Color.M();
+    }
+}
+
+class Base(int i) { public int value = i; }
+
+static class E
+{
+    extension(Base b)
+    {
+        public void M() { System.Console.Write(b.value); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var color = GetSyntax<MemberAccessExpressionSyntax>(tree, "Color.M").Expression;
+        Assert.Equal("Color", model.GetTypeInfo(color).Type.ToTestDisplayString());
+        Assert.Equal("Base", model.GetTypeInfo(color).ConvertedType.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void PropertyAccess_ReceiverConversion()
+    {
+        var src = """
+_  = 42.P;
+
+static class E
+{
+    extension(object o)
+    {
+        public int P => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var literal = GetSyntax<LiteralExpressionSyntax>(tree, "42");
+        Assert.Equal("System.Int32", model.GetTypeInfo(literal).Type.ToTestDisplayString());
+        Assert.Equal("System.Object", model.GetTypeInfo(literal).ConvertedType.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void PropertyAccess_ReceiverConversion_ColorColor()
+    {
+        var src = """
+Color.M2(new Color(42));
+
+class Color(int i) : Base(i)
+{ 
+    public static void M2(Color Color)
+    {
+        _ = Color.P;
+    }
+}
+
+class Base(int i) { public int value = i; }
+
+static class E
+{
+    extension(Base b)
+    {
+        public int P { get { System.Console.Write(b.value); return 0; } }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var color = GetSyntax<MemberAccessExpressionSyntax>(tree, "Color.P").Expression;
+        Assert.Equal("Color", model.GetTypeInfo(color).Type.ToTestDisplayString());
+        Assert.Equal("Base", model.GetTypeInfo(color).ConvertedType.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void MethodInvocation_BrokenConstraint_01()
+    {
+        var src = """
+42.M("", null);
+
+static class E
+{
+    extension(object o)
+    {
+        public void M<T>(T t, C<T> c) where T : struct => throw null;
+    }
+}
+
+class C<U> where U : struct { }
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,4): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'E.extension(object).M<T>(T, C<T>)'
+            // 42.M("", null);
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M").WithArguments("E.extension(object).M<T>(T, C<T>)", "T", "string").WithLocation(1, 4));
+    }
+
+    [Fact]
+    public void MethodInvocation_BrokenConstraint_02()
+    {
+        var src = """
+42.M(null, "");
+
+static class E
+{
+    extension(object o)
+    {
+        public void M<T>(C<T> c, T t) where T : struct => throw null;
+    }
+}
+
+class C<U> where U : struct { }
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,4): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'E.extension(object).M<T>(C<T>, T)'
+            // 42.M(null, "");
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M").WithArguments("E.extension(object).M<T>(C<T>, T)", "T", "string").WithLocation(1, 4));
+    }
+
+    [Fact]
+    public void MethodInvocation_ExtraRef()
+    {
+        var src = """
+int i = 0;
+int.M(ref i);
+
+static class E
+{
+    extension(int)
+    {
+        public static void M(int i) => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (2,11): error CS1615: Argument 2 may not be passed with the 'ref' keyword
+            // int.M(ref i);
+            Diagnostic(ErrorCode.ERR_BadArgExtraRef, "i").WithArguments("2", "ref").WithLocation(2, 11));
+    }
+
+    [Fact]
+    public void SingleCandidate_Extension()
+    {
+        string src = """
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = new C().Test("name", d);
+        System.Console.Write(result);        
+    }
+}
+
+static class Extensions
+{
+    extension(C c)
+    {
+        public int Test(string name, object value) => 123;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp);
+
+        comp.VerifyDiagnostics(
+            // (6,22): error CS1973: 'C' has no applicable method named 'Test' but appears to have an extension method by that name. Extension methods cannot be dynamically dispatched. Consider casting the dynamic arguments or calling the extension method without the extension method syntax.
+            //         var result = new C().Test("name", d);
+            Diagnostic(ErrorCode.ERR_BadArgTypeDynamicExtension, @"new C().Test(""name"", d)").WithArguments("C", "Test").WithLocation(6, 22));
+    }
+
+    [Fact]
+    public void ArgList_Error()
+    {
+        string source = """
+dynamic d = 1;
+object.M(d);
+
+static class Extensions
+{
+    extension(object)
+    {
+        public static int M(__arglist) => 123;
+    }
+}
+""";
+        CreateCompilation(source, targetFramework: TargetFramework.Net90).VerifyDiagnostics(
+            // (2,10): error CS1503: Argument 2: cannot convert from 'dynamic' to '__arglist'
+            // object.M(d);
+            Diagnostic(ErrorCode.ERR_BadArgType, "d").WithArguments("2", "dynamic", "__arglist").WithLocation(2, 10));
+    }
+
+    [Fact]
+    public void ArgList()
+    {
+        string source = """
+int i = 1;
+object.M(__arglist(i));
+
+static class Extensions
+{
+    extension(object)
+    {
+        public static void M(__arglist) { System.Console.Write("ran"); }
+    }
+}
+""";
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void MethodInvocation_ReceiverWithTupleDifferences()
+    {
+        string source = """
+C<(int, int other)>.M();
+
+static class Extensions
+{
+    extension(C<(int a, int b)>)
+    {
+        public static void M() { System.Console.Write("ran"); }
+    }
+}
+
+class C<T> { }
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void PropertyAccess_RemoveStaticInstanceMismatches_InstanceReceiver()
+    {
+        var source = """
+_ = 42.P;
+
+static class E1
+{
+    extension(int i)
+    {
+        public int P => 0;
+    }
+}
+static class E2
+{
+    extension(int)
+    {
+        public static int P => 0;
+    }
+}
+""";
+        // PROTOTYPE Should we prune candidates based on static/instance mismatches?
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (1,8): error CS0229: Ambiguity between 'E1.extension(int).P' and 'E2.extension(int).P'
+            // _ = 42.P;
+            Diagnostic(ErrorCode.ERR_AmbigMember, "P").WithArguments("E1.extension(int).P", "E2.extension(int).P").WithLocation(1, 8));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.P");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+    }
+
+    [Fact]
+    public void PropertyAccess_RemoveStaticInstanceMismatches_StaticReceiver()
+    {
+        var source = """
+_ = int.P;
+
+static class E1
+{
+    extension(int i)
+    {
+        public int P => 0;
+    }
+}
+static class E2
+{
+    extension(int)
+    {
+        public static int P => 0;
+    }
+}
+""";
+        // PROTOTYPE Should we prune candidates based on static/instance mismatches?
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (1,9): error CS0229: Ambiguity between 'E1.extension(int).P' and 'E2.extension(int).P'
+            // _ = int.P;
+            Diagnostic(ErrorCode.ERR_AmbigMember, "P").WithArguments("E1.extension(int).P", "E2.extension(int).P").WithLocation(1, 9));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "int.P");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+    }
+
+    [Fact]
+    public void PropertyAccess_RemoveStaticInstanceMismatches_ColorColor()
+    {
+        var source = """
+class Color
+{
+    static void M(Color Color)
+    {
+        _ = Color.P;
+    }
+}
+
+static class E1
+{
+    extension(Color c)
+    {
+        public int P => 0;
+    }
+}
+static class E2
+{
+    extension(Color)
+    {
+        public static int P => 0;
+    }
+}
+""";
+        // PROTOTYPE Should we prune candidates based on static/instance mismatches? If so, which one should we bind to?
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (5,19): error CS0229: Ambiguity between 'E1.extension(Color).P' and 'E2.extension(Color).P'
+            //         _ = Color.P;
+            Diagnostic(ErrorCode.ERR_AmbigMember, "P").WithArguments("E1.extension(Color).P", "E2.extension(Color).P").WithLocation(5, 19));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "Color.P");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -20339,8 +20339,7 @@ class C
 """;
         comp = CreateCompilation(source);
         comp.VerifyEmitDiagnostics();
-
-        verifier = CompileAndVerify(comp);
+        verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
         verifier.VerifyIL("<top-level-statements-entry-point>", """
 {
   // Code size       19 (0x13)


### PR DESCRIPTION
Since we use a single `AnalyzedArguments` for both kinds of extensions in a single `MethodGroup`, we're including the receiver as an extra argument (see `ResolveExtension`). The PR updates overload resolution to be aware of the extension parameter corresponding to this argument.
After overload resolution completes, when it was successful, we adjust the results and the analyzed arguments back to the original shape and make a `BoundCall` without the extra argument.

The PR also handles the conversion of the receiver (both for method invocations and property accesses).
Introducing a conversion on the receiver caused problems downstream in at least one scenario. I expect we'll find others...

The PR skips a couple of tests related to delegate conversions, that will need similar post-overload-resolution adjustments. This will be handled in a follow-up PR. 

Relates to test plan https://github.com/dotnet/roslyn/issues/76130
