### PR TITLE
Fix Stack Trace Explorer for additional documents

### DIFF
--- a/src/EditorFeatures/Core/Navigation/IDocumentNavigationServiceExtensions.cs
+++ b/src/EditorFeatures/Core/Navigation/IDocumentNavigationServiceExtensions.cs
@@ -75,7 +75,7 @@ internal static class IDocumentNavigationServiceExtensions
         // Navigation should not change the context of linked files and Shared Projects.
         documentId = workspace.GetDocumentIdInCurrentContext(documentId);
 
-        var document = workspace.CurrentSolution.GetDocument(documentId);
+        var document = workspace.CurrentSolution.GetTextDocument(documentId);
         if (document is null)
             return false;
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/IUnitTestingStackTraceServiceAccessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/IUnitTestingStackTraceServiceAccessor.cs
@@ -13,6 +13,6 @@ internal interface IUnitTestingStackTraceServiceAccessor : IWorkspaceService
 {
     Task<ImmutableArray<UnitTestingParsedFrameWrapper>> TryParseAsync(string input, Workspace workspace, CancellationToken cancellationToken);
     Task<UnitTestingDefinitionItemWrapper?> TryFindMethodDefinitionAsync(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame, CancellationToken cancellationToken);
-    (Document? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame);
+    (TextDocument? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame);
     Task<bool> TryNavigateToAsync(Workspace workspace, UnitTestingDefinitionItemWrapper definitionItem, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/IUnitTestingStackTraceServiceAccessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/IUnitTestingStackTraceServiceAccessor.cs
@@ -13,6 +13,7 @@ internal interface IUnitTestingStackTraceServiceAccessor : IWorkspaceService
 {
     Task<ImmutableArray<UnitTestingParsedFrameWrapper>> TryParseAsync(string input, Workspace workspace, CancellationToken cancellationToken);
     Task<UnitTestingDefinitionItemWrapper?> TryFindMethodDefinitionAsync(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame, CancellationToken cancellationToken);
-    (TextDocument? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame);
+    (Document? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame);
+    (TextDocument? textDocument, int lineNumber) GetTextDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame);
     Task<bool> TryNavigateToAsync(Workspace workspace, UnitTestingDefinitionItemWrapper definitionItem, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
@@ -19,7 +19,7 @@ internal sealed class UnitTestingStackTraceServiceAccessor(
 {
     private readonly IStackTraceExplorerService _stackTraceExplorerService = stackTraceExplorerService;
 
-    public (Document? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame)
+    public (TextDocument? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame)
         => _stackTraceExplorerService.GetDocumentAndLine(workspace.CurrentSolution, parsedFrame.UnderlyingObject);
 
     public async Task<UnitTestingDefinitionItemWrapper?> TryFindMethodDefinitionAsync(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
@@ -19,8 +19,19 @@ internal sealed class UnitTestingStackTraceServiceAccessor(
 {
     private readonly IStackTraceExplorerService _stackTraceExplorerService = stackTraceExplorerService;
 
-    public (TextDocument? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame)
+    public (TextDocument? textDocument, int lineNumber) GetTextDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame)
         => _stackTraceExplorerService.GetDocumentAndLine(workspace.CurrentSolution, parsedFrame.UnderlyingObject);
+
+    public (Document? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame)
+    {
+        var (textDocument, lineNumber) = GetTextDocumentAndLine(workspace, parsedFrame);
+        if (textDocument is Document document)
+        {
+            return (document, lineNumber);
+        }
+
+        return (null, default);
+    }
 
     public async Task<UnitTestingDefinitionItemWrapper?> TryFindMethodDefinitionAsync(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame, CancellationToken cancellationToken)
     {

--- a/src/Features/Core/Portable/StackTraceExplorer/IStackTraceExplorerService.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/IStackTraceExplorerService.cs
@@ -16,7 +16,7 @@ internal interface IStackTraceExplorerService : IWorkspaceService
     /// in a solution. Looks for an exact filepath match first, then defaults to 
     /// a best guess.
     /// </summary>
-    (Document? document, int line) GetDocumentAndLine(Solution solution, ParsedFrame frame);
+    (TextDocument? document, int line) GetDocumentAndLine(Solution solution, ParsedFrame frame);
     Task<DefinitionItem?> TryFindDefinitionAsync(Solution solution, ParsedFrame frame, StackFrameSymbolPart symbolPart, CancellationToken cancellationToken);
 }
 

--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.StackTraceExplorer;
@@ -83,6 +84,14 @@ internal sealed class StackTraceExplorerService() : IStackTraceExplorerService
         RoslynDebug.AssertNotNull(lineString);
         lineNumber = int.Parse(lineString);
 
+        var documentId = solution.GetDocumentIdsWithFilePath(fileName).FirstOrDefault();
+
+        if (documentId is not null)
+        {
+            var document = solution.GetRequiredDocument(documentId);
+            return [document];
+        }
+
         var documentName = Path.GetFileName(fileName);
         var potentialMatches = new HashSet<TextDocument>();
 
@@ -95,12 +104,7 @@ internal sealed class StackTraceExplorerService() : IStackTraceExplorerService
 
             foreach (var document in allDocuments)
             {
-                if (document.FilePath == fileName)
-                {
-                    return [document];
-                }
-
-                else if (document.Name == documentName)
+                if (document.Name == documentName)
                 {
                     potentialMatches.Add(document);
                 }

--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.StackTraceExplorer;
 
 [ExportWorkspaceService(typeof(IStackTraceExplorerService)), Shared]
 [method: ImportingConstructor]
-[method: System.Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class StackTraceExplorerService() : IStackTraceExplorerService
 {
     public (TextDocument? document, int line) GetDocumentAndLine(Solution solution, ParsedFrame frame)
@@ -104,7 +105,7 @@ internal sealed class StackTraceExplorerService() : IStackTraceExplorerService
 
             foreach (var document in allDocuments)
             {
-                if (document.Name == documentName)
+                if (string.Equals(document.Name, documentName, StringComparison.OrdinalIgnoreCase))
                 {
                     potentialMatches.Add(document);
                 }

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackFrameViewModel.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackFrameViewModel.cs
@@ -28,30 +28,21 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer;
 using StackFrameToken = EmbeddedSyntaxToken<StackFrameKind>;
 using StackFrameTrivia = EmbeddedSyntaxTrivia<StackFrameKind>;
 
-internal class StackFrameViewModel : FrameViewModel
+internal class StackFrameViewModel(
+    ParsedStackFrame frame,
+    IThreadingContext threadingContext,
+    Workspace workspace,
+    IClassificationFormatMap formatMap,
+    ClassificationTypeMap typeMap) : FrameViewModel(formatMap, typeMap)
 {
-    private readonly ParsedStackFrame _frame;
-    private readonly IThreadingContext _threadingContext;
-    private readonly Workspace _workspace;
-    private readonly IStackTraceExplorerService _stackExplorerService;
+    private readonly ParsedStackFrame _frame = frame;
+    private readonly IThreadingContext _threadingContext = threadingContext;
+    private readonly Workspace _workspace = workspace;
+    private readonly IStackTraceExplorerService _stackExplorerService = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
     private readonly Dictionary<StackFrameSymbolPart, DefinitionItem?> _definitionCache = [];
 
-    private Document? _cachedDocument;
+    private TextDocument? _cachedDocument;
     private int _cachedLineNumber;
-
-    public StackFrameViewModel(
-        ParsedStackFrame frame,
-        IThreadingContext threadingContext,
-        Workspace workspace,
-        IClassificationFormatMap formatMap,
-        ClassificationTypeMap typeMap)
-        : base(formatMap, typeMap)
-    {
-        _frame = frame;
-        _threadingContext = threadingContext;
-        _workspace = workspace;
-        _stackExplorerService = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
-    }
 
     public override bool ShowMouseOver => true;
 
@@ -112,14 +103,11 @@ internal class StackFrameViewModel : FrameViewModel
     {
         try
         {
-            var (document, lineNumber) = GetDocumentAndLine();
+            var (textDocument, lineNumber) = GetDocumentAndLine();
 
-            if (document is not null)
+            if (textDocument is not null)
             {
-                // While navigating do not activate the tab, which will change focus from the tool window
-                var options = new NavigationOptions(PreferProvisionalTab: true, ActivateTab: false);
-
-                var sourceText = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+                var sourceText = await textDocument.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
                 // If the line number is larger than the total lines in the file
                 // then just go to the end of the file (lines count). This can happen
@@ -131,8 +119,13 @@ internal class StackFrameViewModel : FrameViewModel
                 if (navigationService is null)
                     return;
 
-                var location = await navigationService.TryNavigateToLineAndOffsetAsync(
-                    _threadingContext, _workspace, document.Id, lineNumber - 1, offset: 0, options, cancellationToken).ConfigureAwait(false);
+                // While navigating do not activate the tab, which will change focus from the tool window
+                var options = new NavigationOptions(PreferProvisionalTab: true, ActivateTab: false);
+
+                await navigationService.TryNavigateToLineAndOffsetAsync(
+                    _threadingContext, _workspace, textDocument.Id, lineNumber - 1, offset: 0, options, cancellationToken)
+                    .ConfigureAwait(false);
+
             }
         }
         catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))
@@ -208,7 +201,7 @@ internal class StackFrameViewModel : FrameViewModel
         yield return MakeClassifiedRun(ClassificationTypeNames.Text, _frame.Root.EndOfLineToken.ToFullString());
     }
 
-    private (Document? document, int lineNumber) GetDocumentAndLine()
+    private (TextDocument? document, int lineNumber) GetDocumentAndLine()
     {
         if (_cachedDocument is not null)
         {

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackFrameViewModel.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackFrameViewModel.cs
@@ -125,7 +125,6 @@ internal class StackFrameViewModel(
                 await navigationService.TryNavigateToLineAndOffsetAsync(
                     _threadingContext, _workspace, textDocument.Id, lineNumber - 1, offset: 0, options, cancellationToken)
                     .ConfigureAwait(false);
-
             }
         }
         catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))


### PR DESCRIPTION
1. Update IDocumentNavigationService implementation in VS to work on any TextDocument
2. Fix IDocumentNavigationService extension to use TextDocument
3. Fix Stack Trace Explorer to search for AdditionalDocuments when trying to find a match in file path or name

Partial fix for https://github.com/dotnet/roslyn/issues/77499 

There might be more cases where finding symbols doesn't work but filepath+line navigation should now work
