### PR TITLE
Add feature to convert classic extension methods to the new 'extension' form in C# 14.

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Analyzers/CSharp/CodeFixes/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -51,15 +51,15 @@ internal abstract class CSharpGenerateParameterizedMemberService<TService> : Abs
 
         protected override ImmutableArray<ITypeParameterSymbol> GetCapturedTypeParameters(CancellationToken cancellationToken)
         {
-            var result = new List<ITypeParameterSymbol>();
+            using var _ = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var result);
             var semanticModel = Document.SemanticModel;
             foreach (var argument in _invocationExpression.ArgumentList.Arguments)
             {
                 var type = argument.DetermineParameterType(semanticModel, cancellationToken);
-                type.GetReferencedTypeParameters(result);
+                type.AddReferencedTypeParameters(result);
             }
 
-            return [.. result];
+            return result.ToImmutableAndClear();
         }
 
         protected override ImmutableArray<ITypeParameterSymbol> GenerateTypeParameters(CancellationToken cancellationToken)

--- a/src/Analyzers/CSharp/CodeFixes/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyCodeFixProvider.cs
@@ -99,7 +99,7 @@ internal sealed class CSharpMakeStructMemberReadOnlyCodeFixProvider() : SyntaxEd
 
         TNode UpdateReadOnlyModifier<TNode>(TNode node, bool add) where TNode : SyntaxNode
         {
-            return (TNode)generator.WithModifiers(node, generator.GetModifiers(node).WithIsReadOnly(add));
+            return generator.WithModifiers(node, generator.GetModifiers(node).WithIsReadOnly(add));
         }
     }
 }

--- a/src/Analyzers/CSharp/CodeFixes/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyCodeFixProvider.cs
@@ -99,7 +99,7 @@ internal sealed class CSharpMakeStructMemberReadOnlyCodeFixProvider() : SyntaxEd
 
         TNode UpdateReadOnlyModifier<TNode>(TNode node, bool add) where TNode : SyntaxNode
         {
-            return generator.WithModifiers(node, generator.GetModifiers(node).WithIsReadOnly(add));
+            return (TNode)generator.WithModifiers(node, generator.GetModifiers(node).WithIsReadOnly(add));
         }
     }
 }

--- a/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -462,7 +462,9 @@ internal abstract partial class AbstractGenerateVariableService<TService, TSimpl
             // Substitute 'object' for all captured method type parameters.  Note: we may need to
             // do this for things like anonymous types, as well as captured type parameters that
             // aren't in scope in the destination type.
-            var capturedMethodTypeParameters = inferredType.GetReferencedMethodTypeParameters();
+            using var _ = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var capturedMethodTypeParameters);
+            inferredType.AddReferencedMethodTypeParameters(capturedMethodTypeParameters);
+
             var mapping = capturedMethodTypeParameters.ToDictionary(tp => tp,
                 tp => compilation.ObjectType);
 

--- a/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -462,7 +462,7 @@ internal abstract partial class AbstractGenerateVariableService<TService, TSimpl
             // Substitute 'object' for all captured method type parameters.  Note: we may need to
             // do this for things like anonymous types, as well as captured type parameters that
             // aren't in scope in the destination type.
-            using var _ = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var capturedMethodTypeParameters);
+            using var _1 = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var capturedMethodTypeParameters);
             inferredType.AddReferencedMethodTypeParameters(capturedMethodTypeParameters);
 
             var mapping = capturedMethodTypeParameters.ToDictionary(tp => tp,
@@ -476,7 +476,7 @@ internal abstract partial class AbstractGenerateVariableService<TService, TSimpl
             var enclosingMethodSymbol = _document.SemanticModel.GetEnclosingSymbol<IMethodSymbol>(SimpleNameOrMemberAccessExpressionOpt.SpanStart, cancellationToken);
             if (enclosingMethodSymbol != null && enclosingMethodSymbol.TypeParameters != null && enclosingMethodSymbol.TypeParameters.Length != 0)
             {
-                using var _ = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var combinedTypeParameters);
+                using var _2 = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var combinedTypeParameters);
                 combinedTypeParameters.AddRange(availableTypeParameters);
                 combinedTypeParameters.AddRange(enclosingMethodSymbol.TypeParameters);
                 LocalType = inferredType.RemoveUnavailableTypeParameters(compilation, combinedTypeParameters);

--- a/src/Analyzers/VisualBasic/CodeFixes/GenerateParameterizedMember/VisualBasicGenerateParameterizedMemberService.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/GenerateParameterizedMember/VisualBasicGenerateParameterizedMemberService.vb
@@ -62,15 +62,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateMethod
             End Function
 
             Protected Overrides Function GetCapturedTypeParameters(cancellationToken As CancellationToken) As ImmutableArray(Of ITypeParameterSymbol)
-                Dim result = New List(Of ITypeParameterSymbol)()
+                Dim result = ArrayBuilder(Of ITypeParameterSymbol).GetInstance()
                 If Me.InvocationExpression.ArgumentList IsNot Nothing Then
                     For Each argument In Me.InvocationExpression.ArgumentList.Arguments
                         Dim type = DetermineParameterType(argument, cancellationToken)
-                        type.GetReferencedTypeParameters(result)
+                        type.AddReferencedTypeParameters(result)
                     Next
                 End If
 
-                Return result.ToImmutableArray()
+                Return result.ToImmutableAndFree()
             End Function
 
             Protected Overrides Function GenerateTypeParameters(cancellationToken As CancellationToken) As ImmutableArray(Of ITypeParameterSymbol)

--- a/src/Compilers/Test/Core/Traits/Traits.cs
+++ b/src/Compilers/Test/Core/Traits/Traits.cs
@@ -76,6 +76,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsConvertQueryToForEach = "CodeActions.ConvertQueryToForEach";
             public const string CodeActionsConvertToRawString = "CodeActions.CodeActionsConvertToRawString";
             public const string CodeActionsConvertSwitchStatementToExpression = "CodeActions.ConvertSwitchStatementToExpression";
+            public const string CodeActionsConvertToExtension = "CodeActions.ConvertToExtension";
             public const string CodeActionsConvertToInterpolatedString = "CodeActions.ConvertToInterpolatedString";
             public const string CodeActionsConvertToIterator = "CodeActions.ConvertToIterator";
             public const string CodeActionsConvertToRecord = "CodeActions.ConvertToRecord";

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -581,10 +581,10 @@
   <data name="required_property" xml:space="preserve">
     <value>required property</value>
   </data>
-  <data name="Convert_extension_method_to_extension" xml:space="preserve">
-    <value>Convert extension method to extension</value>
+  <data name="Convert_0_extension_methods_to_extension" xml:space="preserve">
+    <value>Convert '0' extension methods to extension</value>
   </data>
-  <data name="Convert_all_extension_methods_to_extension" xml:space="preserve">
-    <value>Convert all extension methods to extension</value>
+  <data name="Convert_all_extension_methods_in_0_to_extension" xml:space="preserve">
+    <value>Convert all extension methods in '0' to extension</value>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -581,4 +581,10 @@
   <data name="required_property" xml:space="preserve">
     <value>required property</value>
   </data>
+  <data name="Convert_extension_method_to_extension" xml:space="preserve">
+    <value>Convert extension method to extension</value>
+  </data>
+  <data name="Convert_all_extension_methods_to_extension" xml:space="preserve">
+    <value>Convert all extension methods to extension</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -585,6 +585,6 @@
     <value>Convert '{0}' extension methods to extension</value>
   </data>
   <data name="Convert_all_extension_methods_in_0_to_extension" xml:space="preserve">
-    <value>Convert all extension methods in '0' to extension</value>
+    <value>Convert all extension methods in '{0}' to extension</value>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -582,7 +582,7 @@
     <value>required property</value>
   </data>
   <data name="Convert_0_extension_methods_to_extension" xml:space="preserve">
-    <value>Convert '0' extension methods to extension</value>
+    <value>Convert '{0}' extension methods to extension</value>
   </data>
   <data name="Convert_all_extension_methods_in_0_to_extension" xml:space="preserve">
     <value>Convert all extension methods in '0' to extension</value>

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.ConvertToExtension;
+
+using FixAllScope = CodeAnalysis.CodeFixes.FixAllScope;
+
+[ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertToExtension), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class ConvertToExtensionCodeRefactoringProvider() : CodeRefactoringProvider
+{
+    internal override FixAllProvider? GetFixAllProvider()
+        => new ConvertToExtensionFixAllProvider();
+
+    public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+    {
+        var cancellationToken = context.CancellationToken;
+        var methodDeclaration = await context.TryGetRelevantNodeAsync<MethodDeclarationSyntax>().ConfigureAwait(false);
+
+        if (methodDeclaration is not { ParameterList.Parameters: [var firstParameter, ..] })
+            return;
+
+        if (!firstParameter.Modifiers.Any(SyntaxKind.ThisKeyword))
+            return;
+
+        if (methodDeclaration.Parent is not ClassDeclarationSyntax classDeclaration)
+            return;
+
+
+    }
+
+    private sealed class ConvertToExtensionFixAllProvider()
+        : DocumentBasedFixAllProvider(
+            [FixAllScope.Document, FixAllScope.Project, FixAllScope.Solution, FixAllScope.ContainingType])
+    {
+        protected override async Task<Document?> FixAllAsync(
+            FixAllContext fixAllContext,
+            Document document,
+            Optional<ImmutableArray<TextSpan>> fixAllSpans)
+        {
+            var cancellationToken = fixAllContext.CancellationToken;
+
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var staticClassDeclarations = GetTopLevelClassDeclarations(root, fixAllSpans);
+        }
+
+        private static IEnumerable<ClassDeclarationSyntax> GetTopLevelClassDeclarations(
+            SyntaxNode root, Optional<ImmutableArray<TextSpan>> fixAllSpans)
+        {
+            if (!fixAllSpans.HasValue)
+            {
+                // Processing the whole file.  Return all top level classes in the file.
+                return root
+                    .DescendantNodes(descendIntoChildren: n => n is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+                    .OfType<ClassDeclarationSyntax>();
+            }
+            else
+            {
+                // User selected 'fix all in containing type'.  Core code refactoring engine will return the spans
+                // of the containing class
+                return fixAllSpans.Value
+                    .Select(span => root.FindNode(span) as ClassDeclarationSyntax)
+                    .WhereNotNull();
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -151,42 +151,6 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
         }
     }
 
-    //private static bool IsExtensionMethod(
-    //    MethodDeclarationSyntax methodDeclaration,
-    //    [NotNullWhen(true)] out ClassDeclarationSyntax? classDeclaration)
-    //{
-    //    classDeclaration = null;
-    //    if (methodDeclaration.ParameterList.Parameters is not [var firstParameter, ..])
-    //        return false;
-
-    //    if (!firstParameter.Modifiers.Any(SyntaxKind.ThisKeyword))
-    //        return false;
-
-    //    classDeclaration = methodDeclaration.Parent as ClassDeclarationSyntax;
-    //    return classDeclaration != null;
-    //}
-
-    //private static ImmutableArray<MethodDeclarationSyntax> GetExtensionMethods(ClassDeclarationSyntax classDeclaration)
-    //    => classDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword) && classDeclaration.Parent is BaseNamespaceDeclarationSyntax
-    //        ? [.. classDeclaration.Members.OfType<MethodDeclarationSyntax>().Where(m => IsExtensionMethod(m, out _))]
-    //        : [];
-
-    //private static void ComputeRefactorings(
-    //    CodeRefactoringContext context,
-    //    ClassDeclarationSyntax classDeclaration,
-    //    ImmutableArray<MethodDeclarationSyntax> extensionMethods,
-    //    string title,
-    //    string equivalenceKey)
-    //{
-    //    if (extensionMethods.IsEmpty)
-    //        return;
-
-    //    context.RegisterRefactoring(CodeAction.Create(
-    //        title,
-    //        cancellationToken => ConvertToExtensionAsync(context.Document, classDeclaration, extensionMethods, cancellationToken),
-    //        equivalenceKey));
-    //}
-
     private static async Task<Document> ConvertToExtensionAsync(
         Document document,
         ClassDeclarationSyntax classDeclaration,

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -227,8 +227,7 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
         {
             // If we were invoked on a specific extension, then only convert the extensions in this class with the same
             // receiver parameter.
-            var matchingExtensions = allExtensionMethods[specificExtension.Value];
-            ConvertAndReplaceExtensions(matchingExtensions);
+            ConvertAndReplaceExtensions(allExtensionMethods[specificExtension.Value]);
         }
         else
         {

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -113,6 +113,10 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
     /// be the extension parameter P in a new <c>extension(P)</c> declaration.  This means they must have the same type,
     /// name, ref-ness, constraints, attributes, etc.
     /// </summary>
+    /// <remarks>
+    /// Because the methods are processed in order within the <paramref name="classDeclaration"/>, the arrays of grouped
+    /// extension methods in the dictionary will also be similarly ordered.
+    /// </remarks>
     private static ImmutableDictionary<ExtensionMethodInfo, ImmutableArray<ExtensionMethodInfo>> GetAllExtensionMethods(
         SemanticModel semanticModel, ClassDeclarationSyntax classDeclaration, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -292,7 +292,7 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
             return extensionMethod.TypeParameterList;
 
         // If we're removing all the type parameters, remove the type parameter list entirely.
-        if (extensionMethodInfo.MethodTypeParameters.Length == movedTypeParameterCount)
+        if (extensionMethod.TypeParameterList.Parameters.Count == movedTypeParameterCount)
             return null;
 
         // We want to remove the type parameter and the comma that follows it.  So we multiple the count of type

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -6,12 +6,15 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -31,19 +34,75 @@ internal sealed class ConvertToExtensionCodeRefactoringProvider() : CodeRefactor
 
     public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
     {
-        var cancellationToken = context.CancellationToken;
+        // If the user is on an extension method, offer to convert it to a modern extension.
         var methodDeclaration = await context.TryGetRelevantNodeAsync<MethodDeclarationSyntax>().ConfigureAwait(false);
+        if (methodDeclaration != null)
+        {
+            if (IsExtensionMethod(methodDeclaration, out var classDeclaration))
+            {
+                await ComputeRefactoringsAsync(
+                    context, classDeclaration, [methodDeclaration],
+                    CSharpFeaturesResources.Convert_extension_method_to_extension,
+                    nameof(CSharpFeaturesResources.Convert_extension_method_to_extension)).ConfigureAwait(false);
+            }
 
-        if (methodDeclaration is not { ParameterList.Parameters: [var firstParameter, ..] })
             return;
+        }
+        else
+        {
+            // Otherwise, if they're on a static class, which contains extension methods, offer to convert all of them.
+            var classDeclaration = await context.TryGetRelevantNodeAsync<ClassDeclarationSyntax>().ConfigureAwait(false);
+            if (classDeclaration != null)
+            {
+                await ComputeRefactoringsAsync(
+                    context, classDeclaration, GetExtensionMethods(classDeclaration),
+                    CSharpFeaturesResources.Convert_all_extension_methods_to_extension,
+                    nameof(CSharpFeaturesResources.Convert_all_extension_methods_to_extension)).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsExtensionMethod(
+        MethodDeclarationSyntax methodDeclaration,
+        [NotNullWhen(true)] out ClassDeclarationSyntax? classDeclaration)
+    {
+        classDeclaration = null;
+        if (methodDeclaration.ParameterList.Parameters is not [var firstParameter, ..])
+            return false;
 
         if (!firstParameter.Modifiers.Any(SyntaxKind.ThisKeyword))
+            return false;
+
+        classDeclaration = methodDeclaration.Parent as ClassDeclarationSyntax;
+        return classDeclaration != null;
+    }
+
+    private static ImmutableArray<MethodDeclarationSyntax> GetExtensionMethods(ClassDeclarationSyntax classDeclaration)
+        => [.. classDeclaration.Members.OfType<MethodDeclarationSyntax>().Where(m => IsExtensionMethod(m, out _))];
+
+    private async Task ComputeRefactoringsAsync(
+        CodeRefactoringContext context,
+        ClassDeclarationSyntax classDeclaration,
+        ImmutableArray<MethodDeclarationSyntax> extensionMethods,
+        string title,
+        string equivalenceKey)
+    {
+        if (extensionMethods.IsEmpty)
             return;
 
-        if (methodDeclaration.Parent is not ClassDeclarationSyntax classDeclaration)
-            return;
+        context.RegisterRefactoring(CodeAction.Create(
+            title,
+            cancellationToken => ConvertToExtensionAsync(context.Document, classDeclaration, extensionMethods, cancellationToken),
+            equivalenceKey));
+    }
 
-
+    private async Task<Document> ConvertToExtensionAsync(
+        Document document,
+        ClassDeclarationSyntax classDeclaration,
+        ImmutableArray<MethodDeclarationSyntax> extensionMethods,
+        CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
     }
 
     private sealed class ConvertToExtensionFixAllProvider()
@@ -57,8 +116,19 @@ internal sealed class ConvertToExtensionCodeRefactoringProvider() : CodeRefactor
         {
             var cancellationToken = fixAllContext.CancellationToken;
 
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var staticClassDeclarations = GetTopLevelClassDeclarations(root, fixAllSpans);
+            var staticClassDeclarations = GetTopLevelClassDeclarations(root, fixAllSpans)
+                .Where(c => c.Modifiers.Any(SyntaxKind.StaticKeyword));
+
+            var editor = new SyntaxEditor(root, document.Project.Solution.Services);
+            foreach (var declaration in staticClassDeclarations)
+            {
+                var newDeclaration = await ConvertToExtensionAsync(
+                    semanticModel, declaration, cancellationToken).ConfigureAwait(false);
+                if (newDeclaration != null)
+                    editor.ReplaceNode(declaration, newDeclaration);
+            }
         }
 
         private static IEnumerable<ClassDeclarationSyntax> GetTopLevelClassDeclarations(

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -25,8 +25,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertToExtension;
 
-using static SyntaxFactory;
 using static CSharpSyntaxTokens;
+using static SyntaxFactory;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertToExtension), Shared]
 [method: ImportingConstructor]

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -38,6 +38,11 @@ using static SyntaxFactory;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : CodeRefactoringProvider
 {
+    /// <summary>
+    /// Information about a class extension method we can convert to a modern extension.  Extension methods with
+    /// 'identical' receiver parameters will compare/hash as equal.  That way we can easily find and group all the
+    /// methods we want to move into a single extension together.
+    /// </summary>
     private readonly record struct ExtensionMethodInfo(
         ClassDeclarationSyntax ClassDeclaration,
         MethodDeclarationSyntax ExtensionMethod,

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -89,7 +89,6 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
             return null;
 
         var firstParameterSymbol = semanticModel.GetRequiredDeclaredSymbol(firstParameter, cancellationToken);
-        var methodSymbol = semanticModel.GetRequiredDeclaredSymbol(methodDeclaration, cancellationToken);
 
         // Gather the referenced method type parameters (in their original method order) in the extension method 'this'
         // parameter.  If method type parameters are used in that parameter, they must be the a prefix of the type

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -241,11 +241,11 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
 
         void ConvertAndReplaceExtensions(ImmutableArray<ExtensionMethodInfo> extensionMethods)
         {
-            var newExtension = CreateExtension(extensionMethods);
-
             // Replace the first extension method in the group (which will always be earliest in the class decl) with
             // the new extension declaration itself.
-            classDeclarationEditor.ReplaceNode(extensionMethods.First().ExtensionMethod, newExtension);
+            classDeclarationEditor.ReplaceNode(
+                extensionMethods.First().ExtensionMethod,
+                CreateExtension(extensionMethods));
 
             // Then remove the rest of the extensions in the group.
             foreach (var siblingExtension in extensionMethods.Skip(1))

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -277,8 +277,8 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
         var extensionMethod = extensionMethodInfo.ExtensionMethod;
 
         // skip the first parameter, which is the 'this' parameter, and the comma that follows it.
-        return extensionMethod.ParameterList.WithParameters(
-            SeparatedList<ParameterSyntax>(extensionMethodInfo.ExtensionMethod.ParameterList.Parameters.GetWithSeparators().Skip(2)));
+        return extensionMethod.ParameterList.WithParameters(SeparatedList<ParameterSyntax>(
+            extensionMethodInfo.ExtensionMethod.ParameterList.Parameters.GetWithSeparators().Skip(2)));
     }
 
     private static TypeParameterListSyntax? ConvertTypeParameters(

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionCodeRefactoringProvider.cs
@@ -261,9 +261,16 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider() : Code
         return extensionMethod.TypeParameterList.WithParameters(SeparatedList<TypeParameterSyntax>(newTypeParameters));
     }
 
-    private static SyntaxList<TypeParameterConstraintClauseSyntax> ConvertConstraintClauses(ExtensionMethodInfo extensionMethodInfo)
+    private static SyntaxList<TypeParameterConstraintClauseSyntax> ConvertConstraintClauses(
+        ExtensionMethodInfo extensionMethodInfo,
+        HashSet<string> typeParametersToRemove)
     {
-        throw new NotImplementedException();
-    }
+        var extensionMethod = extensionMethodInfo.ExtensionMethod;
 
+        // If the extension method had no constraints, or we're not removing any type parameters, there's nothing to do.
+        if (extensionMethod.ConstraintClauses.Count == 0 || typeParametersToRemove.Count == 0)
+            return extensionMethod.ConstraintClauses;
+
+        return [.. extensionMethod.ConstraintClauses.Where(c => !typeParametersToRemove.Contains(c.Name.Identifier.ValueText))];
+    }
 }

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
@@ -47,8 +47,8 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider
 
                 // For each class declaration we hit that has extension methods in it, convert all the extension methods
                 // to extensions and replace the old declaration with the new one.
-                var newDeclaration = await ConvertToExtensionAsync(
-                    codeGenerationService, semanticModel, declaration, extensionMethods, cancellationToken).ConfigureAwait(false);
+                var newDeclaration = ConvertToExtension(
+                    codeGenerationService, semanticModel, declaration, extensionMethods, cancellationToken);
                 editor.ReplaceNode(declaration, newDeclaration);
             }
 

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
@@ -41,14 +41,14 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider
             foreach (var declaration in GetTopLevelClassDeclarations(root, fixAllSpans))
             {
                 // We might hit partial parts that have no extension methods in them.  Just skip those.
-                var extensionMethods = GetExtensionMethods(declaration);
+                var extensionMethods = GetAllExtensionMethods(semanticModel, declaration, cancellationToken);
                 if (extensionMethods.IsEmpty)
                     continue;
 
                 // For each class declaration we hit that has extension methods in it, convert all the extension methods
                 // to extensions and replace the old declaration with the new one.
                 var newDeclaration = ConvertToExtension(
-                    codeGenerationService, semanticModel, declaration, extensionMethods, cancellationToken);
+                    codeGenerationService, semanticModel, declaration, extensionMethods, specificExtension: null, cancellationToken);
                 editor.ReplaceNode(declaration, newDeclaration);
             }
 

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -30,6 +32,8 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider
         {
             var cancellationToken = fixAllContext.CancellationToken;
 
+            var codeGenerationService = (CSharpCodeGenerationService)document.GetRequiredLanguageService<ICodeGenerationService>();
+
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
@@ -44,7 +48,7 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider
                 // For each class declaration we hit that has extension methods in it, convert all the extension methods
                 // to extensions and replace the old declaration with the new one.
                 var newDeclaration = await ConvertToExtensionAsync(
-                    semanticModel, declaration, extensionMethods, cancellationToken).ConfigureAwait(false);
+                    codeGenerationService, semanticModel, declaration, extensionMethods, cancellationToken).ConfigureAwait(false);
                 editor.ReplaceNode(declaration, newDeclaration);
             }
 

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
@@ -48,7 +48,7 @@ internal sealed partial class ConvertToExtensionCodeRefactoringProvider
                 // For each class declaration we hit that has extension methods in it, convert all the extension methods
                 // to extensions and replace the old declaration with the new one.
                 var newDeclaration = ConvertToExtension(
-                    codeGenerationService, semanticModel, declaration, extensionMethods, specificExtension: null, cancellationToken);
+                    codeGenerationService, declaration, extensionMethods, specificExtension: null);
                 editor.ReplaceNode(declaration, newDeclaration);
             }
 

--- a/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ConvertToExtensionFixAllProvider.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.ConvertToExtension;
+
+using FixAllScope = CodeAnalysis.CodeFixes.FixAllScope;
+
+internal sealed partial class ConvertToExtensionCodeRefactoringProvider
+{
+    private sealed class ConvertToExtensionFixAllProvider()
+        : DocumentBasedFixAllProvider(
+            [FixAllScope.Document, FixAllScope.Project, FixAllScope.Solution, FixAllScope.ContainingType])
+    {
+        protected override async Task<Document?> FixAllAsync(
+            FixAllContext fixAllContext,
+            Document document,
+            Optional<ImmutableArray<TextSpan>> fixAllSpans)
+        {
+            var cancellationToken = fixAllContext.CancellationToken;
+
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var editor = new SyntaxEditor(root, document.Project.Solution.Services);
+            foreach (var declaration in GetTopLevelClassDeclarations(root, fixAllSpans))
+            {
+                // We might hit partial parts that have no extension methods in them.  Just skip those.
+                var extensionMethods = GetExtensionMethods(declaration);
+                if (extensionMethods.IsEmpty)
+                    continue;
+
+                // For each class declaration we hit that has extension methods in it, convert all the extension methods
+                // to extensions and replace the old declaration with the new one.
+                var newDeclaration = await ConvertToExtensionAsync(
+                    semanticModel, declaration, extensionMethods, cancellationToken).ConfigureAwait(false);
+                editor.ReplaceNode(declaration, newDeclaration);
+            }
+
+            var newRoot = editor.GetChangedRoot();
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private static IEnumerable<ClassDeclarationSyntax> GetTopLevelClassDeclarations(
+            SyntaxNode root, Optional<ImmutableArray<TextSpan>> fixAllSpans)
+        {
+            if (fixAllSpans.HasValue)
+            {
+                // User selected 'fix all in containing type'.  Core code refactoring engine will return the spans of
+                // the containing class.  Process each of those individually, converting all the extension methods in
+                // each partial part to extension declarations.
+                return fixAllSpans.Value
+                    .Select(span => root.FindNode(span) as ClassDeclarationSyntax)
+                    .WhereNotNull();
+            }
+            else
+            {
+                // Processing the whole file.  Return all top level classes in the file.
+                return root
+                    .DescendantNodes(descendIntoChildren: n => n is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+                    .OfType<ClassDeclarationSyntax>();
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/ConvertToExtension/ExtensionMethodEqualityComparer.cs
+++ b/src/Features/CSharp/Portable/ConvertToExtension/ExtensionMethodEqualityComparer.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.ConvertToExtension;
+
+internal sealed partial class ConvertToExtensionCodeRefactoringProvider
+{
+    private sealed class ExtensionMethodEqualityComparer :
+        IEqualityComparer<AttributeData>,
+        IEqualityComparer<ITypeParameterSymbol>,
+        IEqualityComparer<ExtensionMethodInfo>
+    {
+        public static readonly ExtensionMethodEqualityComparer Instance = new();
+
+        private static readonly SymbolEquivalenceComparer s_equivalenceComparer = new(
+            assemblyComparer: null,
+            distinguishRefFromOut: true,
+            // `void Goo(this (int x, int y) tuple)` doesn't match `void Goo(this (int a, int b) tuple)
+            tupleNamesMustMatch: true,
+            // `void Goo(this string? x)` doesn't matches `void Goo(this string x)`
+            ignoreNullableAnnotations: false,
+            // `void Goo(this object x)` doesn't matches `void Goo(this dynamic x)`
+            objectAndDynamicCompareEqually: false,
+            // `void Goo(this string[] x)` doesn't matches `void Goo(this Span<string> x)`
+            arrayAndReadOnlySpanCompareEqually: false);
+
+        #region IEqualityComparer<AttributeData>
+
+        private bool AttributesMatch(ImmutableArray<AttributeData> attributes1, ImmutableArray<AttributeData> attributes2)
+            => attributes1.SequenceEqual(attributes2, this);
+
+        public bool Equals(AttributeData? x, AttributeData? y)
+        {
+            if (x == y)
+                return true;
+
+            if (x is null || y is null)
+                return false;
+
+            // Ensure the attributes reference the same attribute class, and have the same constructor/named-parameter
+            // values in the same order.
+            if (!Equals(x.AttributeClass, y.AttributeClass))
+                return false;
+
+            return x.ConstructorArguments.SequenceEqual(y.ConstructorArguments) &&
+                   x.NamedArguments.SequenceEqual(y.NamedArguments);
+        }
+
+        // Not needed as we never group by attributes.  We only SequenceEqual compare them.
+        public int GetHashCode([DisallowNull] AttributeData obj)
+            => throw ExceptionUtilities.Unreachable();
+
+        #endregion
+
+        #region IEqualityComparer<ITypeParameterSymbol>
+
+        public bool Equals(ITypeParameterSymbol? x, ITypeParameterSymbol? y)
+        {
+            if (x == y)
+                return true;
+
+            if (x is null || y is null)
+                return false;
+
+            // Names must match as the code in the extension methods may reference the type parameters by name and has
+            // to continue working.
+            if (x.Name != y.Name)
+                return false;
+
+            // Attributes have to match as we're moving these type parameters up to the extension itself.
+            if (!AttributesMatch(x.GetAttributes(), y.GetAttributes()))
+                return false;
+
+            // Constraints have to match as we're moving these type parameters up to the extension itself.
+            if (x.HasConstructorConstraint != y.HasConstructorConstraint)
+                return false;
+
+            if (x.HasNotNullConstraint != y.HasNotNullConstraint)
+                return false;
+
+            if (x.HasReferenceTypeConstraint != y.HasReferenceTypeConstraint)
+                return false;
+
+            if (x.HasUnmanagedTypeConstraint != y.HasUnmanagedTypeConstraint)
+                return false;
+
+            if (x.HasValueTypeConstraint != y.HasValueTypeConstraint)
+                return false;
+
+            // Constraints have to match as we're moving these type parameters up to the extension itself. We again use
+            // s_equivalenceComparer.SignatureTypeEquivalenceComparer here as we want method type parameters compared by
+            // ordinal so that if we constraints that reference the method type parameters, that we can tell they're
+            // equivalent across disparate methods.
+            if (!x.ConstraintTypes.SequenceEqual(y.ConstraintTypes, s_equivalenceComparer.SignatureTypeEquivalenceComparer))
+                return false;
+
+            return true;
+        }
+
+        // Not needed as we never group by type parameters.  We only SequenceEqual compare them.
+        public int GetHashCode([DisallowNull] ITypeParameterSymbol obj)
+            => throw ExceptionUtilities.Unreachable();
+
+        #endregion
+
+        #region IEqualityComparer<ExtensionMethodInfo>
+
+        public bool Equals(ExtensionMethodInfo x, ExtensionMethodInfo y)
+        {
+            if (x.ExtensionMethod == y.ExtensionMethod)
+                return true;
+
+            // For us to consider two extension methods to be equivalent, they must have a first parameter that we
+            // consider equal, any method type parameters they use must have the same constraints, and they must have
+            // the same attributes on them.
+            //
+            // Notes: s_equivalenceComparer.ParameterEquivalenceComparer will check the parameter name, type, ref kinds,
+            //  custom modifiers.  All things we want to match to merge extension methods into the same method.
+            //
+            // Note: The initial check will ensure that the same method-type-parameters are used in both methods *when
+            // compared by type parameter ordinal*.  The MethodTypeParameterMatch will then check that the type
+            // parameters that we would lift to the extension method would be considered the same as well.
+
+            return
+                s_equivalenceComparer.ParameterEquivalenceComparer.Equals(x.FirstParameter, y.FirstParameter, compareParameterName: true, isCaseSensitive: true) &&
+                AttributesMatch(x.FirstParameter.GetAttributes(), y.FirstParameter.GetAttributes()) &&
+                x.MethodTypeParameters.SequenceEqual(y.MethodTypeParameters, this);
+        }
+
+        public int GetHashCode(ExtensionMethodInfo obj)
+            // Loosely match any extension methods if they have the same first parameter type (treating method type
+            // parameters by ordinal) and same name.  We'll do a more full match in .Equals above.
+            => s_equivalenceComparer.ParameterEquivalenceComparer.GetHashCode(obj.FirstParameter) ^ obj.FirstParameter.Name.GetHashCode();
+
+        #endregion
+    }
+}

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Změnit na přetypování</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">Převést {0} na záznam(record)</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -142,10 +142,20 @@
         <target state="translated">In "cast" ändern</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">„{0}“ in record konvertieren</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Cambiar a cast</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">Convertir "{0}" a record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Changer en cast</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">Convertir '{0}' en record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Cambia in cast</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">Convertire '{0}' in record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -142,10 +142,20 @@
         <target state="translated">キャストに変更</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">'{0}' を record に変換</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -142,10 +142,20 @@
         <target state="translated">캐스트로 변경</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">'{0}'을(를) record로 변환</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Zmień na rzutowanie</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">Konwertuj „{0}” do record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Alterar para conversão</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">Converter '{0}' em record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Изменить на приведение</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">Преобразовать "{0}" в record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -142,10 +142,20 @@
         <target state="translated">Tür dönüştürme olarak değiştir</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">'{0}'i record’a dönüştür</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -142,10 +142,20 @@
         <target state="translated">更改为强制转换</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">将“{0}”转换为 record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -153,8 +153,8 @@
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
-        <source>Convert all extension methods in '0' to extension</source>
-        <target state="new">Convert all extension methods in '0' to extension</target>
+        <source>Convert all extension methods in '{0}' to extension</source>
+        <target state="new">Convert all extension methods in '{0}' to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_extension_methods_to_extension">
-        <source>Convert '0' extension methods to extension</source>
-        <target state="new">Convert '0' extension methods to extension</target>
+        <source>Convert '{0}' extension methods to extension</source>
+        <target state="new">Convert '{0}' extension methods to extension</target>
         <note />
       </trans-unit>
       <trans-unit id="Convert_0_to_record">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -142,10 +142,20 @@
         <target state="translated">變更為 'cast'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_0_extension_methods_to_extension">
+        <source>Convert '0' extension methods to extension</source>
+        <target state="new">Convert '0' extension methods to extension</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_0_to_record">
         <source>Convert '{0}' to record</source>
         <target state="translated">將 '{0}' 轉換為 record</target>
         <note>{Locked="record"} "record" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Convert_all_extension_methods_in_0_to_extension">
+        <source>Convert all extension methods in '0' to extension</source>
+        <target state="new">Convert all extension methods in '0' to extension</target>
+        <note />
       </trans-unit>
       <trans-unit id="Convert_to_method">
         <source>Convert to method</source>

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -67,6 +67,54 @@ public sealed class ConvertToExtensionTests
     }
 
     [Fact]
+    public async Task TestInReceiver()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M(this in int i) { }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(in int i)
+                    {
+                        public void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRefReadonlyReceiver()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M(this ref readonly int i) { }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(ref readonly int i)
+                    {
+                        public void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
     public async Task TestNotOnCSharp13()
     {
         await new VerifyCS.Test
@@ -1626,6 +1674,132 @@ public sealed class ConvertToExtensionTests
                         public void O() { }
 
                         public void P() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCodeBody1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M(this int i)
+                    {
+                        return;
+                    }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M()
+                        {
+                            return;
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCodeBody2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                static class C
+                {
+                    [||]public static DateTime M(this int i)
+                    {
+                        return new()
+                        {
+                        };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public DateTime M()
+                        {
+                            return new()
+                            {
+                            };
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleConstraints1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M<K,V>(this IDictionary<K,V> map) where K : struct where V : class { }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    extension<K, V>(IDictionary<K, V> map)
+                        where K : struct
+                        where V : class
+                    {
+                        public void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleConstraints2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M<K,V>(this IList<K> map) where K : struct where V : class { }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    extension<K>(IList<K> map) where K : struct
+                    {
+                        public void M<V>() where V : class { }
                     }
                 }
                 """,

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -650,6 +650,20 @@ public sealed class ConvertToExtensionTests
                     [||]public static void N(this int i) { }
                 }
                 """,
+            FixedCode = """
+                using System;
+                
+                class XAttribute : Attribute { }
+                
+                static class C
+                {
+                    public static void M([X] this int i) { }
+                    extension(int i)
+                    {
+                        public void N() { }
+                    }
+                }
+                """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
@@ -669,6 +683,21 @@ public sealed class ConvertToExtensionTests
                 {
                     public static void M([X] this int i) { }
                     [||]public static void N([Y] this int i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    public static void M([X] this int i) { }
+                    extension([Y] int i)
+                    {
+                        public void N() { }
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
@@ -694,6 +723,23 @@ public sealed class ConvertToExtensionTests
                     [||]public static void N([X(1)] this int i) { }
                 }
                 """,
+            FixedCode = """
+                using System;
+
+                class XAttribute : Attribute
+                {
+                    public XAttribute(int i) { }
+                }
+
+                static class C
+                {
+                    public static void M([X(0)] this int i) { }
+                    extension([X(1)] int i)
+                    {
+                        public void N() { }
+                    }
+                }
+                """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
@@ -708,8 +754,6 @@ public sealed class ConvertToExtensionTests
 
                 class XAttribute : Attribute
                 {
-                    public XAttribute { }
-
                     public int I;
                 }
 
@@ -717,6 +761,23 @@ public sealed class ConvertToExtensionTests
                 {
                     public static void M([X(I=1)] this int i) { }
                     [||]public static void N([X(I=2)] this int i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class XAttribute : Attribute
+                {
+                    public int I;
+                }
+
+                static class C
+                {
+                    public static void M([X(I=1)] this int i) { }
+                    extension([X(I = 2)] int i)
+                    {
+                        public void N() { }
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -23,20 +23,324 @@ public sealed class ConvertToExtensionTests
         await new VerifyCS.Test
         {
             TestCode = """
-            static class C
-            {
-                [||]public static void M(this int i) { }
-            }
-            """,
-            FixedCode = """
-            static class C
-            {
-                extension(int i)
+                static class C
                 {
-                    public void M() { }
+                    [||]public static void M(this int i) { }
                 }
-            }
-            """,
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotOnCSharp13()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M(this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp13,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithMultipleParameters()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M(this int i, string j) { }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M(string j) { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInsideNamespace1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    static class C
+                    {
+                        [||]public static void M(this int i, string j) { }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    static class C
+                    {
+                        extension(int i)
+                        {
+                            public void M(string j) { }
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInsideNamespace2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N;
+
+                static class C
+                {
+                    [||]public static void M(this int i, string j) { }
+                }
+                """,
+            FixedCode = """
+                namespace N;
+
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M(string j) { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithNoParameters()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M() { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotInsideStruct()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                struct C
+                {
+                    [||]public static void M(this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotInsideInstanceClass()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    [||]public static void M(this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotForInstanceMethod()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public void M(this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotForNestedClass()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class Outer
+                {
+                    static class C
+                    {
+                        [||]public void M(this int i) { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithReferencedTypeParameterInOrder1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) { }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    extension<T>(IList<T> list)
+                    {
+                        public void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithReferencedTypeParameterInOrder2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M<K,V>(this IDictionary<K,V> map) { }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    extension<K, V>(IDictionary<K, V> map)
+                    {
+                        public void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithReferencedTypeParameterInOrder3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M<K,V>(this IDictionary<V,K> map) { }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    extension<K, V>(IDictionary<V, K> map)
+                    {
+                        public void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithReferencedTypeParameterInOrder4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M<K,V>(this IList<K> list) { }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    extension<K>(IList<K> list)
+                    {
+                        public void M<V>() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithReferencedTypeParameterNotInOrder1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M<K,V>(this IList<V> list) { }
+                }
+                """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -1055,9 +1055,6 @@ public sealed class ConvertToExtensionTests
                 using System;
                 using System.Collections.Generic;
 
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
-
                 static class C
                 {
                     [||]public static void M<T>(this IList<T> list) where T : new() { }
@@ -1067,9 +1064,6 @@ public sealed class ConvertToExtensionTests
             FixedCode = """
                 using System;
                 using System.Collections.Generic;
-            
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
             
                 static class C
                 {
@@ -1093,9 +1087,6 @@ public sealed class ConvertToExtensionTests
                 using System;
                 using System.Collections.Generic;
 
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
-
                 static class C
                 {
                     [||]public static void M<T>(this IList<T> list) where T : new() { }
@@ -1105,9 +1096,6 @@ public sealed class ConvertToExtensionTests
             FixedCode = """
                 using System;
                 using System.Collections.Generic;
-            
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
             
                 static class C
                 {
@@ -1132,9 +1120,6 @@ public sealed class ConvertToExtensionTests
                 using System;
                 using System.Collections.Generic;
 
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
-
                 static class C
                 {
                     [||]public static void M<T>(this IList<T> list) where T : class { }
@@ -1144,9 +1129,6 @@ public sealed class ConvertToExtensionTests
             FixedCode = """
                 using System;
                 using System.Collections.Generic;
-            
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
             
                 static class C
                 {
@@ -1170,9 +1152,6 @@ public sealed class ConvertToExtensionTests
                 using System;
                 using System.Collections.Generic;
 
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
-
                 static class C
                 {
                     [||]public static void M<T>(this IList<T> list) where T : class { }
@@ -1182,9 +1161,6 @@ public sealed class ConvertToExtensionTests
             FixedCode = """
                 using System;
                 using System.Collections.Generic;
-            
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
             
                 static class C
                 {
@@ -1209,9 +1185,6 @@ public sealed class ConvertToExtensionTests
                 using System;
                 using System.Collections.Generic;
 
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
-
                 static class C
                 {
                     [||]public static void M<T>(this IList<T> list) where T : IList<T> { }
@@ -1221,9 +1194,6 @@ public sealed class ConvertToExtensionTests
             FixedCode = """
                 using System;
                 using System.Collections.Generic;
-            
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
             
                 static class C
                 {
@@ -1247,9 +1217,6 @@ public sealed class ConvertToExtensionTests
                 using System;
                 using System.Collections.Generic;
 
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
-
                 static class C
                 {
                     [||]public static void M<T>(this IList<T> list) where T : IList<T> { }
@@ -1259,9 +1226,6 @@ public sealed class ConvertToExtensionTests
             FixedCode = """
                 using System;
                 using System.Collections.Generic;
-            
-                class XAttribute : Attribute { }
-                class YAttribute : Attribute { }
             
                 static class C
                 {
@@ -1401,6 +1365,217 @@ public sealed class ConvertToExtensionTests
                     }
 
                     public static void N(this int j) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_Parameters_SameParameterTupleNames()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M(this (int i, int j) i) { }
+                    public static void N(this (int i, int j) i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension((int i, int j) i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_Parameters_DifferentParameterTupleNames()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M(this (int i, int j) i) { }
+                    public static void N(this (int k, int l) i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension((int i, int j) i)
+                    {
+                        public void M() { }
+                    }
+
+                    public static void N(this (int k, int l) i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_Parameters_SameParameterNullability()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M(this string? i) { }
+                    public static void N(this string? i) { }
+                }
+                """,
+            FixedCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension(string? i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_Parameters_DifferentParameterNullability()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M(this string? i) { }
+                    public static void N(this string j) { }
+                }
+                """,
+            FixedCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension(string? i)
+                    {
+                        public void M() { }
+                    }
+                
+                    public static void N(this string i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_Parameters_SameParameterDynamic()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M(this dynamic i) { }
+                    public static void N(this dynamic i) { }
+                }
+                """,
+            FixedCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension(dynamic i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_Parameters_DifferentDynamic()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    [||]public static void M(this dynamic i) { }
+                    public static void N(this object i) { }
+                }
+                """,
+            FixedCode = """
+                #nullable enable
+
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension(dynamic i)
+                    {
+                        public void M() { }
+                    }
+                
+                    public static void N(this object i) { }
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -381,4 +381,108 @@ public sealed class ConvertToExtensionTests
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestSimpleGrouping1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M(this int i) { }
+                    public static void N(this int i) { }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping1_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    public static void M(this int i) { }
+                    [||]public static void N(this int i) { }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    [||]public static void M(this int i) { }
+                    public static void N(this int i, string s) { }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M() { }
+                        public void N(string s) { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping2_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                static class C
+                {
+                    public static void M(this int i) { }
+                    [||]public static void N(this int i, string s) { }
+                }
+                """,
+            FixedCode = """
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M() { }
+                        public void N(string s) { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
 }

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -819,4 +819,389 @@ public sealed class ConvertToExtensionTests
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) { }
+                    public static void N<T>(this IList<T> list) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_DifferentName()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) { }
+                    public static void N<X>(this IList<X> list) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list)
+                    {
+                        public void M() { }
+                    }
+
+                    public static void N<X>(this IList<X> list) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_SameAttributes()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>([X] this IList<T> list) { }
+                    public static void N<T>([X] this IList<T> list) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>([X] IList<T> list)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_DifferentAttributes()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>([X] this IList<T> list) { }
+                    public static void N<T>([Y] this IList<T> list) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>([X] IList<T> list)
+                    {
+                        public void M() { }
+                    }
+
+                    public static void N<T>([Y] this IList<T> list) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_SameConstructorConstraint()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) where T : new() { }
+                    public static void N<T>(this IList<T> list) where T : new() { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list) where T : new()
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_DifferentConstructorConstraint()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) where T : new() { }
+                    public static void N<T>(this IList<T> list) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list) where T : new()
+                    {
+                        public void M() { }
+                    }
+
+                    public static void N<T>([Y] this IList<T> list) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_SameClassConstraint()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) where T : class { }
+                    public static void N<T>(this IList<T> list) where T : class { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list) where T : class
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_DifferentClassConstraint()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) where T : class { }
+                    public static void N<T>(this IList<T> list) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list) where T : class
+                    {
+                        public void M() { }
+                    }
+
+                    public static void N<T>(this IList<T> list) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_SameTypeConstraint()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) where T : IList<T> { }
+                    public static void N<T>(this IList<T> list) where T : IList<T> { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list) where T : IList<T>
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_TypeParameters_DifferentTypeConstraint()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    [||]public static void M<T>(this IList<T> list) where T : IList<T> { }
+                    public static void N<T>(this IList<T> list) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension<T>(IList<T> list) where T : IList<T>
+                    {
+                        public void M() { }
+                    }
+
+                    public static void N<T>(this IList<T> list) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
 }

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -485,4 +485,277 @@ public sealed class ConvertToExtensionTests
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestSimpleGrouping_MatchingAttributes1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute { }
+
+                static class C
+                {
+                    public static void M([X] this int i) { }
+                    [||]public static void N([X] this int i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                class XAttribute : Attribute { }
+                
+                static class C
+                {
+                    extension([X] int i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_MatchingAttributes2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute { }
+
+                static class C
+                {
+                    public static void M([X] this int i) { }
+                    [||]public static void N([XAttribute] this int i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                class XAttribute : Attribute { }
+                
+                static class C
+                {
+                    extension([X] int i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_MatchingAttributes3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute
+                {
+                    public XAttribute(int i) { }
+                }
+
+                static class C
+                {
+                    public static void M([X(0)] this int i) { }
+                    [||]public static void N([X(0)] this int i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                class XAttribute : Attribute
+                {
+                    public XAttribute(int i) { }
+                }
+                
+                static class C
+                {
+                    extension([X(0)] int i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_MatchingAttributes4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute
+                {
+                    public int I;
+                }
+
+                static class C
+                {
+                    public static void M([X(I=1)] this int i) { }
+                    [||]public static void N([X(I=1)] this int i) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                class XAttribute : Attribute
+                {
+                    public int I;
+                }
+                
+                static class C
+                {
+                    extension([X(I = 1)] int i)
+                    {
+                        public void M() { }
+                        public void N() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_NonMatchingAttributes1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute { }
+
+                static class C
+                {
+                    public static void M([X] this int i) { }
+                    [||]public static void N(this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_NonMatchingAttributes2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    public static void M([X] this int i) { }
+                    [||]public static void N([Y] this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_NonMatchingAttributes3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute
+                {
+                    public XAttribute(int i) { }
+                }
+
+                static class C
+                {
+                    public static void M([X(0)] this int i) { }
+                    [||]public static void N([X(1)] this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_NonMatchingAttributes4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute
+                {
+                    public XAttribute { }
+
+                    public int I;
+                }
+
+                static class C
+                {
+                    public static void M([X(I=1)] this int i) { }
+                    [||]public static void N([X(I=2)] this int i) { }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSimpleGrouping_UnrelatedAttributes()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+
+                static class C
+                {
+                    public static void M(this int i, [X] string s) { }
+                    [||]public static void N(this int i, [Y] string s) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+            
+                class XAttribute : Attribute { }
+                class YAttribute : Attribute { }
+            
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M([X] string s) { }
+                        public void N([Y] string s) { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
 }

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -1522,8 +1522,8 @@ public sealed class ConvertToExtensionTests
 
                 static class C
                 {
-                    [||]public static void M(this dynamic i) { }
-                    public static void N(this dynamic i) { }
+                    [||]public static void M(this {|CS1103:dynamic|} i) { }
+                    public static void N(this {|CS1103:dynamic|} i) { }
                 }
                 """,
             FixedCode = """
@@ -1542,16 +1542,6 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
-            TestState =
-            {
-                ExpectedDiagnostics =
-                {
-                    // /0/Test0.cs(8,31): error CS1103: The first parameter of an extension method cannot be of type 'dynamic'
-                    DiagnosticResult.CompilerError("CS1103").WithSpan(8, 31, 8, 38).WithArguments("dynamic"),
-                    // /0/Test0.cs(9,31): error CS1103: The first parameter of an extension method cannot be of type 'dynamic'
-                    DiagnosticResult.CompilerError("CS1103").WithSpan(9, 31, 9, 38).WithArguments("dynamic"),
-                }
-            }
         }.RunAsync();
     }
 
@@ -1568,7 +1558,7 @@ public sealed class ConvertToExtensionTests
 
                 static class C
                 {
-                    [||]public static void M(this dynamic i) { }
+                    [||]public static void M(this {|CS1103:dynamic|} i) { }
                     public static void N(this object i) { }
                 }
                 """,
@@ -1589,14 +1579,6 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
-            TestState =
-            {
-                ExpectedDiagnostics =
-                {
-                    // /0/Test0.cs(8,31): error CS1103: The first parameter of an extension method cannot be of type 'dynamic'
-                    DiagnosticResult.CompilerError("CS1103").WithSpan(8, 31, 8, 38).WithArguments("dynamic"),
-                }
-            }
         }.RunAsync();
     }
 

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -1542,4 +1542,94 @@ public sealed class ConvertToExtensionTests
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestFixClass1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                [||]static class C
+                {
+                    public static void M(this int i) { }
+
+                    public static void N(this int i) { }
+                
+                    public static void O(this int j) { }
+                
+                    public static void P(this int j) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M() { }
+
+                        public void N() { }
+                    }
+
+                    extension(int j)
+                    {
+                        public void O() { }
+
+                        public void P() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestFixClass2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                [||]static class C
+                {
+                    public static void M(this int i) { }
+                
+                    public static void O(this int j) { }
+
+                    public static void N(this int i) { }
+                
+                    public static void P(this int j) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Generic;
+            
+                static class C
+                {
+                    extension(int i)
+                    {
+                        public void M() { }
+
+                        public void N() { }
+                    }
+
+                    extension(int j)
+                    {
+                        public void O() { }
+
+                        public void P() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
 }

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.ConvertToExtension;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.ConvertToExtension;
+
+using VerifyCS = CSharpCodeRefactoringVerifier<ConvertToExtensionCodeRefactoringProvider>;
+
+public sealed class ConvertToExtensionTests
+{
+    [Fact]
+    public async Task TestBaseCase()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            static class C
+            {
+                [||]public static void M(this int i) { }
+            }
+            """,
+            FixedCode = """
+            static class C
+            {
+                extension(int i)
+                {
+                    public void M() { }
+                }
+            }
+            """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+}

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -1486,7 +1486,7 @@ public sealed class ConvertToExtensionTests
                 static class C
                 {
                     [||]public static void M(this string? i) { }
-                    public static void N(this string j) { }
+                    public static void N(this string i) { }
                 }
                 """,
             FixedCode = """
@@ -1542,6 +1542,16 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            TestState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(8,31): error CS1103: The first parameter of an extension method cannot be of type 'dynamic'
+                    DiagnosticResult.CompilerError("CS1103").WithSpan(8, 31, 8, 38).WithArguments("dynamic"),
+                    // /0/Test0.cs(9,31): error CS1103: The first parameter of an extension method cannot be of type 'dynamic'
+                    DiagnosticResult.CompilerError("CS1103").WithSpan(9, 31, 9, 38).WithArguments("dynamic"),
+                }
+            }
         }.RunAsync();
     }
 
@@ -1579,6 +1589,14 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            TestState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(8,31): error CS1103: The first parameter of an extension method cannot be of type 'dynamic'
+                    DiagnosticResult.CompilerError("CS1103").WithSpan(8, 31, 8, 38).WithArguments("dynamic"),
+                }
+            }
         }.RunAsync();
     }
 

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.ConvertToExtension;
 using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.ConvertToExtension;
 
 using VerifyCS = CSharpCodeRefactoringVerifier<ConvertToExtensionCodeRefactoringProvider>;
 
+[UseExportProvider]
+[Trait(Traits.Feature, Traits.Features.CodeActionsConvertToExtension)]
 public sealed class ConvertToExtensionTests
 {
     [Fact]

--- a/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
+++ b/src/Features/CSharpTest/ConvertToExtension/ConvertToExtensionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.ConvertToExtension;
 using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.ConvertToExtension;
@@ -165,6 +166,14 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            TestState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(1,8): error CS1106: Extension method must be defined in a non-generic static class
+                    DiagnosticResult.CompilerError("CS1106").WithSpan(1, 8, 1, 9),
+                }
+            }
         }.RunAsync();
     }
 
@@ -180,6 +189,14 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            TestState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(1,7): error CS1106: Extension method must be defined in a non-generic static class
+                    DiagnosticResult.CompilerError("CS1106").WithSpan(1, 7, 1, 8),
+                }
+            }
         }.RunAsync();
     }
 
@@ -195,6 +212,16 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            TestState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(3,17): error CS0708: 'M': cannot declare instance members in a static class
+                    DiagnosticResult.CompilerError("CS0708").WithSpan(3, 17, 3, 18).WithArguments("M"),
+                    // /0/Test0.cs(3,17): error CS1105: Extension method must be static
+                    DiagnosticResult.CompilerError("CS1105").WithSpan(3, 17, 3, 18),
+                }
+            }
         }.RunAsync();
     }
 
@@ -213,6 +240,16 @@ public sealed class ConvertToExtensionTests
                 }
                 """,
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            TestState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(5,21): error CS0708: 'M': cannot declare instance members in a static class
+                    DiagnosticResult.CompilerError("CS0708").WithSpan(5, 21, 5, 22).WithArguments("M"),
+                    // /0/Test0.cs(5,21): error CS1109: Extension methods must be defined in a top level static class; C is a nested class
+                    DiagnosticResult.CompilerError("CS1109").WithSpan(5, 21, 5, 22).WithArguments("C"),
+                }
+            }
         }.RunAsync();
     }
 

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -30,6 +30,7 @@ internal static class PredefinedCodeRefactoringProviderNames
     public const string ConvertNumericLiteral = nameof(ConvertNumericLiteral);
     public const string ConvertPlaceholderToInterpolatedString = nameof(ConvertPlaceholderToInterpolatedString);
     public const string ConvertPrimaryToRegularConstructor = nameof(ConvertPrimaryToRegularConstructor);
+    public const string ConvertToExtension = nameof(ConvertToExtension);
     public const string ConvertToInterpolatedString = "Convert To Interpolated String Code Action Provider";
     public const string ConvertToProgramMain = "Convert To Program.Main";
     public const string ConvertToRawString = nameof(ConvertToRawString);

--- a/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             Dim generator = SyntaxGenerator.GetGenerator(propertyDocument.Project)
             Dim canBeReadOnly = Not isWrittenToOutsideOfConstructor AndAlso Not propertyDeclaration.Accessors.Any(SyntaxKind.SetAccessorBlock)
 
-            statement = DirectCast(generator.WithModifiers(statement, generator.GetModifiers(propertyDeclaration).WithIsReadOnly(canBeReadOnly)), PropertyStatementSyntax)
+            statement = generator.WithModifiers(statement, generator.GetModifiers(propertyDeclaration).WithIsReadOnly(canBeReadOnly))
 
             Dim initializer = Await GetFieldInitializerAsync(fieldSymbol, cancellationToken).ConfigureAwait(False)
             If initializer.equalsValue IsNot Nothing Then

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1613,8 +1613,8 @@ internal sealed class CSharpSyntaxGenerator : SyntaxGenerator
     private static SyntaxTokenList GetModifierTokens(SyntaxNode declaration)
         => CSharpAccessibilityFacts.GetModifierTokens(declaration);
 
-    public override SyntaxNode WithModifiers(SyntaxNode declaration, DeclarationModifiers modifiers)
-        => this.Isolate(declaration, d => this.WithModifiersInternal(d, modifiers));
+    internal override TSyntaxNode WithModifiers<TSyntaxNode>(TSyntaxNode declaration, DeclarationModifiers modifiers)
+        => (TSyntaxNode)this.Isolate(declaration, d => this.WithModifiersInternal(d, modifiers));
 
     private SyntaxNode WithModifiersInternal(SyntaxNode declaration, DeclarationModifiers modifiers)
     {

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1228,7 +1228,11 @@ public abstract class SyntaxGenerator : ILanguageService
     /// <summary>
     /// Changes the <see cref="DeclarationModifiers"/> for the declaration.
     /// </summary>
-    public abstract SyntaxNode WithModifiers(SyntaxNode declaration, DeclarationModifiers modifiers);
+    public SyntaxNode WithModifiers(SyntaxNode declaration, DeclarationModifiers modifiers)
+        => WithModifiers<SyntaxNode>(declaration, modifiers);
+
+    internal abstract TSyntaxNode WithModifiers<TSyntaxNode>(TSyntaxNode declaration, DeclarationModifiers modifiers)
+        where TSyntaxNode : SyntaxNode;
 
     /// <summary>
     /// Gets the <see cref="DeclarationKind"/> for the declaration.

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+*REMOVED*abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithModifiers(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithModifiers(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-
+Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithModifiers(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeGeneration/CSharpSyntaxTokens.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeGeneration/CSharpSyntaxTokens.cs
@@ -32,6 +32,7 @@ internal static class CSharpSyntaxTokens
     public static readonly SyntaxToken EndOfDocumentationCommentToken = Token(SyntaxKind.EndOfDocumentationCommentToken);
     public static readonly SyntaxToken EqualsToken = Token(SyntaxKind.EqualsToken);
     public static readonly SyntaxToken ExplicitKeyword = Token(SyntaxKind.ExplicitKeyword);
+    public static readonly SyntaxToken ExtensionKeyword = Token(SyntaxKind.ExtensionKeyword);
     public static readonly SyntaxToken ExternKeyword = Token(SyntaxKind.ExternKeyword);
     public static readonly SyntaxToken FileKeyword = Token(SyntaxKind.FileKeyword);
     public static readonly SyntaxToken FloatKeyword = Token(SyntaxKind.FloatKeyword);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/LanguageVersionExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/LanguageVersionExtensions.cs
@@ -27,6 +27,9 @@ internal static class LanguageVersionExtensions
     public static bool SupportsPrimaryConstructors(this LanguageVersion languageVersion)
         => languageVersion.IsCSharp12OrAbove();
 
+    public static bool SupportsExtensions(this LanguageVersion languageVersion)
+        => languageVersion.IsCSharp14OrAbove();
+
     /// <remarks>
     /// Corresponds to Microsoft.CodeAnalysis.CSharp.LanguageVersionFacts.CSharpNext.
     /// </remarks>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.CollectTypeParameterSymbolsVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.CollectTypeParameterSymbolsVisitor.cs
@@ -2,20 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
-using System.Collections.Generic;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions;
 
 internal static partial class ITypeSymbolExtensions
 {
     private sealed class CollectTypeParameterSymbolsVisitor(
-         IList<ITypeParameterSymbol> typeParameters,
-        bool onlyMethodTypeParameters) : SymbolVisitor
+        ArrayBuilder<ITypeParameterSymbol> typeParameters,
+        bool onlyMethodTypeParameters) : SymbolVisitor, IDisposable
     {
-        private readonly HashSet<ISymbol> _visited = [];
+        private readonly PooledHashSet<ISymbol> _visited = PooledHashSet<ISymbol>.GetInstance();
+
+        public void Dispose()
+        {
+            _visited.Free();
+        }
 
         public override void DefaultVisit(ISymbol node)
             => throw new NotImplementedException();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -796,20 +797,31 @@ internal static partial class ITypeSymbolExtensions
     {
         return type?.Accept(new UnnamedErrorTypeRemover(compilation));
     }
-    public static IList<ITypeParameterSymbol> GetReferencedMethodTypeParameters(
-        this ITypeSymbol? type, IList<ITypeParameterSymbol>? result = null)
+
+    public static void AddReferencedMethodTypeParameters(
+        this ITypeSymbol? type, ArrayBuilder<ITypeParameterSymbol> result)
     {
-        result ??= [];
-        type?.Accept(new CollectTypeParameterSymbolsVisitor(result, onlyMethodTypeParameters: true));
-        return result;
+        AddReferencedTypeParameters(type, result, onlyMethodTypeParameters: true);
     }
 
-    public static IList<ITypeParameterSymbol> GetReferencedTypeParameters(
-        this ITypeSymbol? type, IList<ITypeParameterSymbol>? result = null)
+    public static void AddReferencedTypeParameters(
+        this ITypeSymbol? type, ArrayBuilder<ITypeParameterSymbol> result)
     {
-        result ??= [];
-        type?.Accept(new CollectTypeParameterSymbolsVisitor(result, onlyMethodTypeParameters: false));
-        return result;
+        AddReferencedTypeParameters(type, result, onlyMethodTypeParameters: false);
+    }
+
+    private static void AddReferencedTypeParameters(
+        this ITypeSymbol? type, ArrayBuilder<ITypeParameterSymbol> result, bool onlyMethodTypeParameters)
+    {
+        using var collector = new CollectTypeParameterSymbolsVisitor(result, onlyMethodTypeParameters);
+        type?.Accept(collector);
+    }
+
+    public static IList<ITypeParameterSymbol> GetReferencedTypeParameters(this ITypeSymbol? type)
+    {
+        using var _ = ArrayBuilder<ITypeParameterSymbol>.GetInstance(out var result);
+        AddReferencedTypeParameters(type, result);
+        return result.ToList();
     }
 
     [return: NotNullIfNotNull(parameterName: nameof(type))]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -813,8 +813,11 @@ internal static partial class ITypeSymbolExtensions
     private static void AddReferencedTypeParameters(
         this ITypeSymbol? type, ArrayBuilder<ITypeParameterSymbol> result, bool onlyMethodTypeParameters)
     {
-        using var collector = new CollectTypeParameterSymbolsVisitor(result, onlyMethodTypeParameters);
-        type?.Accept(collector);
+        if (type != null)
+        {
+            using var collector = new CollectTypeParameterSymbolsVisitor(result, onlyMethodTypeParameters);
+            type.Accept(collector);
+        }
     }
 
     public static IList<ITypeParameterSymbol> GetReferencedTypeParameters(this ITypeSymbol? type)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.ParameterSymbolEqualityComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.ParameterSymbolEqualityComparer.cs
@@ -32,12 +32,13 @@ internal sealed partial class SymbolEquivalenceComparer
                 return false;
             }
 
-            var nameComparisonCheck = true;
             if (compareParameterName)
             {
-                nameComparisonCheck = isCaseSensitive ?
+                var nameComparisonCheck = isCaseSensitive ?
                     x.Name == y.Name
                     : string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
+                if (!nameComparisonCheck)
+                    return false;
             }
 
             // See the comment in the outer type.  If we're comparing two parameters for
@@ -45,7 +46,6 @@ internal sealed partial class SymbolEquivalenceComparer
 
             return
                 AreRefKindsEquivalent(x.RefKind, y.RefKind, distinguishRefFromOut) &&
-                nameComparisonCheck &&
                 symbolEqualityComparer.GetEquivalenceVisitor().AreEquivalent(x.CustomModifiers, y.CustomModifiers, equivalentTypesWithDifferingAssemblies) &&
                 symbolEqualityComparer.SignatureTypeEquivalenceComparer.Equals(x.Type, y.Type, equivalentTypesWithDifferingAssemblies);
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/CSharpCodeGenerationServiceFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/CSharpCodeGenerationServiceFactory.cs
@@ -11,14 +11,10 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 
 [ExportLanguageServiceFactory(typeof(ICodeGenerationService), LanguageNames.CSharp), Shared]
-internal partial class CSharpCodeGenerationServiceFactory : ILanguageServiceFactory
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpCodeGenerationServiceFactory() : ILanguageServiceFactory
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpCodeGenerationServiceFactory()
-    {
-    }
-
     public ILanguageService CreateLanguageService(HostLanguageServices provider)
         => new CSharpCodeGenerationService(provider.LanguageServices);
 }

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -2368,8 +2368,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Return VisualBasicAccessibilityFacts.GetModifierTokens(declaration)
         End Function
 
-        Public Overrides Function WithModifiers(declaration As SyntaxNode, modifiers As DeclarationModifiers) As SyntaxNode
-            Return Isolate(declaration, Function(d) Me.WithModifiersInternal(d, modifiers))
+        Friend Overrides Function WithModifiers(Of TSyntaxNode As SyntaxNode)(declaration As TSyntaxNode, modifiers As DeclarationModifiers) As TSyntaxNode
+            Return DirectCast(Isolate(declaration, Function(d) Me.WithModifiersInternal(d, modifiers)), TSyntaxNode)
         End Function
 
         Private Function WithModifiersInternal(declaration As SyntaxNode, modifiers As DeclarationModifiers) As SyntaxNode


### PR DESCRIPTION
Looks like this:

![image](https://github.com/user-attachments/assets/19f1fa35-27c6-44ce-84f2-5114fad3a077)

And:

![image](https://github.com/user-attachments/assets/15986c37-87d9-4528-a171-89df562a8a27)

Relates to test plan https://github.com/dotnet/roslyn/issues/76130
