### PR TITLE
Extensions: update semantic model APIs

### DIFF
--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.StructDeclaration:
                 case SyntaxKind.RecordDeclaration:
                 case SyntaxKind.RecordStructDeclaration:
-                    // PROTOTYPE likely needs work for semantic model
+                    // PROTOTYPE likely needs work for analyzers
                     {
                         if (associatedSymbol is IMethodSymbol ctor)
                         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1465,7 +1465,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (!typeParameters.IsEmpty)
                     {
-                        if (resolution.IsExtensionMethodGroup)
+                        if (resolution.IsExtensionMethodGroup) // PROTOTYPE we need to handle new extension methods
                         {
                             // We need to validate an ability to infer type arguments as well as check conversion to 'this' parameter.
                             // Overload resolution doesn't check the conversion when 'this' type refers to a type parameter

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8597,7 +8597,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CompoundUseSiteInfo<AssemblySymbol> classicExtensionUseSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
                 scope.Binder.LookupAllExtensionMembersInSingleBinder(
                     lookupResult, memberName, arity, lookupOptions,
-                    originalBinder: binder, classicExtensionUseSiteInfo: ref classicExtensionUseSiteInfo);
+                    originalBinder: binder, useSiteInfo: ref useSiteInfo, classicExtensionUseSiteInfo: ref classicExtensionUseSiteInfo);
 
                 diagnostics.Add(expression, classicExtensionUseSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8589,15 +8589,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = default;
 
                 // 1. gather candidates
-                scope.Binder.LookupExtensionMembersInSingleBinder(
-                    lookupResult, left.Type, memberName, arity,
-                    basesBeingResolved: null, lookupOptions, originalBinder: binder, ref useSiteInfo);
-
                 CompoundUseSiteInfo<AssemblySymbol> classicExtensionUseSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
-                binder.LookupExtensionMethods(classicExtensionLookupResult, scope, memberName, arity, ref classicExtensionUseSiteInfo);
-                diagnostics.Add(expression, classicExtensionUseSiteInfo);
+                scope.Binder.LookupAllExtensionMembersInSingleBinder(
+                    lookupResult, left.Type, memberName, arity,
+                    basesBeingResolved: null, lookupOptions, originalBinder: binder,
+                    ref useSiteInfo, ref classicExtensionUseSiteInfo);
 
-                lookupResult.MergeEqual(classicExtensionLookupResult);
+                diagnostics.Add(expression, classicExtensionUseSiteInfo);
 
                 if (!lookupResult.IsMultiViable)
                 {
@@ -11012,7 +11010,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var scope in new ExtensionScopes(this))
                 {
                     methodGroup.Clear();
-                    PopulateExtensionMethodsFromSingleBinder(scope, methodGroup, node.Syntax, receiver, node.Name, typeArguments, BindingDiagnosticBag.Discarded);
+                    PopulateExtensionMethodsFromSingleBinder(scope, methodGroup, node.Syntax, receiver, node.Name, typeArguments, BindingDiagnosticBag.Discarded); // PROTOTYPE account for new extension members
                     var methods = ArrayBuilder<MethodSymbol>.GetInstance(capacity: methodGroup.Methods.Count);
                     foreach (var extensionMethod in methodGroup.Methods)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8001,7 +8001,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (resolution.IsNonMethodExtensionMember(out Symbol? extensionMember))
             {
                 Debug.Assert(typeArgumentsOpt.IsDefault);
-                diagnostics.AddRange(resolution.Diagnostics); // PROTOTYPE test dependencies/diagnostics
+                if (!receiver.HasErrors)
+                {
+                    diagnostics.AddRange(resolution.Diagnostics); // PROTOTYPE test dependencies/diagnostics
+                }
+
                 resolution.Free();
 
                 return GetExtensionMemberAccess(syntax, receiver, extensionMember, diagnostics);
@@ -8592,8 +8596,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // 1. gather candidates
                 CompoundUseSiteInfo<AssemblySymbol> classicExtensionUseSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
                 scope.Binder.LookupAllExtensionMembersInSingleBinder(
-                    lookupResult, left.Type, memberName, arity,
-                    lookupOptions, originalBinder: binder, classicExtensionUseSiteInfo: ref classicExtensionUseSiteInfo);
+                    lookupResult, memberName, arity, lookupOptions,
+                    originalBinder: binder, classicExtensionUseSiteInfo: ref classicExtensionUseSiteInfo);
 
                 diagnostics.Add(expression, classicExtensionUseSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -44,13 +44,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal void LookupExtensionMethods(LookupResult result, string name, int arity, LookupOptions options, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+#nullable enable
+        internal void LookupAllExtensions(LookupResult result, TypeSymbol receiverType, string? name, LookupOptions options)
         {
+            var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+
             foreach (var scope in new ExtensionScopes(this))
             {
-                this.LookupExtensionMethodsInSingleBinder(scope, result, name, arity, options, ref useSiteInfo);
+                scope.Binder.LookupAllExtensionMembersInSingleBinder(
+                  result, receiverType, name, arity: 0,
+                  basesBeingResolved: null, options, originalBinder: this,
+                  ref discardedUseSiteInfo, ref discardedUseSiteInfo);
             }
         }
+#nullable disable
 
         /// <summary>
         /// Look for any symbols in scope with the given name and arity.
@@ -177,34 +184,75 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        private void LookupExtensionMembersInSingleBinder(LookupResult result, TypeSymbol receiverType,
-            string name, int arity, ConsList<TypeSymbol>? basesBeingResolved, LookupOptions options,
-            Binder originalBinder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private void LookupAllExtensionMembersInSingleBinder(LookupResult result, TypeSymbol receiverType,
+            string? name, int arity, ConsList<TypeSymbol>? basesBeingResolved, LookupOptions options,
+            Binder originalBinder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, ref CompoundUseSiteInfo<AssemblySymbol> classicExtensionUseSiteInfo)
         {
-            Debug.Assert(name is not null);
+            var singleLookupResults = ArrayBuilder<SingleLookupResult>.GetInstance();
+            EnumerateAllExtensionMembersInSingleBinder(singleLookupResults, receiverType, name, arity, options, originalBinder, ref classicExtensionUseSiteInfo);
+            foreach (var singleLookupResult in singleLookupResults)
+            {
+                result.MergeEqual(singleLookupResult);
+            }
 
-            var extensions = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+            singleLookupResults.Free();
+        }
+
+        internal void EnumerateAllExtensionMembersInSingleBinder(ArrayBuilder<SingleLookupResult> result,
+            TypeSymbol receiverType, string? name, int arity, LookupOptions options, Binder originalBinder,
+            ref CompoundUseSiteInfo<AssemblySymbol> classicExtensionUseSiteInfo)
+        {
+            // 1. Collect new extension members
+            var extensionDeclarations = ArrayBuilder<NamedTypeSymbol>.GetInstance();
 
             Debug.Assert(!receiverType.IsDynamic());
             if (!receiverType.IsErrorType())
             {
-                this.GetExtensionDeclarations(extensions, originalBinder);
+                this.GetExtensionDeclarations(extensionDeclarations, originalBinder);
             }
 
-            var tempResult = LookupResult.GetInstance();
-            foreach (NamedTypeSymbol extension in extensions)
+            PooledHashSet<MethodSymbol>? implementationsToShadow = null;
+
+            foreach (NamedTypeSymbol extensionDeclaration in extensionDeclarations)
             {
-                // No need for "diagnose" since we discard the lookup results (and associated diagnostic info)
-                // unless the results are good.
-                LookupMembersInClass(tempResult, extension, name, arity, basesBeingResolved,
-                    options, originalBinder, diagnose: false, ref useSiteInfo);
+                var candidates = name is null ? extensionDeclaration.GetMembers() : extensionDeclaration.GetMembers(name);
 
-                result.MergeEqual(tempResult);
-                tempResult.Clear();
+                foreach (var candidate in candidates)
+                {
+                    SingleLookupResult resultOfThisMember = originalBinder.CheckViability(candidate, arity, options, null, diagnose: true, useSiteInfo: ref classicExtensionUseSiteInfo);
+                    result.Add(resultOfThisMember);
+
+                    if (!candidate.IsStatic)
+                    {
+                        implementationsToShadow ??= PooledHashSet<MethodSymbol>.GetInstance();
+
+                        if (candidate is MethodSymbol { IsStatic: false } shadows &&
+                            shadows.OriginalDefinition.TryGetCorrespondingExtensionImplementationMethod() is { } toShadow)
+                        {
+                            implementationsToShadow.Add(toShadow);
+                        }
+                    }
+                }
             }
 
-            tempResult.Free();
-            extensions.Free();
+            extensionDeclarations.Free();
+
+            // 2. Collect classic extension methods
+            var extensionMethods = ArrayBuilder<MethodSymbol>.GetInstance();
+            this.GetCandidateExtensionMethods(extensionMethods, name, arity, options, originalBinder: originalBinder);
+
+            foreach (var method in extensionMethods)
+            {
+                // Prefer instance extension declarations vs. their implementations
+                if (implementationsToShadow is null || !implementationsToShadow.Remove(method.OriginalDefinition))
+                {
+                    SingleLookupResult resultOfThisMember = originalBinder.CheckViability(method, arity, options, null, diagnose: true, useSiteInfo: ref classicExtensionUseSiteInfo);
+                    result.Add(resultOfThisMember);
+                }
+            }
+
+            extensionMethods.Free();
+            implementationsToShadow?.Free();
         }
 #nullable disable
 
@@ -484,6 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        // PROTOTYPE we should be able to remove this method once all the callers are updated to account for new extension members
         /// <summary>
         /// Lookup extension methods by name and arity in the given binder and
         /// check viability in this binder. The lookup is performed on a single

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1884,7 +1884,7 @@ symIsHidden:;
                     if (arity != 0 || (options & LookupOptions.AllMethodsOnArityZero) == 0)
                     {
                         MethodSymbol method = (MethodSymbol)symbol;
-                        if (method.GetMemberTotalArity() != arity)
+                        if (method.GetMemberArityIncludingExtension() != arity)
                         {
                             if (method.Arity == 0)
                             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1537,7 +1537,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var scope in new ExtensionScopes(this))
                 {
                     lookupResult ??= LookupResult.GetInstance();
-                    LookupExtensionMethods(lookupResult, scope, plainName, arity, ref useSiteInfo);
+                    LookupExtensionMethods(lookupResult, scope, plainName, arity, ref useSiteInfo); // PROTOTYPE account for new extension members
 
                     if (lookupResult.IsMultiViable)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
@@ -75,9 +75,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         UseBaseReferenceAccessibility = 1 << 9,
 
         /// <summary>
-        /// Include extension methods.
+        /// Include extension members.
         /// </summary>
-        IncludeExtensionMethods = 1 << 10,
+        IncludeExtensionMembers = 1 << 10,
 
         /// <summary>
         /// Consider only attribute types.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
@@ -47,40 +47,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.PopulateHelper(receiverOpt, resultKind, error);
             this.IsExtensionMethodGroup = true;
 
-            PooledHashSet<MethodSymbol> implementationsToShadow = null;
-
-            if (members.Any(static m => m is MethodSymbol { IsExtensionMethod: true }) &&
-                members.Any(static m => m is MethodSymbol { IsExtensionMethod: false, IsStatic: false }))
-            {
-                implementationsToShadow = PooledHashSet<MethodSymbol>.GetInstance();
-
-                foreach (var member in members)
-                {
-                    if (member is MethodSymbol { IsExtensionMethod: false, IsStatic: false } shadows &&
-                        shadows.OriginalDefinition.TryGetCorrespondingExtensionImplementationMethod() is { } toShadow)
-                    {
-                        implementationsToShadow.Add(toShadow);
-                    }
-                }
-            }
-
             foreach (var member in members)
             {
                 if (member is MethodSymbol method)
                 {
                     Debug.Assert(method.IsExtensionMethod || method.GetIsNewExtensionMember());
-
-                    // Prefer instance extension declarations vs. their implementations
-                    if (method.IsExtensionMethod && implementationsToShadow?.Remove(method.OriginalDefinition) == true)
-                    {
-                        continue;
-                    }
-
                     this.Methods.Add(method);
                 }
             }
-
-            implementationsToShadow?.Free();
 
             if (!typeArguments.IsDefault)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -812,7 +812,7 @@ outerDefault:
                     ref useSiteDiagnosticsBuilder);
             }
 
-            if (member.GetIsNewExtensionMember() && member.ContainingType is { Arity: > 0 } extension)
+            if (member.GetIsNewExtensionMember() && member.ContainingType is { } extension && ConstraintsHelper.RequiresChecking(extension))
             {
                 constraintsSatisfied &= ConstraintsHelper.CheckConstraints(extension, in constraintsArgs,
                     extension.TypeSubstitution, extension.TypeParameters, extension.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -790,7 +790,7 @@ outerDefault:
 
         private bool FailsConstraintChecks<TMember>(TMember member, out ArrayBuilder<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt, CompoundUseSiteInfo<AssemblySymbol> template) where TMember : Symbol
         {
-            int arity = member.GetMemberTotalArity();
+            int arity = member.GetMemberArityIncludingExtension();
             if (arity == 0 || member.OriginalDefinition == (object)member)
             {
                 constraintFailureDiagnosticsOpt = null;
@@ -1168,7 +1168,7 @@ outerDefault:
             // This is specifying an impossible condition; the member lookup algorithm has already filtered
             // out methods from the method group that have the wrong generic arity.
 
-            Debug.Assert(typeArguments.Count == 0 || typeArguments.Count == member.GetMemberTotalArity());
+            Debug.Assert(typeArguments.Count == 0 || typeArguments.Count == member.GetMemberArityIncludingExtension());
 
             // Second, we need to determine if the method is applicable in its normal form or its expanded form.
             bool disallowExpandedNonArrayParams = (options & Options.DisallowExpandedNonArrayParams) != 0;
@@ -2404,14 +2404,14 @@ outerDefault:
             }
 
             // If MP is a non-generic method and MQ is a generic method, then MP is better than MQ.
-            if (m1.Member.GetMemberTotalArity() == 0)
+            if (m1.Member.GetMemberArityIncludingExtension() == 0)
             {
-                if (m2.Member.GetMemberTotalArity() > 0)
+                if (m2.Member.GetMemberArityIncludingExtension() > 0)
                 {
                     return BetterResult.Left;
                 }
             }
-            else if (m2.Member.GetMemberTotalArity() == 0)
+            else if (m2.Member.GetMemberArityIncludingExtension() == 0)
             {
                 return BetterResult.Right;
             }
@@ -4248,7 +4248,7 @@ outerDefault:
             EffectiveParameters constructedEffectiveParameters;
             bool hasTypeArgumentsInferredFromFunctionType = false;
             if ((options & Options.InferringUniqueMethodGroupSignature) == 0 &&
-                member.GetMemberTotalArity() > 0)
+                member.GetMemberArityIncludingExtension() > 0)
             {
                 ImmutableArray<TypeWithAnnotations> typeArguments;
                 bool isNewExtensionMember = member.GetIsNewExtensionMember();
@@ -4293,8 +4293,8 @@ outerDefault:
                         }
                     }
 
-                    member = member.ConstructWithAllTypeParameters(typeArguments);
-                    leastOverriddenMember = GetConstructedFrom(leastOverriddenMember).ConstructWithAllTypeParameters(typeArguments);
+                    member = member.ConstructIncludingExtension(typeArguments);
+                    leastOverriddenMember = GetConstructedFrom(leastOverriddenMember).ConstructIncludingExtension(typeArguments);
 
                     // Spec (§7.6.5.1)
                     //   Once the (inferred) type arguments are substituted for the corresponding method type parameters, 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -4293,8 +4293,8 @@ outerDefault:
                         }
                     }
 
-                    member = construct(member, typeArguments);
-                    leastOverriddenMember = construct(GetConstructedFrom(leastOverriddenMember), typeArguments);
+                    member = member.ConstructWithAllTypeParameters(typeArguments);
+                    leastOverriddenMember = GetConstructedFrom(leastOverriddenMember).ConstructWithAllTypeParameters(typeArguments);
 
                     // Spec (§7.6.5.1)
                     //   Once the (inferred) type arguments are substituted for the corresponding method type parameters, 
@@ -4367,46 +4367,6 @@ outerDefault:
                 isMethodGroupConversion: isMethodGroupConversion,
                 useSiteInfo: ref useSiteInfo);
             return new MemberResolutionResult<TMember>(member, leastOverriddenMember, applicableResult, hasTypeArgumentsInferredFromFunctionType);
-
-            static TMember construct(TMember member, ImmutableArray<TypeWithAnnotations> typeArguments)
-            {
-                if (member is MethodSymbol method)
-                {
-                    if (method.GetIsNewExtensionMember())
-                    {
-                        NamedTypeSymbol extension = method.ContainingType;
-                        if (extension.Arity > 0)
-                        {
-                            extension = extension.Construct(typeArguments[..extension.Arity]);
-                            method = method.AsMember(extension);
-                        }
-
-                        if (method.Arity > 0)
-                        {
-                            return (TMember)(Symbol)method.Construct(typeArguments[extension.Arity..]);
-                        }
-
-                        return (TMember)(Symbol)method;
-                    }
-
-                    return (TMember)(Symbol)method.Construct(typeArguments);
-                }
-
-                if (member is PropertySymbol property)
-                {
-                    Debug.Assert(property.GetIsNewExtensionMember());
-                    NamedTypeSymbol extension = property.ContainingType;
-                    Debug.Assert(extension.Arity > 0);
-                    Debug.Assert(extension.Arity == typeArguments.Length);
-
-                    extension = extension.Construct(typeArguments);
-                    property = property.AsMember(extension);
-
-                    return (TMember)(Symbol)property;
-                }
-
-                throw ExceptionUtilities.UnexpectedValue(member);
-            }
 
             static ImmutableArray<TypeWithAnnotations> getAllTypeArguments(TMember member, bool isNewExtensionMember)
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -165,7 +165,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node.InstanceOpt != null && node.InstanceOpt.HasDynamicType();
         }
 
-        // TODO2 review
         public static void GetExpressionSymbols(this BoundExpression node, ArrayBuilder<Symbol> symbols, BoundNode parent, Binder binder)
         {
             switch (node.Kind)
@@ -180,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        symbols.AddRange(CSharpSemanticModel.GetReducedAndFilteredMethodGroupSymbols(binder, (BoundMethodGroup)node)); // TODO2
+                        symbols.AddRange(CSharpSemanticModel.GetReducedAndFilteredMethodGroupSymbols(binder, (BoundMethodGroup)node));
                     }
                     break;
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -165,6 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node.InstanceOpt != null && node.InstanceOpt.HasDynamicType();
         }
 
+        // TODO2 review
         public static void GetExpressionSymbols(this BoundExpression node, ArrayBuilder<Symbol> symbols, BoundNode parent, Binder binder)
         {
             switch (node.Kind)
@@ -179,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        symbols.AddRange(CSharpSemanticModel.GetReducedAndFilteredMethodGroupSymbols(binder, (BoundMethodGroup)node));
+                        symbols.AddRange(CSharpSemanticModel.GetReducedAndFilteredMethodGroupSymbols(binder, (BoundMethodGroup)node)); // TODO2
                     }
                     break;
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4690,11 +4690,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     constructedMethod = method.ConstructIncludingExtension(typeArguments);
                     Debug.Assert((object)constructedMethod != null);
-
-                    if (!checkConstraintsIncludingExtension(method, typeArguments, compilation, method.ContainingAssembly.CorLibrary.TypeConversions))
-                    {
-                        return false;
-                    }
+                    // PROTOTYPE we should check constraints
                 }
                 else
                 {
@@ -4746,46 +4742,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             throw ExceptionUtilities.UnexpectedValue(member.Kind);
-
-            static bool checkConstraintsIncludingExtension(MethodSymbol symbol, ImmutableArray<TypeWithAnnotations> typeArgs, CSharpCompilation compilation, TypeConversions conversions)
-            {
-                var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
-                ArrayBuilder<TypeParameterDiagnosticInfo>? useSiteDiagnosticsBuilder = null;
-
-                var constraintArgs = new ConstraintsHelper.CheckConstraintsArgs(compilation, conversions, includeNullability: false, NoLocation.Singleton, diagnostics: null, template: CompoundUseSiteInfo<AssemblySymbol>.Discarded);
-
-                bool success = true;
-
-                if (symbol.GetIsNewExtensionMember())
-                {
-                    NamedTypeSymbol extensionDeclaration = symbol.ContainingType;
-                    if (extensionDeclaration.Arity > 0)
-                    {
-                        var extensionTypeParameters = extensionDeclaration.TypeParameters;
-                        var extensionTypeArguments = typeArgs[..extensionDeclaration.Arity];
-                        var extensionSubstitution = new TypeMap(extensionTypeParameters, extensionTypeArguments);
-
-                        success = extensionDeclaration.CheckConstraints(
-                           constraintArgs, extensionSubstitution, extensionTypeParameters, extensionTypeArguments, diagnosticsBuilder,
-                           nullabilityDiagnosticsBuilderOpt: null, ref useSiteDiagnosticsBuilder, ignoreTypeConstraintsDependentOnTypeParametersOpt: null);
-                    }
-                }
-
-                if (success && symbol.Arity > 0)
-                {
-                    var memberTypeParameters = symbol.TypeParameters;
-                    var memberTypeArguments = typeArgs[^symbol.Arity..];
-                    var memberSubstitution = new TypeMap(memberTypeParameters, memberTypeArguments);
-
-                    success = symbol.CheckConstraints(
-                        constraintArgs, memberSubstitution, memberTypeParameters, memberTypeArguments, diagnosticsBuilder,
-                        nullabilityDiagnosticsBuilderOpt: null, ref useSiteDiagnosticsBuilder, ignoreTypeConstraintsDependentOnTypeParametersOpt: null);
-                }
-
-                diagnosticsBuilder.Free();
-
-                return success;
-            }
 #nullable disable
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4849,7 +4849,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    // TODO2
                     receiverType = call.Arguments[0].Type;
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4638,7 +4638,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var scope in new ExtensionScopes(binder))
                 {
                     singleLookupResults.Clear();
-                    scope.Binder.EnumerateAllExtensionMembersInSingleBinder(singleLookupResults, name, arity, options, originalBinder: binder, classicExtensionUseSiteInfo: ref discardedUseSiteInfo);
+                    scope.Binder.EnumerateAllExtensionMembersInSingleBinder(singleLookupResults, name, arity, options, originalBinder: binder, useSiteInfo: ref discardedUseSiteInfo, classicExtensionUseSiteInfo: ref discardedUseSiteInfo);
 
                     foreach (SingleLookupResult singleLookupResult in singleLookupResults)
                     {
@@ -4849,6 +4849,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
+                    // TODO2
                     receiverType = call.Arguments[0].Type;
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1399,7 +1399,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// scope around position is used.</param>
         /// <param name="name">The name of the symbol to find. If null is specified then symbols
         /// with any names are returned.</param>
-        /// <param name="includeReducedExtensionMethods">Consider (reduced) extension methods.</param>
+        /// <param name="includeReducedExtensionMethods">Consider extension members. Classic extension methods will be returned in reduced form.</param>
         /// <returns>A list of symbols that were found. If no symbols were found, an empty list is returned.</returns>
         /// <remarks>
         /// The "position" is used to determine what variables are visible and accessible. Even if "container" is
@@ -1414,7 +1414,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             int position,
             NamespaceOrTypeSymbol container = null,
             string name = null,
-            bool includeReducedExtensionMethods = false) // TODO2
+            bool includeReducedExtensionMethods = false)
         {
             var options = includeReducedExtensionMethods ? LookupOptions.IncludeExtensionMembers : LookupOptions.Default;
             return LookupSymbolsInternal(position, container, name, options, useBaseReferenceAccessibility: false);
@@ -1687,7 +1687,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (name == null)
-                results.RemoveWhere(static (symbol, _, _) => !symbol.CanBeReferencedByName, arg: 0); // TODO2 test this
+                results.RemoveWhere(static (symbol, _, _) => !symbol.CanBeReferencedByName, arg: 0);
 
             return results.ToImmutableAndFree();
         }
@@ -3369,6 +3369,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.PropertyGroup:
                     symbols = GetPropertyGroupSemanticSymbols((BoundPropertyGroup)boundNode, boundNodeForSyntacticParent, binderOpt, out resultKind, out memberGroup);
                     break;
+                // PROTOTYPE handle BoundPropertyAccess (which now may have a member group)
 
                 case BoundKind.BadExpression:
                     {
@@ -3437,7 +3438,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.Call:
                     {
-                        // TODO2 test this
                         // Either overload resolution succeeded for this call or it did not. If it
                         // did not succeed then we've stashed the original method symbols from the
                         // method group, and we should use those as the symbols displayed for the
@@ -3455,12 +3455,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else
                         {
-                            symbols = CreateReducedAndFilteredSymbolsFromOriginals(call, Compilation); // TODO2 review and test
+                            symbols = CreateReducedAndFilteredSymbolsFromOriginals(call, Compilation);
                             resultKind = call.ResultKind;
                         }
                     }
                     break;
-                // TODO2 add support for properties
 
                 case BoundKind.FunctionPointerInvocation:
                     {
@@ -3539,7 +3538,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             var symbol = conversion.SymbolOpt;
                             Debug.Assert((object)symbol != null);
-                            symbols = OneOrMany.Create<Symbol>(ReducedExtensionMethodSymbol.Create(symbol)); // TODO2
+                            symbols = OneOrMany.Create<Symbol>(ReducedExtensionMethodSymbol.Create(symbol));
                             resultKind = conversion.ResultKind;
                         }
                         else if (conversion.ConversionKind.IsUserDefinedConversion())
@@ -4263,7 +4262,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Binder binder = binderOpt ?? GetEnclosingBinder(GetAdjustedNodePosition(boundNode.Syntax));
             memberGroup = GetReducedAndFilteredMethodGroupSymbols(binder, boundNode);
 
-            // TODO2 test these various cases
             // We want to get the actual node chosen by overload resolution, if possible. 
             if (boundNodeForSyntacticParent != null)
             {
@@ -4285,7 +4283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             else
                             {
                                 resultKind = call.ResultKind.WorseResultKind(LookupResultKind.OverloadResolutionFailure);
-                                symbols = CreateReducedAndFilteredSymbolsFromOriginals(call, Compilation); // TODO2 test
+                                symbols = CreateReducedAndFilteredSymbolsFromOriginals(call, Compilation);
                             }
                         }
                         break;
@@ -4296,7 +4294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var delegateCreation = (BoundDelegateCreationExpression)boundNodeForSyntacticParent;
                         if (delegateCreation.Argument == boundNode && (object)delegateCreation.MethodOpt != null)
                         {
-                            symbols = CreateReducedExtensionMethodIfPossible(delegateCreation, boundNode.ReceiverOpt); // TODO2 test
+                            symbols = CreateReducedExtensionMethodIfPossible(delegateCreation, boundNode.ReceiverOpt);
                         }
                         break;
 
@@ -4319,7 +4317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if (conversion.IsExtensionMethod)
                             {
-                                method = ReducedExtensionMethodSymbol.Create(method); // TODO2
+                                method = ReducedExtensionMethodSymbol.Create(method);
                             }
 
                             symbols = OneOrMany.Create((Symbol)method);
@@ -4571,7 +4569,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static ImmutableArray<Symbol> GetReducedAndFilteredMethodGroupSymbols(Binder binder, BoundMethodGroup node)
         {
-            var members = ArrayBuilder<Symbol>.GetInstance(); // TODO2 not sure what purpose this serves
+            var members = ArrayBuilder<Symbol>.GetInstance();
             var filteredMembers = ArrayBuilder<Symbol>.GetInstance();
             var resultKind = LookupResultKind.Empty;
             var typeArguments = node.TypeArgumentsOpt;
@@ -4616,9 +4614,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiver = node.ReceiverOpt;
             var name = node.Name;
 
-            // Extension methods, all scopes.
-            var receiverType = receiver.Type;
-            if (node.SearchExtensions)
+            // Extension members, all scopes.
+            if (node.SearchExtensions && receiver.Type is { } receiverType)
             {
                 Debug.Assert(receiver != null);
                 int arity;
@@ -4643,7 +4640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     singleLookupResults.Clear();
                     scope.Binder.EnumerateAllExtensionMembersInSingleBinder(singleLookupResults, receiverType, name, arity, options, originalBinder: binder, classicExtensionUseSiteInfo: ref discardedUseSiteInfo);
 
-                    foreach (var singleLookupResult in singleLookupResults)
+                    foreach (SingleLookupResult singleLookupResult in singleLookupResults)
                     {
                         if (singleLookupResult.Symbol is not (MethodSymbol or PropertySymbol))
                         {
@@ -4668,12 +4665,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return filteredMembers.ToImmutableAndFree();
         }
 
-        // TODO2 update comment
-        // Reduce extension methods to their reduced form, and remove:
+        // Reduce classic extension methods to their reduced form, and remove:
         //   a) Extension methods are aren't applicable to receiverType
         //   including constraint checking.
         //   b) Duplicate methods
         //   c) Methods that are hidden or overridden by another method in the group.
+        // For new extension members, infer type arguments for the extension declaration based on the receiver type,
+        //   perform the substitution, and remove:
+        //   a) Members that would break constraints
+        //   b) Members that are not applicable to the receiver type.
         private static bool AddReducedAndFilteredSymbol(
             ArrayBuilder<Symbol> members,
             ArrayBuilder<Symbol> filteredMembers,
@@ -4785,37 +4785,35 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// TODO2 update comment
-        /// If the call represents an extension method invocation with an explicit receiver, return the original
+        /// If the call represents a classic extension method invocation with an explicit receiver, return the original
         /// methods as ReducedExtensionMethodSymbols. Otherwise, return the original methods unchanged.
         /// </summary>
         private static OneOrMany<Symbol> CreateReducedAndFilteredSymbolsFromOriginals(BoundCall call, CSharpCompilation compilation)
         {
             var methods = call.OriginalMethodsOpt;
-            TypeSymbol extensionThisType = null;
+            TypeSymbol receiverType = null;
             Debug.Assert(!methods.IsDefault);
 
+            // Note: A call including new extension members may be marked as InvokedAsExtensionMethod in error scenarios
             if (call.InvokedAsExtensionMethod)
             {
-                // If the call was invoked as an extension method, the receiver
-                // should be non-null and all methods should be extension methods.
                 if (call.ReceiverOpt != null)
                 {
-                    extensionThisType = call.ReceiverOpt.Type;
+                    receiverType = call.ReceiverOpt.Type;
                 }
                 else
                 {
-                    extensionThisType = call.Arguments[0].Type;
+                    receiverType = call.Arguments[0].Type;
                 }
 
-                Debug.Assert((object)extensionThisType != null);
+                Debug.Assert((object)receiverType != null);
             }
 
             var methodBuilder = ArrayBuilder<Symbol>.GetInstance();
             var filteredMethodBuilder = ArrayBuilder<Symbol>.GetInstance();
             foreach (var method in FilterOverriddenOrHiddenMethods(methods))
             {
-                AddReducedAndFilteredSymbol(methodBuilder, filteredMethodBuilder, method, typeArguments: default, extensionThisType, compilation);
+                AddReducedAndFilteredSymbol(methodBuilder, filteredMethodBuilder, method, typeArguments: default, receiverType, compilation);
             }
             methodBuilder.Free();
             return filteredMethodBuilder.ToOneOrManyAndFree();

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1659,7 +1659,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 options |= LookupOptions.AllMethodsOnArityZero;
                 options &= ~LookupOptions.MustBeInstance;
 
-                binder.LookupAllExtensions(lookupResult, receiverType, name, options);
+                binder.LookupAllExtensions(lookupResult, name, options);
 
                 if (lookupResult.IsMultiViable)
                 {
@@ -4638,7 +4638,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var scope in new ExtensionScopes(binder))
                 {
                     singleLookupResults.Clear();
-                    scope.Binder.EnumerateAllExtensionMembersInSingleBinder(singleLookupResults, receiverType, name, arity, options, originalBinder: binder, classicExtensionUseSiteInfo: ref discardedUseSiteInfo);
+                    scope.Binder.EnumerateAllExtensionMembersInSingleBinder(singleLookupResults, name, arity, options, originalBinder: binder, classicExtensionUseSiteInfo: ref discardedUseSiteInfo);
 
                     foreach (SingleLookupResult singleLookupResult in singleLookupResults)
                     {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4691,7 +4691,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     constructedMethod = method.ConstructIncludingExtension(typeArguments);
                     Debug.Assert((object)constructedMethod != null);
 
-                    if (!checkConstraintsIncludingExtension(method, typeArguments, compilation, method.ContainingAssembly.CorLibrary.TypeConversions))
+                    if (!checkConstraintsIncludingExtension(constructedMethod, typeArguments, compilation, method.ContainingAssembly.CorLibrary.TypeConversions))
                     {
                         return false;
                     }
@@ -4761,24 +4761,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                     NamedTypeSymbol extensionDeclaration = symbol.ContainingType;
                     if (extensionDeclaration.Arity > 0)
                     {
-                        var extensionTypeParameters = extensionDeclaration.TypeParameters;
+                        var extensionTypeParameters = extensionDeclaration.OriginalDefinition.TypeParameters;
                         var extensionTypeArguments = typeArgs[..extensionDeclaration.Arity];
-                        var extensionSubstitution = new TypeMap(extensionTypeParameters, extensionTypeArguments);
 
                         success = extensionDeclaration.CheckConstraints(
-                           constraintArgs, extensionSubstitution, extensionTypeParameters, extensionTypeArguments, diagnosticsBuilder,
+                           constraintArgs, extensionDeclaration.TypeSubstitution, extensionTypeParameters, extensionTypeArguments, diagnosticsBuilder,
                            nullabilityDiagnosticsBuilderOpt: null, ref useSiteDiagnosticsBuilder, ignoreTypeConstraintsDependentOnTypeParametersOpt: null);
                     }
                 }
 
                 if (success && symbol.Arity > 0)
                 {
-                    var memberTypeParameters = symbol.TypeParameters;
+                    var memberTypeParameters = symbol.OriginalDefinition.TypeParameters;
                     var memberTypeArguments = typeArgs[^symbol.Arity..];
-                    var memberSubstitution = new TypeMap(memberTypeParameters, memberTypeArguments);
 
                     success = symbol.CheckConstraints(
-                        constraintArgs, memberSubstitution, memberTypeParameters, memberTypeArguments, diagnosticsBuilder,
+                        constraintArgs, symbol.TypeSubstitution, memberTypeParameters, memberTypeArguments, diagnosticsBuilder,
                         nullabilityDiagnosticsBuilderOpt: null, ref useSiteDiagnosticsBuilder, ignoreTypeConstraintsDependentOnTypeParametersOpt: null);
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -1651,7 +1651,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private string GetDeclarationName(CSharpSyntaxNode declaration)
         {
-            // PROTOTYPE likely needs work for semantic model
             switch (declaration.Kind())
             {
                 case SyntaxKind.MethodDeclaration:
@@ -2045,15 +2044,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            // PROTOTYPE use a public API for ExtensionParameter if we add one
-            var extensionParameter = ((Symbols.PublicModel.NamedTypeSymbol)extension).UnderlyingNamedTypeSymbol.ExtensionParameter;
+            IParameterSymbol extensionParameter = extension.ExtensionParameter;
             foreach (var location in extensionParameter.Locations)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (location.SourceTree == this.SyntaxTree && parameter.Span.Contains(location.SourceSpan))
                 {
-                    return extensionParameter;
+                    return extensionParameter.GetSymbol<ParameterSymbol>();
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we need to take special care to intercept with the extension method as though it is being called in reduced form.
             Debug.Assert(receiverOpt is not BoundTypeExpression || method.IsStatic);
             var needToReduce = receiverOpt is not (null or BoundTypeExpression) && interceptor.IsExtensionMethod;
-            var symbolForCompare = needToReduce ? ReducedExtensionMethodSymbol.Create(interceptor, receiverOpt!.Type, _compilation, out _) : interceptor;
+            var symbolForCompare = needToReduce ? ReducedExtensionMethodSymbol.Create(interceptor, receiverOpt!.Type, _compilation, out _) : interceptor; // TODO2
 
             if (!MemberSignatureComparer.InterceptorsComparer.Equals(method, symbolForCompare))
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we need to take special care to intercept with the extension method as though it is being called in reduced form.
             Debug.Assert(receiverOpt is not BoundTypeExpression || method.IsStatic);
             var needToReduce = receiverOpt is not (null or BoundTypeExpression) && interceptor.IsExtensionMethod;
-            var symbolForCompare = needToReduce ? ReducedExtensionMethodSymbol.Create(interceptor, receiverOpt!.Type, _compilation, out _) : interceptor; // TODO2
+            var symbolForCompare = needToReduce ? ReducedExtensionMethodSymbol.Create(interceptor, receiverOpt!.Type, _compilation, out _) : interceptor; // PROTOTYPE test interceptors
 
             if (!MemberSignatureComparer.InterceptorsComparer.Equals(method, symbolForCompare))
             {

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (Format.CompilerInternalOptions.HasFlag(SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames))
                 {
                     var extensionIdentifier = underlyingTypeSymbol!.ExtensionName;
-                    Builder.Add(CreatePart(SymbolDisplayPartKind.ClassName, symbol, extensionIdentifier)); // PROTOTYPE revisit when displaying extensions in the IDE
+                    Builder.Add(CreatePart(SymbolDisplayPartKind.ClassName, symbol, extensionIdentifier));
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -110,7 +110,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return member.GetMemberArity();
         }
 
-        // TODO2 rename/comment
+        /// <summary>
+        /// For an extension member, we distribute the type arguments between the extension declaration and the member.
+        /// Otherwise, we just construct the member with the type arguments.
+        /// </summary>
         internal static TMember ConstructWithAllTypeParameters<TMember>(this TMember member, ImmutableArray<TypeWithAnnotations> typeArguments) where TMember : Symbol
         {
             if (member is MethodSymbol method)

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return member.ContainingSymbol is TypeSymbol { IsExtension: true };
         }
 
-        internal static int GetMemberTotalArity(this Symbol member)
+        internal static int GetMemberArityIncludingExtension(this Symbol member)
         {
             if (member.GetIsNewExtensionMember())
             {
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// For an extension member, we distribute the type arguments between the extension declaration and the member.
         /// Otherwise, we just construct the member with the type arguments.
         /// </summary>
-        internal static TMember ConstructWithAllTypeParameters<TMember>(this TMember member, ImmutableArray<TypeWithAnnotations> typeArguments) where TMember : Symbol
+        internal static TMember ConstructIncludingExtension<TMember>(this TMember member, ImmutableArray<TypeWithAnnotations> typeArguments) where TMember : Symbol
         {
             if (member is MethodSymbol method)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -358,6 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         if ((thisParam.RefKind == RefKind.Ref && !thisParam.Type.IsValueType) ||
                             (thisParam.RefKind is RefKind.In or RefKind.RefReadOnlyParameter && thisParam.Type.TypeKind != TypeKind.Struct))
                         {
+                            // TODO2 what's this?
                             // For ref and ref-readonly extension methods, receivers need to be of the correct types to be considered in lookup
                             continue;
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -355,10 +355,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         var thisParam = method.Parameters.First();
 
+                        // PROTOTYPE we should use similar logic when looking up new extension members
                         if ((thisParam.RefKind == RefKind.Ref && !thisParam.Type.IsValueType) ||
                             (thisParam.RefKind is RefKind.In or RefKind.RefReadOnlyParameter && thisParam.Type.TypeKind != TypeKind.Struct))
                         {
-                            // TODO2 what's this?
                             // For ref and ref-readonly extension methods, receivers need to be of the correct types to be considered in lookup
                             continue;
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
@@ -149,7 +149,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool ITypeSymbol.IsNativeIntegerType => UnderlyingTypeSymbol.IsNativeIntegerType;
 
+#nullable enable
         bool ITypeSymbol.IsExtension => UnderlyingTypeSymbol.IsExtension;
+
+        IParameterSymbol? ITypeSymbol.ExtensionParameter => UnderlyingTypeSymbol.ExtensionParameter?.GetPublicSymbol();
+#nullable disable
 
         string ITypeSymbol.ToDisplayString(CodeAnalysis.NullableFlowState topLevelNullability, SymbolDisplayFormat format)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
@@ -115,7 +115,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _lazyExtensionInfo.LazyImplementationMap.GetValueOrDefault(method);
         }
 
-        // TODO2 test this more
         internal static Symbol? GetCompatibleSubstitutedMember(CSharpCompilation compilation, Symbol extensionMember, TypeSymbol receiverType)
         {
             Debug.Assert(extensionMember.GetIsNewExtensionMember());

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -113,6 +113,91 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return _lazyExtensionInfo.LazyImplementationMap.GetValueOrDefault(method);
+        }
+
+        // TODO2 test this more
+        internal static Symbol? GetCompatibleSubstitutedMember(CSharpCompilation compilation, Symbol extensionMember, TypeSymbol receiverType)
+        {
+            Debug.Assert(extensionMember.GetIsNewExtensionMember());
+
+            NamedTypeSymbol extension = extensionMember.ContainingType;
+            if (extension.ExtensionParameter is null)
+            {
+                return null;
+            }
+
+            Symbol result;
+            if (extensionMember.IsDefinition)
+            {
+                NamedTypeSymbol? constructedExtension = inferExtensionTypeArguments(extension, receiverType, compilation);
+                if (constructedExtension is null)
+                {
+                    return null;
+                }
+
+                result = extensionMember.SymbolAsMember(constructedExtension);
+            }
+            else
+            {
+                result = extensionMember;
+            }
+
+            Debug.Assert(result.ContainingType.ExtensionParameter is not null);
+            var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+            Conversion conversion = compilation.Conversions.ConvertExtensionMethodThisArg(parameterType: result.ContainingType.ExtensionParameter.Type, receiverType, ref discardedUseSiteInfo, isMethodGroupConversion: false);
+            if (!conversion.Exists)
+            {
+                return null;
+            }
+
+            return result;
+
+            static NamedTypeSymbol? inferExtensionTypeArguments(NamedTypeSymbol extension, TypeSymbol receiverType, CSharpCompilation compilation)
+            {
+                if (extension.Arity == 0)
+                {
+                    return extension;
+                }
+
+                TypeConversions conversions = extension.ContainingAssembly.CorLibrary.TypeConversions;
+
+                // Note: we create a value for purpose of inferring type arguments even when the receiver type is static
+                var syntax = (CSharpSyntaxNode)CSharpSyntaxTree.Dummy.GetRoot();
+                var receiverValue = new BoundLiteral(syntax, ConstantValue.Bad, receiverType) { WasCompilerGenerated = true };
+
+                var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+                ImmutableArray<TypeWithAnnotations> typeArguments = MethodTypeInferrer.InferTypeArgumentsFromReceiverType(extension, receiverValue, compilation, conversions, ref discardedUseSiteInfo);
+                if (typeArguments.IsDefault || typeArguments.Any(t => !t.HasType))
+                {
+                    return null;
+                }
+
+                bool success = checkConstraints(extension, typeArguments, compilation, conversions);
+                if (!success)
+                {
+                    return null;
+                }
+
+                return extension.Construct(typeArguments);
+            }
+
+            static bool checkConstraints(NamedTypeSymbol symbol, ImmutableArray<TypeWithAnnotations> typeArgs, CSharpCompilation compilation,
+                TypeConversions conversions)
+            {
+                ImmutableArray<TypeParameterSymbol> typeParams = symbol.TypeParameters;
+                var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
+                var substitution = new TypeMap(typeParams, typeArgs);
+                ArrayBuilder<TypeParameterDiagnosticInfo>? useSiteDiagnosticsBuilder = null;
+
+                bool success = symbol.CheckConstraints(
+                    new ConstraintsHelper.CheckConstraintsArgs(compilation, conversions, includeNullability: false, NoLocation.Singleton, diagnostics: null, template: CompoundUseSiteInfo<AssemblySymbol>.Discarded),
+                    substitution, typeParams, typeArgs, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null,
+                    ref useSiteDiagnosticsBuilder, ignoreTypeConstraintsDependentOnTypeParametersOpt: null);
+
+                diagnosticsBuilder.Free();
+
+                return success;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
@@ -171,31 +171,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return null;
                 }
 
-                bool success = checkConstraints(extension, typeArguments, compilation, conversions);
+                var result = extension.Construct(typeArguments);
+
+                var constraintArgs = new ConstraintsHelper.CheckConstraintsArgs(compilation, conversions, includeNullability: false,
+                    NoLocation.Singleton, diagnostics: BindingDiagnosticBag.Discarded, template: CompoundUseSiteInfo<AssemblySymbol>.Discarded);
+
+                bool success = result.CheckConstraints(constraintArgs);
                 if (!success)
                 {
                     return null;
                 }
 
-                return extension.Construct(typeArguments);
-            }
-
-            static bool checkConstraints(NamedTypeSymbol symbol, ImmutableArray<TypeWithAnnotations> typeArgs, CSharpCompilation compilation,
-                TypeConversions conversions)
-            {
-                ImmutableArray<TypeParameterSymbol> typeParams = symbol.TypeParameters;
-                var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
-                var substitution = new TypeMap(typeParams, typeArgs);
-                ArrayBuilder<TypeParameterDiagnosticInfo>? useSiteDiagnosticsBuilder = null;
-
-                bool success = symbol.CheckConstraints(
-                    new ConstraintsHelper.CheckConstraintsArgs(compilation, conversions, includeNullability: false, NoLocation.Singleton, diagnostics: null, template: CompoundUseSiteInfo<AssemblySymbol>.Discarded),
-                    substitution, typeParams, typeArgs, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null,
-                    ref useSiteDiagnosticsBuilder, ignoreTypeConstraintsDependentOnTypeParametersOpt: null);
-
-                diagnosticsBuilder.Free();
-
-                return success;
+                return result;
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -37,7 +37,7 @@ public class ExtensionTests : CompilingTestBase
         }
     }
 
-    private static void AssertSetStrictlyEqual(string[] expected, string[] actual)
+    private static void AssertEqualAndNoDuplicates(string[] expected, string[] actual)
     {
         Assert.True(expected.All(new HashSet<string>().Add), $"Duplicates were found in '{nameof(expected)}'");
         Assert.True(actual.All(new HashSet<string>().Add), $"Duplicates were found in '{nameof(actual)}'");
@@ -2802,7 +2802,7 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual(_objectMembers, model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(_objectMembers, model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -24364,8 +24364,8 @@ static class E
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "d.P");
         var dynamicType = model.GetTypeInfo(memberAccess.Expression).Type;
         Assert.True(dynamicType.IsDynamic());
-        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.P { get; }"], model.LookupSymbols(position: 0, dynamicType, name: "P", includeReducedExtensionMethods: true).ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.P { get; }"], model.LookupSymbols(position: 0, dynamicType, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0.P { get; }"], model.LookupSymbols(position: 0, dynamicType, name: "P", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0.P { get; }"], model.LookupSymbols(position: 0, dynamicType, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25148,25 +25148,25 @@ public static class E
         Assert.Equal("System.Int32 E.<>E__0.Property { get; }", model.GetSymbolInfo(property).Symbol.ToTestDisplayString());
 
         var e = ((Compilation)comp).GlobalNamespace.GetTypeMember("E");
-        AssertSetStrictlyEqual(["void E.M()"], model.LookupSymbols(position: 0, e, name: "M").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["void E.M()", "void E.<>E__0.M()"], model.LookupSymbols(position: 0, e, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["void E.M()"], model.LookupSymbols(position: 0, e, name: "M").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["void E.M()", "void E.<>E__0.M()"], model.LookupSymbols(position: 0, e, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, e, name: "Property").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.Property { get; }"], model.LookupSymbols(position: 0, e, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, e, name: "Property").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0.Property { get; }"], model.LookupSymbols(position: 0, e, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["System.Int32 E.get_Property()"], model.LookupSymbols(position: 0, e, name: "get_Property").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["System.Int32 E.get_Property()"], model.LookupSymbols(position: 0, e, name: "get_Property").ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["System.Int32 E.get_Property()"],
+        AssertEqualAndNoDuplicates(["System.Int32 E.get_Property()"],
             model.LookupSymbols(position: 0, e, name: "get_Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "M").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["void E.<>E__0.M()"], model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "M").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["void E.<>E__0.M()"], model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.Property { get; }"], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0.Property { get; }"], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["void E.<>E__0.M()", "System.Int32 E.<>E__0.Property { get; }", .. _objectMembers],
+        AssertEqualAndNoDuplicates(["void E.<>E__0.M()", "System.Int32 E.<>E__0.Property { get; }", .. _objectMembers],
             model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
         Assert.Equal([
@@ -25207,13 +25207,13 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "M").ToTestDisplayStrings());
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "M").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(_objectMembers, model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(_objectMembers, model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25240,21 +25240,21 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "M").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["void E.<>E__0<System.Object>.M()"], model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "M").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["void E.<>E__0<System.Object>.M()"], model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["System.Int32 E.<>E__0<System.Object>.Property { get; }"], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0<System.Object>.Property { get; }"], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["void E.<>E__0<System.Object>.M()", "System.Int32 E.<>E__0<System.Object>.Property { get; }", .. _objectMembers],
+        AssertEqualAndNoDuplicates(["void E.<>E__0<System.Object>.M()", "System.Int32 E.<>E__0<System.Object>.Property { get; }", .. _objectMembers],
             model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
         var s = ((Compilation)comp).GetSpecialType(SpecialType.System_String);
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, s, name: "M").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["void E.<>E__0<System.String>.M()"], model.LookupSymbols(position: 0, s, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, s, name: "M").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["void E.<>E__0<System.String>.M()"], model.LookupSymbols(position: 0, s, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, s, name: "Property").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["System.Int32 E.<>E__0<System.String>.Property { get; }"], model.LookupSymbols(position: 0, s, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, s, name: "Property").ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0<System.String>.Property { get; }"], model.LookupSymbols(position: 0, s, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25279,7 +25279,7 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var s = ((Compilation)comp).GetSpecialType(SpecialType.System_String);
-        AssertSetStrictlyEqual(["void E.<>E__0<System.String>.M<U>(U u)"], model.LookupSymbols(position: 0, s, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates(["void E.<>E__0<System.String>.M<U>(U u)"], model.LookupSymbols(position: 0, s, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25309,13 +25309,13 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual(["void E.<>E__0.M()", "void E.<>E__1.M()"],
+        AssertEqualAndNoDuplicates(["void E.<>E__0.M()", "void E.<>E__1.M()"],
             model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.Property { get; }", "System.Int32 E.<>E__1.Property { get; }"],
+        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0.Property { get; }", "System.Int32 E.<>E__1.Property { get; }"],
             model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual([
+        AssertEqualAndNoDuplicates([
             "void E.<>E__0.M()",
             "System.Int32 E.<>E__0.Property { get; }",
             "void E.<>E__1.M()",
@@ -25348,10 +25348,10 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }"],
+        AssertEqualAndNoDuplicates(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }"],
             model.LookupSymbols(position: 0, o, name: "MP", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }", .. _objectMembers],
+        AssertEqualAndNoDuplicates(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }", .. _objectMembers],
             model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
@@ -25379,10 +25379,10 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual(["void E.<>E__0.M()", "void E.<>E__0.M(System.String s)", "void System.Object.M(System.Int32 i)"],
+        AssertEqualAndNoDuplicates(["void E.<>E__0.M()", "void E.<>E__0.M(System.String s)", "void System.Object.M(System.Int32 i)"],
             model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["void E.<>E__0.M()", "void E.<>E__0.M(System.String s)", "void System.Object.M(System.Int32 i)", .. _objectMembers],
+        AssertEqualAndNoDuplicates(["void E.<>E__0.M()", "void E.<>E__0.M(System.String s)", "void System.Object.M(System.Int32 i)", .. _objectMembers],
             model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
@@ -25410,8 +25410,8 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Nested", includeReducedExtensionMethods: true).ToTestDisplayStrings());
-        AssertSetStrictlyEqual([.. _objectMembers], model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([], model.LookupSymbols(position: 0, o, name: "Nested", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertEqualAndNoDuplicates([.. _objectMembers], model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
         Assert.Empty(model.LookupNamespacesAndTypes(position: 0, o, name: null));
     }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -11098,7 +11098,7 @@ static class E
         var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<int, string>()");
         Assert.Null(model.GetSymbolInfo(invocation).Symbol);
         Assert.Equal([], model.GetMemberGroup(invocation).ToTestDisplayStrings());
-        Assert.Equal(["void E.<>E__0<System.Int32>.M<System.String>()"], model.GetMemberGroup(invocation.Expression).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(invocation.Expression).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -12851,7 +12851,7 @@ namespace Inner
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<object>");
         Assert.Equal("void E2.<>E__0.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal(["System.String Inner.E1.<>E__0.M<System.Object>()", "void E2.<>E__0.M<System.Object>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal(["void E2.<>E__0.M<System.Object>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -24885,7 +24885,7 @@ static class E
         Assert.Equal([], model.GetMemberGroup(invocation).ToTestDisplayStrings());
 
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M<object>");
-        Assert.Equal(["void E.<>E__0<System.Object>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25079,11 +25079,13 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M<object>");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        Assert.Equal(["void E.<>E__0.M<System.Object>(System.Object t)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
 
         memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M2<object>");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        Assert.Equal(["void System.Int32.M2<System.Object>(System.Object t)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25444,10 +25446,10 @@ static class E
         var model = comp.GetSemanticModel(tree);
 
         var memberAccess1 = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M<int>");
-        Assert.Equal(["void E.<>E__0.M<System.Int32>()"], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
 
         var memberAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M2<int>");
-        Assert.Equal(["void System.Object.M2<System.Int32>()"], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25516,10 +25518,10 @@ static class E
         var model = comp.GetSemanticModel(tree);
 
         var memberAccess1 = GetSyntax<MemberAccessExpressionSyntax>(tree, "int.M<int>");
-        Assert.Equal(["void E.<>E__0<System.Int32>.M()"], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
 
         var memberAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M2<int>");
-        Assert.Equal(["void System.Int32.M2<System.Int32>()"], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -25876,9 +25876,8 @@ static class E
     }
 
     [Fact]
-    public void GenericMethodInGenericType()
+    public void GetSymbolInfo_GenericMethodInGenericType()
     {
-        // Based on GenericNameTypeInferenceExpansion_GenericBase
         var src = """
 class C<T>
 {

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -18240,12 +18240,12 @@ static class E
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess1 = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "default.Property").First();
-        Assert.Null(model.GetSymbolInfo(memberAccess1).Symbol);
+        Assert.Equal("System.Int32 E.<>E__0.Property { get; set; }", model.GetSymbolInfo(memberAccess1).Symbol.ToTestDisplayString());
         Assert.Equal([], model.GetSymbolInfo(memberAccess1).CandidateSymbols.ToTestDisplayStrings());
         Assert.Equal(CandidateReason.None, model.GetSymbolInfo(memberAccess1).CandidateReason);
 
         var memberAccess2 = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "default.Property").Last();
-        Assert.Null(model.GetSymbolInfo(memberAccess2).Symbol);
+        Assert.Equal("System.Int32 E.<>E__0.Property { get; set; }", model.GetSymbolInfo(memberAccess2).Symbol.ToTestDisplayString());
         Assert.Equal([], model.GetSymbolInfo(memberAccess2).CandidateSymbols.ToTestDisplayStrings());
         Assert.Equal(CandidateReason.None, model.GetSymbolInfo(memberAccess2).CandidateReason);
     }
@@ -24364,8 +24364,8 @@ static class E
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "d.P");
         var dynamicType = model.GetTypeInfo(memberAccess.Expression).Type;
         Assert.True(dynamicType.IsDynamic());
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, dynamicType, name: "P", includeReducedExtensionMethods: true).ToTestDisplayStrings());
-        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, dynamicType, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.P { get; }"], model.LookupSymbols(position: 0, dynamicType, name: "P", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.P { get; }"], model.LookupSymbols(position: 0, dynamicType, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -11098,7 +11098,7 @@ static class E
         var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new C<int>().M<int, string>()");
         Assert.Null(model.GetSymbolInfo(invocation).Symbol);
         Assert.Equal([], model.GetMemberGroup(invocation).ToTestDisplayStrings());
-        Assert.Equal([], model.GetMemberGroup(invocation.Expression).ToTestDisplayStrings());
+        Assert.Equal(["void E.<>E__0<System.Int32>.M<System.String>()"], model.GetMemberGroup(invocation.Expression).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -12851,7 +12851,7 @@ namespace Inner
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<object>");
         Assert.Equal("void E2.<>E__0.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal(["void E2.<>E__0.M<System.Object>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal(["System.String Inner.E1.<>E__0.M<System.Object>()", "void E2.<>E__0.M<System.Object>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -24885,7 +24885,7 @@ static class E
         Assert.Equal([], model.GetMemberGroup(invocation).ToTestDisplayStrings());
 
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M<object>");
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal(["void E.<>E__0<System.Object>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25079,13 +25079,11 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M<object>");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal(["void E.<>E__0.M<System.Object>(System.Object t)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
 
         memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M2<object>");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal(["void System.Int32.M2<System.Object>(System.Object t)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25446,10 +25444,10 @@ static class E
         var model = comp.GetSemanticModel(tree);
 
         var memberAccess1 = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M<int>");
-        Assert.Equal([], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
+        Assert.Equal(["void E.<>E__0.M<System.Int32>()"], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
 
         var memberAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M2<int>");
-        Assert.Equal([], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
+        Assert.Equal(["void System.Object.M2<System.Int32>()"], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -25518,10 +25516,10 @@ static class E
         var model = comp.GetSemanticModel(tree);
 
         var memberAccess1 = GetSyntax<MemberAccessExpressionSyntax>(tree, "int.M<int>");
-        Assert.Equal([], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
+        Assert.Equal(["void E.<>E__0<System.Int32>.M()"], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
 
         var memberAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M2<int>");
-        Assert.Equal([], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
+        Assert.Equal(["void System.Int32.M2<System.Int32>()"], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings());
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -2033,8 +2033,7 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        Assert.Equal("System.Object", internalSymbol.ExtensionParameter.ToTestDisplayString());
+        Assert.Equal("System.Object", symbol.ExtensionParameter.ToTestDisplayString());
     }
 
     [Fact]
@@ -2043,7 +2042,10 @@ public static class Extensions
         var src = """
 public static class Extensions
 {
-    extension(object o) { }
+    extension(object o) 
+    {
+        public object M() { return o; }
+    }
 }
 """;
         var comp = CreateCompilation(src);
@@ -2053,8 +2055,10 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        Assert.Equal("System.Object o", internalSymbol.ExtensionParameter.ToTestDisplayString());
+        Assert.Equal("System.Object o", symbol.ExtensionParameter.ToTestDisplayString());
+
+        var returnStatement = GetSyntax<ReturnStatementSyntax>(tree, "return o;");
+        Assert.Equal("System.Object o", model.GetSymbolInfo(returnStatement.Expression).Symbol.ToTestDisplayString());
     }
 
     [Fact]
@@ -2080,15 +2084,14 @@ class C { }
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        var extensionParameter = internalSymbol.ExtensionParameter;
+        var extensionParameter = symbol.ExtensionParameter;
 
         Assert.Equal("System.Int32 i", extensionParameter.ToTestDisplayString());
         Assert.True(extensionParameter.Equals(extensionParameter));
 
         var parameterSyntaxes = tree.GetRoot().DescendantNodes().OfType<ParameterSyntax>().ToArray();
         Assert.Equal("System.Int32 i", model.GetDeclaredSymbol(parameterSyntaxes[0]).ToTestDisplayString());
-        Assert.Same(extensionParameter.GetPublicSymbol(), model.GetDeclaredSymbol(parameterSyntaxes[0]));
+        Assert.Same(extensionParameter, model.GetDeclaredSymbol(parameterSyntaxes[0]));
 
         Assert.Equal("System.Int32", model.GetTypeInfo(parameterSyntaxes[1].Type).Type.ToTestDisplayString());
         Assert.Null(model.GetDeclaredSymbol(parameterSyntaxes[1]));
@@ -2129,10 +2132,9 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        var extensionParameter = internalSymbol.ExtensionParameter;
+        var extensionParameter = symbol.ExtensionParameter;
         Assert.Equal("T", extensionParameter.ToTestDisplayString());
-        Assert.Same(extensionParameter.Type, internalSymbol.TypeParameters[0]);
+        Assert.Same(extensionParameter.Type, symbol.TypeParameters[0]);
     }
 
     [Fact]
@@ -2154,10 +2156,9 @@ public static class Extensions<T>
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        var extensionParameter = internalSymbol.ExtensionParameter;
+        var extensionParameter = symbol.ExtensionParameter;
         Assert.Equal("T", extensionParameter.ToTestDisplayString());
-        Assert.Same(extensionParameter.Type, internalSymbol.ContainingType.TypeParameters[0]);
+        Assert.Same(extensionParameter.Type, symbol.ContainingType.TypeParameters[0]);
     }
 
     [Fact]
@@ -2181,8 +2182,7 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        var parameter = internalSymbol.ExtensionParameter;
+        var parameter = symbol.ExtensionParameter;
         Assert.Equal("T", parameter.ToTestDisplayString());
         Assert.True(parameter.Type.IsErrorType());
     }
@@ -2292,8 +2292,7 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type1 = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().First();
         var symbol1 = model.GetDeclaredSymbol(type1);
-        var internalSymbol1 = symbol1.GetSymbol<SourceNamedTypeSymbol>();
-        var parameter = internalSymbol1.ExtensionParameter;
+        var parameter = symbol1.ExtensionParameter;
         Assert.Equal("System.Int32[] i", parameter.ToTestDisplayString());
         Assert.False(parameter.IsParams);
     }
@@ -2355,9 +2354,7 @@ public class C<T> where T : struct { }
         var model = comp.GetSemanticModel(tree);
         var type1 = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().First();
         var symbol1 = model.GetDeclaredSymbol(type1);
-        var internalSymbol1 = symbol1.GetSymbol<SourceNamedTypeSymbol>();
-        var parameter = internalSymbol1.ExtensionParameter;
-        Assert.Equal("C<T>", parameter.ToTestDisplayString());
+        Assert.Equal("C<T>", symbol1.ExtensionParameter.ToTestDisplayString());
     }
 
     [Fact]
@@ -2379,9 +2376,7 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        var parameter = internalSymbol.ExtensionParameter;
-        Assert.True(parameter.HasExplicitDefaultValue); // PROTOTYPE consider not recognizing the default value entirely
+        Assert.True(symbol.ExtensionParameter.HasExplicitDefaultValue); // PROTOTYPE consider not recognizing the default value entirely
     }
 
     [Fact]
@@ -2546,8 +2541,7 @@ public class MyAttribute : System.Attribute { }
 
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var extensionSymbol = model.GetDeclaredSymbol(type);
-        var parameterSymbol2 = extensionSymbol.GetSymbol<SourceNamedTypeSymbol>().ExtensionParameter;
-        AssertEx.SetEqual(["MyAttribute"], parameterSymbol2.GetAttributes().Select(a => a.ToString()));
+        AssertEx.SetEqual(["MyAttribute"], extensionSymbol.ExtensionParameter.GetAttributes().Select(a => a.ToString()));
     }
 
     [Fact]
@@ -2663,8 +2657,7 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type1 = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().First();
         var symbol1 = model.GetDeclaredSymbol(type1);
-        var internalSymbol1 = symbol1.GetSymbol<SourceNamedTypeSymbol>();
-        var parameter = internalSymbol1.ExtensionParameter;
+        var parameter = symbol1.ExtensionParameter;
         Assert.Equal("out System.Int32 i", parameter.ToTestDisplayString());
         Assert.Equal(RefKind.Out, parameter.RefKind);
     }
@@ -2804,6 +2797,12 @@ public static class Extensions
             Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(5, 15));
 
         Assert.Empty(comp.GetTypeByMetadataName("Extensions").GetMembers().OfType<MethodSymbol>());
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
+        AssertSetStrictlyEqual(_objectMembers, model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -3071,8 +3070,7 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
-        var internalSymbol = symbol.GetSymbol<SourceNamedTypeSymbol>();
-        Assert.Equal("?", internalSymbol.ExtensionParameter.ToTestDisplayString());
+        Assert.Equal("?", symbol.ExtensionParameter.ToTestDisplayString());
     }
 
     [Fact]
@@ -3150,6 +3148,8 @@ static class Extensions
             AssertEx.Equal("System.String?", m.GlobalNamespace.GetMember<MethodSymbol>("Extensions.<>E__0.<Extension>$").Parameters[0].TypeWithAnnotations.ToTestDisplayString());
             AssertEx.Equal("System.String?", m.GlobalNamespace.GetMember<MethodSymbol>("Extensions.<>E__1.<Extension>$").Parameters[0].TypeWithAnnotations.ToTestDisplayString());
         }).VerifyDiagnostics();
+
+        // PROTOTYPE verify nullability in GetDeclaredSymbol and GetSymbolInfo
     }
 
     [Fact]
@@ -10142,11 +10142,11 @@ public static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.P");
         Assert.Equal("System.Int32 E.<>E__0<T>.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
 
         memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "int.P");
         Assert.Equal("System.Int32 E.<>E__0<System.Int32>.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -10367,7 +10367,7 @@ namespace N3
 
             var invocation = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().Method");
             Assert.Equal($$"""void {{extensionName}}.Method()""", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
-            //Assert.Equal(["void N2.E.<>E__0.Method()"], model.GetMemberGroup(invocation).ToTestDisplayStrings()); // TODO2
+            Assert.Equal([$$"""void {{extensionName}}.Method()"""], model.GetMemberGroup(invocation).ToTestDisplayStrings());
         }
     }
 
@@ -13829,8 +13829,9 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "new object().P()");
         Assert.Null(model.GetSymbolInfo(invocation).Symbol);
-        // PROTOTYPE semantic model is undone
         Assert.Equal([], model.GetSymbolInfo(invocation).CandidateSymbols.ToTestDisplayStrings());
+
+        Assert.Equal(["System.Int32 Extensions.<>E__0.P { get; }"], model.GetMemberGroup(invocation.Expression).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -13854,8 +13855,8 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().P");
         Assert.Equal("System.Action Extensions.<>E__0.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        // PROTOTYPE semantic model is undone
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -13879,7 +13880,6 @@ public static class Extensions
         var model = comp.GetSemanticModel(tree);
         var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "object.M()");
         Assert.Equal("System.Int32 Extensions.<>E__0.M()", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
-        // PROTOTYPE semantic model is undone
         Assert.Equal([], model.GetSymbolInfo(invocation).CandidateSymbols.ToTestDisplayStrings());
     }
 
@@ -15746,7 +15746,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        Assert.Empty(model.GetMemberGroup(memberAccess)); // TODO2
+        Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE consider handling BoundBadExpression better
     }
 
     [Fact]
@@ -15784,7 +15784,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
         Assert.Equal("System.Action E.<>E__0.M { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -15822,7 +15822,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
         Assert.Equal("System.Action E.<>E__0.M { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact(Skip = "PROTOTYPE function type")]
@@ -15863,7 +15863,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
         Assert.Equal("void System.Object.M(System.Int32 i)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal(["void System.Object.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal(["void System.Object.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE should include the extension property
     }
 
     [Fact]
@@ -15989,7 +15989,7 @@ static class E2
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        // PROTOTYPE: Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE semantic model is undone TODO2
+        Assert.Equal(["void N.E1.<>E__0.M(System.Int32 i)", "System.Int32 E2.<>E__0.M { get; }"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -16072,7 +16072,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
         Assert.Equal("System.Int32 E.<>E__0.M { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -16266,6 +16266,38 @@ static class E
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
+        Assert.Equal("void E.<>E__0.M(System.Int32 i)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Null(model.GetTypeInfo(memberAccess).Type);
+        Assert.Equal("D", model.GetTypeInfo(memberAccess).ConvertedType.ToTestDisplayString());
+        Assert.Equal(["void E.<>E__0.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        Assert.Equal(ConversionKind.MethodGroup, model.GetConversion(memberAccess).Kind);
+    }
+
+    [Fact]
+    public void DelegateConversion_InstanceReceiver_Creation()
+    {
+        var source = """
+D d = new D(new C().M);
+d(42);
+
+delegate void D(int i);
+
+class C { }
+
+static class E
+{
+    extension(C)
+    {
+        public void M(int i) { System.Console.Write($"E.M({i})"); }
+    }
+}
+""";
+        var comp = CreateCompilation(source);
+        CompileAndVerify(comp, expectedOutput: "E.M(42)").VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M");
         Assert.Equal("void E.<>E__0.M(System.Int32 i)", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
         Assert.Null(model.GetTypeInfo(memberAccess).Type);
         Assert.Equal("D", model.GetTypeInfo(memberAccess).ConvertedType.ToTestDisplayString());
@@ -17080,9 +17112,14 @@ static class E
 
         var comp = CreateCompilation(source, targetFramework: TargetFramework.Net90);
         comp.VerifyEmitDiagnostics(
-            // (3,21): error CS0123: No overload for 'M' matches delegate 'Action'
+            // (3,21): error CS1061: 'Span<int>' does not contain a definition for 'M' and no accessible extension method 'M' accepting a first argument of type 'Span<int>' could be found (are you missing a using directive or an assembly reference?)
             // System.Action a = s.M;
-            Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "M").WithArguments("M", "System.Action").WithLocation(3, 21));
+            Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M").WithArguments("System.Span<int>", "M").WithLocation(3, 21));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "s.M");
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -17104,9 +17141,9 @@ static class E
         //   is needed in a static scenario. 
         var comp = CreateCompilation(source, targetFramework: TargetFramework.Net90);
         comp.VerifyEmitDiagnostics(
-            // (1,36): error CS0123: No overload for 'M' matches delegate 'Action'
+            // (1,36): error CS0117: 'Span<int>' does not contain a definition for 'M'
             // System.Action a = System.Span<int>.M;
-            Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "M").WithArguments("M", "System.Action").WithLocation(1, 36));
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "M").WithArguments("System.Span<int>", "M").WithLocation(1, 36));
     }
 
     [Fact]
@@ -17212,7 +17249,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var property = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.Property");
         Assert.Equal("System.Int32 E.<>E__0.Property { set; }", model.GetSymbolInfo(property).Symbol.ToTestDisplayString());
-        Assert.Empty(model.GetMemberGroup(property)); // TODO2
+        Assert.Empty(model.GetMemberGroup(property)); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -17244,7 +17281,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var property = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.Property");
         Assert.Equal("System.Int32 E.<>E__0.Property { set; }", model.GetSymbolInfo(property).Symbol.ToTestDisplayString());
-        Assert.Empty(model.GetMemberGroup(property)); // TODO2
+        Assert.Empty(model.GetMemberGroup(property)); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -17635,9 +17672,29 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        // PROTOTYPE semantic model is undone
-        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings()); // TODO2
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+
+        src = """
+new object().M.ToString();
+
+static class E
+{
+    public static int M(this object o) => 42;
+}
+""";
+        comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,14): error CS0119: 'E.M(object)' is a method, which is not valid in the given context
+            // new object().M.ToString();
+            Diagnostic(ErrorCode.ERR_BadSKunknown, "M").WithArguments("E.M(object)", "method").WithLocation(1, 14));
+
+        tree = comp.SyntaxTrees.Single();
+        model = comp.GetSemanticModel(tree);
+        memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -17734,7 +17791,7 @@ static class E
         Assert.Equal(["void E.<>E__0.Method()"], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
 
         var memberAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.Property");
-        Assert.Equal([], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetMemberGroup(memberAccess2).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -17944,7 +18001,7 @@ static class E
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
         Assert.Equal(["System.Int32 E.<>E__0.Property { set; }"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
         Assert.Equal(CandidateReason.NotAVariable, model.GetSymbolInfo(memberAccess).CandidateReason);
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -18091,7 +18148,6 @@ static class E
         Assert.Equal("System.Int32 E.<>E__0.Property { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
     }
 
-    // TODO2 resume scan here
     [Fact]
     public void LiteralReceiver_Property_Integer_Set()
     {
@@ -18362,7 +18418,46 @@ static class E2
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
         Assert.Equal(["System.String E1.<>E__0.M()", "System.String E2.<>E__0.M { get; }"],
             model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
-        Assert.Empty(model.GetMemberGroup(memberAccess)); // TODO2
+        Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE consider handling BoundBadExpression better
+    }
+
+    [Fact]
+    public void PreferMoreSpecific_Static_MethodAndProperty_Generic()
+    {
+        var src = """
+System.Console.Write(object.M);
+
+static class E1
+{
+    extension<T>(T)
+    {
+        public static string M() => throw null;
+    }
+}
+
+static class E2
+{
+    extension<T>(T)
+    {
+        public static string M => throw null;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,22): error CS9505: 'object' does not contain a definition for 'M' and no accessible extension member 'M' for receiver of type 'object' could be found (are you missing a using directive or an assembly reference?)
+            // System.Console.Write(object.M);
+            Diagnostic(ErrorCode.ERR_ExtensionResolutionFailed, "object.M").WithArguments("object", "M").WithLocation(1, 22));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+
+        // PROTOTYPE consider handling BoundBadExpression better
+        Assert.Equal(["System.String E1.<>E__0<T>.M()", "System.String E2.<>E__0<T>.M { get; }"],
+            model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Empty(model.GetMemberGroup(memberAccess));
     }
 
     [Fact]
@@ -18395,7 +18490,7 @@ static class E2
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
         Assert.Equal("System.String E1.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
-        //Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2
+        Assert.Equal(["System.String E1.<>E__0.M()", "System.String E2.<>E__0.M { get; }"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -19951,7 +20046,7 @@ static class E2
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.P<int>");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        //Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings()); // PROTOTYPE semantic model is undone TODO2
+        Assert.Equal(["void E2.<>E__0.P<System.Int32>()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -20202,7 +20297,7 @@ static class E2
         Assert.Equal(["System.String E1.<>E__0.M()", "System.Func<System.String> E2.<>E__0.M { get; }"],
             model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
 
-        Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE semantic model is undone
+        Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE consider handling BoundBadExpression better
     }
 
     [Fact]
@@ -20230,7 +20325,8 @@ static class E
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.Method");
-        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol); // PROTOTYPE semantic model is undone
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal(["System.String E.<>E__0.Method()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -20312,7 +20408,8 @@ static class E
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.Method");
-        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol); // PROTOTYPE semantic model is undone
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal(["System.String E.<>E__0.Method<T>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -20398,7 +20495,7 @@ static class E
     }
 
     [Fact]
-    public void Nameof_Overloads()
+    public void Nameof_Overloads_01()
     {
         var src = """
 System.Console.Write($"{nameof(object.M)} ");
@@ -20417,6 +20514,42 @@ static class E
             // (1,32): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
             // System.Console.Write($"{nameof(object.M)} ");
             Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "object.M").WithLocation(1, 32));
+    }
+
+    [Fact]
+    public void Nameof_Overloads_02()
+    {
+        var src = """
+System.Console.Write($"{nameof(object.M)} ");
+
+static class E1
+{
+    extension<T>(T) where T : class
+    {
+        public static void M() { }
+    }
+}
+
+static class E2
+{
+    extension<T>(T) where T : struct
+    {
+        public static void M() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,32): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+            // System.Console.Write($"{nameof(object.M)} ");
+            Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "object.M").WithLocation(1, 32));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal(["void E1.<>E__0<System.Object>.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal(["void E1.<>E__0<System.Object>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -24226,6 +24359,14 @@ static class E
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
         comp.VerifyEmitDiagnostics();
         CompileAndVerify(comp, expectedOutput: ExpectedOutput("'int' does not contain a definition for 'P'"), verify: Verification.FailsPEVerify);
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "d.P");
+        var dynamicType = model.GetTypeInfo(memberAccess.Expression).Type;
+        Assert.True(dynamicType.IsDynamic());
+        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, dynamicType, name: "P", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, dynamicType, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -24745,7 +24886,7 @@ static class E
         Assert.Equal([], model.GetMemberGroup(invocation).ToTestDisplayStrings());
 
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M<object>");
-        Assert.Equal(["void E.<>E__0<System.Object>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2 broken constraint
+        Assert.Equal(["void E.<>E__0<System.Object>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE incompatible extension due to broken constraint should be removed
     }
 
     [Fact]
@@ -24768,7 +24909,6 @@ static class E
             // (2,7): error CS1061: 'string' does not contain a definition for 'P' and no accessible extension method 'P' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
             // _ = s.P<object>;
             Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "P<object>").WithArguments("string", "P").WithLocation(2, 7));
-        // TODO2 test lookup API here
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -24933,7 +25073,7 @@ static class E
         Assert.Equal("System.Int32 i", symbol.ToTestDisplayString());
     }
 
-    readonly string[] objectMembers = [
+    readonly string[] _objectMembers = [
         "System.String System.Object.ToString()",
         "System.Boolean System.Object.Equals(System.Object obj)",
         "System.Boolean System.Object.Equals(System.Object objA, System.Object objB)",
@@ -24971,7 +25111,7 @@ public static class E
 
         var e = ((Compilation)comp).GlobalNamespace.GetTypeMember("E");
         AssertSetStrictlyEqual(["void E.M()"], model.LookupSymbols(position: 0, e, name: "M").ToTestDisplayStrings());
-        AssertSetStrictlyEqual(["void E.M()", "void E.<>E__0.M()"], model.LookupSymbols(position: 0, e, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings()); // TODO2
+        AssertSetStrictlyEqual(["void E.M()", "void E.<>E__0.M()"], model.LookupSymbols(position: 0, e, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
         AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, e, name: "Property").ToTestDisplayStrings());
         AssertSetStrictlyEqual(["System.Int32 E.<>E__0.Property { get; }"], model.LookupSymbols(position: 0, e, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
@@ -24988,8 +25128,15 @@ public static class E
         AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
         AssertSetStrictlyEqual(["System.Int32 E.<>E__0.Property { get; }"], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["void E.<>E__0.M()", "System.Int32 E.<>E__0.Property { get; }", .. objectMembers],
+        AssertSetStrictlyEqual(["void E.<>E__0.M()", "System.Int32 E.<>E__0.Property { get; }", .. _objectMembers],
             model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+
+        Assert.Equal([
+            "System.Boolean System.Object.Equals(System.Object objA, System.Object objB)",
+            "System.Boolean System.Object.ReferenceEquals(System.Object objA, System.Object objB)"],
+            model.LookupStaticMembers(position: 0, o, name: null).ToTestDisplayStrings()); // PROTOTYPE should we include extension static members?
+
+        Assert.Empty(model.LookupNamespacesAndTypes(position: 0, o, name: null));
     }
 
     [Fact]
@@ -25028,11 +25175,11 @@ public static class E
         AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
         AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(objectMembers, model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertSetStrictlyEqual(_objectMembers, model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
     [Fact]
-    public void LookupSymbols_Substituted()
+    public void LookupSymbols_Substituted_01()
     {
         var src = """
 string.M();
@@ -25061,7 +25208,7 @@ public static class E
         AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Property").ToTestDisplayStrings());
         AssertSetStrictlyEqual(["System.Int32 E.<>E__0<System.Object>.Property { get; }"], model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["void E.<>E__0<System.Object>.M()", "System.Int32 E.<>E__0<System.Object>.Property { get; }", .. objectMembers],
+        AssertSetStrictlyEqual(["void E.<>E__0<System.Object>.M()", "System.Int32 E.<>E__0<System.Object>.Property { get; }", .. _objectMembers],
             model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
         var s = ((Compilation)comp).GetSpecialType(SpecialType.System_String);
@@ -25070,6 +25217,165 @@ public static class E
 
         AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, s, name: "Property").ToTestDisplayStrings());
         AssertSetStrictlyEqual(["System.Int32 E.<>E__0<System.String>.Property { get; }"], model.LookupSymbols(position: 0, s, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void LookupSymbols_Substituted_02()
+    {
+        var src = """
+string.M(42);
+
+public static class E
+{
+    extension<T>(T)
+    {
+        public static void M<U>(U u) => throw null;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var s = ((Compilation)comp).GetSpecialType(SpecialType.System_String);
+        AssertSetStrictlyEqual(["void E.<>E__0<System.String>.M<U>(U u)"], model.LookupSymbols(position: 0, s, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void LookupSymbols_StaticAndInstance()
+    {
+        var src = """
+
+public static class E
+{
+    extension(object)
+    {
+        public static void M() => throw null;
+        public static int Property => throw null;
+    }
+    extension(object)
+    {
+        public void M() => throw null;
+        public int Property => throw null;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
+        AssertSetStrictlyEqual(["void E.<>E__0.M()", "void E.<>E__1.M()"],
+            model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+
+        AssertSetStrictlyEqual(["System.Int32 E.<>E__0.Property { get; }", "System.Int32 E.<>E__1.Property { get; }"],
+            model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+
+        AssertSetStrictlyEqual([
+            "void E.<>E__0.M()",
+            "System.Int32 E.<>E__0.Property { get; }",
+            "void E.<>E__1.M()",
+            "System.Int32 E.<>E__1.Property { get; }",
+            .. _objectMembers], model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void LookupSymbols_MethodAndProperty()
+    {
+        var src = """
+
+public static class E
+{
+    extension(object)
+    {
+        public static void MP() => throw null;
+    }
+    extension(object)
+    {
+        public int MP => throw null;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
+        AssertSetStrictlyEqual(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }"],
+            model.LookupSymbols(position: 0, o, name: "MP", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+
+        AssertSetStrictlyEqual(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }", .. _objectMembers],
+            model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void LookupSymbols_ClassicAndNew()
+    {
+        var src = """
+
+public static class E
+{
+    extension(object)
+    {
+        public static void M() => throw null;
+        public void M(string s) => throw null;
+    }
+
+    public static void M(this object o, int i) { }
+}
+""";
+
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
+        AssertSetStrictlyEqual(["void E.<>E__0.M()", "void E.<>E__0.M(System.String s)", "void System.Object.M(System.Int32 i)"],
+            model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+
+        AssertSetStrictlyEqual(["void E.<>E__0.M()", "void E.<>E__0.M(System.String s)", "void System.Object.M(System.Int32 i)", .. _objectMembers],
+            model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void LookupSymbols_NestedType()
+    {
+        var src = """
+
+public static class E
+{
+    extension(object)
+    {
+        static class Nested { }
+    }
+}
+""";
+
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (6,22): error CS9501: Extension declarations can include only methods or properties
+            //         static class Nested { }
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "Nested").WithLocation(6, 22));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
+        AssertSetStrictlyEqual([], model.LookupSymbols(position: 0, o, name: "Nested", includeReducedExtensionMethods: true).ToTestDisplayStrings());
+        AssertSetStrictlyEqual([.. _objectMembers], model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
+
+        Assert.Empty(model.LookupNamespacesAndTypes(position: 0, o, name: null));
     }
 
     [Fact]
@@ -25101,7 +25407,7 @@ static class E
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
 
-        // TODO2 need to filter out by bad constraint like we do in inferred scenario based on receiver
+        // PROTOTYPE incompatible extension due to broken constraint should be removed
         var memberAccess1 = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M<int>");
         Assert.Equal(["void E.<>E__0.M<System.Int32>()"], model.GetMemberGroup(memberAccess1).ToTestDisplayStrings());
 
@@ -25263,7 +25569,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
 
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.P");
-        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // TODO2 handle BoundPropertyAccess
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 
     [Fact]
@@ -25324,6 +25630,211 @@ static class E2
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "string.M");
+        Assert.Equal("void E2.<>E__0<System.String>.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
         Assert.Equal(["System.Int32 E1.<>E__0<System.String>.M { get; }", "void E2.<>E__0<System.String>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+
+        var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "string.M()");
+        Assert.Equal("void E2.<>E__0<System.String>.M()", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void GetMemberGroup_09()
+    {
+        var src = """
+string.M();
+
+static class E1
+{
+    extension<T>(T)
+    {
+        public static void M() { }
+    }
+}
+static class E2
+{
+    extension<T>(T)
+    {
+        public static void M() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,8): error CS0121: The call is ambiguous between the following methods or properties: 'E1.extension<T>(T).M()' and 'E2.extension<T>(T).M()'
+            // string.M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E1.extension<T>(T).M()", "E2.extension<T>(T).M()").WithLocation(1, 8));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "string.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal(["void E1.<>E__0<System.String>.M()", "void E2.<>E__0<System.String>.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal(["void E1.<>E__0<System.String>.M()", "void E2.<>E__0<System.String>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void GetMemberGroup_10()
+    {
+        var src = """
+System.Action a = new System.Action(object.M);
+
+static class E
+{
+    extension(object)
+    {
+        public static void M() { }
+        public static void M(int i) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
+        Assert.Equal("void E.<>E__0.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal(["void E.<>E__0.M()", "void E.<>E__0.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void GetMemberGroup_11()
+    {
+        var src = """
+System.Action a = new System.Action(object.M);
+
+static class E
+{
+    extension<T>(T)
+    {
+        public static void M() { }
+        public static void M(int i) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
+        Assert.Equal("void E.<>E__0<System.Object>.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal(["void E.<>E__0<System.Object>.M()", "void E.<>E__0<System.Object>.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void GetMemberGroup_12()
+    {
+        var src = """
+System.Action a = (System.Action)object.M;
+
+static class E
+{
+    extension<T>(T)
+    {
+        public static void M() { }
+        public static void M(int i) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.M");
+        Assert.Equal("void E.<>E__0<System.Object>.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal(["void E.<>E__0<System.Object>.M()", "void E.<>E__0<System.Object>.M(System.Int32 i)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+
+        var cast = GetSyntax<CastExpressionSyntax>(tree, "(System.Action)object.M");
+        Assert.Equal("void E.<>E__0<System.Object>.M()", model.GetSymbolInfo(cast).Symbol.ToTestDisplayString());
+        Assert.Equal([], model.GetSymbolInfo(cast).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(cast).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void ToBadExpression_01()
+    {
+        var source = """
+class A
+{
+    void F() { }
+}
+
+class C
+{
+    static void M(A a)
+    {
+        a.F();
+        M(a.F);
+    }
+    static void M(System.Action a) { }
+}
+
+static class E1
+{
+    static void F<T>(this T t) { }
+}
+
+static class E2
+{
+    extension<T>(T)
+    {
+        static void F() { }
+    }
+}
+""";
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (10,11): error CS0122: 'A.F()' is inaccessible due to its protection level
+            //         a.F();
+            Diagnostic(ErrorCode.ERR_BadAccess, "F").WithArguments("A.F()").WithLocation(10, 11),
+            // (11,13): error CS0122: 'A.F()' is inaccessible due to its protection level
+            //         M(a.F);
+            Diagnostic(ErrorCode.ERR_BadAccess, "F").WithArguments("A.F()").WithLocation(11, 13));
+
+        var tree = comp.SyntaxTrees[0];
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "a.F").ToArray();
+        Assert.Null(model.GetSymbolInfo(memberAccess[0]).Symbol);
+        Assert.Equal(["void A.F()"], model.GetSymbolInfo(memberAccess[0]).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal(["void A.F()", "void E2.<>E__0<A>.F()", "void A.F<A>()"], model.GetMemberGroup(memberAccess[0]).ToTestDisplayStrings());
+
+        Assert.Null(model.GetSymbolInfo(memberAccess[1]).Symbol);
+        Assert.Equal(["void A.F()", "void E2.<>E__0<A>.F()", "void A.F<A>()"], model.GetSymbolInfo(memberAccess[1]).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal(["void A.F()", "void E2.<>E__0<A>.F()", "void A.F<A>()"], model.GetMemberGroup(memberAccess[1]).ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void PropertyAccess_NotAmbiguousWithInapplicableMethod()
+    {
+        var src = """
+int i = object.P;
+System.Console.Write(i);
+
+static class E
+{
+    extension<T>(T) where T : struct
+    {
+        public static void P() { }
+    }
+
+    extension<T>(T) where T : class
+    {
+        public static int P => 42;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.P");
+        Assert.Equal("System.Int32 E.<>E__1<System.Object>.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -3018,7 +3018,7 @@ public class C
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<int>");
             Assert.Equal("void C.M<System.Int32>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-            AssertEx.Equal(["void C.M<System.Int32>()", "void C.M<System.Int32>(System.Object o)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+            AssertEx.Equal(["void C.M<System.Int32>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
@@ -3142,7 +3142,7 @@ static class E2
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M<object>");
             Assert.Equal("void System.Object.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-            AssertEx.Equal(["void System.Object.M<System.Object>()", "void System.Object.M<System.Object>(System.Object ignored)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+            AssertEx.Equal(["void System.Object.M<System.Object>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Theory, CombinatorialData]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -3018,7 +3018,7 @@ public class C
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<int>");
             Assert.Equal("void C.M<System.Int32>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-            AssertEx.Equal(["void C.M<System.Int32>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+            AssertEx.Equal(["void C.M<System.Int32>()", "void C.M<System.Int32>(System.Object o)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
@@ -3142,7 +3142,7 @@ static class E2
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M<object>");
             Assert.Equal("void System.Object.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-            AssertEx.Equal(["void System.Object.M<System.Object>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+            AssertEx.Equal(["void System.Object.M<System.Object>()", "void System.Object.M<System.Object>(System.Object ignored)"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Theory, CombinatorialData]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -3018,9 +3018,7 @@ public class C
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<int>");
             Assert.Equal("void C.M<System.Int32>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-
-            AssertEx.Equal(["void C.M<System.Int32>()", "void C.M<System.Int32>(System.Object o)"],
-                model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+            AssertEx.Equal(["void C.M<System.Int32>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
@@ -3144,9 +3142,7 @@ static class E2
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M<object>");
             Assert.Equal("void System.Object.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
-
-            AssertEx.Equal(["void System.Object.M<System.Object>()", "void System.Object.M<System.Object>(System.Object ignored)"],
-                model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+            AssertEx.Equal(["void System.Object.M<System.Object>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Theory, CombinatorialData]

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis
         /// scope around position is used.</param>
         /// <param name="name">The name of the symbol to find. If null is specified then symbols
         /// with any names are returned.</param>
-        /// <param name="includeReducedExtensionMethods">Consider (reduced) extension methods.</param>
+        /// <param name="includeReducedExtensionMethods">Consider (reduced) extension methods.</param> // TODO2
         /// <returns>A list of symbols that were found. If no symbols were found, an empty list is returned.</returns>
         /// <remarks>
         /// The "position" is used to determine what variables are visible and accessible. Even if "container" is

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis
         /// scope around position is used.</param>
         /// <param name="name">The name of the symbol to find. If null is specified then symbols
         /// with any names are returned.</param>
-        /// <param name="includeReducedExtensionMethods">Consider (reduced) extension methods.</param> // TODO2
+        /// <param name="includeReducedExtensionMethods">Consider extension members. Classic extension methods will be returned in reduced form.</param>
         /// <returns>A list of symbols that were found. If no symbols were found, an empty list is returned.</returns>
         /// <remarks>
         /// The "position" is used to determine what variables are visible and accessible. Even if "container" is

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,7 +2,8 @@ Microsoft.CodeAnalysis.IEventSymbol.IsPartialDefinition.get -> bool
 Microsoft.CodeAnalysis.IEventSymbol.PartialDefinitionPart.get -> Microsoft.CodeAnalysis.IEventSymbol?
 Microsoft.CodeAnalysis.IEventSymbol.PartialImplementationPart.get -> Microsoft.CodeAnalysis.IEventSymbol?
 Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext.AddEmbeddedAttributeDefinition() -> void
-Microsoft.CodeAnalysis.ITypeSymbol.ExtensionParameter.get -> Microsoft.CodeAnalysis.IParameterSymbol?
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.ToString() -> string!
+
 Microsoft.CodeAnalysis.ITypeSymbol.IsExtension.get -> bool
 Microsoft.CodeAnalysis.TypeKind.Extension = 14 -> Microsoft.CodeAnalysis.TypeKind
+Microsoft.CodeAnalysis.ITypeSymbol.ExtensionParameter.get -> Microsoft.CodeAnalysis.IParameterSymbol?

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,7 +2,7 @@ Microsoft.CodeAnalysis.IEventSymbol.IsPartialDefinition.get -> bool
 Microsoft.CodeAnalysis.IEventSymbol.PartialDefinitionPart.get -> Microsoft.CodeAnalysis.IEventSymbol?
 Microsoft.CodeAnalysis.IEventSymbol.PartialImplementationPart.get -> Microsoft.CodeAnalysis.IEventSymbol?
 Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext.AddEmbeddedAttributeDefinition() -> void
+Microsoft.CodeAnalysis.ITypeSymbol.ExtensionParameter.get -> Microsoft.CodeAnalysis.IParameterSymbol?
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.ToString() -> string!
-
 Microsoft.CodeAnalysis.ITypeSymbol.IsExtension.get -> bool
 Microsoft.CodeAnalysis.TypeKind.Extension = 14 -> Microsoft.CodeAnalysis.TypeKind

--- a/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -87,6 +87,11 @@ namespace Microsoft.CodeAnalysis
         bool IsExtension { get; }
 
         /// <summary>
+        /// The extension parameter if this is an extension declaration (<see cref="IsExtension"/> is true).
+        /// </summary>
+        IParameterSymbol? ExtensionParameter { get; }
+
+        /// <summary>
         /// The original definition of this symbol. If this symbol is constructed from another
         /// symbol by type substitution then <see cref="OriginalDefinition"/> gets the original symbol as it was defined in
         /// source or metadata.

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -789,5 +789,10 @@ Done:
             End Get
         End Property
 
+        Public ReadOnly Property ExtensionParameter As IParameterSymbol Implements ITypeSymbol.ExtensionParameter
+            Get
+                Return Nothing
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10727,8 +10727,7 @@ AnonymousTypes(
                 }
             }
             """,
-            // PROTOTYPE: There should be no overloads here.  Need GetMemberGroup fixed for skeleton vs impl extensions.
-            MainDescription($"void Extensions.extension(string).Goo() (+ 1 {FeaturesResources.overload})"));
+            MainDescription($"void Extensions.extension(string).Goo()"));
     }
 
     [Fact]
@@ -10757,8 +10756,7 @@ AnonymousTypes(
                 }
             }
             """,
-            // PROTOTYPE: There should be one overload here.  Need GetMemberGroup fixed for skeleton vs impl extensions.
-            MainDescription($"void Extensions.extension(string).Goo() (+ 2 {FeaturesResources.overloads_})"));
+            MainDescription($"void Extensions.extension(string).Goo() (+ 1 {FeaturesResources.overload})"));
     }
 
     [Fact]
@@ -10787,8 +10785,7 @@ AnonymousTypes(
                 }
             }
             """,
-            // PROTOTYPE: There should be one overload here.  Need GetMemberGroup fixed for skeleton vs impl extensions.
-            MainDescription($"void Extensions.extension(string).Goo(int i) (+ 2 {FeaturesResources.overloads_})"));
+            MainDescription($"void Extensions.extension(string).Goo(int i) (+ 1 {FeaturesResources.overload})"));
     }
 
     [Fact]

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -146,6 +146,8 @@ internal abstract partial class AbstractMetadataAsSourceService
 
         public bool IsExtension => _symbol.IsExtension;
 
+        public IParameterSymbol ExtensionParameter => _symbol.ExtensionParameter;
+
         public bool IsFileLocal => _symbol.IsFileLocal;
 
         public INamedTypeSymbol NativeIntegerUnderlyingType => _symbol.NativeIntegerUnderlyingType;

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -146,7 +146,9 @@ internal abstract partial class AbstractMetadataAsSourceService
 
         public bool IsExtension => _symbol.IsExtension;
 
-        public IParameterSymbol ExtensionParameter => _symbol.ExtensionParameter;
+        // PROTOTYPE this may need an implementation
+        public IParameterSymbol ExtensionParameter 
+            => throw new NotImplementedException();
 
         public bool IsFileLocal => _symbol.IsFileLocal;
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -147,7 +147,7 @@ internal abstract partial class AbstractMetadataAsSourceService
         public bool IsExtension => _symbol.IsExtension;
 
         // PROTOTYPE this may need an implementation
-        public IParameterSymbol ExtensionParameter 
+        public IParameterSymbol ExtensionParameter
             => throw new NotImplementedException();
 
         public bool IsFileLocal => _symbol.IsFileLocal;

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
@@ -1471,6 +1471,7 @@ Microsoft.CodeAnalysis.ITypeSymbol.ToMinimalDisplayString(Microsoft.CodeAnalysis
 Microsoft.CodeAnalysis.ITypeSymbol.WithNullableAnnotation(Microsoft.CodeAnalysis.NullableAnnotation)
 Microsoft.CodeAnalysis.ITypeSymbol.get_AllInterfaces
 Microsoft.CodeAnalysis.ITypeSymbol.get_BaseType
+Microsoft.CodeAnalysis.ITypeSymbol.get_ExtensionParameter
 Microsoft.CodeAnalysis.ITypeSymbol.get_Interfaces
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsAnonymousType
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsExtension

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -49,6 +49,8 @@ internal abstract class CodeGenerationTypeSymbol(
 
     public bool IsExtension => false;
 
+    public IParameterSymbol ExtensionParameter => null;
+
     public static ImmutableArray<ITypeSymbol> TupleElementTypes => default;
 
     public static ImmutableArray<string> TupleElementNames => default;


### PR DESCRIPTION
Updates GetDeclaredSymbol, LookupSymbols and GetMemberGroup
Adds ExtensionParameter

A number of APIs are out-of-scope for this PR and will be in follow-ups: GetOperation, GetSpeculativeSymbolInfo, GetSpeculativeTypeInfo, GetAliasInfo, GetSpeculativeAliasInfo, IsAccessible, AnalyzeDataFlow.

Relates to test plan https://github.com/dotnet/roslyn/issues/76130
Fixes https://github.com/dotnet/roslyn/issues/77502