### PR TITLE
Deterministic BuildProtocol.cs dll output

### DIFF
--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -426,7 +426,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         }
     }
 
-    file sealed class MismatchedVersionBuildResponse : BuildResponse
+    internal sealed class MismatchedVersionBuildResponse : BuildResponse
     {
         public override ResponseType Type => ResponseType.MismatchedVersion;
 


### PR DESCRIPTION
Use internal sealed instead of file sealed to make BuildProtocol.cs dll output more deterministic

We ran into strange CI behavior for our internal .NET toolchain. We rely on compiling a custom VBCSCompiler client as part of CI. This client repackages BuildProtocol.cs. After investigating build cache misses we noticed that our CompilerClient.dll's file hash differed from time to time. I assume this was due to CI agents having different checkout roots of the codebase. Investigating further the dll's binary content differed around this file scoped class.

I assume roslyn leaks absolute path information when using the file scope into the dll, even with /deterministic+. I am not sure if this should be regarded a bug. To protect ourselves from re-copying the faulty code from upstream roslyn, I am submitting a PR.