### PR TITLE
Fix incremental generator in deterministic key file

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/DeterministicKeyBuilder.cs
+++ b/src/Compilers/Core/Portable/Compilation/DeterministicKeyBuilder.cs
@@ -185,8 +185,11 @@ namespace Microsoft.CodeAnalysis
                 writer.WriteArrayStart();
                 foreach (var generator in generators)
                 {
+                    object obj = generator is IncrementalGeneratorWrapper w
+                        ? w.Generator
+                        : generator;
                     cancellationToken.ThrowIfCancellationRequested();
-                    WriteType(writer, generator.GetType());
+                    WriteType(writer, obj.GetType());
                 }
                 writer.WriteArrayEnd();
             }

--- a/src/Compilers/Core/Portable/Compilation/DeterministicKeyBuilder.cs
+++ b/src/Compilers/Core/Portable/Compilation/DeterministicKeyBuilder.cs
@@ -185,11 +185,8 @@ namespace Microsoft.CodeAnalysis
                 writer.WriteArrayStart();
                 foreach (var generator in generators)
                 {
-                    object obj = generator is IncrementalGeneratorWrapper w
-                        ? w.Generator
-                        : generator;
                     cancellationToken.ThrowIfCancellationRequested();
-                    WriteType(writer, obj.GetType());
+                    WriteType(writer, obj.GetGeneratorType());
                 }
                 writer.WriteArrayEnd();
             }

--- a/src/Compilers/Core/Portable/Compilation/DeterministicKeyBuilder.cs
+++ b/src/Compilers/Core/Portable/Compilation/DeterministicKeyBuilder.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis
                 foreach (var generator in generators)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    WriteType(writer, obj.GetGeneratorType());
+                    WriteType(writer, generator.GetGeneratorType());
                 }
                 writer.WriteArrayEnd();
             }

--- a/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.Helpers.cs
+++ b/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.Helpers.cs
@@ -54,5 +54,10 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
 
             public void Initialize(GeneratorInitializationContext context) => throw new NotImplementedException();
         }
+
+        private sealed class Generator3 : IIncrementalGenerator
+        {
+            public void Initialize(IncrementalGeneratorInitializationContext context) => throw new NotImplementedException();
+        }
     }
 }

--- a/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
+++ b/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
@@ -803,7 +803,8 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
             var array = GetGeneratorValues(
                 CreateCompilation(Array.Empty<SyntaxTree>()),
                 new Generator(),
-                new Generator2());
+                new Generator2(),
+                new Generator3().AsSourceGenerator());
 
             var assembly = typeof(Generator).Assembly;
             var expected = @$"
@@ -815,6 +816,11 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
   }},
   {{
     ""fullName"": ""{typeof(Generator2).FullName}"",
+    ""assemblyName"": ""{assembly.FullName}"",
+    ""mvid"": ""{DeterministicKeyBuilder.GetGuidValue(assembly.ManifestModule.ModuleVersionId)}""
+  }},
+  {{
+    ""fullName"": ""{typeof(Generator3).FullName}"",
     ""assemblyName"": ""{assembly.FullName}"",
     ""mvid"": ""{DeterministicKeyBuilder.GetGuidValue(assembly.ManifestModule.ModuleVersionId)}""
   }}


### PR DESCRIPTION
The key file was not unwrapping `IIncrementalGenerator` instances when writing out the generator section of the deterministic key file. This meant that they all appeared as `IncrementalGeneratorWrapper` instead of the actual generator type.

Noticed this today when debugging a determinism failure in a different change.