### PR TITLE
Filter down the list of files we need to examing when looking for a `:base(...)` call in find refs

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -29,8 +29,20 @@ internal sealed class ConstructorInitializerSymbolReferenceFinder : AbstractRefe
         return FindDocumentsAsync(project, documents, static async (document, name, cancellationToken) =>
         {
             var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
+
             if (index.ContainsBaseConstructorInitializer)
-                return true;
+            {
+                // if we have `partial class C { ... : base(...) }` we have to assume it might be a match, as the base
+                // type reference might be in a another part of the partial in another file.
+                if (index.ContainsPartialClass)
+                    return true;
+
+                // Otherwise, if it doesn't have any partial types, ensure that the base type name is referenced in the
+                // same file.  e.g. `partial class C : B { ... base(...) }`.   This allows us to greatly filter down the
+                // number of matches, presuming that most inheriting types in a project are not themselves partial.
+                if (index.ProbablyContainsIdentifier(name))
+                    return true;
+            }
 
             if (index.ProbablyContainsIdentifier(name))
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -23,7 +23,7 @@ internal abstract partial class AbstractSyntaxIndex<TIndex>
     /// that we will not try to read previously cached data from a prior version of roslyn with a different format and
     /// will instead regenerate all the indices with the new format.
     /// </summary>
-    private static readonly Checksum s_serializationFormatChecksum = CodeAnalysis.Checksum.Create("45");
+    private static readonly Checksum s_serializationFormatChecksum = CodeAnalysis.Checksum.Create("46");
 
     /// <summary>
     /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -37,7 +37,8 @@ internal sealed partial class SyntaxTreeIndex
             bool containsCollectionInitializer,
             bool containsAttribute,
             bool containsDirective,
-            bool containsPrimaryConstructorBaseType)
+            bool containsPrimaryConstructorBaseType,
+            bool containsPartialClass)
             : this(predefinedTypes, predefinedOperators,
                    ConvertToContainingNodeFlag(
                      containsForEachStatement,
@@ -58,7 +59,8 @@ internal sealed partial class SyntaxTreeIndex
                      containsCollectionInitializer,
                      containsAttribute,
                      containsDirective,
-                     containsPrimaryConstructorBaseType))
+                     containsPrimaryConstructorBaseType,
+                     containsPartialClass))
         {
         }
 
@@ -88,7 +90,8 @@ internal sealed partial class SyntaxTreeIndex
             bool containsCollectionInitializer,
             bool containsAttribute,
             bool containsDirective,
-            bool containsPrimaryConstructorBaseType)
+            bool containsPrimaryConstructorBaseType,
+            bool containsPartialClass)
         {
             var containingNodes = ContainingNodes.None;
 
@@ -111,6 +114,7 @@ internal sealed partial class SyntaxTreeIndex
             containingNodes |= containsAttribute ? ContainingNodes.ContainsAttribute : 0;
             containingNodes |= containsDirective ? ContainingNodes.ContainsDirective : 0;
             containingNodes |= containsPrimaryConstructorBaseType ? ContainingNodes.ContainsPrimaryConstructorBaseType : 0;
+            containingNodes |= containsPartialClass ? ContainingNodes.ContainsPartialClass : 0;
 
             return containingNodes;
         }
@@ -135,6 +139,9 @@ internal sealed partial class SyntaxTreeIndex
 
         public bool ContainsLockStatement
             => (_containingNodes & ContainingNodes.ContainsLockStatement) == ContainingNodes.ContainsLockStatement;
+
+        public bool ContainsPartialClass
+            => (_containingNodes & ContainingNodes.ContainsPartialClass) == ContainingNodes.ContainsPartialClass;
 
         public bool ContainsUsingStatement
             => (_containingNodes & ContainingNodes.ContainsUsingStatement) == ContainingNodes.ContainsUsingStatement;
@@ -225,6 +232,7 @@ internal sealed partial class SyntaxTreeIndex
             ContainsAttribute = 1 << 16,
             ContainsDirective = 1 << 17,
             ContainsPrimaryConstructorBaseType = 1 << 18,
+            ContainsPartialClass = 1 << 19,
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -32,6 +32,7 @@ internal sealed partial class SyntaxTreeIndex
     public bool ContainsImplicitObjectCreation => _contextInfo.ContainsImplicitObjectCreation;
     public bool ContainsIndexerMemberCref => _contextInfo.ContainsIndexerMemberCref;
     public bool ContainsLockStatement => _contextInfo.ContainsLockStatement;
+    public bool ContainsPartialClass => _contextInfo.ContainsPartialClass;
     public bool ContainsQueryExpression => _contextInfo.ContainsQueryExpression;
     public bool ContainsThisConstructorInitializer => _contextInfo.ContainsThisConstructorInitializer;
     public bool ContainsTupleExpressionOrTupleType => _contextInfo.ContainsTupleExpressionOrTupleType;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
@@ -70,6 +70,7 @@ internal class CSharpSyntaxKinds : ISyntaxKinds
     public int FalseKeyword => (int)SyntaxKind.FalseKeyword;
     public int IfKeyword => (int)SyntaxKind.IfKeyword;
     public int NewKeyword => (int)SyntaxKind.NewKeyword;
+    public int PartialKeyword => (int)SyntaxKind.PartialKeyword;
     public int TrueKeyword => (int)SyntaxKind.TrueKeyword;
     public int UsingKeyword => (int)SyntaxKind.UsingKeyword;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
@@ -56,6 +56,7 @@ internal interface ISyntaxKinds
     int? GlobalStatement { get; }
     int IfKeyword { get; }
     int NewKeyword { get; }
+    int PartialKeyword { get; }
     int TrueKeyword { get; }
     int UsingKeyword { get; }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
@@ -73,6 +73,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
         Public ReadOnly Property IfKeyword As Integer = SyntaxKind.IfKeyword Implements ISyntaxKinds.IfKeyword
         Public ReadOnly Property NewKeyword As Integer = SyntaxKind.NewKeyword Implements ISyntaxKinds.NewKeyword
         Public ReadOnly Property TrueKeyword As Integer = SyntaxKind.TrueKeyword Implements ISyntaxKinds.TrueKeyword
+        Public ReadOnly Property PartialKeyword As Integer = SyntaxKind.PartialKeyword Implements ISyntaxKinds.PartialKeyword
         Public ReadOnly Property UsingKeyword As Integer = SyntaxKind.UsingKeyword Implements ISyntaxKinds.UsingKeyword
 
         Public ReadOnly Property AliasQualifiedName As Integer? Implements ISyntaxKinds.AliasQualifiedName


### PR DESCRIPTION
Note: we already have tests for tehse scenarios.  This just adds a speedup optimization to avoid looking at unnecessary files.