### PR TITLE
Relax signature collision rules for static extension methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -102,6 +102,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
+        /// Same as <see cref="DuplicateSourceComparer"/>, but also considers return type_and_ref-ness differences
+        /// </summary>
+        public static readonly MemberSignatureComparer DuplicateSourceWithReturnComparer = new MemberSignatureComparer(
+            considerName: true,
+            considerExplicitlyImplementedInterfaces: true,
+            considerReturnType: true,
+            considerTypeConstraints: false,
+            considerCallingConvention: false,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
+
+        /// <summary>
         /// This instance is used to determine if some API specific to records is explicitly declared.
         /// It is the same as <see cref="DuplicateSourceComparer"/> except it considers ref kinds as well.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1972,6 +1972,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var conversionsAsMethods = new Dictionary<MethodSymbol, SourceMemberMethodSymbol>(MemberSignatureComparer.DuplicateSourceComparer);
             var conversionsAsConversions = new HashSet<SourceUserDefinedConversionSymbol>(ConversionSignatureComparer.Comparer);
 
+            Dictionary<MethodSymbol, OneOrMany<MethodSymbol>>? staticExtensionImplementationsWithoutReturn = null;
+            Dictionary<MethodSymbol, MethodSymbol>? staticExtensionImplementationsWithReturn = null;
+
             // SPEC: The signature of an operator must differ from the signatures of all other
             // SPEC: operators declared in the same class.
 
@@ -2113,11 +2116,89 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             ReportMethodSignatureCollision(diagnostics, conversion, previousMethod);
                         }
+
+                        if (staticExtensionImplementationsWithoutReturn?.TryGetValue(conversion, out OneOrMany<MethodSymbol> previousStaticExtension) == true)
+                        {
+                            Debug.Assert(false); // At the moment this code path is not reachable because implementation methods always come after all user defined methods
+                            ReportMethodSignatureCollision(diagnostics, conversion, previousStaticExtension.First());
+                        }
+
                         // Do not add the conversion to the set of previously-seen methods; that set
                         // is only non-conversion methods.
                     }
+                    else if (symbol is SourceExtensionImplementationMethodSymbol { UnderlyingMethod.IsStatic: true } staticExtension)
+                    {
+                        staticExtensionImplementationsWithReturn ??= new Dictionary<MethodSymbol, MethodSymbol>(MemberSignatureComparer.DuplicateSourceWithReturnComparer);
+
+                        // Does this method collide with any previously-seen static extension implementation?
+                        if (staticExtensionImplementationsWithReturn.TryGetValue(staticExtension, out var fullMatch))
+                        {
+                            ReportMethodSignatureCollision(diagnostics, staticExtension, fullMatch);
+                        }
+                        else
+                        {
+                            staticExtensionImplementationsWithReturn.Add(staticExtension, staticExtension);
+
+                            staticExtensionImplementationsWithoutReturn ??= new Dictionary<MethodSymbol, OneOrMany<MethodSymbol>>(MemberSignatureComparer.DuplicateSourceComparer);
+
+                            if (staticExtensionImplementationsWithoutReturn.TryGetValue(staticExtension, out OneOrMany<MethodSymbol> previousStaticExtension))
+                            {
+                                NamedTypeSymbol extension = staticExtension.UnderlyingMethod.ContainingType;
+                                var extensionParameter = extension.ExtensionParameter;
+                                bool foundExtendedTypeConflict = false;
+
+                                if (extensionParameter is not null)
+                                {
+                                    foreach (SourceExtensionImplementationMethodSymbol partialMatch in previousStaticExtension)
+                                    {
+                                        NamedTypeSymbol partialMatchExtension = partialMatch.UnderlyingMethod.ContainingType;
+                                        if (extension.Arity != partialMatchExtension.Arity ||
+                                            partialMatchExtension.ExtensionParameter is not { } partialMatchExtensionParameter)
+                                        {
+                                            continue;
+                                        }
+
+                                        if (extensionParameter.Type.Equals(
+                                                extension.Arity == 0 ?
+                                                    partialMatchExtensionParameter.Type :
+                                                    (new TypeMap(partialMatchExtension.TypeParameters, extension.TypeParameters)).SubstituteType(partialMatchExtensionParameter.Type).Type,
+                                                TypeCompareKind.AllIgnoreOptions))
+                                        {
+                                            foundExtendedTypeConflict = true;
+                                            ReportMethodSignatureCollision(diagnostics, staticExtension, partialMatch);
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                if (!foundExtendedTypeConflict)
+                                {
+                                    staticExtensionImplementationsWithoutReturn[staticExtension] = previousStaticExtension.Add(staticExtension);
+                                }
+                            }
+                            else
+                            {
+                                staticExtensionImplementationsWithoutReturn.Add(staticExtension, OneOrMany.Create<MethodSymbol>(staticExtension));
+                            }
+                        }
+
+                        // Does this static extension implementation collide *as a method* with any previously-seen
+                        // non-static-extension-implementation method?
+
+                        if (methodsBySignature.TryGetValue(staticExtension, out var previousMethod))
+                        {
+                            ReportMethodSignatureCollision(diagnostics, staticExtension, previousMethod);
+                        }
+
+                        if (conversionsAsMethods.TryGetValue(staticExtension, out var previousConversion))
+                        {
+                            ReportMethodSignatureCollision(diagnostics, staticExtension, previousConversion);
+                        }
+                    }
                     else if (symbol is MethodSymbol method && method is (SourceMemberMethodSymbol or SourceExtensionImplementationMethodSymbol))
                     {
+                        Debug.Assert(method is not SourceExtensionImplementationMethodSymbol { UnderlyingMethod.IsStatic: true });
+
                         // Does this method collide *as a method* with any previously-seen
                         // conversion?
 
@@ -2128,7 +2209,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // Do not add the method to the set of previously-seen conversions.
 
                         // Does this method collide *as a method* with any previously-seen
-                        // non-conversion method?
+                        // static extension implementation method?
+
+                        if (staticExtensionImplementationsWithoutReturn?.TryGetValue(method, out OneOrMany<MethodSymbol> previousStaticExtension) == true)
+                        {
+                            ReportMethodSignatureCollision(diagnostics, method, previousStaticExtension.First());
+                        }
+
+                        // Does this method collide *as a method* with any previously-seen
+                        // non-conversion or non-static-extension-implementation method?
 
                         if (methodsBySignature.TryGetValue(method, out var previousMethod))
                         {

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -20235,14 +20235,11 @@ static class Extensions
             //         static public void M5() {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M5").WithArguments("M5", "Extensions.extension(object)").WithLocation(46, 28),
 
-            // PROTOTYPE: It feels unfortunate that we generate conflicting signatures, the methods extend different types (refer to M6 and M7 cases)
+            // PROTOTYPE: It feels unfortunate that we generate conflicting signatures, the methods extend different types (refer to M6 case)
 
             // (56,28): error CS0111: Type 'Extensions' already defines a member called 'M6' with the same parameter types
             //         static public void M6() {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M6").WithArguments("M6", "Extensions").WithLocation(56, 28),
-            // (66,28): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
-            //         static public long M7() => 0;
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(66, 28), // PROTOTYPE: Signatures in metadata are different in this case (return type is different), consider if we want to enable this specific case 
 
             // (76,28): error CS0111: Type 'Extensions' already defines a member called 'M8' with the same parameter types
             //         public static void M8() {}
@@ -21058,6 +21055,917 @@ static class Extensions
             // (11,23): error CS0082: Type 'Extensions' already reserves a member called 'set_P2' with the same parameter types
             //     public static int P2 => 4;
             Diagnostic(ErrorCode.ERR_MemberReserved, "P2").WithArguments("set_P2", "Extensions").WithLocation(11, 23)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_18()
+    {
+        var src = """
+public static class Extensions
+{
+    extension(object receiver)
+    {
+        static public void M1(int x) {}
+    }
+
+    public static int M1 => 4;
+
+    extension(object receiver)
+    {
+        static public void M2(int x) {}
+    }
+
+    public static int M2 = 4;
+
+    extension(object receiver)
+    {
+        static public void M3(int x) {}
+    }
+
+#pragma warning disable CS0067 // The event 'Extensions.M3' is never used
+    public static event System.Action M3;
+}
+""";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (5,28): error CS0102: The type 'Extensions' already contains a definition for 'M1'
+            //         static public void M1(int x) {}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "M1").WithArguments("Extensions", "M1").WithLocation(5, 28),
+            // (12,28): error CS0102: The type 'Extensions' already contains a definition for 'M2'
+            //         static public void M2(int x) {}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "M2").WithArguments("Extensions", "M2").WithLocation(12, 28),
+            // (19,28): error CS0102: The type 'Extensions' already contains a definition for 'M3'
+            //         static public void M3(int x) {}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "M3").WithArguments("Extensions", "M3").WithLocation(19, 28)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_19()
+    {
+        var src = """
+public static class Extensions
+{
+    public static int M1 => 4;
+
+    extension(object receiver)
+    {
+        static public void M1(int x) {}
+    }
+
+    public static int M2 = 4;
+
+    extension(object receiver)
+    {
+        static public void M2(int x) {}
+    }
+
+#pragma warning disable CS0067 // The event 'Extensions.M3' is never used
+    public static event System.Action M3;
+
+    extension(object receiver)
+    {
+        static public void M3(int x) {}
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (7,28): error CS0102: The type 'Extensions' already contains a definition for 'M1'
+            //         static public void M1(int x) {}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "M1").WithArguments("Extensions", "M1").WithLocation(7, 28),
+            // (14,28): error CS0102: The type 'Extensions' already contains a definition for 'M2'
+            //         static public void M2(int x) {}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "M2").WithArguments("Extensions", "M2").WithLocation(14, 28),
+            // (22,28): error CS0102: The type 'Extensions' already contains a definition for 'M3'
+            //         static public void M3(int x) {}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "M3").WithArguments("Extensions", "M3").WithLocation(22, 28)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_20_DifferentReturn()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public int M7() => 1;
+    }
+
+    extension(long receiver)
+    {
+        static public long M7() => 2;
+    }
+}
+""";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(int.M7());
+        System.Console.Write(long.M7());
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: "12").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        Extensions.M7();
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+        comp.VerifyDiagnostics(
+            // (5,20): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions.M7()' and 'Extensions.M7()'
+            //         Extensions.M7();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M7").WithArguments("Extensions.M7()", "Extensions.M7()").WithLocation(5, 20)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_21_DifferentReturn_PropertyGetVsMethod()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public int get_M7() => 1;
+    }
+
+    extension(long receiver)
+    {
+        static public long M7 => 2;
+    }
+}
+""";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(int.get_M7());
+        System.Console.Write(long.M7);
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: "12").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        Extensions.get_M7();
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+        comp.VerifyDiagnostics(
+            // (5,20): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions.get_M7()' and 'Extensions.get_M7()'
+            //         Extensions.get_M7();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "get_M7").WithArguments("Extensions.get_M7()", "Extensions.get_M7()").WithLocation(5, 20)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void SignatureConflict_22_DifferentReturn_SameReceiverType(
+        [CombinatorialValues("", "in ", "ref ", "ref readonly ")] string modifier1,
+        [CombinatorialValues("", "in ", "ref ", "ref readonly ")] string modifier2)
+    {
+        var src1 = @"
+public static class Extensions
+{
+    extension(" + modifier1 + @"int receiver)
+    {
+        static public int M7() => 1;
+    }
+
+    extension(" + modifier2 + @"int receiver)
+    {
+        static public long M7() => 2;
+    }
+}
+";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (11,28): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public long M7() => 2;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(11, 28)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_23_DifferentReturn_SameReceiverType_Generic()
+    {
+        var src1 = @"
+public static class Extensions
+{
+    extension<T>(T receiver)
+    {
+        static public int M7() => 1;
+    }
+
+    extension<T>(T receiver)
+    {
+        static public long M7() => 2;
+    }
+}
+";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (11,28): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public long M7() => 2;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(11, 28)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_24_SameReturn_Generic_DifferentReceiverType()
+    {
+        var src1 = @"
+public static class Extensions
+{
+    extension<T>(T[] receiver)
+    {
+        static public T M7() => default;
+    }
+
+    extension<T>(T receiver)
+    {
+        static public T M7() => default;
+    }
+}
+";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (11,25): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public T M7() => default;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(11, 25)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_25_DifferentReturn_SameReceiverType_DifferentTupleNames()
+    {
+        var src1 = @"
+public static class Extensions
+{
+    extension((int a, int b) receiver)
+    {
+        static public int M7() => 1;
+    }
+
+    extension((int c, int d) receiver)
+    {
+        static public long M7() => 2;
+    }
+}
+";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (11,28): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public long M7() => 2;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(11, 28)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_26_SameReturn_DifferentRefKind()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public int M7() => 1;
+    }
+
+    extension(long receiver)
+    {
+        static public ref int M7() => ref F;
+    }
+
+    public static int F;
+}
+""";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(int.M7());
+        long.M7() = 2;
+        System.Console.Write(Extensions.F);
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: "12").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        Extensions.M7();
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+        comp.VerifyDiagnostics(
+            // (5,20): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions.M7()' and 'Extensions.M7()'
+            //         Extensions.M7();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M7").WithArguments("Extensions.M7()", "Extensions.M7()").WithLocation(5, 20)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_27_SameReturn_DifferentRefKind()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public int M7() => 1;
+    }
+
+    extension(long receiver)
+    {
+        static public ref readonly int M7() => ref F;
+    }
+
+    public static int F = 2;
+}
+""";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(int.M7());
+        System.Console.Write(long.M7());
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: "12").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(Extensions.M7());
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like by value return is preferred. Why?
+        CompileAndVerify(comp, expectedOutput: "1").VerifyDiagnostics();
+
+        var src4 = """
+class Program
+{
+    static void Main()
+    {
+        ref readonly int x = ref Extensions.M7();
+    }
+}
+""";
+        comp = CreateCompilation([src1, src4], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like by value return is preferred. Why?
+        comp.VerifyDiagnostics(
+            // (5,34): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+            //         ref readonly int x = ref Extensions.M7();
+            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "Extensions.M7()").WithLocation(5, 34)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_28_SameReturn_DifferentRefKind()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(long receiver)
+    {
+        static public ref readonly int M7() => ref F;
+    }
+
+    extension(int receiver)
+    {
+        static public int M7() => 1;
+    }
+
+    public static int F = 2;
+}
+""";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(int.M7());
+        System.Console.Write(long.M7());
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: "12").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(Extensions.M7());
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like by value return is preferred. Why?
+        CompileAndVerify(comp, expectedOutput: "1").VerifyDiagnostics();
+
+        var src4 = """
+class Program
+{
+    static void Main()
+    {
+        ref readonly int x = ref Extensions.M7();
+    }
+}
+""";
+        comp = CreateCompilation([src1, src4], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like by value return is preferred. Why?
+        comp.VerifyDiagnostics(
+            // (5,34): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+            //         ref readonly int x = ref Extensions.M7();
+            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "Extensions.M7()").WithLocation(5, 34)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_29_SameReturn_DifferentRefKind()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public ref readonly int M7() => ref F1;
+    }
+
+    extension(long receiver)
+    {
+        static public ref int M7() => ref F2;
+    }
+
+    public static int F1 = 1;
+    public static int F2 = 2;
+}
+""";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(int.M7());
+        long.M7()++;
+        System.Console.Write(Extensions.F2);
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+
+        // 'ref readonly' return gets 'modreq([System.Runtime]System.Runtime.InteropServices.InAttribute)'
+        // This makes signatures different in metadata
+        CompileAndVerify(comp, expectedOutput: "13").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(Extensions.M7());
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like 'ref' return is preferred. Why? Probably due to 'modreq' on 'ref readonly'.
+        CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+        var src4 = """
+class Program
+{
+    static void Main()
+    {
+        Extensions.M7()++;
+        System.Console.Write(Extensions.F2);
+    }
+}
+""";
+        comp = CreateCompilation([src1, src4], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like 'ref' return is preferred. Why? Probably due to 'modreq' on 'ref readonly'.
+        CompileAndVerify(comp, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void SignatureConflict_30_SameReturn_DifferentRefKind()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(long receiver)
+    {
+        static public ref int M7() => ref F2;
+    }
+
+    extension(int receiver)
+    {
+        static public ref readonly int M7() => ref F1;
+    }
+
+    public static int F1 = 1;
+    public static int F2 = 2;
+}
+""";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(int.M7());
+        long.M7()++;
+        System.Console.Write(Extensions.F2);
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+
+        // 'ref readonly' return gets 'modreq([System.Runtime]System.Runtime.InteropServices.InAttribute)'
+        // This makes signatures different in metadata
+        CompileAndVerify(comp, expectedOutput: "13").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(Extensions.M7());
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like 'ref' return is preferred. Why? Probably due to 'modreq' on 'ref readonly'.
+        CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+        var src4 = """
+class Program
+{
+    static void Main()
+    {
+        Extensions.M7()++;
+        System.Console.Write(Extensions.F2);
+    }
+}
+""";
+        comp = CreateCompilation([src1, src4], options: TestOptions.DebugExe);
+
+        // PROTOTYPE: It looks like 'ref' return is preferred. Why? Probably due to 'modreq' on 'ref readonly'.
+        CompileAndVerify(comp, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void SignatureConflict_31_SameReturn_SameRefKind([CombinatorialValues("", "ref ", "ref readonly ")] string modifier)
+    {
+        var src1 = @"
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public " + modifier + @"int M7() => throw null;
+    }
+
+    extension(long receiver)
+    {
+        static public " + modifier + @"int M7() => throw null;
+    }
+}
+";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (11,27): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public int M7() => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(11, 27 + modifier.Length)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_32_SameReturn_DifferentRefKind_SameReceiverType()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public int M7() => throw null;
+    }
+
+    extension(int receiver)
+    {
+        static public ref int M7() => throw null;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (10,31): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public ref int M7() => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(10, 31)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_33_SameReturn_DifferentRefKind_SameReceiverType()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public int M7() => throw null;
+    }
+
+    extension(int receiver)
+    {
+        static public ref readonly int M7() => throw null;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (10,40): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public ref readonly int M7() => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(10, 40)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_34_SameReturn_DifferentRefKind_SameReceiverType()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public ref readonly int M7() => throw null;
+    }
+
+    extension(int receiver)
+    {
+        static public ref int M7() => throw null;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (10,31): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public ref int M7() => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(10, 31)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void SignatureConflict_35_DifferentReturn_SameReceiverTypeAndDifferentReceiverType([CombinatorialValues(0, 1, 2)] int insertPosition)
+    {
+        string[] inserts = ["", "", ""];
+
+        inserts[insertPosition] = @"
+    extension(long receiver)
+    {
+        static public long M7() => 2;
+    }
+";
+
+        var src1 = @"
+public static class Extensions
+{
+" + inserts[0] + @"
+    extension(int receiver)
+    {
+        static public byte M7() => 1;
+    }
+" + inserts[1] + @"
+    extension(int receiver)
+    {
+#line 300
+        static public int M7() => 3;
+    }
+" + inserts[2] + @"
+}
+";
+
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (300,27): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public int M7() => 3;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(300, 27)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_36_DifferentReturn_SameReceiverType()
+    {
+        var src1 = @"
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public long M7() => 1;
+    }
+    extension(int receiver)
+    {
+        static public int M7() => 2;
+    }
+    extension(int receiver)
+    {
+        static public byte M7() => 3;
+    }
+}
+";
+
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (10,27): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public int M7() => 2;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(10, 27),
+            // (14,28): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
+            //         static public byte M7() => 3;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(14, 28)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_37_DifferentReturn_Generic_DifferentReceiverType()
+    {
+        var src1 = @"
+public static class Extensions
+{
+    extension<T, U>(C<T, U> receiver)
+    {
+        static public int M7(C<T, U> x) => 1;
+    }
+
+    extension<T>(T receiver)
+    {
+        static public long M7<U>(C<T, U> x) => 2;
+    }
+}
+
+public class C<T, U>{}
+";
+
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(C<int, int>.M7(new C<int, int>()));
+        System.Console.Write(int.M7(new C<int, int>()));
+    }
+}
+""";
+        var comp = CreateCompilation([src1, src2], options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: "12").VerifyDiagnostics();
+
+        var src3 = """
+class Program
+{
+    static void Main()
+    {
+        Extensions.M7(new C<int, int>());
+    }
+}
+""";
+        comp = CreateCompilation([src1, src3], options: TestOptions.DebugExe);
+        comp.VerifyDiagnostics(
+            // (5,20): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions.M7<T, U>(C<T, U>)' and 'Extensions.M7<T, U>(C<T, U>)'
+            //         Extensions.M7(new C<int, int>());
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M7").WithArguments("Extensions.M7<T, U>(C<T, U>)", "Extensions.M7<T, U>(C<T, U>)").WithLocation(5, 20)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_38_DifferentReturn_ConflictWithConversion()
+    {
+        var src1 = """
+public static class Extensions
+{
+    public static implicit operator int(long x) => throw null;
+
+    extension(int receiver)
+    {
+        static public string op_Implicit(long x) => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (3,37): error CS0715: 'Extensions.implicit operator int(long)': static classes cannot contain user-defined operators
+            //     public static implicit operator int(long x) => throw null;
+            Diagnostic(ErrorCode.ERR_OperatorInStaticClass, "int").WithArguments("Extensions.implicit operator int(long)").WithLocation(3, 37),
+            // (7,30): error CS0111: Type 'Extensions' already defines a member called 'op_Implicit' with the same parameter types
+            //         static public string op_Implicit(long x) => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "op_Implicit").WithArguments("op_Implicit", "Extensions").WithLocation(7, 30)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_39_DifferentReturn_ConflictWithConversion()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public string op_Implicit(long x) => throw null;
+    }
+
+    public static implicit operator int(long x) => throw null;
+}
+""";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (5,30): error CS0111: Type 'Extensions' already defines a member called 'op_Implicit' with the same parameter types
+            //         static public string op_Implicit(long x) => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "op_Implicit").WithArguments("op_Implicit", "Extensions").WithLocation(5, 30),
+            // (8,37): error CS0715: 'Extensions.implicit operator int(long)': static classes cannot contain user-defined operators
+            //     public static implicit operator int(long x) => throw null;
+            Diagnostic(ErrorCode.ERR_OperatorInStaticClass, "int").WithArguments("Extensions.implicit operator int(long)").WithLocation(8, 37)
+            );
+    }
+
+    [Fact]
+    public void SignatureConflict_40_StaticVsInstance()
+    {
+        var src1 = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        static public string M1(long x) => throw null;
+        public string M2() => throw null;
+    }
+
+    extension(long receiver)
+    {
+        public string M1() => throw null;
+        static public string M2(int x) => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(src1);
+        comp.VerifyDiagnostics(
+            // (11,23): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
+            //         public string M1() => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "Extensions").WithLocation(11, 23),
+            // (12,30): error CS0111: Type 'Extensions' already defines a member called 'M2' with the same parameter types
+            //         static public string M2(int x) => throw null;
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M2").WithArguments("M2", "Extensions").WithLocation(12, 30)
             );
     }
 


### PR DESCRIPTION
Specifically, two static extension methods are allowed to have the same signature (according to the current language rules) as long as all the following conditions are met:
- methods have different return type and/or different return ref-ness
- methods extending different types (ref-ness of the receiver parameter is not considered)