### PR TITLE
Auto merge PRs instead of just applying a label to them

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -27,23 +27,6 @@ configuration:
 
     eventResponderTasks:
 
-    - description: Auto-approve auto-merge PRs
-      triggerOnOwnActions: false
-      if:
-      - payloadType: Pull_Request
-      - isPullRequest
-      - labelAdded:
-          label: auto-merge
-      - or:
-        - activitySenderHasPermission:
-            permission: Admin
-        - isActivitySender:
-            user: dotnet-bot
-            issueAuthor: False
-      then:
-      - approvePullRequest:
-          comment: Auto-approval
-
     - description: Auto-approve maestro PRs
       triggerOnOwnActions: false
       if:
@@ -80,7 +63,7 @@ configuration:
       - addMilestone:
           milestone: Next
 
-    - description: Auto-approve OneLoc PRs
+    - description: Auto-approve/merge OneLoc PRs
       triggerOnOwnActions: false
       if:
       - payloadType: Pull_Request
@@ -94,8 +77,10 @@ configuration:
       - isAction:
           action: Opened
       then:
-      - addLabel:
-          label: auto-merge
+      - approvePullRequest:
+          comment: Auto-approve
+      - enableAutoMerge:
+          mergeMethod: merge
 
     - description: Auto-approve/merge automated merge PRs
       triggerOnOwnActions: false
@@ -113,8 +98,8 @@ configuration:
       then:
       - approvePullRequest:
           comment: Auto-approve
-      - addLabel:
-          label: auto-merge
+      - enableAutoMerge:
+          mergeMethod: merge
 
     - description: Remove "Need More Info" on comment
       triggerOnOwnActions: false


### PR DESCRIPTION
I'm not sure why we were just adding a label, perhaps the new bot did not support auto merging at the beginning. It would definitely be useful for Tiger if the automated branch flows would auto merged. Not sure about the automated loc PRs.