### PR TITLE
Do not offer 'extract interface' on an extension type

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.ExtractInterface;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Extensions;
@@ -2086,5 +2087,25 @@ public sealed class ExtractInterfaceTests : AbstractExtractInterfaceTests
             """;
 
         await TestExtractInterfaceCodeActionCSharpAsync(markup, expectedMarkup);
+    }
+
+    [WpfFact]
+    public async Task ExtractInterface_Invocation_FromExtension()
+    {
+        var markup = """
+            using System;
+
+            static class C
+            {
+                $$extension(string s)
+                {
+                    public void Goo() { }
+                }
+            }
+            """;
+
+        await TestExtractInterfaceCommandCSharpAsync(
+            markup, expectedSuccess: false,
+            parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
     }
 }

--- a/src/EditorFeatures/TestUtilities/ExtractInterface/AbstractExtractInterfaceTests.cs
+++ b/src/EditorFeatures/TestUtilities/ExtractInterface/AbstractExtractInterfaceTests.cs
@@ -26,7 +26,8 @@ public abstract class AbstractExtractInterfaceTests
         string expectedNamespaceName = null,
         string expectedTypeParameterSuffix = null,
         string expectedUpdatedOriginalDocumentCode = null,
-        string expectedInterfaceCode = null)
+        string expectedInterfaceCode = null,
+        ParseOptions parseOptions = null)
     {
         await TestExtractInterfaceCommandAsync(
             markup,
@@ -37,7 +38,8 @@ public abstract class AbstractExtractInterfaceTests
             expectedNamespaceName,
             expectedTypeParameterSuffix,
             expectedUpdatedOriginalDocumentCode,
-            expectedInterfaceCode);
+            expectedInterfaceCode,
+            parseOptions: parseOptions);
     }
 
     public static async Task TestExtractInterfaceCodeActionCSharpAsync(
@@ -94,9 +96,11 @@ public abstract class AbstractExtractInterfaceTests
         string expectedTypeParameterSuffix = null,
         string expectedUpdatedOriginalDocumentCode = null,
         string expectedInterfaceCode = null,
-        CompilationOptions compilationOptions = null)
+        CompilationOptions compilationOptions = null,
+        ParseOptions parseOptions = null)
     {
-        using var testState = ExtractInterfaceTestState.Create(markup, languageName, compilationOptions,
+        using var testState = ExtractInterfaceTestState.Create(
+            markup, languageName, compilationOptions, parseOptions,
             options: new OptionsCollection(languageName)
             {
                 { CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.Never, NotificationOption2.Silent }
@@ -112,7 +116,7 @@ public abstract class AbstractExtractInterfaceTests
 
             if (expectedMemberName != null)
             {
-                Assert.Equal(1, testState.TestExtractInterfaceOptionsService.AllExtractableMembers.Count());
+                Assert.Equal(1, testState.TestExtractInterfaceOptionsService.AllExtractableMembers.Length);
                 Assert.Equal(expectedMemberName, testState.TestExtractInterfaceOptionsService.AllExtractableMembers.Single().Name);
             }
 

--- a/src/EditorFeatures/TestUtilities/ExtractInterface/TestExtractInterfaceOptions.cs
+++ b/src/EditorFeatures/TestUtilities/ExtractInterface/TestExtractInterfaceOptions.cs
@@ -6,8 +6,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
-using System.Threading;
 using Microsoft.CodeAnalysis.ExtractInterface;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class TestExtractInterfaceOptionsService() : IExtractInterfaceOptionsService
 {
-    public IEnumerable<ISymbol> AllExtractableMembers { get; private set; }
+    public ImmutableArray<ISymbol> AllExtractableMembers { get; private set; }
     public string DefaultInterfaceName { get; private set; }
     public List<string> ConflictingTypeNames { get; private set; }
     public string DefaultNamespace { get; private set; }
@@ -32,12 +32,11 @@ internal sealed class TestExtractInterfaceOptionsService() : IExtractInterfaceOp
 
     public ExtractInterfaceOptionsResult GetExtractInterfaceOptions(
         Document document,
-        List<ISymbol> extractableMembers,
+        ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
         List<string> conflictingTypeNames,
         string defaultNamespace,
-        string generatedNameTypeParameterSuffix,
-        CancellationToken cancellationToken)
+        string generatedNameTypeParameterSuffix)
     {
         this.AllExtractableMembers = extractableMembers;
         this.DefaultInterfaceName = defaultInterfaceName;

--- a/src/EditorFeatures/TestUtilities/ExtractInterface/TestExtractInterfaceOptions.cs
+++ b/src/EditorFeatures/TestUtilities/ExtractInterface/TestExtractInterfaceOptions.cs
@@ -20,7 +20,7 @@ internal sealed class TestExtractInterfaceOptionsService() : IExtractInterfaceOp
 {
     public ImmutableArray<ISymbol> AllExtractableMembers { get; private set; }
     public string DefaultInterfaceName { get; private set; }
-    public List<string> ConflictingTypeNames { get; private set; }
+    public ImmutableArray<string> ConflictingTypeNames { get; private set; }
     public string DefaultNamespace { get; private set; }
     public string GeneratedNameTypeParameterSuffix { get; set; }
 
@@ -34,7 +34,7 @@ internal sealed class TestExtractInterfaceOptionsService() : IExtractInterfaceOp
         Document document,
         ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
-        List<string> conflictingTypeNames,
+        ImmutableArray<string> conflictingTypeNames,
         string defaultNamespace,
         string generatedNameTypeParameterSuffix)
     {

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -51,6 +51,11 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
         if (typeDeclaration is RecordDeclarationSyntax)
             return;
 
+        // Extensions use the .ParameterList to represent the parameters of the extension method.  But this is not a
+        // constructor, and we cannot offer to convert it to have a regular constructor.
+        if (typeDeclaration is ExtensionDeclarationSyntax)
+            return;
+
         var triggerSpan = TextSpan.FromBounds(typeDeclaration.SpanStart, typeDeclaration.ParameterList.FullSpan.End);
         if (!triggerSpan.Contains(span))
             return;

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -5,6 +5,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.ConvertPrimaryToRegularConstructor;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
@@ -2736,6 +2737,24 @@ public sealed class ConvertPrimaryToRegularConstructorTests
 
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotOnExtension()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class Class1
+                {
+                    [|extension(string s)|]
+                    {
+                        public void Goo() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 }

--- a/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
@@ -85,7 +85,8 @@ internal sealed class ExtractClassWithDialogCodeAction(
             _selectedType.IsRecord,
             TypeKind.Class,
             extractClassOptions.TypeName,
-            typeParameters: ExtractTypeHelpers.GetRequiredTypeParametersForMembers(_selectedType, extractClassOptions.MemberAnalysisResults.Select(m => m.Member)));
+            typeParameters: ExtractTypeHelpers.GetRequiredTypeParametersForMembers(
+                _selectedType, extractClassOptions.MemberAnalysisResults.SelectAsArray(m => m.Member)));
 
         var containingNamespaceDisplay = namespaceService.GetContainingNamespaceDisplay(
             _selectedType,

--- a/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
@@ -259,7 +259,7 @@ internal abstract class AbstractExtractInterfaceService : ILanguageService
         SyntaxFormattingOptions formattingOptions,
         CancellationToken cancellationToken)
     {
-        var conflictingTypeNames = type.ContainingNamespace.GetAllTypes(cancellationToken).Select(t => t.Name);
+        var conflictingTypeNames = type.ContainingNamespace.GetAllTypes(cancellationToken).SelectAsArray(t => t.Name);
         var candidateInterfaceName = type.TypeKind == TypeKind.Interface ? type.Name : "I" + type.Name;
         var defaultInterfaceName = NameGenerator.GenerateUniqueName(candidateInterfaceName, name => !conflictingTypeNames.Contains(name));
         var generatedNameTypeParameterSuffix = ExtractTypeHelpers.GetTypeParameterSuffix(document, formattingOptions, type, extractableMembers, cancellationToken);
@@ -269,7 +269,7 @@ internal abstract class AbstractExtractInterfaceService : ILanguageService
             document,
             extractableMembers,
             defaultInterfaceName,
-            [.. conflictingTypeNames],
+            conflictingTypeNames,
             containingNamespace,
             generatedNameTypeParameterSuffix);
     }

--- a/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceTypeAnalysisResult.cs
+++ b/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceTypeAnalysisResult.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Microsoft.CodeAnalysis.ExtractInterface;
@@ -15,7 +16,7 @@ internal sealed class ExtractInterfaceTypeAnalysisResult
     public readonly Document DocumentToExtractFrom;
     public readonly SyntaxNode TypeNode;
     public readonly INamedTypeSymbol TypeToExtractFrom;
-    public readonly IEnumerable<ISymbol> ExtractableMembers;
+    public readonly ImmutableArray<ISymbol> ExtractableMembers;
     public readonly SyntaxFormattingOptions FormattingOptions;
     public readonly string ErrorMessage;
 
@@ -23,7 +24,7 @@ internal sealed class ExtractInterfaceTypeAnalysisResult
         Document documentToExtractFrom,
         SyntaxNode typeNode,
         INamedTypeSymbol typeToExtractFrom,
-        IEnumerable<ISymbol> extractableMembers,
+        ImmutableArray<ISymbol> extractableMembers,
         SyntaxFormattingOptions formattingOptions)
     {
         CanExtractInterface = true;

--- a/src/Features/Core/Portable/ExtractInterface/IExtractInterfaceOptionsService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/IExtractInterfaceOptionsService.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.ExtractInterface;
@@ -15,7 +13,7 @@ internal interface IExtractInterfaceOptionsService : IWorkspaceService
         Document document,
         ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
-        List<string> conflictingTypeNames,
+        ImmutableArray<string> conflictingTypeNames,
         string defaultNamespace,
         string generatedNameTypeParameterSuffix);
 }

--- a/src/Features/Core/Portable/ExtractInterface/IExtractInterfaceOptionsService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/IExtractInterfaceOptionsService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 
@@ -12,10 +13,9 @@ internal interface IExtractInterfaceOptionsService : IWorkspaceService
 {
     ExtractInterfaceOptionsResult GetExtractInterfaceOptions(
         Document document,
-        List<ISymbol> extractableMembers,
+        ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
         List<string> conflictingTypeNames,
         string defaultNamespace,
-        string generatedNameTypeParameterSuffix,
-        CancellationToken cancellationToken);
+        string generatedNameTypeParameterSuffix);
 }

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -112,7 +112,8 @@ internal static class ExtractTypeHelpers
         return (formattedDocument, typeAnnotation);
     }
 
-    public static string GetTypeParameterSuffix(Document document, SyntaxFormattingOptions formattingOptions, INamedTypeSymbol type, IEnumerable<ISymbol> extractableMembers, CancellationToken cancellationToken)
+    public static string GetTypeParameterSuffix(
+        Document document, SyntaxFormattingOptions formattingOptions, INamedTypeSymbol type, ImmutableArray<ISymbol> extractableMembers, CancellationToken cancellationToken)
     {
         var typeParameters = GetRequiredTypeParametersForMembers(type, extractableMembers);
 
@@ -127,7 +128,8 @@ internal static class ExtractTypeHelpers
         return Formatter.Format(syntaxGenerator.SyntaxGeneratorInternal.TypeParameterList(typeParameterNames), document.Project.Solution.Services, formattingOptions, cancellationToken).ToString();
     }
 
-    public static ImmutableArray<ITypeParameterSymbol> GetRequiredTypeParametersForMembers(INamedTypeSymbol type, IEnumerable<ISymbol> includedMembers)
+    public static ImmutableArray<ITypeParameterSymbol> GetRequiredTypeParametersForMembers(
+        INamedTypeSymbol type, ImmutableArray<ISymbol> includedMembers)
     {
         var potentialTypeParameters = GetPotentialTypeParameters(type);
 
@@ -181,7 +183,8 @@ internal static class ExtractTypeHelpers
         return typeParameters.ToImmutableAndClear();
     }
 
-    private static ImmutableArray<ITypeParameterSymbol> GetDirectlyReferencedTypeParameters(IEnumerable<ITypeParameterSymbol> potentialTypeParameters, IEnumerable<ISymbol> includedMembers)
+    private static ImmutableArray<ITypeParameterSymbol> GetDirectlyReferencedTypeParameters(
+        ImmutableArray<ITypeParameterSymbol> potentialTypeParameters, ImmutableArray<ISymbol> includedMembers)
     {
         using var _ = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var directlyReferencedTypeParameters);
         foreach (var typeParameter in potentialTypeParameters)

--- a/src/Features/ExternalAccess/OmniSharp/Internal/ExtractInterface/OmniSharpExtractInterfaceOptionsService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Internal/ExtractInterface/OmniSharpExtractInterfaceOptionsService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.ExtractInterface;
@@ -22,14 +23,14 @@ internal sealed class OmniSharpExtractInterfaceOptionsService(
 
     public ExtractInterfaceOptionsResult GetExtractInterfaceOptions(
         Document document,
-        List<ISymbol> extractableMembers,
+        ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
         List<string> conflictingTypeNames,
         string defaultNamespace,
-        string generatedNameTypeParameterSuffix,
-        CancellationToken cancellationToken)
+        string generatedNameTypeParameterSuffix)
     {
-        var result = _omniSharpExtractInterfaceOptionsService.GetExtractInterfaceOptions(extractableMembers, defaultInterfaceName);
+        var result = _omniSharpExtractInterfaceOptionsService.GetExtractInterfaceOptions(
+            [.. extractableMembers], defaultInterfaceName);
         return new(
             result.IsCancelled,
             result.IncludedMembers,

--- a/src/Features/ExternalAccess/OmniSharp/Internal/ExtractInterface/OmniSharpExtractInterfaceOptionsService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Internal/ExtractInterface/OmniSharpExtractInterfaceOptionsService.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Threading;
 using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.ExtractInterface;
 using Microsoft.CodeAnalysis.ExtractInterface;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -25,7 +23,7 @@ internal sealed class OmniSharpExtractInterfaceOptionsService(
         Document document,
         ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
-        List<string> conflictingTypeNames,
+        ImmutableArray<string> conflictingTypeNames,
         string defaultNamespace,
         string generatedNameTypeParameterSuffix)
     {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Services/LspExtractInterfaceOptionsService.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Services/LspExtractInterfaceOptionsService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.ExtractInterface;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -15,12 +16,11 @@ internal sealed class LspExtractInterfaceOptionsService() : IExtractInterfaceOpt
 {
     public ExtractInterfaceOptionsResult GetExtractInterfaceOptions(
         Document document,
-        List<ISymbol> extractableMembers,
+        ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
         List<string> conflictingTypeNames,
         string defaultNamespace,
-        string generatedNameTypeParameterSuffix,
-        CancellationToken cancellationToken)
+        string generatedNameTypeParameterSuffix)
     {
         var extension = document.Project.Language == LanguageNames.CSharp ? ".cs" : ".vb";
         return new(

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Services/LspExtractInterfaceOptionsService.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Services/LspExtractInterfaceOptionsService.cs
@@ -18,14 +18,14 @@ internal sealed class LspExtractInterfaceOptionsService() : IExtractInterfaceOpt
         Document document,
         ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
-        List<string> conflictingTypeNames,
+        ImmutableArray<string> conflictingTypeNames,
         string defaultNamespace,
         string generatedNameTypeParameterSuffix)
     {
         var extension = document.Project.Language == LanguageNames.CSharp ? ".cs" : ".vb";
         return new(
             isCancelled: false,
-            [.. extractableMembers],
+            extractableMembers,
             defaultInterfaceName,
             defaultInterfaceName + extension,
             ExtractInterfaceOptionsResult.ExtractLocation.SameFile);

--- a/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialogViewModel.cs
@@ -27,7 +27,7 @@ internal class ExtractInterfaceDialogViewModel : AbstractNotifyPropertyChanged
         IUIThreadOperationExecutor uiThreadOperationExecutor,
         INotificationService notificationService,
         string defaultInterfaceName,
-        List<string> conflictingTypeNames,
+        ImmutableArray<string> conflictingTypeNames,
         ImmutableArray<LanguageServices.Utilities.MemberSymbolViewModel> memberViewModels,
         string defaultNamespace,
         string generatedNameTypeParameterSuffix,
@@ -49,7 +49,7 @@ internal class ExtractInterfaceDialogViewModel : AbstractNotifyPropertyChanged
             languageName,
             defaultNamespace,
             generatedNameTypeParameterSuffix,
-            [.. conflictingTypeNames],
+            conflictingTypeNames,
             syntaxFactsService,
             canAddDocument);
     }

--- a/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialogViewModel.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/ExtractInterface/VisualStudioExtractInterfaceOptionsService.cs
+++ b/src/VisualStudio/Core/Def/ExtractInterface/VisualStudioExtractInterfaceOptionsService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -26,7 +27,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractInterfac
 [ExportWorkspaceService(typeof(IExtractInterfaceOptionsService), ServiceLayer.Host), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class VisualStudioExtractInterfaceOptionsService(IGlyphService glyphService, IThreadingContext threadingContext, IUIThreadOperationExecutor uiThreadOperationExecutor) : IExtractInterfaceOptionsService
+internal sealed class VisualStudioExtractInterfaceOptionsService(
+    IGlyphService glyphService,
+    IThreadingContext threadingContext,
+    IUIThreadOperationExecutor uiThreadOperationExecutor) : IExtractInterfaceOptionsService
 {
     private readonly IGlyphService _glyphService = glyphService;
     private readonly IThreadingContext _threadingContext = threadingContext;
@@ -34,12 +38,11 @@ internal sealed class VisualStudioExtractInterfaceOptionsService(IGlyphService g
 
     public ExtractInterfaceOptionsResult GetExtractInterfaceOptions(
         Document document,
-        List<ISymbol> extractableMembers,
+        ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
         List<string> allTypeNames,
         string defaultNamespace,
-        string generatedNameTypeParameterSuffix,
-        CancellationToken cancellationToken)
+        string generatedNameTypeParameterSuffix)
     {
         _threadingContext.ThrowIfNotOnUIThread();
         var solution = document.Project.Solution;

--- a/src/VisualStudio/Core/Def/ExtractInterface/VisualStudioExtractInterfaceOptionsService.cs
+++ b/src/VisualStudio/Core/Def/ExtractInterface/VisualStudioExtractInterfaceOptionsService.cs
@@ -40,7 +40,7 @@ internal sealed class VisualStudioExtractInterfaceOptionsService(
         Document document,
         ImmutableArray<ISymbol> extractableMembers,
         string defaultInterfaceName,
-        List<string> allTypeNames,
+        ImmutableArray<string> allTypeNames,
         string defaultNamespace,
         string generatedNameTypeParameterSuffix)
     {

--- a/src/VisualStudio/Core/Test/ExtractInterface/ExtractInterfaceViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/ExtractInterface/ExtractInterfaceViewModelTests.vb
@@ -265,7 +265,7 @@ public class $$MyClass
 }"]]></Text>
 
             Dim viewModel = Await GetViewModelAsync(markup, LanguageNames.CSharp, "IMyClass")
-            Assert.Equal(5, viewModel.MemberContainers.Count)
+            Assert.Equal(5, viewModel.MemberContainers.Length)
             Assert.Equal("Goo()", viewModel.MemberContainers.ElementAt(0).SymbolName)
             Assert.Equal("Goo(int)", viewModel.MemberContainers.ElementAt(1).SymbolName)
             Assert.Equal("Goo(int, int)", viewModel.MemberContainers.ElementAt(2).SymbolName)
@@ -291,7 +291,7 @@ public class $$MyClass
             Using workspace = EditorTestWorkspace.Create(workspaceXml)
                 Dim doc = workspace.Documents.Single()
                 Dim workspaceDoc = workspace.CurrentSolution.GetDocument(doc.Id)
-                If (Not doc.CursorPosition.HasValue) Then
+                If Not doc.CursorPosition.HasValue Then
                     Assert.True(False, "Missing caret location in document.")
                 End If
 
@@ -300,16 +300,15 @@ public class $$MyClass
                 Dim symbol = (Await workspaceDoc.GetSemanticModelAsync()).GetDeclaredSymbol(token.Parent)
                 Dim extractableMembers = DirectCast(symbol, INamedTypeSymbol).GetMembers().Where(Function(s) Not (TypeOf s Is IMethodSymbol) OrElse DirectCast(s, IMethodSymbol).MethodKind <> MethodKind.Constructor)
 
-                Dim memberViewModels = extractableMembers.Select(Function(member As ISymbol)
-                                                                     Return New MemberSymbolViewModel(member, Nothing)
-                                                                 End Function)
+                Dim memberViewModels = extractableMembers.Select(
+                    Function(member As ISymbol) New MemberSymbolViewModel(member, Nothing))
 
                 Return New ExtractInterfaceDialogViewModel(
                     workspaceDoc.Project.Services.GetService(Of ISyntaxFactsService)(),
                     notificationService:=New TestNotificationService(),
                     uiThreadOperationExecutor:=Nothing,
                     defaultInterfaceName:=defaultInterfaceName,
-                    conflictingTypeNames:=If(conflictingTypeNames, New List(Of String)),
+                    conflictingTypeNames:=conflictingTypeNames.AsImmutableOrEmpty(),
                     memberViewModels:=memberViewModels.ToImmutableArray(),
                     defaultNamespace:=defaultNamespace,
                     generatedNameTypeParameterSuffix:=generatedNameTypeParameterSuffix,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpHeaderFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpHeaderFacts.cs
@@ -28,11 +28,32 @@ internal class CSharpHeaderFacts : AbstractHeaderFacts
         if (node == null)
             return false;
 
-        var lastToken = (node as TypeDeclarationSyntax)?.TypeParameterList?.GetLastToken() ?? node.Identifier;
-        if (fullHeader)
-            lastToken = node.BaseList?.GetLastToken() ?? lastToken;
+        return IsOnHeader(root, position, node, GetLastToken());
 
-        return IsOnHeader(root, position, node, lastToken);
+        SyntaxToken GetLastToken()
+        {
+            if (fullHeader && node.BaseList != null)
+                return node.BaseList.GetLastToken();
+
+            if (node is TypeDeclarationSyntax typeDeclaration)
+            {
+                if (typeDeclaration.TypeParameterList != null)
+                    return typeDeclaration.TypeParameterList.GreaterThanToken;
+
+                if (typeDeclaration.Identifier != default)
+                    return typeDeclaration.Identifier;
+
+                return typeDeclaration.Keyword;
+            }
+            else if (node is EnumDeclarationSyntax enumDeclaration)
+            {
+                return enumDeclaration.Identifier;
+            }
+            else
+            {
+                throw ExceptionUtilities.Unreachable();
+            }
+        }
     }
 
     public override bool IsOnPropertyDeclarationHeader(SyntaxNode root, int position, [NotNullWhen(true)] out SyntaxNode? propertyDeclaration)


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/77505.