### PR TITLE
Extensions: address some delegate conversion issues

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -340,11 +340,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else if (method.IsStatic)
                             {
-                                thisParameter = null; // PROTOTYPE: Test this code path with respect to ERR_ValueTypeExtDelegate
+                                thisParameter = null;
                             }
                             else
                             {
-                                thisParameter = method.ContainingType.ExtensionParameter; // PROTOTYPE: Test this code path with respect to ERR_ValueTypeExtDelegate
+                                thisParameter = method.ContainingType.ExtensionParameter;
                             }
 
                             if (thisParameter?.Type.IsReferenceType == false)
@@ -468,7 +468,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             MethodSymbol method = result.BestResult.Member;
 
-            if (methodGroup.IsExtensionMethodGroup && !method.Parameters[0].Type.IsReferenceType)
+            if (methodGroup.IsExtensionMethodGroup && !Binder.GetReceiverParameter(method).Type.IsReferenceType)
             {
                 return Conversion.NoConversion;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -458,7 +458,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((options & Options.IsFunctionPointerResolution) != 0)
             {
-                // PROTOTYPE function pointer conversions are not handled yet
                 RemoveCallingConventionMismatches(results, callingConventionInfo);
                 RemoveMethodsNotDeclaredStatic(results);
             }


### PR DESCRIPTION
A couple of tests had to be skipped in a previous PR. This PR re-enables them.

Relates to test plan https://github.com/dotnet/roslyn/issues/76130