### PR TITLE
Disable downloading the runtime packages during build and instead ensure that it happens when needed (pack)

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -44,14 +44,6 @@
     <PublishDir Condition="'$(RuntimeIdentifier)' != ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <PublishDir Condition="'$(RuntimeIdentifier)' == ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/neutral</PublishDir>
 
-    <!-- List of runtime identifiers that we want to publish an executable for. -->
-    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseOS.
-         TargetRid and BaseOS are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
-         https://github.com/dotnet/dotnet/blob/main/repo-projects/roslyn.proj. For definitions of the TargetRid
-         and other common properties, see https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
-    <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(TargetRid)' == '' and '$(BaseOS)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
@@ -5,6 +5,15 @@
     <_RoslynPublishReadyToRun>false</_RoslynPublishReadyToRun>
     <_RoslynPublishReadyToRun Condition="'$(Configuration)' == 'Release'">true</_RoslynPublishReadyToRun>
 
+    <!-- 
+      List of runtime identifiers that we want to publish an executable for.
+      This cannot be set in the base project as it will cause issues when roslyn is built
+      as a test project for SDK insertions.  The RuntimeIdentifiers property will cause the build to
+      attempt to download unpublished packages, which fails (until the packages eventually get published).
+
+      The test doesn't actually run pack, so we can instead skip setting the RuntimeIdentifiers property unless
+      we're actually trying to build packages.
+    -->
     <!-- List of runtime identifiers that we want to publish an executable for. -->
     <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseOS.
          TargetRid and BaseOS are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
@@ -27,7 +36,7 @@
 
     <ItemGroup>
       <!-- Transform RuntimeIdentifiers property to item -->
-      <RuntimeIdentifierForPack Include="$(RuntimeIdentifiers)" />
+      <RuntimeIdentifierForPack Include="$(_RoslynRuntimeIdentifiers)" />
       <RuntimeIdentifierForPack Include="neutral" />
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
@@ -4,6 +4,15 @@
     <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <_RoslynPublishReadyToRun>false</_RoslynPublishReadyToRun>
     <_RoslynPublishReadyToRun Condition="'$(Configuration)' == 'Release'">true</_RoslynPublishReadyToRun>
+
+    <!-- List of runtime identifiers that we want to publish an executable for. -->
+    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseOS.
+         TargetRid and BaseOS are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
+         https://github.com/dotnet/dotnet/blob/main/repo-projects/roslyn.proj. For definitions of the TargetRid
+         and other common properties, see https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
+    <_RoslynRuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</_RoslynRuntimeIdentifiers>
+    <_RoslynRuntimeIdentifiers Condition="'$(BaseOS)' != ''">$(BaseOS)</_RoslynRuntimeIdentifiers>
+    <_RoslynRuntimeIdentifiers Condition="'$(TargetRid)' == '' and '$(BaseOS)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</_RoslynRuntimeIdentifiers>
   </PropertyGroup>
 
   <Target Name="Pack">
@@ -14,7 +23,7 @@
         We also pass the RestoreUseStaticGraphEvaluation=false flag to workaround a long path issue when calling the restore target.
         See https://github.com/NuGet/Home/issues/11968
     -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="PublishReadyToRun=$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RuntimeIdentifiers=$(_RoslynRuntimeIdentifiers);PublishReadyToRun=$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
 
     <ItemGroup>
       <!-- Transform RuntimeIdentifiers property to item -->


### PR DESCRIPTION
During the most recent SDK insertion, allocation regressions were reported in the C# editing speedometer test. Investigation yielded that these were because of restore failures in the test project as the runtime packages are not published at the point of the SDK insertion.

Looking at the MS.CodeAnalysis.LanguageServer project closer revealed that these runtime identifiers needed to only be set during the pack task. This PR moves setting the RuntimeIdentifiers property to only be done during the pack task, and thus the restore task won't attempt to download these packages. As the test doesn't perform a pack on the roslyn solution, this should prevent future SDK insertions from hitting this issue again.