### PR TITLE
Make ISemanticSearchCopilotUIProvider import lazy to avoid loading VS.EA.Copilot

### DIFF
--- a/src/VisualStudio/CSharp/Impl/SemanticSearch/SemanticSearchToolWindowImpl.cs
+++ b/src/VisualStudio/CSharp/Impl/SemanticSearch/SemanticSearchToolWindowImpl.cs
@@ -64,7 +64,7 @@ internal sealed class SemanticSearchToolWindowImpl(
     IStreamingFindUsagesPresenter resultsPresenter,
     ITextUndoHistoryRegistry undoHistoryRegistry,
     ISemanticSearchCopilotService copilotService,
-    ISemanticSearchCopilotUIProvider copilotUIProvider,
+    Lazy<ISemanticSearchCopilotUIProvider> copilotUIProvider, // lazy to avoid loading Microsoft.VisualStudio.LanguageServices.ExternalAccess.Copilot
     IVsService<SVsUIShell, IVsUIShell> vsUIShellProvider) : ISemanticSearchWorkspaceHost, OptionsProvider<ClassificationOptions>
 {
     private const int ToolBarHeight = 26;
@@ -193,7 +193,7 @@ internal sealed class SemanticSearchToolWindowImpl(
 
     private CopilotUI? CreateCopilotUI()
     {
-        if (!copilotUIProvider.IsAvailable || !copilotService.IsAvailable)
+        if (!copilotUIProvider.Value.IsAvailable || !copilotService.IsAvailable)
         {
             return null;
         }
@@ -216,7 +216,7 @@ internal sealed class SemanticSearchToolWindowImpl(
         promptGrid.ColumnDefinitions.Add(new ColumnDefinition { MaxWidth = 600, Width = GridLength.Auto });
         promptGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
-        var promptTextBox = copilotUIProvider.GetTextBox();
+        var promptTextBox = copilotUIProvider.Value.GetTextBox();
 
         var panel = new StackPanel()
         {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2398928