### PR TITLE
Fix bug where exact path match would throw for additional files

### DIFF
--- a/src/EditorFeatures/Test/StackTraceExplorer/StackTraceExplorerTests.cs
+++ b/src/EditorFeatures/Test/StackTraceExplorer/StackTraceExplorerTests.cs
@@ -32,8 +32,7 @@ public class StackTraceExplorerTests
         var reparsedResult = await StackTraceAnalyzer.AnalyzeAsync(stackFrame.ToString(), CancellationToken.None);
         Assert.Single(reparsedResult.ParsedFrames);
 
-        var reparsedFrame = reparsedResult.ParsedFrames[0] as ParsedStackFrame;
-        AssertEx.NotNull(reparsedFrame);
+        var reparsedFrame = Assert.IsType<ParsedStackFrame>(reparsedResult.ParsedFrames[0]);
         StackFrameUtils.AssertEqual(stackFrame.Root, reparsedFrame.Root);
 
         // Get the definition for the parsed frame
@@ -820,9 +819,9 @@ class C
         var result = await StackTraceAnalyzer.AnalyzeAsync(line, CancellationToken.None);
         Assert.Equal(1, result.ParsedFrames.Length);
 
-        var parsedFame = result.ParsedFrames.OfType<ParsedStackFrame>().Single();
+        var parsedFrame = Assert.IsType<ParsedStackFrame>(result.ParsedFrames[0]);
         var service = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
-        var definition = await service.TryFindDefinitionAsync(workspace.CurrentSolution, parsedFame, StackFrameSymbolPart.Method, CancellationToken.None);
+        var definition = await service.TryFindDefinitionAsync(workspace.CurrentSolution, parsedFrame, StackFrameSymbolPart.Method, CancellationToken.None);
         Assert.Null(definition);
     }
 
@@ -850,9 +849,7 @@ class C
         var result = await StackTraceAnalyzer.AnalyzeAsync("at System.String.ToLower()", CancellationToken.None);
         Assert.Single(result.ParsedFrames);
 
-        var frame = result.ParsedFrames[0] as ParsedStackFrame;
-        AssertEx.NotNull(frame);
-
+        var frame = Assert.IsType<ParsedStackFrame>(result.ParsedFrames[0]);
         var service = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
         var definition = await service.TryFindDefinitionAsync(workspace.CurrentSolution, frame, StackFrameSymbolPart.Method, CancellationToken.None);
 
@@ -890,9 +887,7 @@ class C
         var result = await StackTraceAnalyzer.AnalyzeAsync("at Path.To.Component.M() in C:/path/to/Component.razor:line 5", CancellationToken.None);
         Assert.Single(result.ParsedFrames);
 
-        var frame = result.ParsedFrames[0] as ParsedStackFrame;
-        AssertEx.NotNull(frame);
-
+        var frame = Assert.IsType<ParsedStackFrame>(result.ParsedFrames[0]);
         var service = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
         var (document, line) = service.GetDocumentAndLine(workspace.CurrentSolution, frame);
         Assert.Equal(5, line);
@@ -932,9 +927,7 @@ class C
         var result = await StackTraceAnalyzer.AnalyzeAsync("at Path.To.Component.M() in Component.razor:line 5", CancellationToken.None);
         Assert.Single(result.ParsedFrames);
 
-        var frame = result.ParsedFrames[0] as ParsedStackFrame;
-        AssertEx.NotNull(frame);
-
+        var frame = Assert.IsType<ParsedStackFrame>(result.ParsedFrames[0]);
         var service = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
         var (document, line) = service.GetDocumentAndLine(workspace.CurrentSolution, frame);
         Assert.Equal(5, line);

--- a/src/EditorFeatures/Test/StackTraceExplorer/StackTraceExplorerTests.cs
+++ b/src/EditorFeatures/Test/StackTraceExplorer/StackTraceExplorerTests.cs
@@ -894,7 +894,6 @@ class C
 
         AssertEx.NotNull(document);
         Assert.Equal(@"C:/path/to/Component.razor", document.FilePath);
-
     }
 
     [Fact]

--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
@@ -89,7 +89,7 @@ internal sealed class StackTraceExplorerService() : IStackTraceExplorerService
 
         if (documentId is not null)
         {
-            var document = solution.GetRequiredDocument(documentId);
+            var document = solution.GetRequiredTextDocument(documentId);
             return [document];
         }
 

--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
@@ -105,11 +105,8 @@ internal sealed class StackTraceExplorerService() : IStackTraceExplorerService
 
             foreach (var document in allDocuments)
             {
-                if (document.FilePath?.EndsWith(documentName, StringComparison.OrdinalIgnoreCase) is true)
-                {
-                    potentialMatches.Add(document);
-                }
-                else if (document.Name.Equals(documentName, StringComparison.OrdinalIgnoreCase))
+                var name = Path.GetFileName(document.Name);
+                if (name.Equals(documentName, StringComparison.OrdinalIgnoreCase))
                 {
                     potentialMatches.Add(document);
                 }

--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerService.cs
@@ -105,7 +105,11 @@ internal sealed class StackTraceExplorerService() : IStackTraceExplorerService
 
             foreach (var document in allDocuments)
             {
-                if (string.Equals(document.Name, documentName, StringComparison.OrdinalIgnoreCase))
+                if (document.FilePath?.EndsWith(documentName, StringComparison.OrdinalIgnoreCase) is true)
+                {
+                    potentialMatches.Add(document);
+                }
+                else if (document.Name.Equals(documentName, StringComparison.OrdinalIgnoreCase))
                 {
                     potentialMatches.Add(document);
                 }


### PR DESCRIPTION
From https://github.com/dotnet/roslyn/pull/77517/files/45c0e103f76f36bed6004f836d3dcfeae4bfae0d#r1992506030
