### PR TITLE
Attempt to further reduce thread switches during package load.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -62,10 +62,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         {
             base.RegisterInitializationWork(packageRegistrationTasks);
 
-            packageRegistrationTasks.AddTask(isMainThreadTask: false, task: PackageInitializationBgThreadAsync);
+            packageRegistrationTasks.AddTask(isMainThreadTask: false, task: PackageInitializationBackgroundThreadAsync);
         }
 
-        private Task PackageInitializationBgThreadAsync(IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken)
+        private Task PackageInitializationBackgroundThreadAsync(IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -70,10 +70,10 @@ internal sealed partial class ColorSchemeApplier
             _isInitialized = true;
         }
 
-        packageRegistrationTasks.AddTask(isMainThreadTask: false, task: PackageInitializationBgThreadAsync);
+        packageRegistrationTasks.AddTask(isMainThreadTask: false, task: PackageInitializationBackgroundThreadAsync);
     }
 
-    private async Task PackageInitializationBgThreadAsync(IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken)
+    private async Task PackageInitializationBackgroundThreadAsync(IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken)
     {
         var settingsManager = await _asyncServiceProvider.GetServiceAsync<SVsSettingsPersistenceManager, ISettingsManager>(_threadingContext.JoinableTaskFactory).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -28,7 +28,8 @@ internal abstract class AbstractPackage : AsyncPackage
     protected virtual void RegisterInitializationWork(PackageRegistrationTasks packageRegistrationTasks)
     {
         // This treatment of registering work on the bg/main threads is a bit unique as we want the component model initialized at the beginning
-        // of whichever context is invoked first.
+        // of whichever context is invoked first. The current architecture doesn't execute any of the registered tasks concurrently,
+        // so that isn't a concern for running calculating or setting _componentModel_doNotAccessDirectly multiple times.
         packageRegistrationTasks.AddTask(isMainThreadTask: false, task: EnsureComponentModelAsync);
         packageRegistrationTasks.AddTask(isMainThreadTask: true, task: EnsureComponentModelAsync);
 
@@ -42,6 +43,9 @@ internal abstract class AbstractPackage : AsyncPackage
         }
     }
 
+    /// This method is called upon package creation and is the mechanism by which roslyn packages calculate and
+    /// process all package initialization work. Do not override this sealed method, instead override RegisterInitializationWork
+    /// to indicate the work your package needs upon initialization.
     protected sealed override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
         var packageRegistrationTasks = new PackageRegistrationTasks(JoinableTaskFactory);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 
@@ -25,10 +26,69 @@ internal abstract class AbstractPackage : AsyncPackage
         }
     }
 
-    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    protected virtual void RegisterInitializationWork(List<Func<IProgress<ServiceProgressData>, CancellationToken, Task>> bgThreadWorkTasks, List<Func<IProgress<ServiceProgressData>, CancellationToken, Task>> mainThreadWorkTasks)
     {
-        _componentModel_doNotAccessDirectly = (IComponentModel?)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(false);
-        Assumes.Present(_componentModel_doNotAccessDirectly);
+        // This treatment of registering work on the bg/main threads is a bit unique as we want the component model initialized at the beginning
+        // of whichever context is invoked first.
+        bgThreadWorkTasks.Add(EnsureComponentModelAsync);
+        mainThreadWorkTasks.Add(EnsureComponentModelAsync);
+
+        async Task EnsureComponentModelAsync(IProgress<ServiceProgressData> progress, CancellationToken token)
+        {
+            if (_componentModel_doNotAccessDirectly == null)
+            {
+                _componentModel_doNotAccessDirectly = (IComponentModel?)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(false);
+                Assumes.Present(_componentModel_doNotAccessDirectly);
+            }
+        }
+    }
+
+    protected sealed override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        var bgThreadWorkTasks = new List<Func<IProgress<ServiceProgressData>, CancellationToken, Task>>();
+        var mainThreadWorkTasks = new List<Func<IProgress<ServiceProgressData>, CancellationToken, Task>>();
+
+        // Request all initially known work, classified into whether it should be processed on the main or
+        // background thread. These lists can be modified by the work itself to add more work for subsequent processing.
+        // Requesting this information is useful as it lets us batch up work on these threads, significantly
+        // reducing thread switches during package load.
+        RegisterInitializationWork(bgThreadWorkTasks, mainThreadWorkTasks);
+
+        // prime the pump by doing the first group of bg thread work if the initiating thread is not the main thread
+        if (!JoinableTaskFactory.Context.IsOnMainThread)
+            await PerformWorkAsync(useMainThread: false).ConfigureAwait(false);
+
+        // Continue processing work until everything is completed, switching between main and bg threads as needed.
+        while (mainThreadWorkTasks.Count > 0 || bgThreadWorkTasks.Count > 0)
+        {
+            await PerformWorkAsync(useMainThread: true).ConfigureAwait(false);
+            await PerformWorkAsync(useMainThread: false).ConfigureAwait(false);
+        }
+
+        return;
+
+        async Task PerformWorkAsync(bool useMainThread)
+        {
+            var workTasks = useMainThread ? mainThreadWorkTasks : bgThreadWorkTasks;
+
+            // Ensure we're invoking the task on the right thread
+            if (useMainThread)
+                await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            else if (JoinableTaskFactory.Context.IsOnMainThread)
+                await TaskScheduler.Default;
+
+            for (var i = 0; i < workTasks.Count; i++)
+            {
+                var work = workTasks[i];
+
+                // CA(true) is important here, as we want to ensure that each iteration is done in the same
+                // captured context. Thus, even poorly behaving tasks (ie, those that do their own thread switching)
+                // don't effect the next loop iteration.
+                await work(progress, cancellationToken).ConfigureAwait(true);
+            }
+
+            workTasks.Clear();
+        }
     }
 
     protected override async Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -34,63 +34,58 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
     {
     }
 
-    protected override void RegisterInitializationWork(List<Func<IProgress<ServiceProgressData>, CancellationToken, Task>> bgThreadWorkTasks, List<Func<IProgress<ServiceProgressData>, CancellationToken, Task>> mainThreadWorkTasks)
+    protected override void RegisterInitializationWork(PackageRegistrationTasks packageRegistrationTasks)
     {
-        base.RegisterInitializationWork(bgThreadWorkTasks, mainThreadWorkTasks);
+        base.RegisterInitializationWork(packageRegistrationTasks);
 
-        mainThreadWorkTasks.Add(async (progress, cancellationToken) =>
+        packageRegistrationTasks.AddTask(isMainThreadTask: true, task: PackageInitializationMainThreadAsync);
+    }
+
+    private async Task PackageInitializationMainThreadAsync(IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken)
+    {
+        var shell = (IVsShell7?)await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
+        var solution = (IVsSolution?)await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(true);
+        Assumes.Present(shell);
+        Assumes.Present(solution);
+
+        _shell = (IVsShell?)shell;
+        Assumes.Present(_shell);
+
+        foreach (var editorFactory in CreateEditorFactories())
         {
-            var shell = (IVsShell7?)await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
-            var solution = (IVsSolution?)await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(true);
-            Assumes.Present(shell);
-            Assumes.Present(solution);
+            RegisterEditorFactory(editorFactory);
+        }
 
-            _shell = (IVsShell?)shell;
-            Assumes.Present(_shell);
+        RegisterLanguageService(typeof(TLanguageService), async cancellationToken =>
+        {
+            // Ensure we're on the BG when creating the language service.
+            await TaskScheduler.Default;
 
-            foreach (var editorFactory in CreateEditorFactories())
-            {
-                RegisterEditorFactory(editorFactory);
-            }
+            // Create the language service, tell it to set itself up, then store it in a field
+            // so we can notify it that it's time to clean up.
+            _languageService = CreateLanguageService();
+            await _languageService.SetupAsync(cancellationToken).ConfigureAwait(false);
 
-            RegisterLanguageService(typeof(TLanguageService), async cancellationToken =>
-            {
-                // Ensure we're on the BG when creating the language service.
-                await TaskScheduler.Default;
-
-                // Create the language service, tell it to set itself up, then store it in a field
-                // so we can notify it that it's time to clean up.
-                _languageService = CreateLanguageService();
-                await _languageService.SetupAsync(cancellationToken).ConfigureAwait(false);
-
-                return _languageService.ComAggregate!;
-            });
-
-            var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
-
-            await shell.LoadPackageAsync(Guids.RoslynPackageId);
-
-            // Be a bit paranoid, as LoadPackageAsync returns an IVsTask, and I'm not certain of it's
-            // behavior if call finishes on a different thread. This should be removed soon anyway as the code
-            // following this looks like it can be reordered/refactored to not require the main thread.
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            // LoadPackageAsync can transition us to a bg thread, so ensure we're back on the main thread
-            if (!JoinableTaskFactory.Context.IsOnMainThread)
-            {
-                System.Diagnostics.Debugger.Launch();
-                await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            }
-
-            RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
-
-            if (!_shell.IsInCommandLineMode())
-            {
-                // not every derived package support object browser and for those languages
-                // this is a no op
-                RegisterObjectBrowserLibraryManager();
-            }
+            return _languageService.ComAggregate!;
         });
+
+        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
+
+        await shell.LoadPackageAsync(Guids.RoslynPackageId);
+
+        // Be a bit paranoid, as LoadPackageAsync returns an IVsTask, and I'm not certain of it's
+        // behavior if call finishes on a different thread. This should be removed soon anyway as the code
+        // following this looks like it can be reordered/refactored to not require the main thread.
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
+
+        if (!_shell.IsInCommandLineMode())
+        {
+            // not every derived package support object browser and for those languages
+            // this is a no op
+            RegisterObjectBrowserLibraryManager();
+        }
     }
 
     protected override async Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -48,9 +48,7 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
         Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread);
 
         var shell = (IVsShell7?)await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
-        var solution = (IVsSolution?)await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(true);
         Assumes.Present(shell);
-        Assumes.Present(solution);
 
         _shell = (IVsShell?)shell;
         Assumes.Present(_shell);
@@ -75,12 +73,8 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
         var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
 
+        // awaiting an IVsTask guarantees to return on the captured context
         await shell.LoadPackageAsync(Guids.RoslynPackageId);
-
-        // Be a bit paranoid, as LoadPackageAsync returns an IVsTask, and I'm not certain of it's
-        // behavior if the call finishes on a different thread. This should be removed soon anyway as the code
-        // following this looks like it can be reordered/refactored to not require the main thread.
-        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 

--- a/src/VisualStudio/Core/Def/LanguageService/PackageRegistrationTasks.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/PackageRegistrationTasks.cs
@@ -8,12 +8,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using WorkTask = System.Func<
-    System.IProgress<Microsoft.VisualStudio.Shell.ServiceProgressData>,
-    Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService.PackageRegistrationTasks,
-    System.Threading.CancellationToken, System.Threading.Tasks.Task>;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
+
+using WorkTask = Func<IProgress<ServiceProgressData>, PackageRegistrationTasks, CancellationToken, Task>;
 
 /// <summary>
 /// Provides a mechanism for registering work to be done during package initialization. Work is registered

--- a/src/VisualStudio/Core/Def/LanguageService/PackageRegistrationTasks.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/PackageRegistrationTasks.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
+
+internal class PackageRegistrationTasks(JoinableTaskFactory jtf)
+{
+    private readonly List<Func<IProgress<ServiceProgressData>, PackageRegistrationTasks, CancellationToken, Task>> _bgThreadWorkTasks = new();
+    private readonly List<Func<IProgress<ServiceProgressData>, PackageRegistrationTasks, CancellationToken, Task>> _mainThreadWorkTasks = new();
+    private readonly JoinableTaskFactory _jtf = jtf;
+
+    public void AddTask(bool isMainThreadTask, Func<IProgress<ServiceProgressData>, PackageRegistrationTasks, CancellationToken, Task> task)
+    {
+        if (isMainThreadTask)
+            _mainThreadWorkTasks.Add(task);
+        else
+            _bgThreadWorkTasks.Add(task);
+    }
+
+    public async Task ProcessTasksAsync(IProgress<ServiceProgressData> progress, CancellationToken cancellationToken)
+    {
+        // prime the pump by doing the first group of bg thread work if the initiating thread is not the main thread
+        if (!_jtf.Context.IsOnMainThread)
+            await PerformWorkAsync(useMainThread: false, progress, cancellationToken).ConfigureAwait(false);
+
+        // Continue processing work until everything is completed, switching between main and bg threads as needed.
+        while (_mainThreadWorkTasks.Count > 0 || _bgThreadWorkTasks.Count > 0)
+        {
+            await PerformWorkAsync(useMainThread: true, progress, cancellationToken).ConfigureAwait(false);
+            await PerformWorkAsync(useMainThread: false, progress, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task PerformWorkAsync(bool useMainThread, IProgress<ServiceProgressData> progress, CancellationToken cancellationToken)
+    {
+        var workTasks = useMainThread ? _mainThreadWorkTasks : _bgThreadWorkTasks;
+
+        if (workTasks.Count == 0)
+            return;
+
+        // Ensure we're invoking the task on the right thread
+        if (useMainThread)
+            await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        else if (_jtf.Context.IsOnMainThread)
+            await TaskScheduler.Default;
+
+        for (var i = 0; i < workTasks.Count; i++)
+        {
+            var work = workTasks[i];
+
+            // CA(true) is important here, as we want to ensure that each iteration is done in the same
+            // captured context. Thus, even poorly behaving tasks (ie, those that do their own thread switching)
+            // don't effect the next loop iteration.
+            await work(progress, this, cancellationToken).ConfigureAwait(true);
+        }
+
+        workTasks.Clear();
+    }
+}

--- a/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
@@ -35,7 +35,7 @@ internal sealed class VisualStudioSettingsOptionPersister
         = ImmutableDictionary<string, (OptionKey2, string)>.Empty;
 
     /// <remarks>
-    /// We make sure this code is from the UI by asking for all <see cref="IOptionPersister"/> in <see cref="RoslynPackage.InitializeAsync"/>
+    /// We make sure this code is from the UI by asking for all <see cref="IOptionPersister"/> in <see cref="RoslynPackage.OnAfterPackageLoadedAsync"/>
     /// </remarks>
     public VisualStudioSettingsOptionPersister(Action<OptionKey2, object?> refreshOption, ImmutableDictionary<string, Lazy<IVisualStudioStorageReadFallback, OptionNameMetadata>> readFallbacks, ISettingsManager settingsManager)
     {

--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -74,7 +74,6 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
 
     public async Task InitializeAsync()
     {
-        await TaskScheduler.Default;
         _textManager = await _textManagerService.GetValueAsync().ConfigureAwait(false);
     }
 

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -144,10 +144,10 @@ internal sealed class RoslynPackage : AbstractPackage
     {
         base.RegisterInitializationWork(packageRegistrationTasks);
 
-        packageRegistrationTasks.AddTask(isMainThreadTask: false, task: PackageInitializationBgThreadAsync);
+        packageRegistrationTasks.AddTask(isMainThreadTask: false, task: PackageInitializationBackgroundThreadAsync);
     }
 
-    private Task PackageInitializationBgThreadAsync(IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken)
+    private Task PackageInitializationBackgroundThreadAsync(IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken)
     {
         _colorSchemeApplier = ComponentModel.GetService<ColorSchemeApplier>();
         _colorSchemeApplier.RegisterInitializationWork(packageRegistrationTasks);

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -145,7 +145,7 @@ internal sealed class RoslynPackage : AbstractPackage
     {
         base.RegisterInitializationWork(bgThreadWorkTasks, mainThreadWorkTasks);
 
-        bgThreadWorkTasks.Add(async (progress, cancellationToken) =>
+        bgThreadWorkTasks.Add((progress, cancellationToken) =>
         {
             _colorSchemeApplier = ComponentModel.GetService<ColorSchemeApplier>();
             _colorSchemeApplier.RegisterInitializationWork(bgThreadWorkTasks, mainThreadWorkTasks);
@@ -185,6 +185,8 @@ internal sealed class RoslynPackage : AbstractPackage
                     await miscellaneousFilesWorkspace.InitializeAsync().ConfigureAwait(false);
                 });
             });
+
+            return Task.CompletedTask;
         });
     }
 


### PR DESCRIPTION
This is the 3rd part of a multi-part PR series focused on improving the performance of loading the roslyn packages.

This PR focuses mostly on creating a mechanism to significantly reduce thread switches during package load.

Part 1: https://github.com/dotnet/roslyn/pull/77439
Part 2: https://github.com/dotnet/roslyn/pull/77561

The Rolsyn package load sequence is quite confusing, and trying to re-order statements is difficult and fraught with danger if one of the calls is entered or returns on an unexpected thread. For example, one component created during load, the ColorSchemeApplier, needs to be initialized during this sequence, but does up to three thread switches during it's initialization. Every time work is added to the package load sequence, we run a pretty high risk of adding new thread switches during this critical period.

Instead, this change allows packages to add work to main thread or background thread work lists. Items in each of these lists are batched together and can use a single thread switch for the entire batch. These lists can be added to during processing, allowing packages to "discover" new work that needs to be processed as they proceed.