### PR TITLE
[Rename flyout] Fixed cropping issue on small screens

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -12,7 +12,6 @@
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
-             MinWidth="200"
              KeyDown="Adornment_KeyDown"
              MouseDown="Adornment_ConsumeMouseEvent"
              MouseUp="Adornment_ConsumeMouseEvent"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -97,13 +97,14 @@
                 </Grid.ColumnDefinitions>
 
                 <imaging:CrispImage Grid.Column="0" Moniker="{Binding StatusImageMoniker}" />
-                <TextBlock Grid.Column="1" Text="{Binding StatusText}" />
+                <TextBlock Grid.Column="1" Text="{Binding StatusText}" TextWrapping="Wrap" />
             </Grid>
 
             <TextBlock
                 Text="{Binding SearchText}"
                 Visibility="{Binding ShowSearchText, Converter={StaticResource BooleanToVisibilityConverter}}"
                 FontWeight="Light"
+                TextWrapping="Wrap"
                 VerticalAlignment="Center"
                 Margin="0,0,0,5" />
 
@@ -125,6 +126,7 @@
                 Text="{Binding ElementName=control, Path=SubmitText}"
                 Margin="5, 5, 0, 0"
                 FontStyle="Italic"
+                TextWrapping="Wrap"
                 />
         </StackPanel>
     </Border>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
     /// </summary>
     internal partial class RenameFlyout : InlineRenameAdornment
     {
+        private const int DefaultMinWidth = 200;
+
         private readonly RenameFlyoutViewModel _viewModel;
         private readonly IEditorFormatMap _editorFormatMap;
         private readonly IWpfTextView _textView;
@@ -148,10 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 : desiredLeft;
 
             MaxWidth = _textView.ViewportRight;
-            if (MinWidth > _textView.ViewportWidth)
-            {
-                MinWidth = _textView.ViewportWidth;
-            }
+            MinWidth = Math.Min(DefaultMinWidth, _textView.ViewportWidth);
 
             Canvas.SetTop(this, Math.Max(0, top));
             Canvas.SetLeft(this, Math.Max(0, left));

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -147,8 +147,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 ? _textView.ViewportRight - width
                 : desiredLeft;
 
-            Canvas.SetTop(this, top);
-            Canvas.SetLeft(this, left);
+            MaxWidth = _textView.ViewportRight;
+            if (MinWidth > _textView.ViewportWidth)
+            {
+                MinWidth = _textView.ViewportWidth;
+            }
+
+            Canvas.SetTop(this, Math.Max(0, top));
+            Canvas.SetLeft(this, Math.Max(0, left));
         }
 
         public override void Dispose()


### PR DESCRIPTION
# Problem

Rename flyout is being cropped on small screens. The issue being that:
1. The flyout is larger than the document's view port
2. The flyout's left position is negative (which makes it disappear to the left).
3. Text within the flyout doesn't wrap.

![image](https://github.com/user-attachments/assets/c33a2b34-a942-409b-b87b-7016445a1df2)

# Solution

Basically, address all of the above:
1. Limit the size of the flyout to the width of the document's view port.
2. Ensure the flyout's position is always positive.
3. Wrap text blocks.

![image](https://github.com/user-attachments/assets/d09f4013-f440-4c6d-8f2e-5d8064bc48d1)
