### PR TITLE
Fix watch window completion window upon manual completion invocation

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
@@ -102,6 +102,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 // where [] denotes CurrentStatementSpan, should use the start of CurrentStatementSpan
                 // as the adjusted context, and should not place a semicolon before debuggerMappedSpan.
                 // Not doing either of those would place debuggerMappedSpan outside the for loop.
+                // We use a space as the separator in this case (instead of an empty string) to help
+                // the vs editor out and not have a projection seam at the location they will bring
+                // up completion.
                 separatorBeforeDebuggerMappedSpan = " ";
                 adjustedStart = token.Parent.SpanStart;
             }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpDebuggerIntelliSenseContext.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 // where [] denotes CurrentStatementSpan, should use the start of CurrentStatementSpan
                 // as the adjusted context, and should not place a semicolon before debuggerMappedSpan.
                 // Not doing either of those would place debuggerMappedSpan outside the for loop.
-                separatorBeforeDebuggerMappedSpan = string.Empty;
+                separatorBeforeDebuggerMappedSpan = " ";
                 adjustedStart = token.Parent.SpanStart;
             }
 
@@ -110,10 +110,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             var afterAdjustedStart = ContextBuffer.CurrentSnapshot.CreateTrackingSpanFromIndexToEnd(adjustedStart, SpanTrackingMode.EdgePositive);
 
             return ProjectionBufferFactoryService.CreateProjectionBuffer(
-                projectionEditResolver: null,
-                sourceSpans: [beforeAdjustedStart, separatorBeforeDebuggerMappedSpan, debuggerMappedSpan, StatementTerminator, afterAdjustedStart],
-                options: ProjectionBufferOptions.None,
-                contentType: ContentType);
+                    projectionEditResolver: null,
+                    sourceSpans: [beforeAdjustedStart, separatorBeforeDebuggerMappedSpan, debuggerMappedSpan, StatementTerminator, afterAdjustedStart],
+                    options: ProjectionBufferOptions.None,
+                    contentType: ContentType);
         }
 
         public override bool CompletionStartsOnQuestionMark

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -339,6 +339,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Function
 
         <WpfFact>
+        Public Async Function SingleStatementBlockInvokeCompletion() As Task
+            Dim text = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>class Program
+{
+    static void Main()
+    {
+        for (int variable1 = 0; variable1 &lt; 10; variable1++)
+            [|Console.Write(0);|]
+        int variable2 = 0;
+    }
+}</Document>
+                           </Project>
+                       </Workspace>
+
+            Using state = TestState.CreateCSharpTestState(text, False)
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContainAll("variable1")
+            End Using
+        End Function
+
+        <WpfFact>
         Public Async Function SignatureHelpInParameterizedConstructor() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">


### PR DESCRIPTION
Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2287966

This recently regressed due to this recent PR: https://github.com/dotnet/roslyn/pull/77204

The issue here is that I changed the csharp debugger context's projection buffer creation code from always having a one char string as the second sourceSpan to sometimes having that string be empty. This allowed the completion context to include items for which a semicolon would close that scope. However, by having a zero length span, a seam was created for a tracking span at priorTrackingSpan to be introduced into the set of tracking positions that can contribute to completion. Editor completion doesn't handle this well, so we're best off always sending a non-zero length source Span, so we do so and just use a space as the value.