### PR TITLE
Another small set of package initialization optimizations

### DIFF
--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -14,11 +14,9 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Threading;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.CodeAnalysis.ColorSchemes;
@@ -42,7 +40,6 @@ internal sealed partial class ColorSchemeApplier
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public ColorSchemeApplier(
         IThreadingContext threadingContext,
-        IVsService<SVsFontAndColorStorage, IVsFontAndColorStorage> fontAndColorStorage,
         IGlobalOptionService globalOptions,
         SVsServiceProvider serviceProvider,
         IAsynchronousOperationListenerProvider listenerProvider)

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -58,6 +58,8 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
             RegisterEditorFactory(editorFactory);
         }
 
+        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
+
         // awaiting an IVsTask guarantees to return on the captured context
         await shell.LoadPackageAsync(Guids.RoslynPackageId);
 
@@ -77,8 +79,6 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
                      return _languageService.ComAggregate!;
                  });
-
-                 var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
 
                  RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -58,8 +58,6 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
             RegisterEditorFactory(editorFactory);
         }
 
-        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
-
         // awaiting an IVsTask guarantees to return on the captured context
         await shell.LoadPackageAsync(Guids.RoslynPackageId);
 
@@ -79,6 +77,8 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
                      return _languageService.ComAggregate!;
                  });
+
+                 var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
 
                  RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -65,7 +65,7 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
 
         packageRegistrationTasks.AddTask(
              isMainThreadTask: false,
-             task: async (IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken) =>
+             task: (IProgress<ServiceProgressData> progress, PackageRegistrationTasks packageRegistrationTasks, CancellationToken cancellationToken) =>
              {
                  RegisterLanguageService(typeof(TLanguageService), async cancellationToken =>
                  {
@@ -81,6 +81,8 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
                  });
 
                  RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
+
+                 return Task.CompletedTask;
              });
     }
 

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -158,11 +158,6 @@ internal sealed class RoslynPackage : AbstractPackage
 
         var settingsEditorFactory = this.ComponentModel.GetService<SettingsEditorFactory>();
 
-        // Misc workspace has to be up and running by the time our package is usable so that it can track running
-        // doc events and appropriately map files to/from it and other relevant workspaces (like the
-        // metadata-as-source workspace).
-        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
-
         packageRegistrationTasks.AddTask(
             isMainThreadTask: true,
             task: async (progress, packageRegistrationTasks, cancellationToken) =>
@@ -183,6 +178,11 @@ internal sealed class RoslynPackage : AbstractPackage
                 serviceBrokerContainer.Proffer(
                     ManagedHotReloadLanguageServiceDescriptor.Descriptor,
                     (_, _, _, _) => ValueTaskFactory.FromResult<object?>(new ManagedEditAndContinueLanguageServiceBridge(this.ComponentModel.GetService<EditAndContinueLanguageService>())));
+
+                // Misc workspace has to be up and running by the time our package is usable so that it can track running
+                // doc events and appropriately map files to/from it and other relevant workspaces (like the
+                // metadata-as-source workspace).
+                var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
             });
 
         return Task.CompletedTask;

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -163,9 +163,9 @@ internal sealed class RoslynPackage : AbstractPackage
         // metadata-as-source workspace).
         var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
 
-        packageInitializeTasks.AddTask(
+        packageRegistrationTasks.AddTask(
             isMainThreadTask: true,
-            task: async (packageInitializeTasks, cancellationToken) =>
+            task: async (progress, packageRegistrationTasks, cancellationToken) =>
             {
                 _solutionEventMonitor = new SolutionEventMonitor(globalNotificationService);
                 TrackBulkFileOperations(globalNotificationService);

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -183,13 +183,6 @@ internal sealed class RoslynPackage : AbstractPackage
                 serviceBrokerContainer.Proffer(
                     ManagedHotReloadLanguageServiceDescriptor.Descriptor,
                     (_, _, _, _) => ValueTaskFactory.FromResult<object?>(new ManagedEditAndContinueLanguageServiceBridge(this.ComponentModel.GetService<EditAndContinueLanguageService>())));
-
-                packageRegistrationTasks.AddTask(
-                    isMainThreadTask: false,
-                    task: async (progress, packageRegistrationTasks, cancellationToken) =>
-                    {
-                        await miscellaneousFilesWorkspace.InitializeAsync().ConfigureAwait(false);
-                    });
             });
 
         return Task.CompletedTask;

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -158,17 +158,17 @@ internal sealed class RoslynPackage : AbstractPackage
 
         var settingsEditorFactory = this.ComponentModel.GetService<SettingsEditorFactory>();
 
-        packageRegistrationTasks.AddTask(
+        // Misc workspace has to be up and running by the time our package is usable so that it can track running
+        // doc events and appropriately map files to/from it and other relevant workspaces (like the
+        // metadata-as-source workspace).
+        var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
+
+        packageInitializeTasks.AddTask(
             isMainThreadTask: true,
-            task: async (progress, packageRegistrationTasks, cancellationToken) =>
+            task: async (packageInitializeTasks, cancellationToken) =>
             {
                 _solutionEventMonitor = new SolutionEventMonitor(globalNotificationService);
                 TrackBulkFileOperations(globalNotificationService);
-
-                // Misc workspace has to be up and running by the time our package is usable so that it can track running
-                // doc events and appropriately map files to/from it and other relevant workspaces (like the
-                // metadata-as-source workspace).
-                var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
 
                 RegisterEditorFactory(settingsEditorFactory);
 


### PR DESCRIPTION
1) Move RegisterLanguageService call in AbstractPackage<> to be on the background. This method was already thread safe. 

2) Move RegisterMiscellaneousFilesWorkspaceInformation call in AbstractPackage<> to be on the background. This required changing the data structure holding these strings to be a concurrent dictionary. 

3) Move RegisterObjectBrowserLibraryManager call in AbstractPackge package initialization to OnAfterPackageLoadedAsync 

4) Change MiscellaneousFilesWorkspace to not require a bg thread initialize call and instead get the text manager when needed.