### PR TITLE
Add CI validation of Semantic Search API lists

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -406,7 +406,7 @@ stages:
       - powershell: eng/build.ps1 -configuration Release -prepareMachine -ci -restore -binaryLogName Restore.binlog 
         displayName: Restore
 
-      - powershell: eng/build.ps1 -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLogName Build.binlog /p:DotnetPublishUsingPipelines=true
+      - powershell: eng/build.ps1 -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLogName Build.binlog /p:DotnetPublishUsingPipelines=true /p:ContinuousIntegrationBuildCorrectness=true
         displayName: Build
 
       # While this task is not executed in the official build, this serves as a PR check for whether symbol exclusions

--- a/src/Tools/SemanticSearch/BuildTask/GenerateFilteredReferenceAssembliesTask.cs
+++ b/src/Tools/SemanticSearch/BuildTask/GenerateFilteredReferenceAssembliesTask.cs
@@ -54,6 +54,7 @@ public sealed class GenerateFilteredReferenceAssembliesTask : Task
         $
         """, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace);
 
+
     [Required]
     public ITaskItem[] ApiSets { get; private set; } = null!;
 
@@ -65,6 +66,11 @@ public sealed class GenerateFilteredReferenceAssembliesTask : Task
 
     [Required]
     public string ApisDir { get; private set; } = null!;
+
+    /// <summary>
+    /// True to report an error if any changes in Semantic Search APIs are detected.
+    /// </summary>
+    public bool RequireNoApiChanges { get; private set; } = false;
 
     public override bool Execute()
     {
@@ -123,12 +129,14 @@ public sealed class GenerateFilteredReferenceAssembliesTask : Task
                 return;
             }
 
-            WriteApis(Path.Combine(ApisDir, assemblyName + ".txt"), peImageBuffer);
+            WriteApis(assemblyName, peImageBuffer);
         }
     }
 
-    internal void WriteApis(string outputFilePath, byte[] peImage)
+    internal void WriteApis(string assemblyName, byte[] peImage)
     {
+        string outputFilePath = Path.Combine(ApisDir, assemblyName + ".txt");
+
         using var readableStream = new MemoryStream(peImage, writable: false);
         var metadataRef = MetadataReference.CreateFromStream(readableStream);
         var compilation = CSharpCompilation.Create("Metadata", references: [metadataRef]);
@@ -149,9 +157,38 @@ public sealed class GenerateFilteredReferenceAssembliesTask : Task
         var newContent = $"# Generated, do not update manually{Environment.NewLine}" +
             string.Join(Environment.NewLine, apis);
 
+        if (RequireNoApiChanges)
+        {
+            var oldContent = "";
+
+            if (File.Exists(outputFilePath))
+            {
+                try
+                {
+                    oldContent = File.ReadAllText(outputFilePath, Encoding.UTF8);
+                }
+                catch (FileNotFoundException)
+                {
+                }
+                catch (Exception e)
+                {
+                    Log.LogWarning($"Unable to read '{outputFilePath}': {e.Message}");
+                }
+            }
+
+            if (oldContent != newContent)
+            {
+                Log.LogError(
+                    $"APIs listed in file '{outputFilePath}' do not match the public APIs exposed by '{assemblyName}'. " +
+                    $"Build SemanticSearch.ReferenceAssemblies project locally to update the file and review the changes.");
+
+                return;
+            }
+        }
+
         try
         {
-            File.WriteAllText(outputFilePath, newContent);
+            File.WriteAllText(outputFilePath, newContent, Encoding.UTF8);
             Log.LogMessage($"Baseline updated: '{outputFilePath}'");
         }
         catch (Exception e)

--- a/src/Tools/SemanticSearch/BuildTask/GenerateFilteredReferenceAssembliesTask.cs
+++ b/src/Tools/SemanticSearch/BuildTask/GenerateFilteredReferenceAssembliesTask.cs
@@ -54,7 +54,6 @@ public sealed class GenerateFilteredReferenceAssembliesTask : Task
         $
         """, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace);
 
-
     [Required]
     public ITaskItem[] ApiSets { get; private set; } = null!;
 
@@ -172,7 +171,8 @@ public sealed class GenerateFilteredReferenceAssembliesTask : Task
                 }
                 catch (Exception e)
                 {
-                    Log.LogWarning($"Unable to read '{outputFilePath}': {e.Message}");
+                    Log.LogError($"Unable to read '{outputFilePath}': {e.Message}");
+                    return;
                 }
             }
 

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
@@ -45,7 +45,7 @@
                                   '%(ReferencePath.FileName)' == 'Microsoft.CodeAnalysis.CSharp'" />
 
       <ApiSet Include="@(None)" Condition="'%(None.IsApiSet)' == 'true'" />
-      <Apis Include="@(ApiSet->'$(_ApisDir)%(FileName)%(Extension)')"  />
+      <Apis Include="@(ApiSet->'$(_ApisDir)%(FileName)%(Extension)')" />
       
       <_InputFile Include="@(ApiSet)" />
       <_InputFile Include="@(_InputReference)" />
@@ -58,7 +58,13 @@
   <Target Name="GenerateFilteredReferenceAssemblies" Condition="Exists('$(_BuildTaskAssemblyFile)')" BeforeTargets="AfterBuild" DependsOnTargets="_CalculateFilteredReferenceAssembliesInputsAndOutputs" Inputs="@(_InputFile)" Outputs="@(_OutputFile)">
 
     <MakeDir Directories="$(_OutputDir)" />
-    <Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask References="@(_InputReference)" ApiSets="@(ApiSet)" OutputDir="$(_OutputDir)" ApisDir="$(_ApisDir)" />
+
+    <PropertyGroup>
+      <_RequireNoApiChanges>false</_RequireNoApiChanges>
+      <_RequireNoApiChanges Condition="'$(ContinuousIntegrationBuildCorrectness)' == 'true'">true</_RequireNoApiChanges>
+    </PropertyGroup>
+
+    <Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask References="@(_InputReference)" ApiSets="@(ApiSet)" OutputDir="$(_OutputDir)" ApisDir="$(_ApisDir)" RequireNoApiChanges="$(_RequireNoApiChanges)" />
 
     <ItemGroup>
       <FileWrites Include="@(_OutputFile)" />
@@ -66,7 +72,7 @@
   </Target>
 
   <!-- Used from Setup and test projects to fetch the list of generated ref assemblies -->
-  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="_CalculateFilteredReferenceAssembliesInputsAndOutputs" Returns="@(_OutputFile)"  />
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="_CalculateFilteredReferenceAssembliesInputsAndOutputs" Returns="@(_OutputFile)" />
 
   <!-- Generates ref assemblies -->
   <Target Name="PublishVsixItems" DependsOnTargets="PublishedProjectOutputGroup;GenerateFilteredReferenceAssemblies" Returns="@(_OutputFile)" />


### PR DESCRIPTION
Validate in correctness CI build that the Semantic Search API files are up to date.

Reports error if a new public API is added to the compiler in a PR but the SemanticSearch.ReferenceAssemblies project hasn't been built locally and thus the API files were not updated.