### PR TITLE
Fix NFW due to invoking Workspace.RaiseEventForHandlers in the CA process

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -78,14 +78,19 @@ public abstract partial class Workspace
             projectId = documentId.ProjectId;
         }
 
-        var args = new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId);
-
+        WorkspaceChangeEventArgs args = null;
         var ev = GetEventHandlers<WorkspaceChangeEventArgs>(WorkspaceChangedImmediateEventName);
-        RaiseEventForHandlers(ev, args, FunctionId.Workspace_EventsImmediate);
+
+        if (ev.HasHandlers)
+        {
+            args = new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId);
+            RaiseEventForHandlers(ev, args, FunctionId.Workspace_EventsImmediate);
+        }
 
         ev = GetEventHandlers<WorkspaceChangeEventArgs>(WorkspaceChangeEventName);
         if (ev.HasHandlers)
         {
+            args ??= new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId);
             return this.ScheduleTask(() =>
             {
                 RaiseEventForHandlers(ev, args, FunctionId.Workspace_Events);


### PR DESCRIPTION
NFW telemetry indicates Solution.Workspace is getting called in our server process. This is due to a recent change I made around immediate eventing. In the server process, there are no immediate (or standard) workspace event handlers, but due to this recent changewe were always calling RaiseEventForHandlers for the immediate handlers without checking for their presence.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2394018