### PR TITLE
Fix issue with disappearing newlines after multiline documentation comment

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -119,6 +119,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     lineBreaksAfter: lineBreaksAfter));
 
                 return tk;
+
+                int LineBreaksAfterLeading(SyntaxToken syntaxToken)
+                {
+                    if (syntaxToken.LeadingTrivia.Count < 2)
+                    {
+                        return 0;
+                    }
+
+                    if (syntaxToken.LeadingTrivia[^2].IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia) &&
+                        syntaxToken.LeadingTrivia[^1].IsKind(SyntaxKind.EndOfLineTrivia))
+                    {
+                        return 1;
+                    }
+
+                    return 0;
+                }
             }
             finally
             {
@@ -173,22 +189,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         private static bool NeedsIndentAfterLineBreak(SyntaxToken token)
         {
             return !token.IsKind(SyntaxKind.EndOfFileToken);
-        }
-
-        private static int LineBreaksAfterLeading(SyntaxToken token)
-        {
-            if (token.LeadingTrivia.Count < 2)
-            {
-                return 0;
-            }
-
-            if (token.LeadingTrivia[^2].IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia) &&
-                token.LeadingTrivia[^1].IsKind(SyntaxKind.EndOfLineTrivia))
-            {
-                return 1;
-            }
-
-            return 0;
         }
 
         private int LineBreaksAfter(SyntaxToken currentToken, SyntaxToken nextToken)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                 return tk;
 
-                int LineBreaksAfterLeading(SyntaxToken syntaxToken)
+                static int lineBreaksAfterLeading(SyntaxToken syntaxToken)
                 {
                     if (syntaxToken.LeadingTrivia.Count < 2)
                     {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -94,14 +94,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                 var depth = GetDeclarationDepth(token);
 
-                var lineBreaksAfterLeading = LineBreaksAfterLeading(token);
                 tk = tk.WithLeadingTrivia(RewriteTrivia(
                     token.LeadingTrivia,
                     depth,
                     isTrailing: false,
                     indentAfterLineBreak: NeedsIndentAfterLineBreak(token),
                     mustHaveSeparator: false,
-                    lineBreaksAfter: lineBreaksAfterLeading));
+                    lineBreaksAfter: lineBreaksAfterLeading(token)));
 
                 var nextToken = this.GetNextRelevantToken(token);
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -175,13 +175,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return !token.IsKind(SyntaxKind.EndOfFileToken);
         }
 
-        private int LineBreaksAfterLeading(SyntaxToken token)
+        private static int LineBreaksAfterLeading(SyntaxToken token)
         {
             if (token.LeadingTrivia.Count < 2)
             {
                 return 0;
             }
-            
+
             if (token.LeadingTrivia[^2].IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia) &&
                 token.LeadingTrivia[^1].IsKind(SyntaxKind.EndOfLineTrivia))
             {
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             {
                 return 1;
             }
-            
+
             if (nextToken.Kind() == SyntaxKind.None)
             {
                 return 0;

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -3790,6 +3790,26 @@ $"  ///  </summary>{Environment.NewLine}" +
 "}");
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76856")]
+        public void TestNormalizeDocumentationMultiLineCommentsWithTrailingNewline()
+        {
+            TestNormalizeStatement("""
+               /**
+                * 
+                * Escape XML special characters
+                */
+               private String EscapeXML(String str)
+               {
+               """, """
+                    ///
+                    /// 
+                    /// Escape XML special characters
+                    //////
+                    private String EscapeXML(String str)
+                    {
+                    """);
+        }
+
         [Fact]
         public void TestNormalizeEOL()
         {


### PR DESCRIPTION
This PR fixes #76856, where multi-line doc comments ending in a newline would have the newline disappearing afterwards.

Based on my investigation, the situation can be described as follows:
- The structured multiline comment token does not contain the newline by itself, and the normalizer's loop for `RewriteTrivia` skips newline tokens.
- `NeedsLineBreakAfter` call can't be the target for this fix, because not every comment needs a new line after it. Wider context is needed.
- `EndsInLineBreak` can be true for the doc token in cases where in reality the documentation end token is the ending token, due to the 0 width of the `EndOfDocumentationCommentToken` type.

The proposed fix adds a linebreak if the leading SyntaxToken is a multiline documentation ending in linebreak, and forces it to be retained during rewriting by slightly modifying `EndsInLineBreak` too.

As this is my first time contributing, let me know if I have not grasped the codebase correctly and there is a cleaner way to apply this.
