### PR TITLE
Extensions: Handle explicit type arguments

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8610,7 +8610,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     lookupResult, analyzedArguments, ref actualMethodArguments, options, in callingConvention, binder, diagnostics);
 
                 // 3. resolve properties
-                OverloadResolutionResult<PropertySymbol>? propertyResult = resolveProperties(left, lookupResult, binder, ref actualReceiverArguments, ref useSiteInfo);
+                OverloadResolutionResult<PropertySymbol>? propertyResult = arity != 0 ? null : resolveProperties(left, lookupResult, binder, ref actualReceiverArguments, ref useSiteInfo);
 
                 // 4. determine member kind
                 if (!methodResult.HasAnyApplicableMethod && propertyResult?.HasAnyApplicableMember != true)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8511,7 +8511,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             AnalyzedArguments? actualMethodArguments = null;
             AnalyzedArguments? actualReceiverArguments = null;
 
-            // PROTOTYPE we need to lookup on combined arity of extension declaration and extension method
             int arity = typeArgumentsWithAnnotations.IsDefault ? 0 : typeArgumentsWithAnnotations.Length;
             var lookupOptions = (arity == 0) ? LookupOptions.AllMethodsOnArityZero : LookupOptions.Default;
             if (analyzedArguments is not null)
@@ -8610,6 +8609,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     lookupResult, analyzedArguments, ref actualMethodArguments, options, in callingConvention, binder, diagnostics);
 
                 // 3. resolve properties
+                Debug.Assert(arity == 0 || lookupResult.Symbols.All(s => s.Kind != SymbolKind.Property));
                 OverloadResolutionResult<PropertySymbol>? propertyResult = arity != 0 ? null : resolveProperties(left, lookupResult, binder, ref actualReceiverArguments, ref useSiteInfo);
 
                 // 4. determine member kind

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -196,14 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // No need for "diagnose" since we discard the lookup results (and associated diagnostic info)
                 // unless the results are good.
-                int remainingArity = arity == 0 ? 0 : arity - extension.Arity;
-
-                if (remainingArity < 0)
-                {
-                    continue;
-                }
-
-                LookupMembersInClass(tempResult, extension, name, remainingArity, basesBeingResolved,
+                LookupMembersInClass(tempResult, extension, name, arity, basesBeingResolved,
                     options, originalBinder, diagnose: false, ref useSiteInfo);
 
                 result.MergeEqual(tempResult);
@@ -1846,7 +1839,7 @@ symIsHidden:;
                     if (arity != 0 || (options & LookupOptions.AllMethodsOnArityZero) == 0)
                     {
                         MethodSymbol method = (MethodSymbol)symbol;
-                        if (method.Arity != arity)
+                        if (method.GetMemberTotalArity() != arity)
                         {
                             if (method.Arity == 0)
                             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -196,7 +196,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // No need for "diagnose" since we discard the lookup results (and associated diagnostic info)
                 // unless the results are good.
-                LookupMembersInClass(tempResult, extension, name, arity, basesBeingResolved,
+                int remainingArity = arity == 0 ? 0 : arity - extension.Arity;
+
+                if (remainingArity < 0)
+                {
+                    continue;
+                }
+
+                LookupMembersInClass(tempResult, extension, name, remainingArity, basesBeingResolved,
                     options, originalBinder, diagnose: false, ref useSiteInfo);
 
                 result.MergeEqual(tempResult);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1169,7 +1169,7 @@ outerDefault:
             // This is specifying an impossible condition; the member lookup algorithm has already filtered
             // out methods from the method group that have the wrong generic arity.
 
-            Debug.Assert(typeArguments.Count == 0 || typeArguments.Count == member.GetMemberArity()); // PROTOTYPE deal with explicit type arguments
+            Debug.Assert(typeArguments.Count == 0 || typeArguments.Count == GetMemberTotalArity(member));
 
             // Second, we need to determine if the method is applicable in its normal form or its expanded form.
             bool disallowExpandedNonArrayParams = (options & Options.DisallowExpandedNonArrayParams) != 0;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -791,7 +791,7 @@ outerDefault:
 
         private bool FailsConstraintChecks<TMember>(TMember member, out ArrayBuilder<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt, CompoundUseSiteInfo<AssemblySymbol> template) where TMember : Symbol
         {
-            int arity = GetMemberTotalArity(member);
+            int arity = member.GetMemberTotalArity();
             if (arity == 0 || member.OriginalDefinition == (object)member)
             {
                 constraintFailureDiagnosticsOpt = null;
@@ -1169,7 +1169,7 @@ outerDefault:
             // This is specifying an impossible condition; the member lookup algorithm has already filtered
             // out methods from the method group that have the wrong generic arity.
 
-            Debug.Assert(typeArguments.Count == 0 || typeArguments.Count == GetMemberTotalArity(member));
+            Debug.Assert(typeArguments.Count == 0 || typeArguments.Count == member.GetMemberTotalArity());
 
             // Second, we need to determine if the method is applicable in its normal form or its expanded form.
             bool disallowExpandedNonArrayParams = (options & Options.DisallowExpandedNonArrayParams) != 0;
@@ -2405,14 +2405,14 @@ outerDefault:
             }
 
             // If MP is a non-generic method and MQ is a generic method, then MP is better than MQ.
-            if (GetMemberTotalArity(m1.Member) == 0)
+            if (m1.Member.GetMemberTotalArity() == 0)
             {
-                if (GetMemberTotalArity(m2.Member) > 0)
+                if (m2.Member.GetMemberTotalArity() > 0)
                 {
                     return BetterResult.Left;
                 }
             }
-            else if (GetMemberTotalArity(m2.Member) == 0)
+            else if (m2.Member.GetMemberTotalArity() == 0)
             {
                 return BetterResult.Right;
             }
@@ -2604,16 +2604,6 @@ outerDefault:
                     return type;
                 }
             }
-        }
-
-        private static int GetMemberTotalArity<TMember>(TMember member) where TMember : Symbol
-        {
-            if (member.GetIsNewExtensionMember())
-            {
-                return member.ContainingType.Arity + member.GetMemberArity();
-            }
-
-            return member.GetMemberArity();
         }
 
         /// <summary>
@@ -4259,7 +4249,7 @@ outerDefault:
             EffectiveParameters constructedEffectiveParameters;
             bool hasTypeArgumentsInferredFromFunctionType = false;
             if ((options & Options.InferringUniqueMethodGroupSignature) == 0 &&
-                GetMemberTotalArity(member) > 0)
+                member.GetMemberTotalArity() > 0)
             {
                 ImmutableArray<TypeWithAnnotations> typeArguments;
                 bool isNewExtensionMember = member.GetIsNewExtensionMember();

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -99,6 +99,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return member.ContainingSymbol is TypeSymbol { IsExtension: true };
         }
+
+        internal static int GetMemberTotalArity(this Symbol member)
+        {
+            if (member.GetIsNewExtensionMember())
+            {
+                return member.ContainingType.Arity + member.GetMemberArity();
+            }
+
+            return member.GetMemberArity();
+        }
 #nullable disable
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -10653,8 +10653,8 @@ static class E
         Assert.Equal("void E.<>E__0<System.Int32>.M()", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
     }
 
-    [Fact(Skip = "PROTOTYPE explicit type arguments")]
-    public void InstanceMethodInvocation_MatchingExtendedType_GenericType_GenericMember()
+    [Fact]
+    public void InstanceMethodInvocation_MatchingExtendedType_GenericType_GenericMember_01()
     {
         var src = """
 new C<int>().M<string>();
@@ -10670,18 +10670,45 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
-        // PROTOTYPE metadata is undone
-        //CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+        comp.VerifyEmitDiagnostics(
+            // (1,14): error CS1061: 'C<int>' does not contain a definition for 'M' and no accessible extension method 'M' accepting a first argument of type 'C<int>' could be found (are you missing a using directive or an assembly reference?)
+            // new C<int>().M<string>();
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M<string>").WithArguments("C<int>", "M").WithLocation(1, 14));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<string>()");
+        Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+    }
+
+    [Fact]
+    public void InstanceMethodInvocation_MatchingExtendedType_GenericType_GenericMember_02()
+    {
+        var src = """
+new C<int>().M<int, string>();
+
+class C<T> { }
+
+static class E
+{
+    extension<T>(C<T> c)
+    {
+        public void M<U>() { System.Console.Write("ran"); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<int, string>()");
         Assert.Equal("void E.<>E__0<System.Int32>.M<System.String>()", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
     }
 
-    [Fact(Skip = "PROTOTYPE explicit type arguments")]
-    public void InstanceMethodInvocation_MatchingExtendedType_GenericType_GenericMember_OmittedTypeArgument()
+    [Fact]
+    public void InstanceMethodInvocation_MatchingExtendedType_GenericType_GenericMember_OmittedTypeArgument_01()
     {
         var src = """
 new C<int>().M<,>();
@@ -10700,19 +10727,53 @@ static class E
         comp.VerifyEmitDiagnostics(
             // (1,1): error CS8389: Omitting the type argument is not allowed in the current context
             // new C<int>().M<,>();
-            Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "new C<int>().M<,>").WithLocation(1, 1));
+            Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "new C<int>().M<,>").WithLocation(1, 1),
+            // (1,14): error CS1061: 'C<int>' does not contain a definition for 'M' and no accessible extension method 'M' accepting a first argument of type 'C<int>' could be found (are you missing a using directive or an assembly reference?)
+            // new C<int>().M<,>();
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M<,>").WithArguments("C<int>", "M").WithLocation(1, 14));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<,>()");
-        Assert.Equal("void E.<>E__0<System.Int32>.M<?, ?>()", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        Assert.Null(model.GetSymbolInfo(invocation).Symbol);
     }
 
-    [Fact(Skip = "PROTOTYPE explicit type arguments")]
+    [Fact]
+    public void InstanceMethodInvocation_MatchingExtendedType_GenericType_GenericMember_OmittedTypeArgument_02()
+    {
+        var src = """
+new C<int>().M<,,>();
+
+class C<T> { }
+
+static class E
+{
+    extension<T>(C<T> c)
+    {
+        public void M<U, V>() => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,1): error CS8389: Omitting the type argument is not allowed in the current context
+            // new C<int>().M<,,>();
+            Diagnostic(ErrorCode.ERR_OmittedTypeArgument, "new C<int>().M<,,>").WithLocation(1, 1),
+            // (1,1): error CS1929: 'C<int>' does not contain a definition for 'M' and the best extension method overload 'E.extension<?>(C<?>).M<?, ?>()' requires a receiver of type 'C<?>'
+            // new C<int>().M<,,>();
+            Diagnostic(ErrorCode.ERR_BadInstanceArgType, "new C<int>()").WithArguments("C<int>", "M", "E.extension<?>(C<?>).M<?, ?>()", "C<?>").WithLocation(1, 1));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<,,>()");
+        Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+    }
+
+    [Fact]
     public void InstanceMethodInvocation_MatchingExtendedType_GenericType_GenericMember_BrokenConstraint()
     {
         var src = """
-new C<int>().M<string>();
+new C<int>().M<int, string>();
 
 class C<T> { }
 
@@ -10727,12 +10788,12 @@ static class E
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
             // (1,14): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U' in the generic type or method 'E.extension<int>(C<int>).M<U>()'
-            // new C<int>().M<string>();
-            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M<string>").WithArguments("E.extension<int>(C<int>).M<U>()", "U", "string").WithLocation(1, 14));
+            // new C<int>().M<int, string>();
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M<int, string>").WithArguments("E.extension<int>(C<int>).M<U>()", "U", "string").WithLocation(1, 14));
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
-        var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<string>()");
+        var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<int, string>()");
         Assert.Null(model.GetSymbolInfo(invocation).Symbol);
     }
 
@@ -12444,11 +12505,11 @@ namespace Inner
         //Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
     }
 
-    [Fact(Skip = "PROTOTYPE explicit type arguments")]
+    [Fact]
     public void InstanceMethodInvocation_MultipleSubstitutions()
     {
         var src = """
-new C().M<int>();
+new C().M();
 
 interface I<T> { }
 class C : I<int>, I<string> { }
@@ -12457,19 +12518,19 @@ static class E
 {
     extension<T>(I<T> i)
     {
-        public void M<U>() { }
+        public void M() { }
     }
 }
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
             // (1,9): error CS1061: 'C' does not contain a definition for 'M' and no accessible extension method 'M' accepting a first argument of type 'C' could be found (are you missing a using directive or an assembly reference?)
-            // new C().M<int>();
-            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M<int>").WithArguments("C", "M").WithLocation(1, 9));
+            // new C().M();
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M").WithArguments("C", "M").WithLocation(1, 9));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
-        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<int>");
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
         Assert.Empty(model.GetMemberGroup(memberAccess));
@@ -23519,5 +23580,143 @@ _ = i.P(1);
             // (2,7): error CS1061: 'int' does not contain a definition for 'P' and no accessible extension method 'P' accepting a first argument of type 'int' could be found (are you missing a using directive or an assembly reference?)
             // _ = i.P(1);
             Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "P").WithArguments("int", "P").WithLocation(2, 7));
+    }
+    [Fact]
+    public void ExplicitTypeArguments_01()
+    {
+        var src = """
+string s = "ran";
+s.M<object>();
+
+static class E
+{
+    extension<T>(T t)
+    {
+        public void M() { System.Console.Write(t); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "s.M<object>()");
+        Assert.Equal("void E.<>E__0<System.Object>.M()", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_02()
+    {
+        var src = """
+42.M<object>();
+
+static class E
+{
+    extension<T>(T t) where T : struct
+    {
+        public void M() { System.Console.Write(t); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,4): error CS0453: The type 'object' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'E.extension<T>(T)'
+            // 42.M<object>();
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M<object>").WithArguments("E.extension<T>(T)", "T", "object").WithLocation(1, 4));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "42.M<object>()");
+        Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_03()
+    {
+        var src = """
+string s = "ran";
+_ = s.P<object>;
+
+static class E
+{
+    extension<T>(T t)
+    {
+        public int P => 0;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (2,7): error CS1061: 'string' does not contain a definition for 'P' and no accessible extension method 'P' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+            // _ = s.P<object>;
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "P<object>").WithArguments("string", "P").WithLocation(2, 7));
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_04()
+    {
+        var src = """
+string s = "ran";
+s.M<string>();
+
+static class E
+{
+    extension<T>(T t)
+    {
+        public void M() => throw null;
+    }
+    extension(string s)
+    {
+        public void M<T>() { System.Console.Write("ran"); }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_05()
+    {
+        var src = """
+string s = null;
+s.M<string>();
+
+static class E
+{
+    extension<T>(T t)
+    {
+        public void M<U>() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (2,3): error CS1061: 'string' does not contain a definition for 'M' and no accessible extension method 'M' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+            // s.M<string>();
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M<string>").WithArguments("string", "M").WithLocation(2, 3));
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_06()
+    {
+        var src = """
+C<string, string>.M<string>();
+
+class C<T1, T2> { }
+static class E
+{
+    extension<T, U>(C<T, U> t)
+    {
+        public void M() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,19): error CS0117: 'C<string, string>' does not contain a definition for 'M'
+            // C<string, string>.M<string>();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "M<string>").WithArguments("C<string, string>", "M").WithLocation(1, 19));
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -23668,7 +23668,7 @@ static class E
     }
     extension(string s)
     {
-        public void M<T>() { System.Console.Write("ran"); }
+        public void M<T>() { System.Console.Write(s); }
     }
 }
 """;
@@ -23709,7 +23709,7 @@ static class E
 {
     extension<T, U>(C<T, U> t)
     {
-        public void M() { }
+        public static void M() { }
     }
 }
 """;


### PR DESCRIPTION
As part of resolving new extension members like classic extension methods, LDM decided that the explicit type arguments would apply to the extension declaration and member together (with a combined type parameter list). 
The spec was updated already: https://github.com/dotnet/csharplang/blob/main/proposals/extensions.md#consumption

Relates to test plan https://github.com/dotnet/roslyn/issues/76130