### PR TITLE
Allow modification of source generated documents

### DIFF
--- a/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHelper.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHelper.cs
@@ -184,6 +184,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
                     newSolution.GetDocument,
                     solution.GetDocument).ConfigureAwait(false);
 
+                // Changed source generated documents
+                if (newSolution.CompilationState.FrozenSourceGeneratedDocumentStates is not null)
+                {
+                    await AddTextDocumentEditsAsync(
+                        changes.GetChangedFrozenSourceGeneratedDocuments(),
+                        newSolution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId,
+                        solution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId).ConfigureAwait(false);
+                }
+
                 // Changed analyzer config documents
                 await AddTextDocumentEditsAsync(
                     projectChanges.SelectMany(pc => pc.GetChangedAnalyzerConfigDocuments()),

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction_Cleanup.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction_Cleanup.cs
@@ -94,7 +94,9 @@ public abstract partial class CodeAction
             using var _ = ArrayBuilder<(DocumentId documentId, CodeCleanupOptions options)>.GetInstance(documentIds.Length, out var documentIdsAndOptions);
             foreach (var documentId in documentIds)
             {
-                var document = changedSolution.GetRequiredDocument(documentId);
+                var document = documentId.IsSourceGenerated
+                    ? changedSolution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(documentId)
+                    : changedSolution.GetRequiredDocument(documentId);
 
                 // Only care about documents that support syntax.  Non-C#/VB files can't be cleaned.
                 if (document.SupportsSyntaxTree)
@@ -157,7 +159,9 @@ public abstract partial class CodeAction
                     var (documentId, options) = documentIdAndOptions;
 
                     // Fetch the current state of the document from this fork of the solution.
-                    var document = solution.GetRequiredDocument(documentId);
+                    var document = documentId.IsSourceGenerated
+                        ? solution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(documentId)
+                        : solution.GetRequiredDocument(documentId);
                     Contract.ThrowIfFalse(document.SupportsSyntaxTree, "GetDocumentIdsAndOptionsAsync should only be returning documents that support syntax");
 
                     // Now, perform the requested cleanup pass on it.

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction_Cleanup.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction_Cleanup.cs
@@ -64,9 +64,14 @@ public abstract partial class CodeAction
         var documentIds = solutionChanges
             .GetProjectChanges()
             .SelectMany(p => p.GetChangedDocuments(onlyGetDocumentsWithTextChanges: true).Concat(p.GetAddedDocuments()))
-            .Concat(solutionChanges.GetAddedProjects().SelectMany(p => p.DocumentIds))
-            .ToImmutableArray();
-        return documentIds;
+            .Concat(solutionChanges.GetAddedProjects().SelectMany(p => p.DocumentIds));
+
+        if (changedSolution.CompilationState.FrozenSourceGeneratedDocumentStates is not null)
+        {
+            documentIds = documentIds.Concat(changedSolution.CompilationState.FrozenSourceGeneratedDocumentStates.States.Select(s => s.Key));
+        }
+
+        return documentIds.ToImmutableArray();
     }
 
     internal static async Task<Solution> CleanSyntaxAndSemanticsAsync(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -391,13 +391,9 @@ public class Document : TextDocument
     {
         var solution = this.Project.Solution.WithDocumentText(this.Id, text, PreservationMode.PreserveIdentity);
 
-        if (Id.IsSourceGenerated)
-        {
-            return solution.GetRequiredProject(Id.ProjectId).TryGetSourceGeneratedDocumentForAlreadyGeneratedId(Id)
-                ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document));
-        }
-
-        return solution.GetRequiredDocument(Id);
+        return this.Id.IsSourceGenerated
+            ? solution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(Id)
+            : solution.GetRequiredDocument(Id);
     }
 
     /// <summary>
@@ -407,13 +403,9 @@ public class Document : TextDocument
     {
         var solution = this.Project.Solution.WithDocumentSyntaxRoot(this.Id, root, PreservationMode.PreserveIdentity);
 
-        if (Id.IsSourceGenerated)
-        {
-            return solution.GetRequiredProject(Id.ProjectId).TryGetSourceGeneratedDocumentForAlreadyGeneratedId(Id)
-                ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document));
-        }
-
-        return solution.GetRequiredDocument(Id);
+        return this.Id.IsSourceGenerated
+            ? solution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(Id)
+            : solution.GetRequiredDocument(Id);
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -388,7 +388,17 @@ public class Document : TextDocument
     /// Creates a new instance of this document updated to have the text specified.
     /// </summary>
     public Document WithText(SourceText text)
-        => this.Project.Solution.WithDocumentText(this.Id, text, PreservationMode.PreserveIdentity).GetRequiredDocument(Id);
+    {
+        var solution = this.Project.Solution.WithDocumentText(this.Id, text, PreservationMode.PreserveIdentity);
+
+        if (Id.IsSourceGenerated)
+        {
+            return solution.GetRequiredProject(Id.ProjectId).TryGetSourceGeneratedDocumentForAlreadyGeneratedId(Id)
+                ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document));
+        }
+
+        return solution.GetRequiredDocument(Id);
+    }
 
     /// <summary>
     /// Creates a new instance of this document updated to have a syntax tree rooted by the specified syntax node.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -404,7 +404,17 @@ public class Document : TextDocument
     /// Creates a new instance of this document updated to have a syntax tree rooted by the specified syntax node.
     /// </summary>
     public Document WithSyntaxRoot(SyntaxNode root)
-        => this.Project.Solution.WithDocumentSyntaxRoot(this.Id, root, PreservationMode.PreserveIdentity).GetRequiredDocument(Id);
+    {
+        var solution = this.Project.Solution.WithDocumentSyntaxRoot(this.Id, root, PreservationMode.PreserveIdentity);
+
+        if (Id.IsSourceGenerated)
+        {
+            return solution.GetRequiredProject(Id.ProjectId).TryGetSourceGeneratedDocumentForAlreadyGeneratedId(Id)
+                ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document));
+        }
+
+        return solution.GetRequiredDocument(Id);
+    }
 
     /// <summary>
     /// Creates a new instance of this document updated to have the specified name.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -549,7 +549,7 @@ internal partial class DocumentState : TextDocumentState
         }
     }
 
-    private VersionStamp GetNewTreeVersionForUpdatedTree(SyntaxNode newRoot, VersionStamp newTextVersion, PreservationMode mode)
+    protected VersionStamp GetNewTreeVersionForUpdatedTree(SyntaxNode newRoot, VersionStamp newTextVersion, PreservationMode mode)
     {
         RoslynDebug.Assert(TreeSource != null);
 
@@ -576,7 +576,7 @@ internal partial class DocumentState : TextDocumentState
         return base.GetLoadDiagnosticAsync(cancellationToken);
     }
 
-    private VersionStamp GetNewerVersion()
+    protected VersionStamp GetNewerVersion()
     {
         if (TextAndVersionSource.TryGetValue(LoadTextOptions, out var textAndVersion))
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1616,7 +1616,7 @@ public partial class Solution
     internal Document WithFrozenSourceGeneratedDocument(
         SourceGeneratedDocumentIdentity documentIdentity, DateTime generationDateTime, SourceText text)
     {
-        var newCompilationState = CompilationState.WithFrozenSourceGeneratedDocuments([(documentIdentity, generationDateTime, text)]);
+        var newCompilationState = CompilationState.WithFrozenSourceGeneratedDocuments([(documentIdentity, generationDateTime, text, syntaxNode: null)]);
         var newSolution = WithCompilationState(newCompilationState);
 
         var newDocumentState = newCompilationState.TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentIdentity.DocumentId);
@@ -1627,7 +1627,7 @@ public partial class Solution
     }
 
     internal Solution WithFrozenSourceGeneratedDocuments(ImmutableArray<(SourceGeneratedDocumentIdentity documentIdentity, DateTime generationDateTime, SourceText text)> documents)
-        => WithCompilationState(CompilationState.WithFrozenSourceGeneratedDocuments(documents));
+        => WithCompilationState(CompilationState.WithFrozenSourceGeneratedDocuments(documents.SelectAsArray(d => (d.documentIdentity, d.generationDateTime, d.text, (SyntaxNode?)null))));
 
     /// <inheritdoc cref="SolutionCompilationState.UpdateSpecificSourceGeneratorExecutionVersions"/>
     internal Solution UpdateSpecificSourceGeneratorExecutionVersions(SourceGeneratorExecutionVersionMap sourceGeneratorExecutionVersionMap)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1740,10 +1740,20 @@ public partial class Solution
             throw new ArgumentNullException(nameof(documentId));
         }
 
-        if (!ContainsDocument(documentId))
+        // For source generated documents we expect them to be already generated to use any of the APIs that call this
+        if (documentId.IsSourceGenerated &&
+            ContainsProject(documentId.ProjectId) &&
+            this.GetRequiredProject(documentId.ProjectId).TryGetSourceGeneratedDocumentForAlreadyGeneratedId(documentId) is not null)
         {
-            throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
+            return;
         }
+
+        if (ContainsDocument(documentId))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
     }
 
     private void CheckContainsDocuments(ImmutableArray<DocumentId> documentIds)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -189,6 +189,27 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
             generationDateTime);
     }
 
+    public SourceGeneratedDocumentState WithSyntaxRoot(SyntaxNode newRoot)
+    {
+        var newTextVersion = GetNewerVersion();
+        var newTreeVersion = GetNewTreeVersionForUpdatedTree(newRoot, newTextVersion, PreservationMode.PreserveValue);
+        var treeAndVersion = new TreeAndVersion(newRoot.SyntaxTree, newTreeVersion);
+        var newTreeSource = SimpleTreeAndVersionSource.Create(treeAndVersion);
+
+        return new(
+            this.Identity,
+            this.LanguageServices,
+            this.DocumentServiceProvider,
+            this.Attributes,
+            this.ParseOptions,
+            this.TextAndVersionSource,
+            this.SourceText,
+            this.LoadTextOptions,
+            newTreeSource,
+            this._lazyContentHash,
+            this.GenerationDateTime);
+    }
+
     /// <summary>
     /// This is modeled after <see cref="DefaultTextDocumentServiceProvider"/>, but sets
     /// <see cref="IDocumentOperationService.CanApplyChange"/> to <see langword="false"/> for source generated

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -975,7 +975,7 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
         Assert.NotEqual(checksum2, checksum3);
     }
 
-    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/56702")]
+    [Theory, CombinatorialData]
     public async Task WithDocumentTexts_OrdinaryAndSourceGeneratedDocuments(TestHost testHost)
     {
         using var workspace = CreateWorkspaceWithPartialSemantics(testHost);
@@ -1008,7 +1008,7 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
         Assert.Equal("// Regular modified", sourceText.ToString());
     }
 
-    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/56702")]
+    [Theory, CombinatorialData]
     public async Task WithSyntaxRootWorksOnSourceGeneratedDocument(TestHost testHost)
     {
         using var workspace = CreateWorkspaceWithPartialSemantics(testHost);
@@ -1068,7 +1068,7 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
         Assert.Equal("// Something else", sourceText.ToString());
     }
 
-    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/56702")]
+    [Theory, CombinatorialData]
     public async Task WithTextWorksOnSourceGeneratedDocument_Multiple(TestHost testHost)
     {
         using var workspace = CreateWorkspaceWithPartialSemantics(testHost);
@@ -1101,7 +1101,7 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
         Assert.Equal("// Thrice is nice", sourceText.ToString());
     }
 
-    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/56702")]
+    [Theory, CombinatorialData]
     public async Task MultipleWithTextUnfreezesFully(TestHost testHost)
     {
         using var workspace = CreateWorkspaceWithPartialSemantics(testHost);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ISolutionExtensions.cs
@@ -63,6 +63,19 @@ internal static partial class ISolutionExtensions
     }
 
 #if !CODE_STYLE
+    public static SourceGeneratedDocument GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(this Solution solution, DocumentId documentId)
+    {
+        if (documentId is null)
+            throw new ArgumentNullException(nameof(documentId));
+
+        var project = solution.GetRequiredProject(documentId.ProjectId);
+        var sourceGeneratedDocument = project.TryGetSourceGeneratedDocumentForAlreadyGeneratedId(documentId);
+        if (sourceGeneratedDocument == null)
+            throw CreateDocumentNotFoundException();
+
+        return sourceGeneratedDocument;
+    }
+
     public static async ValueTask<Document> GetRequiredDocumentAsync(this Solution solution, DocumentId documentId, bool includeSourceGenerated = false, CancellationToken cancellationToken = default)
         => (await solution.GetDocumentAsync(documentId, includeSourceGenerated, cancellationToken).ConfigureAwait(false)) ?? throw CreateDocumentNotFoundException();
 


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/10693

This unblocks Razor completion and most of code actions in cohosting. It allows `WithText` and `WithSyntaxRoot` to work on source generated documents, creating a forked solution with frozen source generated documents. Solutions can be continually frozen without issue, and unfreezing puts them back to their original state. This also allows code actions to run on modified source generated documents, but only if they have been frozen.

As discussed there aren't any flags for this to only be possible from/for Razor.

Still investigating individual code actions that aren't working in Razor, but those will probably be a follow up. Enough of the Razor tests pass now that it proves the system generally works (see comment below).
