### PR TITLE
WIP: First attempt at cleaning up package load to do less thread switching during InitializeAsync

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -57,7 +57,7 @@
       Visual Studio
     -->
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.13.40008" />
-    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="17.9.36524" />
+    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="17.13.39276" />
     <PackageVersion Include="Microsoft.ServiceHub.Client" Version="4.2.1017" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="17.13.40008" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility" Version="17.12.2037-preview3" />

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -101,6 +101,7 @@
       <_Dependency Remove="@(_Dependency)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('Microsoft.ServiceHub.'))"/>
       <_Dependency Remove="@(_Dependency)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('System.Composition.'))"/>
       <_Dependency Remove="@(_Dependency)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('Microsoft.Internal.VisualStudio.'))"/>
+      <_Dependency Remove="Azure.Core"/>
       <_Dependency Remove="EnvDTE"/>
       <_Dependency Remove="EnvDTE80"/>
       <_Dependency Remove="EnvDTE90"/>
@@ -128,6 +129,7 @@
       <_Dependency Remove="stdole"/>
       <_Dependency Remove="StreamJsonRpc"/>
       <_Dependency Remove="System.Buffers" />
+      <_Dependency Remove="System.ClientModel" />
       <_Dependency Remove="System.Collections.Immutable"/>
       <_Dependency Remove="System.Configuration.ConfigurationManager"/>
       <_Dependency Remove="System.Diagnostics.DiagnosticSource"/>
@@ -135,6 +137,7 @@
       <_Dependency Remove="System.IO.Packaging"/>
       <_Dependency Remove="System.IO.Pipelines"/>
       <_Dependency Remove="System.Memory"/>
+      <_Dependency Remove="System.Memory.Data"/>
       <_Dependency Remove="System.Numerics.Vectors"/>
       <_Dependency Remove="System.Reflection.Metadata"/>
       <_Dependency Remove="System.Reflection.MetadataLoadContext"/>

--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
@@ -64,14 +63,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            // Execution should initiate on a threadpool as package load sequence thread switches are impactful.
-            await TaskScheduler.Default;
-
-            Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
-
             try
             {
-                await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
+                await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(false);
 
                 this.RegisterService<ICSharpTempPECompilerService>(async ct =>
                 {

--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -19,7 +19,6 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService

--- a/src/VisualStudio/Core/Def/Interop/IVsAppId.cs
+++ b/src/VisualStudio/Core/Def/Interop/IVsAppId.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+
+namespace Microsoft.VisualStudio.LanguageServices.Interop;
+
+[Guid("1EAA526A-0898-11d3-B868-00C04F79F802"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IVsAppId
+{
+    [PreserveSig]
+    int SetSite(IOleServiceProvider pSP);
+
+    [PreserveSig]
+    int GetProperty(int propid, // VSAPROPID
+        [MarshalAs(UnmanagedType.Struct)] out object pvar);
+
+    [PreserveSig]
+    int SetProperty(int propid, //[in] VSAPROPID
+        [MarshalAs(UnmanagedType.Struct)] object var);
+
+    [PreserveSig]
+    int GetGuidProperty(int propid, // VSAPROPID
+        out Guid guid);
+
+    [PreserveSig]
+    int SetGuidProperty(int propid, // [in] VSAPROPID
+        ref Guid rguid);
+
+    [PreserveSig]
+    int Initialize();  // called after main initialization and before command executing and entering main loop
+}

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -27,18 +27,12 @@ internal abstract class AbstractPackage : AsyncPackage
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
-        Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
-
         _componentModel_doNotAccessDirectly = await GetServiceAsync<SComponentModel, IComponentModel>(throwOnFailure: true, cancellationToken).ConfigureAwait(true);
         Assumes.Present(_componentModel_doNotAccessDirectly);
     }
 
     protected override async Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)
     {
-        // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
-        Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
-
         // TODO: remove, workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1985204
         var globalOptions = ComponentModel.GetService<IGlobalOptionService>();
         if (globalOptions.GetOption(SemanticSearchFeatureFlag.Enabled))

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -30,8 +30,6 @@ internal abstract class AbstractPackage : AsyncPackage
         // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
         Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
 
-        await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
-
         _componentModel_doNotAccessDirectly = await GetServiceAsync<SComponentModel, IComponentModel>(throwOnFailure: true, cancellationToken).ConfigureAwait(true);
         Assumes.Present(_componentModel_doNotAccessDirectly);
     }
@@ -40,8 +38,6 @@ internal abstract class AbstractPackage : AsyncPackage
     {
         // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
         Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
-
-        await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         // TODO: remove, workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1985204
         var globalOptions = ComponentModel.GetService<IGlobalOptionService>();

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -37,10 +37,7 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
-        Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
-
-        await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
+        await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(false);
 
         RegisterLanguageService(typeof(TLanguageService), async cancellationToken =>
         {
@@ -71,10 +68,7 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
     protected override async Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)
     {
-        // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
-        Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
-
-        await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(true);
+        await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         if (!IVsShellExtensions.IsInCommandLineMode(JoinableTaskFactory))
         {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -74,7 +74,7 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
         // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
         Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
 
-        await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(false);
+        await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(true);
 
         if (!IVsShellExtensions.IsInCommandLineMode(JoinableTaskFactory))
         {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -80,10 +80,10 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
         LoadComponentsInUIContextOnceSolutionFullyLoadedAsync(cancellationToken).Forget();
     }
 
-    protected override Task LoadComponentsAsync(CancellationToken cancellationToken)
+    protected override async Task LoadComponentsAsync(CancellationToken cancellationToken)
     {
-        // Should only be called from a threadpool thread as this may do MEF loads and initialization
-        Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
+        // Do the MEF loads and initialization in the BG explicitly.
+        await TaskScheduler.Default;
 
         // Ensure the nuget package services are initialized. This initialization pass will only run
         // once our package is loaded indirectly through a legacy COM service we proffer (like the legacy project systems
@@ -100,8 +100,6 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
         _packageInstallerService?.RegisterLanguage(this.RoslynLanguageName);
         _symbolSearchService?.RegisterLanguage(this.RoslynLanguageName);
-
-        return Task.CompletedTask;
     }
 
     protected abstract void RegisterMiscellaneousFilesWorkspaceInformation(MiscellaneousFilesWorkspace miscellaneousFilesWorkspace);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -52,9 +52,6 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
             return _languageService.ComAggregate;
         });
 
-        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
-        RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
-
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         foreach (var editorFactory in CreateEditorFactories())
@@ -69,6 +66,11 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
     protected override async Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)
     {
         await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
+        RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 
         if (!IVsShellExtensions.IsInCommandLineMode(JoinableTaskFactory))
         {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -55,7 +55,8 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
             return _languageService.ComAggregate;
         });
 
-        var shell = await GetServiceAsync<SVsShell, IVsShell7>(throwOnFailure: true, cancellationToken).ConfigureAwait(true);
+        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
+        RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
@@ -64,9 +65,7 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
             RegisterEditorFactory(editorFactory);
         }
 
-        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
-        RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
-
+        var shell = await GetServiceAsync<SVsShell, IVsShell7>(throwOnFailure: true, cancellationToken).ConfigureAwait(true);
         await shell.LoadPackageAsync(Guids.RoslynPackageId);
     }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -76,7 +76,6 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
 
     public async Task InitializeAsync()
     {
-        await TaskScheduler.Default;
         _textManager = await _textManagerService.GetValueAsync().ConfigureAwait(false);
     }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -36,7 +36,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     private readonly OpenTextBufferProvider _openTextBufferProvider;
     private readonly IMetadataAsSourceFileService _fileTrackingMetadataAsSourceService;
 
-    private readonly Dictionary<Guid, LanguageInformation> _languageInformationByLanguageGuid = [];
+    private ImmutableDictionary<Guid, LanguageInformation> _languageInformationByLanguageGuid = ImmutableDictionary<Guid, LanguageInformation>.Empty;
 
     /// <summary>
     /// <see cref="WorkspaceRegistration"/> instances for all open buffers being tracked by by this object
@@ -114,7 +114,12 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     void IOpenTextBufferEventListener.OnSaveDocument(string moniker) { }
 
     public void RegisterLanguage(Guid languageGuid, string languageName, string scriptExtension)
-        => _languageInformationByLanguageGuid.Add(languageGuid, new LanguageInformation(languageName, scriptExtension));
+    {
+        ImmutableInterlocked.TryAdd(
+            ref _languageInformationByLanguageGuid,
+            languageGuid,
+            new LanguageInformation(languageName, scriptExtension));
+    }
 
     private LanguageInformation TryGetLanguageInformation(string filename)
     {

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -144,10 +144,7 @@ internal sealed class RoslynPackage : AbstractPackage
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        // Execution should initiate on a threadpool as package load sequence thread switches are impactful.
-        await TaskScheduler.Default;
-
-        await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
+        await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(false);
 
         // Misc workspace has to be up and running by the time our package is usable so that it can track running
         // doc events and appropriately map files to/from it and other relevant workspaces (like the
@@ -162,10 +159,7 @@ internal sealed class RoslynPackage : AbstractPackage
 
     protected override async Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)
     {
-        // Execution should initiate on a threadpool as package load sequence thread switches are impactful.
-        await TaskScheduler.Default;
-
-        await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(true);
+        await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -144,8 +144,8 @@ internal sealed class RoslynPackage : AbstractPackage
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        // Should only be called from a threadpool. Opinionated, as package load sequence thread switches are impactful.
-        Contract.ThrowIfTrue(JoinableTaskFactory.Context.IsOnMainThread);
+        // Execution should initiate on a threadpool as package load sequence thread switches are impactful.
+        await TaskScheduler.Default;
 
         await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
 

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -146,11 +146,6 @@ internal sealed class RoslynPackage : AbstractPackage
     {
         await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(false);
 
-        // Misc workspace has to be up and running by the time our package is usable so that it can track running
-        // doc events and appropriately map files to/from it and other relevant workspaces (like the
-        // metadata-as-source workspace).
-        await this.ComponentModel.GetService<MiscellaneousFilesWorkspace>().InitializeAsync().ConfigureAwait(false);
-
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var settingsEditorFactory = this.ComponentModel.GetService<SettingsEditorFactory>();
@@ -162,6 +157,11 @@ internal sealed class RoslynPackage : AbstractPackage
         await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        // Misc workspace has to be up and running by the time our package is usable so that it can track running
+        // doc events and appropriately map files to/from it and other relevant workspaces (like the
+        // metadata-as-source workspace).
+        this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
 
         // Ensure the options persisters are loaded since we have to fetch options from the shell
         LoadOptionPersistersAsync(this.ComponentModel, cancellationToken).Forget();

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -162,7 +162,6 @@ internal sealed class RoslynPackage : AbstractPackage
         await base.OnAfterPackageLoadedAsync(cancellationToken).ConfigureAwait(false);
 
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-        cancellationToken.ThrowIfCancellationRequested();
 
         // Ensure the options persisters are loaded since we have to fetch options from the shell
         LoadOptionPersistersAsync(this.ComponentModel, cancellationToken).Forget();

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -17,6 +17,7 @@ Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
 Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
+Imports Microsoft.VisualStudio.Threading
 Imports Task = System.Threading.Tasks.Task
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
@@ -67,8 +68,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         Protected Overrides Async Function InitializeAsync(cancellationToken As CancellationToken, progress As IProgress(Of ServiceProgressData)) As Task
             Try
+                ' Execution should initiate on a threadpool as package load sequence thread switches are impactful.
+                Await TaskScheduler.Default
+
                 Await MyBase.InitializeAsync(cancellationToken, progress).ConfigureAwait(True)
-                Await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken)
 
                 RegisterLanguageService(GetType(IVbCompilerService), Function() Task.FromResult(_comAggregate))
 

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -17,7 +17,6 @@ Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
 Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
-Imports Microsoft.VisualStudio.Threading
 Imports Task = System.Threading.Tasks.Task
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
@@ -68,9 +67,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         Protected Overrides Async Function InitializeAsync(cancellationToken As CancellationToken, progress As IProgress(Of ServiceProgressData)) As Task
             Try
-                ' Execution should initiate on a threadpool as package load sequence thread switches are impactful.
-                Await TaskScheduler.Default
-
                 Await MyBase.InitializeAsync(cancellationToken, progress).ConfigureAwait(True)
 
                 RegisterLanguageService(GetType(IVbCompilerService), Function() Task.FromResult(_comAggregate))

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         Protected Overrides Async Function InitializeAsync(cancellationToken As CancellationToken, progress As IProgress(Of ServiceProgressData)) As Task
             Try
-                Await MyBase.InitializeAsync(cancellationToken, progress).ConfigureAwait(True)
+                Await MyBase.InitializeAsync(cancellationToken, progress).ConfigureAwait(False)
 
                 RegisterLanguageService(GetType(IVbCompilerService), Function() Task.FromResult(_comAggregate))
 


### PR DESCRIPTION
This is going to be a post 17.14 PR, just wanted to get something out to start the conversation about what I've currently got.

Manual testing of opening Roslyn.sln with a single file opened in the sln showed the stopwatch time spent in CSharpPackage.InitializeAsync from about 2000 ms without this change to about 700 ms with this change.

Test insertion to see if speedometer shows anything:
commit 6: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=11106739&view=results