### PR TITLE
Move feature-oriented helpers to appropriate location

### DIFF
--- a/src/Features/CSharp/Portable/SolutionCrawler/CSharpDocumentDifferenceService.cs
+++ b/src/Features/CSharp/Portable/SolutionCrawler/CSharpDocumentDifferenceService.cs
@@ -2,21 +2,40 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.SolutionCrawler;
 
 [ExportLanguageService(typeof(IDocumentDifferenceService), LanguageNames.CSharp), Shared]
-internal class CSharpDocumentDifferenceService : AbstractDocumentDifferenceService
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpDocumentDifferenceService() : AbstractDocumentDifferenceService
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpDocumentDifferenceService()
+    protected override bool IsContainedInMemberBody(SyntaxNode node, TextSpan span)
     {
+        switch (node)
+        {
+            case ConstructorDeclarationSyntax constructor:
+                return (constructor.Body != null && GetBlockBodySpan(constructor.Body).Contains(span)) ||
+                       (constructor.Initializer != null && constructor.Initializer.Span.Contains(span));
+            case BaseMethodDeclarationSyntax method:
+                return method.Body != null && GetBlockBodySpan(method.Body).Contains(span);
+            case BasePropertyDeclarationSyntax property:
+                return property.AccessorList != null && property.AccessorList.Span.Contains(span);
+            case EnumMemberDeclarationSyntax @enum:
+                return @enum.EqualsValue != null && @enum.EqualsValue.Span.Contains(span);
+            case BaseFieldDeclarationSyntax field:
+                return field.Declaration != null && field.Declaration.Span.Contains(span);
+        }
+
+        return false;
     }
+
+    private static TextSpan GetBlockBodySpan(BlockSyntax body)
+        => TextSpan.FromBounds(body.OpenBraceToken.Span.End, body.CloseBraceToken.SpanStart);
 }

--- a/src/Features/Core/Portable/SolutionCrawler/AbstractDocumentDifferenceService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/AbstractDocumentDifferenceService.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler;
 
 internal abstract class AbstractDocumentDifferenceService : IDocumentDifferenceService
 {
+    protected abstract bool IsContainedInMemberBody(SyntaxNode oldMember, TextSpan span);
+
     public async Task<SyntaxNode?> GetChangedMemberAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)
     {
         try
@@ -99,7 +101,7 @@ internal abstract class AbstractDocumentDifferenceService : IDocumentDifferenceS
         }
     }
 
-    private static SyntaxNode? GetChangedMember(
+    private SyntaxNode? GetChangedMember(
         ISyntaxFactsService syntaxFactsService, SyntaxNode oldRoot, SyntaxNode newRoot, TextChangeRange range)
     {
         // if either old or new tree contains skipped text, re-analyze whole document
@@ -118,7 +120,7 @@ internal abstract class AbstractDocumentDifferenceService : IDocumentDifferenceS
         }
 
         // member doesn't contain the change
-        if (!syntaxFactsService.ContainsInMemberBody(oldMember, range.Span))
+        if (!IsContainedInMemberBody(oldMember, range.Span))
         {
             return null;
         }

--- a/src/Features/VisualBasic/Portable/SolutionCrawler/VisualBasicDocumentDifferenceService.vb
+++ b/src/Features/VisualBasic/Portable/SolutionCrawler/VisualBasicDocumentDifferenceService.vb
@@ -5,15 +5,69 @@
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.SolutionCrawler
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.SolutionCrawler
     <ExportLanguageService(GetType(IDocumentDifferenceService), LanguageNames.VisualBasic), [Shared]>
-    Friend Class VisualBasicDocumentDifferenceService
+    Friend NotInheritable Class VisualBasicDocumentDifferenceService
         Inherits AbstractDocumentDifferenceService
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
         End Sub
+
+        Protected Overrides Function IsContainedInMemberBody(node As SyntaxNode, span As Text.TextSpan) As Boolean
+            Dim method = TryCast(node, MethodBlockBaseSyntax)
+            If method IsNot Nothing Then
+                Return method.Statements.Count > 0 AndAlso ContainsExclusively(GetSyntaxListSpan(method.Statements), span)
+            End If
+
+            Dim [event] = TryCast(node, EventBlockSyntax)
+            If [event] IsNot Nothing Then
+                Return [event].Accessors.Count > 0 AndAlso ContainsExclusively(GetSyntaxListSpan([event].Accessors), span)
+            End If
+
+            Dim [property] = TryCast(node, PropertyBlockSyntax)
+            If [property] IsNot Nothing Then
+                Return [property].Accessors.Count > 0 AndAlso ContainsExclusively(GetSyntaxListSpan([property].Accessors), span)
+            End If
+
+            Dim field = TryCast(node, FieldDeclarationSyntax)
+            If field IsNot Nothing Then
+                Return field.Declarators.Count > 0 AndAlso ContainsExclusively(GetSeparatedSyntaxListSpan(field.Declarators), span)
+            End If
+
+            Dim [enum] = TryCast(node, EnumMemberDeclarationSyntax)
+            If [enum] IsNot Nothing Then
+                Return [enum].Initializer IsNot Nothing AndAlso ContainsExclusively([enum].Initializer.Span, span)
+            End If
+
+            Dim propStatement = TryCast(node, PropertyStatementSyntax)
+            If propStatement IsNot Nothing Then
+                Return propStatement.Initializer IsNot Nothing AndAlso ContainsExclusively(propStatement.Initializer.Span, span)
+            End If
+
+            Return False
+        End Function
+
+        Private Shared Function ContainsExclusively(outerSpan As TextSpan, innerSpan As TextSpan) As Boolean
+            If innerSpan.IsEmpty Then
+                Return outerSpan.Contains(innerSpan.Start)
+            End If
+
+            Return outerSpan.Contains(innerSpan)
+        End Function
+
+        Private Shared Function GetSyntaxListSpan(Of T As SyntaxNode)(list As SyntaxList(Of T)) As TextSpan
+            Debug.Assert(list.Count > 0)
+            Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
+        End Function
+
+        Private Shared Function GetSeparatedSyntaxListSpan(Of T As SyntaxNode)(list As SeparatedSyntaxList(Of T)) As TextSpan
+            Debug.Assert(list.Count > 0)
+            Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteDocumentDifferenceService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteDocumentDifferenceService.cs
@@ -18,30 +18,20 @@ namespace Microsoft.CodeAnalysis.Remote;
 /// Default <see cref="AbstractDocumentDifferenceService"/> is optimized for typing case in editor where we have events
 /// for each typing. But in remote workspace, we aggregate changes and update solution in bulk and we don't have concept
 /// of active file making default implementation unsuitable. Functionally, default one is still correct, but it often
-/// time makes us to do more than we need. Basically, it always says this project has semantic change which can cause
-/// a lot of re-analysis.
+/// time makes us to do more than we need. Basically, it always says this project has semantic change which can cause a
+/// lot of re-analysis.
 /// </summary>
 internal class RemoteDocumentDifferenceService : IDocumentDifferenceService
 {
     [ExportLanguageService(typeof(IDocumentDifferenceService), LanguageNames.CSharp, layer: ServiceLayer.Host), Shared]
-    internal sealed class CSharpDocumentDifferenceService : RemoteDocumentDifferenceService
-    {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpDocumentDifferenceService()
-        {
-        }
-    }
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class CSharpDocumentDifferenceService() : RemoteDocumentDifferenceService;
 
     [ExportLanguageService(typeof(IDocumentDifferenceService), LanguageNames.VisualBasic, layer: ServiceLayer.Host), Shared]
-    internal sealed class VisualBasicDocumentDifferenceService : AbstractDocumentDifferenceService
-    {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualBasicDocumentDifferenceService()
-        {
-        }
-    }
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class VisualBasicDocumentDifferenceService() : RemoteDocumentDifferenceService;
 
     public Task<SyntaxNode?> GetChangedMemberAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -912,52 +912,18 @@ internal class CSharpSyntaxFacts : AbstractSyntaxFacts, ISyntaxFacts
     public TextSpan GetMemberBodySpanForSpeculativeBinding(SyntaxNode node)
     {
         if (node.Span.IsEmpty)
-        {
             return default;
-        }
 
         var member = GetContainingMemberDeclaration(node, node.SpanStart);
         if (member == null)
-        {
             return default;
-        }
 
         // TODO: currently we only support method for now
-        if (member is BaseMethodDeclarationSyntax method)
-        {
-            if (method.Body == null)
-            {
-                return default;
-            }
-
-            return GetBlockBodySpan(method.Body);
-        }
+        if (member is BaseMethodDeclarationSyntax { Body: not null } method)
+            return TextSpan.FromBounds(method.Body.OpenBraceToken.Span.End, method.Body.CloseBraceToken.SpanStart);
 
         return default;
     }
-
-    public bool ContainsInMemberBody([NotNullWhen(true)] SyntaxNode? node, TextSpan span)
-    {
-        switch (node)
-        {
-            case ConstructorDeclarationSyntax constructor:
-                return (constructor.Body != null && GetBlockBodySpan(constructor.Body).Contains(span)) ||
-                       (constructor.Initializer != null && constructor.Initializer.Span.Contains(span));
-            case BaseMethodDeclarationSyntax method:
-                return method.Body != null && GetBlockBodySpan(method.Body).Contains(span);
-            case BasePropertyDeclarationSyntax property:
-                return property.AccessorList != null && property.AccessorList.Span.Contains(span);
-            case EnumMemberDeclarationSyntax @enum:
-                return @enum.EqualsValue != null && @enum.EqualsValue.Span.Contains(span);
-            case BaseFieldDeclarationSyntax field:
-                return field.Declaration != null && field.Declaration.Span.Contains(span);
-        }
-
-        return false;
-    }
-
-    private static TextSpan GetBlockBodySpan(BlockSyntax body)
-        => TextSpan.FromBounds(body.OpenBraceToken.Span.End, body.CloseBraceToken.SpanStart);
 
     public SyntaxNode? TryGetBindableParent(SyntaxToken token)
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -420,8 +420,6 @@ internal interface ISyntaxFacts
     SyntaxList<SyntaxNode> GetMembersOfTypeDeclaration(SyntaxNode typeDeclaration);
 
     // Violation.  This is a feature level API.
-    bool ContainsInMemberBody([NotNullWhen(true)] SyntaxNode? node, TextSpan span);
-    // Violation.  This is a feature level API.
     TextSpan GetInactiveRegionSpanAroundPosition(SyntaxTree tree, int position, CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -834,58 +834,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return Nothing
         End Function
 
-        Public Function ContainsInMemberBody(node As SyntaxNode, span As TextSpan) As Boolean Implements ISyntaxFacts.ContainsInMemberBody
-            Dim method = TryCast(node, MethodBlockBaseSyntax)
-            If method IsNot Nothing Then
-                Return method.Statements.Count > 0 AndAlso ContainsExclusively(GetSyntaxListSpan(method.Statements), span)
-            End If
-
-            Dim [event] = TryCast(node, EventBlockSyntax)
-            If [event] IsNot Nothing Then
-                Return [event].Accessors.Count > 0 AndAlso ContainsExclusively(GetSyntaxListSpan([event].Accessors), span)
-            End If
-
-            Dim [property] = TryCast(node, PropertyBlockSyntax)
-            If [property] IsNot Nothing Then
-                Return [property].Accessors.Count > 0 AndAlso ContainsExclusively(GetSyntaxListSpan([property].Accessors), span)
-            End If
-
-            Dim field = TryCast(node, FieldDeclarationSyntax)
-            If field IsNot Nothing Then
-                Return field.Declarators.Count > 0 AndAlso ContainsExclusively(GetSeparatedSyntaxListSpan(field.Declarators), span)
-            End If
-
-            Dim [enum] = TryCast(node, EnumMemberDeclarationSyntax)
-            If [enum] IsNot Nothing Then
-                Return [enum].Initializer IsNot Nothing AndAlso ContainsExclusively([enum].Initializer.Span, span)
-            End If
-
-            Dim propStatement = TryCast(node, PropertyStatementSyntax)
-            If propStatement IsNot Nothing Then
-                Return propStatement.Initializer IsNot Nothing AndAlso ContainsExclusively(propStatement.Initializer.Span, span)
-            End If
-
-            Return False
-        End Function
-
-        Private Shared Function ContainsExclusively(outerSpan As TextSpan, innerSpan As TextSpan) As Boolean
-            If innerSpan.IsEmpty Then
-                Return outerSpan.Contains(innerSpan.Start)
-            End If
-
-            Return outerSpan.Contains(innerSpan)
-        End Function
-
-        Private Shared Function GetSyntaxListSpan(Of T As SyntaxNode)(list As SyntaxList(Of T)) As TextSpan
-            Debug.Assert(list.Count > 0)
-            Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
-        End Function
-
-        Private Shared Function GetSeparatedSyntaxListSpan(Of T As SyntaxNode)(list As SeparatedSyntaxList(Of T)) As TextSpan
-            Debug.Assert(list.Count > 0)
-            Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
-        End Function
-
         Public Function GetMembersOfTypeDeclaration(typeDeclaration As SyntaxNode) As SyntaxList(Of SyntaxNode) Implements ISyntaxFacts.GetMembersOfTypeDeclaration
             Return DirectCast(typeDeclaration, TypeBlockSyntax).Members
         End Function


### PR DESCRIPTION
ISyntaxFacts is not a dumping ground for individual features to place their logic in a shared location.  It is intended to supply a uniform way of talkign to VB/C# when both are identical in syntactic structure.  