### PR TITLE
Add null-conditional-assignment tests.

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10701,4 +10701,21 @@ AnonymousTypes(
             """,
             MainDescription($"({CSharpFeaturesResources.awaitable}) ValueTask IAsyncDisposable.DisposeAsync()"));
     }
+
+    [Fact]
+    public async Task NullConditionalAssignment()
+    {
+        await VerifyWithNet8Async("""
+            class C
+            {
+                string s;
+
+                void M(C c)
+                {
+                    c?.$$s = "";
+                }
+            }
+            """,
+            MainDescription($"({FeaturesResources.field}) string C.s"));
+    }
 }

--- a/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
@@ -4426,6 +4426,28 @@ public partial class Program
             Await TestAsync(workspace)
         End Function
 
+        <WpfFact>
+        Public Async Function TestCSharpGotoDefinitionNullConditionalAwait() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            partial class Test
+            {
+                string [|s|];
+
+                public void M(Test t)
+                {
+                    t?.$$s = "";
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
 #Enable Warning RSEXPERIMENTAL002 ' Type is for evaluation purposes only and is subject to change or removal in future updates.
     End Class
 End Namespace

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -12502,4 +12502,16 @@ public sealed class FormattingTests : CSharpFormattingTestBase
     {
         await AssertFormatAsync(expected, text);
     }
+
+    [Fact]
+    public async Task FormatNullConditionalAssignment()
+    {
+        await AssertFormatAsync(
+            expected: """
+            x?.y = z;
+            """,
+            code: """
+             x ? . y  =  z ;
+            """);
+    }
 }


### PR DESCRIPTION
* Rename parser method

* Cleanup

* Inline methods

* Share

* fix

* Docs

* rename

* Remove unnecessayr check

* Update src/Compilers/CSharp/Portable/Parser/LanguageParser.cs

Co-authored-by: Rikki Gibson <rikkigibson@gmail.com>

* Fix

* Cleaner

* Update src/Compilers/CSharp/Portable/Parser/LanguageParser.cs

Co-authored-by: Rikki Gibson <rikkigibson@gmail.com>

* Apply suggestions from code review

---------

Co-authored-by: Rikki Gibson <rikkigibson@gmail.com>