### PR TITLE
Correct how we pick up options for `ICopilotOptionsService`

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
@@ -85,8 +85,10 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
 
         try
         {
-            var setting = _settingsReader.GetValue<bool>($"{option.Name}");
-            return setting.Value;
+            if (_settingsReader.GetValue<bool>(option.Name) is { Outcome: SettingRetrievalOutcome.Success } setting)
+                return setting.Value;
+
+            return option.DefaultValue;
         }
         catch
         {

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
@@ -4,15 +4,14 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Copilot;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities.UnifiedSettings;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options;
 
@@ -40,14 +39,12 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
     /// </summary>
     private const string GitHubAccountStatusIsCopilotEntitled = "3DE3FA6E-91B2-46C1-9E9E-DD04975BB890";
 
-    private const string CopilotOptionNamePrefix = "Microsoft.VisualStudio.Conversations";
-
     // Default value must reflect their default values in ConversationsOptions in Copilot repo.
-    private readonly CopilotOption _copilotCodeAnalysisOption = new("EnableCSharpCodeAnalysis", false);
-    private readonly CopilotOption _copilotRefineOption = new("EnableCSharpRefineQuickActionSuggestion", false);
-    private readonly CopilotOption _copilotOnTheFlyDocsOption = new("EnableOnTheFlyDocs", true);
-    private readonly CopilotOption _copilotGenerateDocumentationCommentOption = new("EnableCSharpGenerateDocumentationComment", true);
-    private readonly CopilotOption _copilotGenerateMethodImplementationOption = new("EnableCSharpGenerateMethodImplementation", true);
+    private readonly CopilotOption _copilotCodeAnalysisOption = new("copilot.featureFlags.editor.enableCSharpCodeAnalysis", false);
+    private readonly CopilotOption _copilotRefineOption = new("copilot.featureFlags.editor.enableCSharpRefineQuickActionSuggestion", false);
+    private readonly CopilotOption _copilotOnTheFlyDocsOption = new("copilot.general.editor.enableOnTheFlyDocs", true);
+    private readonly CopilotOption _copilotGenerateDocumentationCommentOption = new("copilot.general.editor.enableCSharpGenerateDocumentationComment", true);
+    private readonly CopilotOption _copilotGenerateMethodImplementationOption = new("copilot.featureFlags.editor.enableCSharpGenerateMethodImplementation", true);
 
     private static readonly UIContext s_copilotHasLoadedUIContext = UIContext.FromUIContextGuid(new Guid(CopilotHasLoadedGuid));
     private static readonly UIContext s_gitHubAccountStatusDeterminedContext = UIContext.FromUIContextGuid(new Guid(GitHubAccountStatusDetermined));
@@ -55,6 +52,7 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
     private static readonly UIContext s_gitHubAccountStatusSignedInUIContext = UIContext.FromUIContextGuid(new Guid(GitHubAccountStatusSignedIn));
 
     private readonly Task<ISettingsManager> _settingsManagerTask;
+    private ISettingsReader? _settingsReader;
 
     /// <summary>
     /// Determines if Copilot is active and the user is signed in and entitled to use Copilot.
@@ -68,7 +66,7 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
     [method: ImportingConstructor]
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public CSharpVisualStudioCopilotOptionsService(
-        IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManagerService,
+        IVsService<SVsUnifiedSettingsManager, ISettingsManager> settingsManagerService,
         IThreadingContext threadingContext)
     {
         _settingsManagerTask = settingsManagerService.GetValueAsync(threadingContext.DisposalToken);
@@ -79,11 +77,21 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
         if (!IsGithubCopilotLoadedAndSignedIn)
             return false;
 
-        var settingManager = await _settingsManagerTask.ConfigureAwait(false);
-        // The bool setting is persisted as 0=None, 1=True, 2=False, so it needs to be retrieved as an int.
-        // If isEnabled is 0 or the value is not persisted, we should return the default value for the option.
-        var isEnabled = settingManager.GetValueOrDefault($"{CopilotOptionNamePrefix}.{option.Name}", 0);
-        return isEnabled == 1 || (isEnabled == 0 && option.DefaultValue);
+        if (_settingsReader == null)
+        {
+            var settingsManager = await _settingsManagerTask.ConfigureAwait(false);
+            _settingsReader = settingsManager.GetReader();
+        }
+
+        try
+        {
+            var setting = _settingsReader.GetValue<bool>($"{option.Name}");
+            return setting.Value;
+        }
+        catch
+        {
+            return option.DefaultValue;
+        }
     }
 
     public Task<bool> IsCodeAnalysisOptionEnabledAsync()

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
@@ -44,7 +44,7 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
     private readonly CopilotOption _copilotRefineOption = new("copilot.featureFlags.editor.enableCSharpRefineQuickActionSuggestion", false);
     private readonly CopilotOption _copilotOnTheFlyDocsOption = new("copilot.general.editor.enableOnTheFlyDocs", true);
     private readonly CopilotOption _copilotGenerateDocumentationCommentOption = new("copilot.general.editor.enableCSharpGenerateDocumentationComment", true);
-    private readonly CopilotOption _copilotGenerateMethodImplementationOption = new("copilot.featureFlags.editor.enableCSharpGenerateMethodImplementation", true);
+    private readonly CopilotOption _copilotGenerateMethodImplementationOption = new("copilot.featureFlags.editor.enableCSharpGenerateMethodImplementation", false);
 
     private static readonly UIContext s_copilotHasLoadedUIContext = UIContext.FromUIContextGuid(new Guid(CopilotHasLoadedGuid));
     private static readonly UIContext s_gitHubAccountStatusDeterminedContext = UIContext.FromUIContextGuid(new Guid(GitHubAccountStatusDetermined));

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
@@ -43,7 +43,7 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
     private readonly CopilotOption _copilotCodeAnalysisOption = new("copilot.featureFlags.editor.enableCSharpCodeAnalysis", false);
     private readonly CopilotOption _copilotRefineOption = new("copilot.featureFlags.editor.enableCSharpRefineQuickActionSuggestion", false);
     private readonly CopilotOption _copilotOnTheFlyDocsOption = new("copilot.general.editor.enableOnTheFlyDocs", true);
-    private readonly CopilotOption _copilotGenerateDocumentationCommentOption = new("copilot.general.editor.enableCSharpGenerateDocumentationComment", true);
+    private readonly CopilotOption _copilotGenerateDocumentationCommentOption = new("copilot.general.editor.enableGenerateDocumentationComment", true);
     private readonly CopilotOption _copilotGenerateMethodImplementationOption = new("copilot.featureFlags.editor.enableCSharpGenerateMethodImplementation", false);
 
     private static readonly UIContext s_copilotHasLoadedUIContext = UIContext.FromUIContextGuid(new Guid(CopilotHasLoadedGuid));


### PR DESCRIPTION
This is to ensure Roslyn properly picks up copilot options using unified settings, needed so we can control the roll out of roslyn copilot features since the recent migration to unified settings.