### PR TITLE
Dictionary expressions: support concrete target types that do not use `[CollectionBuilder]`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ReadOnlySpan,
         CollectionBuilder,
         ImplementsIEnumerable,
+        ImplementsIEnumerableWithIndexer,
         ArrayInterface,
         DictionaryInterface,
     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -890,7 +890,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
-                // PROTOTYPE: Handle input type inference for key:value elements.
+                // PROTOTYPE: Handle output type inference for key:value elements.
                 if (element is BoundExpression expression)
                 {
                     MakeOutputTypeInferences(binder, expression, targetElementType, ref useSiteInfo);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1920,10 +1920,12 @@
     <Field Name="CollectionTypeKind" Type="CollectionExpressionTypeKind"/>
     <!-- An expression placeholder value representing the initialized collection. -->
     <Field Name="Placeholder" Type="BoundObjectOrCollectionValuePlaceholder?" Null="allow" SkipInVisitor="true"/>
-    <!-- Constructor call to create the empty collection type. -->
+    <!-- Constructor or factory method call to create the collection instance. -->
     <Field Name="CollectionCreation" Type="BoundExpression?" Null="allow" SkipInVisitor="true"/>
     <!-- Placeholder for collection builder elements span. -->
     <Field Name="CollectionBuilderSpanPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
+    <!-- Indexer setter used to set items for dictionary. -->
+    <Field Name="SetMethod" Type="MethodSymbol?" Null="allow"/>
     <!-- Indicates whether the collection expression was successfully target-typed (it is inside a conversion) -->
     <Field Name="WasTargetTyped" Type="bool" />
     <Field Name="UnconvertedCollectionExpression" Type="BoundUnconvertedCollectionExpression" Null="disallow" SkipInVisitor="true"/>
@@ -1944,14 +1946,33 @@
     <Field Name="LengthOrCount" Type="BoundExpression?" SkipInVisitor="true" Null="allow"/>
     <!-- Collection element placeholder, used in IteratorBody. -->
     <Field Name="ElementPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
-    <!-- Statement executed for each collection element. -->
-    <Field Name="IteratorBody" Type="BoundStatement?" SkipInVisitor="true" Null="allow"/>
+    <!-- Code executed for each collection element. -->
+    <Field Name="IteratorBody" Type="BoundNode?" SkipInVisitor="true" Null="allow"/>
   </Node>
 
   <!-- A key:value pair element within a collection expression. -->
   <Node Name="BoundKeyValuePairElement" Base="BoundNode">
+    <!-- Key expression. -->
     <Field Name="Key" Type="BoundExpression"/>
+    <!-- Value expression. -->
     <Field Name="Value" Type="BoundExpression"/>
+    <!-- Placeholder for Key in assignment. -->
+    <Field Name="KeyPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
+    <!-- Placeholder for Value in assignment. -->
+    <Field Name="ValuePlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
+    <!-- Indexer assignment of key:value pair to containing dictionary. -->
+    <Field Name="IndexerAssignment" Type="BoundExpression?" SkipInVisitor="true" Null="allow"/>
+  </Node>
+
+  <!-- PROTOTYPE: Use more specific name if this is only used for expression elements (where spread elements use BoundAssignmentOperator directly). -->
+  <!-- An assignment of an expression of KeyValuePair&lt;,&gt; type to a dictionary. -->
+  <Node Name="BoundIndexerAssignmentFromExpression" Base="BoundNode">
+    <!-- Expression. -->
+    <Field Name="Expression" Type="BoundExpression"/>
+    <!-- Placeholder for Expression in assignment. -->
+    <Field Name="ExpressionPlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
+    <!-- Indexer assignment of Key and Value properties of Expression to containing dictionary. -->
+    <Field Name="IndexerAssignment" Type="BoundExpression" SkipInVisitor="true"/>
   </Node>
 
   <!-- Unconverted collection expression arguments. -->
@@ -1961,7 +1982,7 @@
     <Field Name="ArgumentRefKindsOpt" Type="ImmutableArray&lt;RefKind&gt;" Null="allow"/>
     <Field Name="Binder" Type="Binder" Null="disallow"/>
   </Node>
-  
+
   <!-- 
   Tuple literals can exist in two forms - literal and converted literal.
   This is the base node for both forms.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2113,6 +2113,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitIndexerAssignmentFromExpression(BoundIndexerAssignmentFromExpression node)
+        {
+            VisitRvalue(node.Expression);
+            return null;
+        }
+
         public override BoundNode VisitNewT(BoundNewT node)
         {
             VisitRvalue(node.InitializerExpressionOpt);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3795,6 +3795,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         VisitRvalue(keyValuePair.Value);
                         // PROTOTYPE: Check nullability from conversions of key and value.
                         break;
+                    case BoundIndexerAssignmentFromExpression indexerAssignment:
+                        VisitRvalue(indexerAssignment.Expression);
+                        // PROTOTYPE: Check nullability from conversions of key and value.
+                        break;
                     default:
                         var elementExpr = (BoundExpression)element;
                         if (!targetElementType.HasType)

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -192,6 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         CollectionExpressionSpreadExpressionPlaceholder,
         CollectionExpressionSpreadElement,
         KeyValuePairElement,
+        IndexerAssignmentFromExpression,
         CollectionExpressionWithElement,
         TupleLiteral,
         ConvertedTupleLiteral,
@@ -6433,7 +6434,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundCollectionExpression : BoundCollectionExpressionBase
     {
-        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, BoundValuePlaceholder? collectionBuilderSpanPlaceholder, bool wasTargetTyped, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type, bool hasErrors = false)
+        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, BoundValuePlaceholder? collectionBuilderSpanPlaceholder, MethodSymbol? setMethod, bool wasTargetTyped, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.CollectionExpression, syntax, elements, type, hasErrors || placeholder.HasErrors() || collectionCreation.HasErrors() || collectionBuilderSpanPlaceholder.HasErrors() || unconvertedCollectionExpression.HasErrors() || elements.HasErrors())
         {
 
@@ -6445,6 +6446,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Placeholder = placeholder;
             this.CollectionCreation = collectionCreation;
             this.CollectionBuilderSpanPlaceholder = collectionBuilderSpanPlaceholder;
+            this.SetMethod = setMethod;
             this.WasTargetTyped = wasTargetTyped;
             this.UnconvertedCollectionExpression = unconvertedCollectionExpression;
         }
@@ -6454,17 +6456,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundObjectOrCollectionValuePlaceholder? Placeholder { get; }
         public BoundExpression? CollectionCreation { get; }
         public BoundValuePlaceholder? CollectionBuilderSpanPlaceholder { get; }
+        public MethodSymbol? SetMethod { get; }
         public bool WasTargetTyped { get; }
         public BoundUnconvertedCollectionExpression UnconvertedCollectionExpression { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitCollectionExpression(this);
 
-        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, BoundValuePlaceholder? collectionBuilderSpanPlaceholder, bool wasTargetTyped, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type)
+        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, BoundValuePlaceholder? collectionBuilderSpanPlaceholder, MethodSymbol? setMethod, bool wasTargetTyped, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type)
         {
-            if (collectionTypeKind != this.CollectionTypeKind || placeholder != this.Placeholder || collectionCreation != this.CollectionCreation || collectionBuilderSpanPlaceholder != this.CollectionBuilderSpanPlaceholder || wasTargetTyped != this.WasTargetTyped || unconvertedCollectionExpression != this.UnconvertedCollectionExpression || elements != this.Elements || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (collectionTypeKind != this.CollectionTypeKind || placeholder != this.Placeholder || collectionCreation != this.CollectionCreation || collectionBuilderSpanPlaceholder != this.CollectionBuilderSpanPlaceholder || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(setMethod, this.SetMethod) || wasTargetTyped != this.WasTargetTyped || unconvertedCollectionExpression != this.UnconvertedCollectionExpression || elements != this.Elements || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundCollectionExpression(this.Syntax, collectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, wasTargetTyped, unconvertedCollectionExpression, elements, type, this.HasErrors);
+                var result = new BoundCollectionExpression(this.Syntax, collectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, setMethod, wasTargetTyped, unconvertedCollectionExpression, elements, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -6502,7 +6505,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundCollectionExpressionSpreadElement : BoundNode
     {
-        public BoundCollectionExpressionSpreadElement(SyntaxNode syntax, BoundExpression expression, BoundCollectionExpressionSpreadExpressionPlaceholder? expressionPlaceholder, BoundExpression? conversion, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundExpression? lengthOrCount, BoundValuePlaceholder? elementPlaceholder, BoundStatement? iteratorBody, bool hasErrors = false)
+        public BoundCollectionExpressionSpreadElement(SyntaxNode syntax, BoundExpression expression, BoundCollectionExpressionSpreadExpressionPlaceholder? expressionPlaceholder, BoundExpression? conversion, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundExpression? lengthOrCount, BoundValuePlaceholder? elementPlaceholder, BoundNode? iteratorBody, bool hasErrors = false)
             : base(BoundKind.CollectionExpressionSpreadElement, syntax, hasErrors || expression.HasErrors() || expressionPlaceholder.HasErrors() || conversion.HasErrors() || lengthOrCount.HasErrors() || elementPlaceholder.HasErrors() || iteratorBody.HasErrors())
         {
 
@@ -6523,12 +6526,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public ForEachEnumeratorInfo? EnumeratorInfoOpt { get; }
         public BoundExpression? LengthOrCount { get; }
         public BoundValuePlaceholder? ElementPlaceholder { get; }
-        public BoundStatement? IteratorBody { get; }
+        public BoundNode? IteratorBody { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitCollectionExpressionSpreadElement(this);
 
-        public BoundCollectionExpressionSpreadElement Update(BoundExpression expression, BoundCollectionExpressionSpreadExpressionPlaceholder? expressionPlaceholder, BoundExpression? conversion, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundExpression? lengthOrCount, BoundValuePlaceholder? elementPlaceholder, BoundStatement? iteratorBody)
+        public BoundCollectionExpressionSpreadElement Update(BoundExpression expression, BoundCollectionExpressionSpreadExpressionPlaceholder? expressionPlaceholder, BoundExpression? conversion, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundExpression? lengthOrCount, BoundValuePlaceholder? elementPlaceholder, BoundNode? iteratorBody)
         {
             if (expression != this.Expression || expressionPlaceholder != this.ExpressionPlaceholder || conversion != this.Conversion || enumeratorInfoOpt != this.EnumeratorInfoOpt || lengthOrCount != this.LengthOrCount || elementPlaceholder != this.ElementPlaceholder || iteratorBody != this.IteratorBody)
             {
@@ -6542,8 +6545,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundKeyValuePairElement : BoundNode
     {
-        public BoundKeyValuePairElement(SyntaxNode syntax, BoundExpression key, BoundExpression value, bool hasErrors = false)
-            : base(BoundKind.KeyValuePairElement, syntax, hasErrors || key.HasErrors() || value.HasErrors())
+        public BoundKeyValuePairElement(SyntaxNode syntax, BoundExpression key, BoundExpression value, BoundValuePlaceholder? keyPlaceholder, BoundValuePlaceholder? valuePlaceholder, BoundExpression? indexerAssignment, bool hasErrors = false)
+            : base(BoundKind.KeyValuePairElement, syntax, hasErrors || key.HasErrors() || value.HasErrors() || keyPlaceholder.HasErrors() || valuePlaceholder.HasErrors() || indexerAssignment.HasErrors())
         {
 
             RoslynDebug.Assert(key is object, "Field 'key' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
@@ -6551,19 +6554,59 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.Key = key;
             this.Value = value;
+            this.KeyPlaceholder = keyPlaceholder;
+            this.ValuePlaceholder = valuePlaceholder;
+            this.IndexerAssignment = indexerAssignment;
         }
 
         public BoundExpression Key { get; }
         public BoundExpression Value { get; }
+        public BoundValuePlaceholder? KeyPlaceholder { get; }
+        public BoundValuePlaceholder? ValuePlaceholder { get; }
+        public BoundExpression? IndexerAssignment { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitKeyValuePairElement(this);
 
-        public BoundKeyValuePairElement Update(BoundExpression key, BoundExpression value)
+        public BoundKeyValuePairElement Update(BoundExpression key, BoundExpression value, BoundValuePlaceholder? keyPlaceholder, BoundValuePlaceholder? valuePlaceholder, BoundExpression? indexerAssignment)
         {
-            if (key != this.Key || value != this.Value)
+            if (key != this.Key || value != this.Value || keyPlaceholder != this.KeyPlaceholder || valuePlaceholder != this.ValuePlaceholder || indexerAssignment != this.IndexerAssignment)
             {
-                var result = new BoundKeyValuePairElement(this.Syntax, key, value, this.HasErrors);
+                var result = new BoundKeyValuePairElement(this.Syntax, key, value, keyPlaceholder, valuePlaceholder, indexerAssignment, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundIndexerAssignmentFromExpression : BoundNode
+    {
+        public BoundIndexerAssignmentFromExpression(SyntaxNode syntax, BoundExpression expression, BoundValuePlaceholder expressionPlaceholder, BoundExpression indexerAssignment, bool hasErrors = false)
+            : base(BoundKind.IndexerAssignmentFromExpression, syntax, hasErrors || expression.HasErrors() || expressionPlaceholder.HasErrors() || indexerAssignment.HasErrors())
+        {
+
+            RoslynDebug.Assert(expression is object, "Field 'expression' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(expressionPlaceholder is object, "Field 'expressionPlaceholder' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(indexerAssignment is object, "Field 'indexerAssignment' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.Expression = expression;
+            this.ExpressionPlaceholder = expressionPlaceholder;
+            this.IndexerAssignment = indexerAssignment;
+        }
+
+        public BoundExpression Expression { get; }
+        public BoundValuePlaceholder ExpressionPlaceholder { get; }
+        public BoundExpression IndexerAssignment { get; }
+
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitIndexerAssignmentFromExpression(this);
+
+        public BoundIndexerAssignmentFromExpression Update(BoundExpression expression, BoundValuePlaceholder expressionPlaceholder, BoundExpression indexerAssignment)
+        {
+            if (expression != this.Expression || expressionPlaceholder != this.ExpressionPlaceholder || indexerAssignment != this.IndexerAssignment)
+            {
+                var result = new BoundIndexerAssignmentFromExpression(this.Syntax, expression, expressionPlaceholder, indexerAssignment, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -9274,6 +9317,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitCollectionExpressionSpreadElement((BoundCollectionExpressionSpreadElement)node, arg);
                 case BoundKind.KeyValuePairElement:
                     return VisitKeyValuePairElement((BoundKeyValuePairElement)node, arg);
+                case BoundKind.IndexerAssignmentFromExpression:
+                    return VisitIndexerAssignmentFromExpression((BoundIndexerAssignmentFromExpression)node, arg);
                 case BoundKind.CollectionExpressionWithElement:
                     return VisitCollectionExpressionWithElement((BoundCollectionExpressionWithElement)node, arg);
                 case BoundKind.TupleLiteral:
@@ -9578,6 +9623,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitKeyValuePairElement(BoundKeyValuePairElement node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitIndexerAssignmentFromExpression(BoundIndexerAssignmentFromExpression node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitCollectionExpressionWithElement(BoundCollectionExpressionWithElement node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitTupleLiteral(BoundTupleLiteral node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node, A arg) => this.DefaultVisit(node, arg);
@@ -9816,6 +9862,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitKeyValuePairElement(BoundKeyValuePairElement node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitIndexerAssignmentFromExpression(BoundIndexerAssignmentFromExpression node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitCollectionExpressionWithElement(BoundCollectionExpressionWithElement node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitTupleLiteral(BoundTupleLiteral node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node) => this.DefaultVisit(node);
@@ -10613,6 +10660,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             this.Visit(node.Key);
             this.Visit(node.Value);
+            return null;
+        }
+        public override BoundNode? VisitIndexerAssignmentFromExpression(BoundIndexerAssignmentFromExpression node)
+        {
+            this.Visit(node.Expression);
             return null;
         }
         public override BoundNode? VisitCollectionExpressionWithElement(BoundCollectionExpressionWithElement node)
@@ -11902,7 +11954,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundUnconvertedCollectionExpression unconvertedCollectionExpression = node.UnconvertedCollectionExpression;
             ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, node.WasTargetTyped, unconvertedCollectionExpression, elements, type);
+            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, node.SetMethod, node.WasTargetTyped, unconvertedCollectionExpression, elements, type);
         }
         public override BoundNode? VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node)
         {
@@ -11916,14 +11968,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? conversion = node.Conversion;
             BoundExpression? lengthOrCount = node.LengthOrCount;
             BoundValuePlaceholder? elementPlaceholder = node.ElementPlaceholder;
-            BoundStatement? iteratorBody = node.IteratorBody;
+            BoundNode? iteratorBody = node.IteratorBody;
             return node.Update(expression, expressionPlaceholder, conversion, node.EnumeratorInfoOpt, lengthOrCount, elementPlaceholder, iteratorBody);
         }
         public override BoundNode? VisitKeyValuePairElement(BoundKeyValuePairElement node)
         {
             BoundExpression key = (BoundExpression)this.Visit(node.Key);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(key, value);
+            BoundValuePlaceholder? keyPlaceholder = node.KeyPlaceholder;
+            BoundValuePlaceholder? valuePlaceholder = node.ValuePlaceholder;
+            BoundExpression? indexerAssignment = node.IndexerAssignment;
+            return node.Update(key, value, keyPlaceholder, valuePlaceholder, indexerAssignment);
+        }
+        public override BoundNode? VisitIndexerAssignmentFromExpression(BoundIndexerAssignmentFromExpression node)
+        {
+            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
+            BoundValuePlaceholder expressionPlaceholder = node.ExpressionPlaceholder;
+            BoundExpression indexerAssignment = node.IndexerAssignment;
+            return node.Update(expression, expressionPlaceholder, indexerAssignment);
         }
         public override BoundNode? VisitCollectionExpressionWithElement(BoundCollectionExpressionWithElement node)
         {
@@ -14169,6 +14231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
+            MethodSymbol? setMethod = GetUpdatedSymbol(node, node.SetMethod);
             BoundObjectOrCollectionValuePlaceholder? placeholder = node.Placeholder;
             BoundExpression? collectionCreation = node.CollectionCreation;
             BoundValuePlaceholder? collectionBuilderSpanPlaceholder = node.CollectionBuilderSpanPlaceholder;
@@ -14178,12 +14241,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, node.WasTargetTyped, unconvertedCollectionExpression, elements, infoAndType.Type!);
+                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, setMethod, node.WasTargetTyped, unconvertedCollectionExpression, elements, infoAndType.Type!);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, node.WasTargetTyped, unconvertedCollectionExpression, elements, node.Type);
+                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderSpanPlaceholder, setMethod, node.WasTargetTyped, unconvertedCollectionExpression, elements, node.Type);
             }
             return updatedNode;
         }
@@ -16599,6 +16662,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("placeholder", null, new TreeDumperNode[] { Visit(node.Placeholder, null) }),
             new TreeDumperNode("collectionCreation", null, new TreeDumperNode[] { Visit(node.CollectionCreation, null) }),
             new TreeDumperNode("collectionBuilderSpanPlaceholder", null, new TreeDumperNode[] { Visit(node.CollectionBuilderSpanPlaceholder, null) }),
+            new TreeDumperNode("setMethod", node.SetMethod, null),
             new TreeDumperNode("wasTargetTyped", node.WasTargetTyped, null),
             new TreeDumperNode("unconvertedCollectionExpression", null, new TreeDumperNode[] { Visit(node.UnconvertedCollectionExpression, null) }),
             new TreeDumperNode("elements", null, from x in node.Elements select Visit(x, null)),
@@ -16630,6 +16694,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             new TreeDumperNode("key", null, new TreeDumperNode[] { Visit(node.Key, null) }),
             new TreeDumperNode("value", null, new TreeDumperNode[] { Visit(node.Value, null) }),
+            new TreeDumperNode("keyPlaceholder", null, new TreeDumperNode[] { Visit(node.KeyPlaceholder, null) }),
+            new TreeDumperNode("valuePlaceholder", null, new TreeDumperNode[] { Visit(node.ValuePlaceholder, null) }),
+            new TreeDumperNode("indexerAssignment", null, new TreeDumperNode[] { Visit(node.IndexerAssignment, null) }),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
+        public override TreeDumperNode VisitIndexerAssignmentFromExpression(BoundIndexerAssignmentFromExpression node, object? arg) => new TreeDumperNode("indexerAssignmentFromExpression", null, new TreeDumperNode[]
+        {
+            new TreeDumperNode("expression", null, new TreeDumperNode[] { Visit(node.Expression, null) }),
+            new TreeDumperNode("expressionPlaceholder", null, new TreeDumperNode[] { Visit(node.ExpressionPlaceholder, null) }),
+            new TreeDumperNode("indexerAssignment", null, new TreeDumperNode[] { Visit(node.IndexerAssignment, null) }),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -60,6 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
                         return VisitCollectionInitializerCollectionExpression(node, node.Type);
+                    case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
+                        return VisitDictionaryExpression(node, (NamedTypeSymbol)node.Type);
                     case CollectionExpressionTypeKind.Array:
                     case CollectionExpressionTypeKind.Span:
                     case CollectionExpressionTypeKind.ReadOnlySpan:
@@ -481,14 +483,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(_diagnostics.DiagnosticBag is { });
             Debug.Assert(node.Type is NamedTypeSymbol);
             Debug.Assert(node.CollectionCreation is null);
-            Debug.Assert(node.Placeholder is null);
+            Debug.Assert(node.Placeholder is { });
 
-            var collectionType = (NamedTypeSymbol)node.Type;
-            var typeArguments = collectionType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
-            var elements = node.Elements;
+            var interfaceType = (NamedTypeSymbol)node.Type;
+            var typeArguments = interfaceType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+            var collectionType = _factory.WellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV).Construct(typeArguments);
+
             // PROTOTYPE: Create a custom interface implementation for IReadOnlyDictionary<K, V> to enforce immutability?
-            var collection = CreateAndPopulateDictionary(node, typeArguments, elements);
-            return _factory.Convert(collectionType, collection);
+            // Dictionary<K, V> dictionary = new();
+            var constructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor)).AsMember(collectionType);
+            var rewrittenReceiver = _factory.New(constructor, ImmutableArray<BoundExpression>.Empty);
+
+            var collection = PopulateDictionary(node, collectionType, rewrittenReceiver);
+            return _factory.Convert(node.Type, collection);
         }
 
         private BoundExpression VisitCollectionBuilderCollectionExpression(BoundCollectionExpression node)
@@ -1205,22 +1212,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionType);
         }
 
-        /// <summary>
-        /// Create and populate a dictionary from a collection expression.
-        /// The collection may or may not have a known length.
-        /// </summary>
-        private BoundExpression CreateAndPopulateDictionary(BoundCollectionExpression node, ImmutableArray<TypeWithAnnotations> typeArguments, ImmutableArray<BoundNode> elements)
+        private BoundExpression VisitDictionaryExpression(BoundCollectionExpression node, NamedTypeSymbol collectionType)
         {
             Debug.Assert(!_inExpressionLambda);
 
-            var collectionType = _factory.WellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV).Construct(typeArguments);
+            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
+            Debug.Assert(rewrittenReceiver is { });
+            return PopulateDictionary(node, collectionType, rewrittenReceiver);
+        }
 
+        /// <summary>
+        /// Populate a dictionary from a collection expression.
+        /// The collection may or may not have a known length.
+        /// </summary>
+        private BoundExpression PopulateDictionary(BoundCollectionExpression node, NamedTypeSymbol collectionType, BoundExpression rewrittenReceiver)
+        {
+            var elements = node.Elements;
             var localsBuilder = ArrayBuilder<BoundLocal>.GetInstance();
-            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance(elements.Length + 1);
-
-            // Dictionary<K, V> dictionary = new();
-            var constructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor)).AsMember(collectionType);
-            BoundObjectCreationExpression rewrittenReceiver = _factory.New(constructor, ImmutableArray<BoundExpression>.Empty);
+            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance(elements.Length + 1); // PROTOTYPE: Is this length correct?
 
             // Create a temp for the dictionary.
             BoundAssignmentOperator assignmentToTemp;
@@ -1228,10 +1237,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             localsBuilder.Add(dictionaryTemp);
             sideEffects.Add(assignmentToTemp);
 
+            var placeholder = node.Placeholder;
+            Debug.Assert(placeholder is { });
+
+            AddPlaceholderReplacement(placeholder, dictionaryTemp);
+
             var setItemMethod = _factory.WellKnownMethod(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item).AsMember(collectionType);
-            for (int i = 0; i < elements.Length; i++)
+            foreach (var element in elements)
             {
-                var element = elements[i];
                 switch (element)
                 {
                     case BoundKeyValuePairElement keyValuePairElement:
@@ -1242,36 +1255,39 @@ namespace Microsoft.CodeAnalysis.CSharp
                             sideEffects.Add(_factory.Call(dictionaryTemp, setItemMethod, rewrittenKey, rewrittenValue));
                         }
                         break;
-                    case BoundCollectionExpressionSpreadElement spreadElement:
-                        var rewrittenExpression = VisitExpression(spreadElement.Expression);
-                        var rewrittenElement = MakeCollectionExpressionSpreadElement(
-                            spreadElement,
-                            rewrittenExpression,
-                            iteratorBody =>
-                            {
-                                // dictionary[item.Key] = item.Value;
-                                var expression = ((BoundExpressionStatement)iteratorBody).Expression;
-                                var builder = ArrayBuilder<BoundExpression>.GetInstance();
-                                var (rewrittenKey, rewrittenValue) = RewriteKeyValuePair(expression, setItemMethod, builder, localsBuilder);
-                                builder.Add(_factory.Call(dictionaryTemp, setItemMethod, rewrittenKey, rewrittenValue));
-                                var statements = builder.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));
-                                builder.Free();
-                                Debug.Assert(statements.Length > 0);
-                                return statements.Length == 1 ?
-                                    statements[0] :
-                                    new BoundBlock(iteratorBody.Syntax, locals: ImmutableArray<LocalSymbol>.Empty, statements);
-                            });
-                        sideEffects.Add(rewrittenElement);
-                        break;
-                    default:
+                    case BoundIndexerAssignmentFromExpression indexerAssignment:
                         {
                             // dictionary[element.Key] = element.Value;
-                            var (rewrittenKey, rewrittenValue) = RewriteKeyValuePair((BoundExpression)element, setItemMethod, sideEffects, localsBuilder);
-                            sideEffects.Add(_factory.Call(dictionaryTemp, setItemMethod, rewrittenKey, rewrittenValue));
+                            var rewrittenExpression = VisitExpression(indexerAssignment.Expression);
+                            BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+                            localsBuilder.Add(exprTemp);
+                            sideEffects.Add(assignmentToTemp);
+                            AddPlaceholderReplacement(indexerAssignment.ExpressionPlaceholder, exprTemp);
+                            sideEffects.Add(VisitExpression(indexerAssignment.IndexerAssignment));
+                            RemovePlaceholderReplacement(indexerAssignment.ExpressionPlaceholder);
                         }
                         break;
+                    case BoundCollectionExpressionSpreadElement spreadElement:
+                        {
+                            var rewrittenExpression = VisitExpression(spreadElement.Expression);
+                            var rewrittenElement = MakeCollectionExpressionSpreadElement(
+                                spreadElement,
+                                rewrittenExpression,
+                                iteratorBody =>
+                                {
+                                    // dictionary[item.Key] = item.Value;
+                                    var expr = VisitExpression(((BoundExpressionStatement)iteratorBody).Expression);
+                                    return new BoundExpressionStatement(expr.Syntax, expr);
+                                });
+                            sideEffects.Add(rewrittenElement);
+                        }
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(element);
                 }
             }
+
+            RemovePlaceholderReplacement(placeholder);
 
             var locals = localsBuilder.SelectAsArray(l => l.LocalSymbol);
             localsBuilder.Free();
@@ -1282,31 +1298,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 sideEffects.ToImmutableAndFree(),
                 dictionaryTemp,
                 collectionType);
-        }
-
-        private (BoundExpression, BoundExpression) RewriteKeyValuePair(
-            BoundExpression expression,
-            MethodSymbol addMethod,
-            ArrayBuilder<BoundExpression> sideEffects,
-            ArrayBuilder<BoundLocal> localsBuilder)
-        {
-            Debug.Assert(expression.Type is { });
-
-            var sourceType = (NamedTypeSymbol)expression.Type;
-            if (!ConversionsBase.IsKeyValuePairType(_compilation, sourceType, WellKnownType.System_Collections_Generic_KeyValuePair_KV, out var sourceKeyType, out var sourceValueType))
-            {
-                throw ExceptionUtilities.UnexpectedValue(expression.Type);
-            }
-
-            BoundAssignmentOperator assignmentToTemp;
-            BoundLocal expressionTemp = _factory.StoreToTemp(VisitExpression(expression), out assignmentToTemp);
-            localsBuilder.Add(expressionTemp);
-            sideEffects.Add(assignmentToTemp);
-            var getKeyMethod = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key)).AsMember(sourceType);
-            var getValueMethod = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value)).AsMember(sourceType);
-            Debug.Assert(ConversionsBase.HasIdentityConversion(getKeyMethod.ReturnType, addMethod.Parameters[0].Type));
-            Debug.Assert(ConversionsBase.HasIdentityConversion(getValueMethod.ReturnType, addMethod.Parameters[1].Type));
-            return (_factory.Call(expressionTemp, getKeyMethod), _factory.Call(expressionTemp, getValueMethod));
         }
 
         private BoundExpression RewriteCollectionExpressionElementExpression(BoundNode element)
@@ -1430,7 +1421,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression MakeCollectionExpressionSpreadElement(
             BoundCollectionExpressionSpreadElement node,
             BoundExpression rewrittenExpression,
-            Func<BoundStatement, BoundStatement> rewriteBody)
+            Func<BoundNode, BoundStatement> rewriteBody)
         {
             var enumeratorInfo = node.EnumeratorInfoOpt;
             var convertedExpression = (BoundConversion?)node.Conversion;


### PR DESCRIPTION
Proposal: [dictionary-expressions.md](https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#conversions)