### PR TITLE
Add IsAvailable to ISemanticSearchCopilotUIProviderImpl

### DIFF
--- a/src/VisualStudio/ExternalAccess/Copilot/Internal/SemanticSearch/SemanticSearchCopilotUIProviderWrapper.cs
+++ b/src/VisualStudio/ExternalAccess/Copilot/Internal/SemanticSearch/SemanticSearchCopilotUIProviderWrapper.cs
@@ -28,7 +28,7 @@ internal sealed class SemanticSearchCopilotUIProviderWrapper(
     }
 
     bool ISemanticSearchCopilotUIProvider.IsAvailable
-        => impl != null;
+        => impl?.Value.IsAvailable == true;
 
     ITextBoxControl ISemanticSearchCopilotUIProvider.GetTextBox()
     {

--- a/src/VisualStudio/ExternalAccess/Copilot/InternalAPI.Unshipped.txt
+++ b/src/VisualStudio/ExternalAccess/Copilot/InternalAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.SemanticSearch.ISemanticSearchCopilotUIProviderImpl
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.SemanticSearch.ISemanticSearchCopilotUIProviderImpl.GetTextBox() -> Microsoft.CodeAnalysis.ExternalAccess.Copilot.SemanticSearch.ITextBoxControlImpl!
+Microsoft.CodeAnalysis.ExternalAccess.Copilot.SemanticSearch.ISemanticSearchCopilotUIProviderImpl.IsAvailable.get -> bool
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.SemanticSearch.ITextBoxControlImpl
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.SemanticSearch.ITextBoxControlImpl.CommandTarget.get -> Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget!
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.SemanticSearch.ITextBoxControlImpl.Control.get -> System.Windows.Controls.Control!

--- a/src/VisualStudio/ExternalAccess/Copilot/SemanticSearch/ISemanticSearchCopilotUIProviderImpl.cs
+++ b/src/VisualStudio/ExternalAccess/Copilot/SemanticSearch/ISemanticSearchCopilotUIProviderImpl.cs
@@ -18,5 +18,6 @@ internal interface ITextBoxControlImpl
 
 internal interface ISemanticSearchCopilotUIProviderImpl
 {
+    bool IsAvailable { get; }
     ITextBoxControlImpl GetTextBox();
 }


### PR DESCRIPTION
Allows Copilot to check a feature flag that determines whether or not to display the prompt in semantic search.