### PR TITLE
Include the contents of System.Composition in Setup.Dependencies

### DIFF
--- a/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
@@ -36,6 +36,17 @@
     <PackageReference Include="System.CodeDom" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="System.Collections.Immutable" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="System.Configuration.ConfigurationManager" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
+    
+    <!-- Include System.Composition until the 9.0 version is included in Visual Studio. Our MSBuild support for IncludeInVsix only looks at the direct contents
+         of that package and doesn't include any dependencies, which is unfortunate here: System.Composition is a metapackage, and all the actual stuff is in other
+         packages. We workaround that here by listing all of the "real" packages. I'm using VersionOverride here rather than creating a bunch of new entries in
+         our Directories.props files, because eventually we can go and delete these and it keeps the hack self-contained. -->
+    <PackageReference Include="System.Composition.AttributedModel" IncludeInVsix="true" PkgDefEntry="BindingRedirect" VersionOverride="$(SystemCompositionVersion)" />
+    <PackageReference Include="System.Composition.Convention" IncludeInVsix="true" PkgDefEntry="BindingRedirect" VersionOverride="$(SystemCompositionVersion)" />
+    <PackageReference Include="System.Composition.Hosting" IncludeInVsix="true" PkgDefEntry="BindingRedirect" VersionOverride="$(SystemCompositionVersion)" />
+    <PackageReference Include="System.Composition.Runtime" IncludeInVsix="true" PkgDefEntry="BindingRedirect" VersionOverride="$(SystemCompositionVersion)" />
+    <PackageReference Include="System.Composition.TypedParts" IncludeInVsix="true" PkgDefEntry="BindingRedirect" VersionOverride="$(SystemCompositionVersion)" />
+    
     <PackageReference Include="System.Drawing.Common" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="System.Diagnostics.EventLog" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />

--- a/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="Microsoft.Extensions.Options" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="Microsoft.Extensions.Primitives" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="System.Buffers" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="System.CodeDom" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="System.Collections.Immutable" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
@@ -66,7 +67,6 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="Nerdbank.Streams" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
     <PackageReference Include="StreamJsonRpc" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" IncludeInVsix="true" PkgDefEntry="BindingRedirect" />
   </ItemGroup>
   <ItemGroup>
     <None Include="source.extension.vsixmanifest">


### PR DESCRIPTION
This gets us loading on 17.14 builds again.