### PR TITLE
Add RuntimeAsyncMethodGenerationAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -316,9 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Returns true if this method should be processed with runtime async handling instead
         /// of compiler async state machine generation.
         /// </summary>
-#pragma warning disable IDE0060 // Remove unused parameter
         internal bool IsRuntimeAsyncEnabledIn(MethodSymbol method)
-#pragma warning restore IDE0060 // Remove unused parameter
         {
             // PROTOTYPE: EE tests fail this assert, handle and test
             //Debug.Assert(ReferenceEquals(method.ContainingAssembly, Assembly));
@@ -327,8 +325,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            // PROTOTYPE: Check for attributes that turn on/off the feature member-by-member
-            return true;
+            return method switch
+            {
+                SourceMethodSymbol { IsRuntimeAsyncEnabledInMethod: ThreeState.True } => true,
+                SourceMethodSymbol { IsRuntimeAsyncEnabledInMethod: ThreeState.False } => false,
+                _ => Feature("runtime-async") == "on"
+            };
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -149,5 +149,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SetDataStored();
             }
         }
+
+        private ThreeState _hasRuntimeAsyncMethodGenerationAttribute;
+        public ThreeState HasRuntimeAsyncMethodGenerationAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasRuntimeAsyncMethodGenerationAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasRuntimeAsyncMethodGenerationAttribute = value;
+                SetDataStored();
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -150,18 +150,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private ThreeState _hasRuntimeAsyncMethodGenerationAttribute;
-        public ThreeState HasRuntimeAsyncMethodGenerationAttribute
+        private ThreeState _runtimeAsyncMethodGenerationSetting;
+        public ThreeState RuntimeAsyncMethodGenerationSetting
         {
             get
             {
                 VerifySealed(expected: true);
-                return _hasRuntimeAsyncMethodGenerationAttribute;
+                return _runtimeAsyncMethodGenerationSetting;
             }
             set
             {
                 VerifySealed(expected: false);
-                _hasRuntimeAsyncMethodGenerationAttribute = value;
+                _runtimeAsyncMethodGenerationSetting = value;
                 SetDataStored();
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -651,6 +651,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         arguments.AttributeSyntaxOpt);
                 }
             }
+            else if (attribute.IsTargetAttribute(AttributeDescription.RuntimeAsyncMethodGenerationAttribute))
+            {
+                // PROTOTYPE: Validate langversion? Validate previewness of the runtime feature flag?
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasRuntimeAsyncMethodGenerationAttribute =
+                    attribute.CommonConstructorArguments[0].DecodeValue<bool>(SpecialType.System_Boolean)
+                        ? ThreeState.True
+                        : ThreeState.False;
+            }
             else
             {
                 var compilation = this.DeclaringCompilation;
@@ -658,6 +666,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     attribute.DecodeSecurityAttribute<MethodWellKnownAttributeData>(this, compilation, ref arguments);
                 }
+            }
+        }
+
+        internal ThreeState IsRuntimeAsyncEnabledInMethod
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.HasRuntimeAsyncMethodGenerationAttribute ?? ThreeState.Unknown;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(AttributeDescription.RuntimeAsyncMethodGenerationAttribute))
             {
                 // PROTOTYPE: Validate langversion? Validate previewness of the runtime feature flag?
-                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasRuntimeAsyncMethodGenerationAttribute =
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().RuntimeAsyncMethodGenerationSetting =
                     attribute.CommonConstructorArguments[0].DecodeValue<bool>(SpecialType.System_Boolean)
                         ? ThreeState.True
                         : ThreeState.False;
@@ -670,13 +670,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal ThreeState IsRuntimeAsyncEnabledInMethod
-        {
-            get
-            {
-                var data = GetDecodedWellKnownAttributeData();
-                return data?.HasRuntimeAsyncMethodGenerationAttribute ?? ThreeState.Unknown;
-            }
-        }
+            => GetDecodedWellKnownAttributeData()?.RuntimeAsyncMethodGenerationSetting ?? ThreeState.Unknown;
 
         internal override ImmutableArray<string> NotNullMembers =>
             GetDecodedWellKnownAttributeData()?.NotNullMembers ?? ImmutableArray<string>.Empty;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -7297,7 +7297,7 @@ class Test1
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
             comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify with { ILVerifyMessage = ReturnValueMissing("<Main>$", "0xa") });
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>$", "0xa") });
 
             verifier.VerifyIL("<top-level-statements-entry-point>", """
                 {
@@ -7321,7 +7321,7 @@ class Test1
 
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
 
-            var verifier = CompileAndVerify(comp, verify: Verification.Passes);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
 
             verifier.VerifyIL("<top-level-statements-entry-point>", """
                 {
@@ -7364,7 +7364,7 @@ class Test1
 
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
 
-            var verifier = CompileAndVerify(comp, verify: Verification.Passes);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
 
             verifier.VerifyIL("<top-level-statements-entry-point>", """
                 {
@@ -7415,7 +7415,7 @@ class Test1
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
             comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify with { ILVerifyMessage = ReturnValueMissing("Main", "0xa") });
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("Main", "0xa") });
 
             verifier.VerifyIL("Program.Main()", """
                 {
@@ -7456,7 +7456,7 @@ class Test1
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
             comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify with { ILVerifyMessage = ReturnValueMissing("Main", "0xa") });
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("Main", "0xa") });
 
             verifier.VerifyIL("Program.Main()", """
                 {
@@ -7519,7 +7519,7 @@ class Test1
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
             comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify with { ILVerifyMessage = ReturnValueMissing("Main", "0x26") });
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("Main", "0x26") });
 
             verifier.VerifyIL("Program.Main()", """
                 {
@@ -7579,7 +7579,7 @@ class Test1
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
             comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
-            var verifier = CompileAndVerify(comp, verify: Verification.Passes);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
 
             verifier.VerifyIL("Program.Main()", """
                 {
@@ -7625,7 +7625,7 @@ class Test1
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
             comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify with { ILVerifyMessage = ReturnValueMissing("<Main>g__LocalFunc|0_0", "0xa") });
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>g__LocalFunc|0_0", "0xa") });
 
             verifier.VerifyIL("Program.Main()", """
                 {
@@ -7681,7 +7681,7 @@ class Test1
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
             comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify with { ILVerifyMessage = ReturnValueMissing("<Main>b__0_0", "0xa") });
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>b__0_0", "0xa") });
 
             verifier.VerifyIL("Program.Main()", """
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 using Basic.Reference.Assemblies;
 using System.Runtime.CompilerServices;
 using System.Reflection;
-using ICSharpCode.Decompiler.IL;
 
 // PROTOTYPE: Verify execution of runtime async methods
 // PROTOTYPE: ILVerify for runtime async?

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -7362,6 +7362,7 @@ class Test1
             }
 
             var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
+            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
 
             var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
 

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -491,5 +491,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription CollectionBuilderAttribute = new AttributeDescription("System.Runtime.CompilerServices", "CollectionBuilderAttribute", s_signaturesOfCollectionBuilderAttribute);
         internal static readonly AttributeDescription OverloadResolutionPriorityAttribute = new AttributeDescription("System.Runtime.CompilerServices", "OverloadResolutionPriorityAttribute", s_signatures_HasThis_Void_Int32_Only);
         internal static readonly AttributeDescription CompilerLoweringPreserveAttribute = new AttributeDescription("System.Runtime.CompilerServices", "CompilerLoweringPreserveAttribute", s_signatures_HasThis_Void_Only);
+        internal static readonly AttributeDescription RuntimeAsyncMethodGenerationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "RuntimeAsyncMethodGenerationAttribute", s_signatures_HasThis_Void_Boolean_Only);
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -813,6 +813,13 @@ namespace System.Diagnostics.CodeAnalysis
             }
             """;
 
+        internal const string RuntimeAsyncMethodGenerationAttributeDefinition = """
+            namespace System.Runtime.CompilerServices;
+
+            [AttributeUsage(AttributeTargets.Method)]
+            public class RuntimeAsyncMethodGenerationAttribute(bool runtimeAsync) : Attribute();
+            """;
+
         protected static T GetSyntax<T>(SyntaxTree tree, string text)
         {
             return GetSyntaxes<T>(tree, text).Single();


### PR DESCRIPTION
Adds control for whether to use runtime async. The flowchart is as follows:

1. The flag `System.Runtime.CompilerServices.RuntimeFeature.Async` must be present.
2. Assuming that flag is present, we look for the presence of `System.Runtime.CompilerServices.RuntimeAsyncMethodGenerationAttribute` on the method. If that attribute is present, we use the preference expressed in the attribute. The preference does not carry to nested contexts, such as local functions or lambdas.
3. If the attribute is not present, we look for `features:runtime-async=on` on the command line. If that is present, then the feature is on by default. Otherwise, the feature is off.

Relates to test plan https://github.com/dotnet/roslyn/issues/75960