### PR TITLE
Fix design time build error in Roslyn.VisualStudio.Setup

### DIFF
--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -186,7 +186,7 @@
     </ItemGroup>
     <MSBuild Projects="@(_ProjectsToPublishForUpToDateCheck)"
            BuildInParallel="$(BuildInParallel)"
-           Properties="%(_ProjectsToPublish.SetConfiguration);%(_ProjectsToPublish.SetPlatform);%(_ProjectsToPublish.SetTargetFramework)"
+           Properties="%(_ProjectsToPublishForUpToDateCheck.SetConfiguration);%(_ProjectsToPublishForUpToDateCheck.SetPlatform);%(_ProjectsToPublishForUpToDateCheck.SetTargetFramework)"
            Targets="PublishItemsOutputGroup"
            RebaseOutputs="true"
            ContinueOnError="$(ContinueOnError)">


### PR DESCRIPTION
The MSBuild task invocation here is a copy/paste from earlier in the file, but the item group renamed so it didn't conflict. The rename was in complete, so the use in the Properties property was still using the old name; this had the effect that we wouldn't set the TFM property, which would cause problems for multi-targeting projects.