### PR TITLE
Small cleanup in the packages and editor factories

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -57,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
     [Guid(Guids.CSharpPackageIdString)]
     internal sealed class CSharpPackage : AbstractPackage<CSharpPackage, CSharpLanguageService>, IVsUserSettingsQuery
     {
-        private ObjectBrowserLibraryManager _libraryManager;
+        private ObjectBrowserLibraryManager? _libraryManager;
         private uint _libraryManagerCookie;
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
@@ -79,13 +77,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
         }
 
-        protected override async Task RegisterObjectBrowserLibraryManagerAsync(CancellationToken cancellationToken)
+        protected override void RegisterObjectBrowserLibraryManager()
         {
+            Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread);
+
             var workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
 
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            if (await GetServiceAsync(typeof(SVsObjectManager)).ConfigureAwait(true) is IVsObjectManager2 objectManager)
+            if (GetService(typeof(SVsObjectManager)) is IVsObjectManager2 objectManager)
             {
                 _libraryManager = new ObjectBrowserLibraryManager(this, ComponentModel, workspace);
 
@@ -96,19 +94,19 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
         }
 
-        protected override async Task UnregisterObjectBrowserLibraryManagerAsync(CancellationToken cancellationToken)
+        protected override void UnregisterObjectBrowserLibraryManager()
         {
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread);
 
             if (_libraryManagerCookie != 0)
             {
-                if (await GetServiceAsync(typeof(SVsObjectManager)).ConfigureAwait(true) is IVsObjectManager2 objectManager)
+                if (GetService(typeof(SVsObjectManager)) is IVsObjectManager2 objectManager)
                 {
                     objectManager.UnregisterLibrary(_libraryManagerCookie);
                     _libraryManagerCookie = 0;
                 }
 
-                _libraryManager.Dispose();
+                _libraryManager?.Dispose();
                 _libraryManager = null;
             }
         }
@@ -136,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             var editorFactory = new CSharpEditorFactory(this.ComponentModel);
             var codePageEditorFactory = new CSharpCodePageEditorFactory(editorFactory);
 
-            return new IVsEditorFactory[] { editorFactory, codePageEditorFactory };
+            return [editorFactory, codePageEditorFactory];
         }
 
         protected override CSharpLanguageService CreateLanguageService()

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodePageEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodePageEditorFactory.cs
@@ -2,19 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.LanguageServices.Implementation;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 {
     [Guid(Guids.CSharpCodePageEditorFactoryIdString)]
-    internal class CSharpCodePageEditorFactory : AbstractCodePageEditorFactory
+    internal sealed class CSharpCodePageEditorFactory(AbstractEditorFactory editorFactory) : AbstractCodePageEditorFactory(editorFactory)
     {
-        public CSharpCodePageEditorFactory(AbstractEditorFactory editorFactory)
-            : base(editorFactory)
-        {
-        }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -18,13 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 {
     [ExcludeFromCodeCoverage]
     [Guid(Guids.CSharpEditorFactoryIdString)]
-    internal class CSharpEditorFactory : AbstractEditorFactory
+    internal class CSharpEditorFactory(IComponentModel componentModel) : AbstractEditorFactory(componentModel)
     {
-        public CSharpEditorFactory(IComponentModel componentModel)
-            : base(componentModel)
-        {
-        }
-
         protected override string ContentTypeName => ContentTypeNames.CSharpContentType;
         protected override string LanguageName => LanguageNames.CSharp;
 

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -25,21 +24,17 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.WinForms.Interfaces;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation;
 
 /// <summary>
 /// The base class of both the Roslyn editor factories.
 /// </summary>
-internal abstract class AbstractEditorFactory : IVsEditorFactory, IVsEditorFactory4, IVsEditorFactoryNotify
+internal abstract class AbstractEditorFactory(IComponentModel componentModel) : IVsEditorFactory, IVsEditorFactory4, IVsEditorFactoryNotify
 {
-    private readonly IComponentModel _componentModel;
+    private readonly IComponentModel _componentModel = componentModel;
     private Microsoft.VisualStudio.OLE.Interop.IServiceProvider? _oleServiceProvider;
     private bool _encoding;
-
-    protected AbstractEditorFactory(IComponentModel componentModel)
-        => _componentModel = componentModel;
 
     protected abstract string ContentTypeName { get; }
     protected abstract string LanguageName { get; }

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -42,7 +42,6 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
         var shell = (IVsShell7?)await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
         var solution = (IVsSolution?)await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(true);
-        cancellationToken.ThrowIfCancellationRequested();
         Assumes.Present(shell);
         Assumes.Present(solution);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.SymbolSearch;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -25,10 +24,11 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
     where TPackage : AbstractPackage<TPackage, TLanguageService>
     where TLanguageService : AbstractLanguageService<TPackage, TLanguageService>
 {
-    private TLanguageService _languageService;
+    private TLanguageService? _languageService;
 
-    private PackageInstallerService _packageInstallerService;
-    private VisualStudioSymbolSearchService _symbolSearchService;
+    private PackageInstallerService? _packageInstallerService;
+    private VisualStudioSymbolSearchService? _symbolSearchService;
+    private IVsShell? _shell;
 
     protected AbstractPackage()
     {
@@ -40,11 +40,14 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-        var shell = (IVsShell7)await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
-        var solution = (IVsSolution)await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(true);
+        var shell = (IVsShell7?)await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
+        var solution = (IVsSolution?)await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(true);
         cancellationToken.ThrowIfCancellationRequested();
         Assumes.Present(shell);
         Assumes.Present(solution);
+
+        _shell = (IVsShell?)shell;
+        Assumes.Present(_shell);
 
         foreach (var editorFactory in CreateEditorFactories())
         {
@@ -61,7 +64,7 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
             _languageService = CreateLanguageService();
             await _languageService.SetupAsync(cancellationToken).ConfigureAwait(false);
 
-            return _languageService.ComAggregate;
+            return _languageService.ComAggregate!;
         });
 
         await shell.LoadPackageAsync(Guids.RoslynPackageId);
@@ -69,11 +72,11 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
         var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
         RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 
-        if (!IVsShellExtensions.IsInCommandLineMode(JoinableTaskFactory))
+        if (!_shell.IsInCommandLineMode())
         {
             // not every derived package support object browser and for those languages
             // this is a no op
-            await RegisterObjectBrowserLibraryManagerAsync(cancellationToken).ConfigureAwait(true);
+            RegisterObjectBrowserLibraryManager();
         }
 
         LoadComponentsInUIContextOnceSolutionFullyLoadedAsync(cancellationToken).Forget();
@@ -117,9 +120,11 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
     {
         if (disposing)
         {
-            if (!IVsShellExtensions.IsInCommandLineMode(JoinableTaskFactory))
+            // Per VS core team, Package.Dispose is called on the UI thread.
+            Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread);
+            if (_shell != null && !_shell.IsInCommandLineMode())
             {
-                JoinableTaskFactory.Run(async () => await UnregisterObjectBrowserLibraryManagerAsync(CancellationToken.None).ConfigureAwait(true));
+                UnregisterObjectBrowserLibraryManager();
             }
 
             // If we've created the language service then tell it it's time to clean itself up now.
@@ -135,17 +140,15 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
     protected abstract string RoslynLanguageName { get; }
 
-    protected virtual Task RegisterObjectBrowserLibraryManagerAsync(CancellationToken cancellationToken)
+    protected virtual void RegisterObjectBrowserLibraryManager()
     {
         // it is virtual rather than abstract to not break other languages which derived from our
         // base package implementations
-        return Task.CompletedTask;
     }
 
-    protected virtual Task UnregisterObjectBrowserLibraryManagerAsync(CancellationToken cancellationToken)
+    protected virtual void UnregisterObjectBrowserLibraryManager()
     {
         // it is virtual rather than abstract to not break other languages which derived from our
         // base package implementations
-        return Task.CompletedTask;
     }
 }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -60,11 +60,11 @@ internal sealed class RoslynPackage : AbstractPackage
     private const string BackgroundAnalysisScopeOptionKey = "AnalysisScope-DCE33A29A768";
     private const byte BackgroundAnalysisScopeOptionVersion = 1;
 
-    private static RoslynPackage? _lazyInstance;
+    private static RoslynPackage? s_lazyInstance;
 
     private RuleSetEventHandler? _ruleSetEventHandler;
     private ColorSchemeApplier? _colorSchemeApplier;
-    private IDisposable? _solutionEventMonitor;
+    private SolutionEventMonitor? _solutionEventMonitor;
 
     private BackgroundAnalysisScope? _analysisScope;
 
@@ -95,7 +95,7 @@ internal sealed class RoslynPackage : AbstractPackage
 
     internal static async ValueTask<RoslynPackage?> GetOrLoadAsync(IThreadingContext threadingContext, IAsyncServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
-        if (_lazyInstance is null)
+        if (s_lazyInstance is null)
         {
             await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
@@ -105,11 +105,11 @@ internal sealed class RoslynPackage : AbstractPackage
 
             if (ErrorHandler.Succeeded(((IVsShell)shell).IsPackageLoaded(typeof(RoslynPackage).GUID, out var package)))
             {
-                _lazyInstance = (RoslynPackage)package;
+                s_lazyInstance = (RoslynPackage)package;
             }
         }
 
-        return _lazyInstance;
+        return s_lazyInstance;
     }
 
     protected override void OnLoadOptions(string key, Stream stream)

--- a/src/VisualStudio/Core/Def/Utilities/IVsShellExtensions.cs
+++ b/src/VisualStudio/Core/Def/Utilities/IVsShellExtensions.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 
@@ -19,30 +15,21 @@ internal static class IVsShellExtensions
     /// <summary>
     /// Returns true if devenv is invoked in command line mode for build, e.g. devenv /rebuild MySolution.sln
     /// </summary>
-    public static bool IsInCommandLineMode(JoinableTaskFactory joinableTaskFactory)
+    public static bool IsInCommandLineMode(this IVsShell shell)
     {
-        var result = s_isInCommandLineMode;
-        if (result == 0)
+        if (s_isInCommandLineMode == 0)
         {
-            s_isInCommandLineMode = result = joinableTaskFactory.Run(async () =>
-            {
-                await joinableTaskFactory.SwitchToMainThreadAsync();
-
-                var shell = ServiceProvider.GlobalProvider.GetService<SVsShell, IVsShell>(joinableTaskFactory);
-                return
-                    (shell != null) &&
-                    ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out var result)) &&
-                    (bool)result ? 1 : -1;
-            });
+            s_isInCommandLineMode =
+                ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out var result)) &&
+                (bool)result ? 1 : -1;
         }
 
-        return result == 1;
+        return s_isInCommandLineMode == 1;
     }
 
     public static bool TryGetPropertyValue(this IVsShell shell, __VSSPROPID id, out IntPtr value)
     {
-        var hresult = shell.GetProperty((int)id, out var objValue);
-        if (ErrorHandler.Succeeded(hresult) && objValue != null)
+        if (ErrorHandler.Succeeded(shell.GetProperty((int)id, out var objValue)) && objValue != null)
         {
             value = (IntPtr.Size == 4) ? (IntPtr)(int)objValue : (IntPtr)(long)objValue;
             return true;

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodePageEditorFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodePageEditorFactory.vb
@@ -7,7 +7,7 @@ Imports Microsoft.VisualStudio.LanguageServices.Implementation
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     <Guid(Guids.VisualBasicCodePageEditorFactoryIdString)>
-    Friend Class VisualBasicCodePageEditorFactory
+    Friend NotInheritable Class VisualBasicCodePageEditorFactory
         Inherits AbstractCodePageEditorFactory
 
         Public Sub New(editorFactory As AbstractEditorFactory)

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
@@ -5,7 +5,6 @@
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
-Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -7,7 +7,6 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.Options
-Imports Microsoft.VisualStudio.LanguageServices.Implementation
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
@@ -83,12 +82,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
             End Try
         End Function
 
-        Protected Overrides Async Function RegisterObjectBrowserLibraryManagerAsync(cancellationToken As CancellationToken) As Task
+        Protected Overrides Sub RegisterObjectBrowserLibraryManager()
             Dim workspace As VisualStudioWorkspace = ComponentModel.GetService(Of VisualStudioWorkspace)()
 
-            Await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken)
+            Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread)
 
-            Dim objectManager = TryCast(Await GetServiceAsync(GetType(SVsObjectManager)).ConfigureAwait(True), IVsObjectManager2)
+            Dim objectManager = TryCast(GetService(GetType(SVsObjectManager)), IVsObjectManager2)
             If objectManager IsNot Nothing Then
                 Me._libraryManager = New ObjectBrowserLibraryManager(Me, ComponentModel, workspace)
 
@@ -96,13 +95,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                     Me._libraryManagerCookie = 0
                 End If
             End If
-        End Function
+        End Sub
 
-        Protected Overrides Async Function UnregisterObjectBrowserLibraryManagerAsync(cancellationToken As CancellationToken) As Task
-            Await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken)
+        Protected Overrides Sub UnregisterObjectBrowserLibraryManager()
+            Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread)
 
             If _libraryManagerCookie <> 0 Then
-                Dim objectManager = TryCast(Await GetServiceAsync(GetType(SVsObjectManager)).ConfigureAwait(True), IVsObjectManager2)
+                Dim objectManager = TryCast(GetService(GetType(SVsObjectManager)), IVsObjectManager2)
                 If objectManager IsNot Nothing Then
                     objectManager.UnregisterLibrary(Me._libraryManagerCookie)
                     Me._libraryManagerCookie = 0
@@ -111,7 +110,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 Me._libraryManager.Dispose()
                 Me._libraryManager = Nothing
             End If
-        End Function
+        End Sub
 
         Public Function NeedExport(pageID As String, <Out> ByRef needExportParam As Integer) As Integer Implements IVsUserSettingsQuery.NeedExport
             ' We need to override MPF's definition of NeedExport since it doesn't know about our automation object


### PR DESCRIPTION
This area is going to get some larger changes in Dev18. As I'm waiting for that branch to become available, do a small cleanup in the area in anticipation of those changes.

These changes are mostly cosmetic. The only change that is a bit more than that is the (Un)RegisterObjectBrowserLibraryManager changes to not be sync. This was done to remove a couple JTF.Runs in the code, and was done after verifying with JeffRo that our package disposal will indeed always be done on the main thread.