### PR TITLE
Fix issue where goto-def wouldn't go to the right place after invokining twice in a MAS file.

### DIFF
--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
@@ -31,15 +31,11 @@ namespace Microsoft.CodeAnalysis.GoToDefinition;
 [method: ImportingConstructor]
 [method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
 internal class GoToDefinitionCommandHandler(
-    IGlobalOptionService globalOptionService,
     IThreadingContext threadingContext,
-    IUIThreadOperationExecutor executor,
     IAsynchronousOperationListenerProvider listenerProvider) :
     ICommandHandler<GoToDefinitionCommandArgs>
 {
-    private readonly IGlobalOptionService _globalOptionService = globalOptionService;
     private readonly IThreadingContext _threadingContext = threadingContext;
-    private readonly IUIThreadOperationExecutor _executor = executor;
     private readonly IAsynchronousOperationListener _listener = listenerProvider.GetListener(FeatureAttribute.GoToDefinition);
 
     public string DisplayName => EditorFeaturesResources.Go_to_Definition;

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
@@ -56,9 +56,7 @@ class C
                 Dim provider = workspace.GetService(Of IAsynchronousOperationListenerProvider)()
                 Dim waiter = provider.GetWaiter(FeatureAttribute.GoToDefinition)
                 Dim handler = New GoToDefinitionCommandHandler(
-                    workspace.GetService(Of IGlobalOptionService),
                     workspace.GetService(Of IThreadingContext),
-                    workspace.GetService(Of IUIThreadOperationExecutor),
                     provider)
 
                 handler.ExecuteCommand(New GoToDefinitionCommandArgs(view, baseDocument.GetTextBuffer()), TestCommandExecutionContext.Create())
@@ -98,9 +96,7 @@ int y = x$$</Document>
                 Dim provider = workspace.GetService(Of IAsynchronousOperationListenerProvider)()
                 Dim waiter = provider.GetWaiter(FeatureAttribute.GoToDefinition)
                 Dim handler = New GoToDefinitionCommandHandler(
-                    workspace.GetService(Of IGlobalOptionService),
                     workspace.GetService(Of IThreadingContext),
-                    workspace.GetService(Of IUIThreadOperationExecutor),
                     provider)
 
                 handler.ExecuteCommand(New GoToDefinitionCommandArgs(view, document.GetTextBuffer()), TestCommandExecutionContext.Create())
@@ -143,9 +139,7 @@ class C
                 Dim provider = workspace.GetService(Of IAsynchronousOperationListenerProvider)()
                 Dim waiter = provider.GetWaiter(FeatureAttribute.GoToDefinition)
                 Dim handler = New GoToDefinitionCommandHandler(
-                    workspace.GetService(Of IGlobalOptionService),
                     workspace.GetService(Of IThreadingContext),
-                    workspace.GetService(Of IUIThreadOperationExecutor),
                     provider)
 
                 Dim snapshot = document.GetTextBuffer().CurrentSnapshot

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolNavigationService.cs
@@ -154,7 +154,13 @@ internal sealed partial class VisualStudioSymbolNavigationService(
                 ErrorHandler.ThrowOnFailure(windowFrame.SetProperty((int)__VSFPROPID5.VSFPROPID_OverrideToolTip, result.DocumentTooltip));
             }
 
+            // Subtle issue.  We may already be in a provisional-tab. 'Showing' the window frame here will cause it to
+            // to take over the curren provisional-tab, cause a wait-indicators in the original to be dismissed (causing
+            // cancellation).   To avoid that problem, we disable cancellation from this point.  While not ideal, it is
+            // not problematic as we already forced the document to be opened here.  So actually navigating to the
+            // location in it is effectively free.
             windowFrame.Show();
+            cancellationToken = default;
 
             var openedDocument = textBuffer?.AsTextContainer().GetRelatedDocuments().FirstOrDefault();
             if (openedDocument != null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/77382