### PR TITLE
Share Copilot doc comment option for C# and C++

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
@@ -45,7 +45,7 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
     private readonly CopilotOption _copilotCodeAnalysisOption = new("EnableCSharpCodeAnalysis", false);
     private readonly CopilotOption _copilotRefineOption = new("EnableCSharpRefineQuickActionSuggestion", false);
     private readonly CopilotOption _copilotOnTheFlyDocsOption = new("EnableOnTheFlyDocs", true);
-    private readonly CopilotOption _copilotGenerateDocumentationCommentOption = new("EnableCSharpGenerateDocumentationComment", true);
+    private readonly CopilotOption _copilotGenerateDocumentationCommentOption = new("EnableGenerateDocumentationComment", true);
 
     private static readonly UIContext s_copilotHasLoadedUIContext = UIContext.FromUIContextGuid(new Guid(CopilotHasLoadedGuid));
     private static readonly UIContext s_gitHubAccountStatusDeterminedContext = UIContext.FromUIContextGuid(new Guid(GitHubAccountStatusDetermined));


### PR DESCRIPTION
This change unifies the option for Copilot doc comments across languages. Updates the option introduced in #76665 

Corresponding PR to Copilot https://devdiv.visualstudio.com/DevDiv/_git/VisualStudio.Conversations/pullrequest/618297

@akhera99 for review