### PR TITLE
Support textDocument/semanticTokens/full

### DIFF
--- a/src/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
+++ b/src/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
@@ -90,10 +90,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             // Using only range handling has shown to be more performant than using a combination of full/edits/range
             // handling, especially for larger files. With range handling, we only need to compute tokens for whatever
             // is in view, while with full/edits handling we need to compute tokens for the entire file and then
-            // potentially run a diff between the old and new tokens.
+            // potentially run a diff between the old and new tokens. Therefore, we only enable full handling if
+            // the client does not support ranges.
+            var rangeCapabilities = clientCapabilities.TextDocument?.SemanticTokens?.Requests?.Range;
+            var supportsSemanticTokensRange = rangeCapabilities?.Value is not (false or null);
             capabilities.SemanticTokensOptions = new SemanticTokensOptions
             {
-                Full = false,
+                Full = !supportsSemanticTokensRange,
                 Range = true,
                 Legend = new SemanticTokensLegend
                 {

--- a/src/LanguageServer/Protocol/ExternalAccess/Razor/SemanticTokensRangesHandler.cs
+++ b/src/LanguageServer/Protocol/ExternalAccess/Razor/SemanticTokensRangesHandler.cs
@@ -42,6 +42,9 @@ internal class SemanticTokensRangesHandler : ILspServiceDocumentRequestHandler<S
             CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(request.TextDocument, "TextDocument is null.");
+        if (request.Ranges.Length == 0)
+            return new SemanticTokens { Data = [] };
+
         var tokensData = await SemanticTokensHelpers.HandleRequestHelperAsync(_globalOptions, _semanticTokenRefreshQueue, request.Ranges, context, cancellationToken).ConfigureAwait(false);
         return new SemanticTokens { Data = tokensData };
     }

--- a/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensFullHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensFullHandler.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.LanguageServer.Protocol;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
+
+[Method(Methods.TextDocumentSemanticTokensFullName)]
+internal sealed class SemanticTokensFullHandler(
+    IGlobalOptionService globalOptions,
+    SemanticTokensRefreshQueue semanticTokensRefreshQueue)
+    : ILspServiceDocumentRequestHandler<SemanticTokensFullParams, LSP.SemanticTokens>
+{
+    private readonly IGlobalOptionService _globalOptions = globalOptions;
+    private readonly SemanticTokensRefreshQueue _semanticTokenRefreshQueue = semanticTokensRefreshQueue;
+
+    public bool MutatesSolutionState => false;
+    public bool RequiresLSPSolution => true;
+
+    public TextDocumentIdentifier GetTextDocumentIdentifier(LSP.SemanticTokensFullParams request)
+    {
+        Contract.ThrowIfNull(request.TextDocument);
+        return request.TextDocument;
+    }
+
+    public async Task<LSP.SemanticTokens> HandleRequestAsync(
+        SemanticTokensFullParams request,
+        RequestContext context,
+        CancellationToken cancellationToken)
+    {
+        Contract.ThrowIfNull(request.TextDocument);
+        // Passing an empty array of ranges will cause the helper to return tokens for the entire document.
+        var tokensData = await SemanticTokensHelpers.HandleRequestHelperAsync(_globalOptions, _semanticTokenRefreshQueue, ranges: [], context, cancellationToken).ConfigureAwait(false);
+        return new LSP.SemanticTokens { Data = tokensData };
+    }
+}

--- a/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensFullHandlerFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensFullHandlerFactory.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
+
+[ExportCSharpVisualBasicLspServiceFactory(typeof(SemanticTokensFullHandler)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class SemanticTokensFullHandlerFactory(IGlobalOptionService globalOptions) : ILspServiceFactory
+{
+    private readonly IGlobalOptionService _globalOptions = globalOptions;
+
+    public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
+    {
+        var semanticTokensRefreshQueue = lspServices.GetRequiredService<SemanticTokensRefreshQueue>();
+        return new SemanticTokensFullHandler(_globalOptions, semanticTokensRefreshQueue);
+    }
+}

--- a/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -30,11 +30,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             RequestContext context,
             CancellationToken cancellationToken)
         {
-            if (ranges.Length == 0)
-            {
-                return [];
-            }
-
             var contextDocument = context.GetRequiredDocument();
             var project = contextDocument.Project;
             var options = globalOptions.GetClassificationOptions(project.Language);

--- a/src/LanguageServer/Protocol/Protocol/SemanticTokens/SemanticTokensFullParams.cs
+++ b/src/LanguageServer/Protocol/Protocol/SemanticTokens/SemanticTokensFullParams.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Text.Json.Serialization;
+
+namespace Roslyn.LanguageServer.Protocol;
+
+/// <summary>
+/// Parameters for 'textDocument/semanticTokens/full' request.
+/// <para>
+/// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#semanticTokensFullParams">Language Server Protocol specification</see> for additional information.
+/// </para>
+/// </summary>
+/// <remarks>Since LSP 3.16</remarks>
+internal sealed class SemanticTokensFullParams : ITextDocumentParams, IWorkDoneProgressParams, IPartialResultParams<SemanticTokensPartialResult>
+{
+    /// <summary>
+    /// Gets or sets an identifier for the document to fetch semantic tokens from.
+    /// </summary>
+    [JsonPropertyName("textDocument")]
+    [JsonRequired]
+    public TextDocumentIdentifier TextDocument { get; set; }
+
+    /// <inheritdoc/>
+    [JsonPropertyName(Methods.WorkDoneTokenName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IProgress<WorkDoneProgress>? WorkDoneToken { get; set; }
+
+    /// <inheritdoc/>
+    [JsonPropertyName(Methods.PartialResultTokenName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IProgress<SemanticTokensPartialResult>? PartialResultToken { get; set; }
+}

--- a/src/LanguageServer/ProtocolUnitTests/SemanticTokens/AbstractSemanticTokensTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SemanticTokens/AbstractSemanticTokensTests.cs
@@ -27,6 +27,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SemanticTokens
         private protected static IReadOnlyDictionary<string, int> GetTokenTypeToIndex(TestLspServer server)
             => SemanticTokensSchema.GetSchema(server.ClientCapabilities.HasVisualStudioLspCapability()).TokenTypeToIndex;
 
+        private protected static async Task<LSP.SemanticTokens> RunGetSemanticTokensFullAsync(TestLspServer testLspServer, LSP.Location caret)
+        {
+            var result = await testLspServer.ExecuteRequestAsync<LSP.SemanticTokensFullParams, LSP.SemanticTokens>(LSP.Methods.TextDocumentSemanticTokensFullName,
+                CreateSemanticTokensFullParams(caret), CancellationToken.None);
+            Contract.ThrowIfNull(result);
+            return result;
+        }
+
         private protected static async Task<LSP.SemanticTokens> RunGetSemanticTokensRangeAsync(TestLspServer testLspServer, LSP.Location caret, LSP.Range range)
         {
             var result = await testLspServer.ExecuteRequestAsync<LSP.SemanticTokensRangeParams, LSP.SemanticTokens>(LSP.Methods.TextDocumentSemanticTokensRangeName,
@@ -42,6 +50,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SemanticTokens
             Contract.ThrowIfNull(result);
             return result;
         }
+
+        private static LSP.SemanticTokensFullParams CreateSemanticTokensFullParams(LSP.Location caret)
+            => new LSP.SemanticTokensFullParams
+            {
+                TextDocument = new LSP.TextDocumentIdentifier { Uri = caret.Uri }
+            };
 
         private static LSP.SemanticTokensRangeParams CreateSemanticTokensRangeParams(LSP.Location caret, LSP.Range range)
             => new LSP.SemanticTokensRangeParams

--- a/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensFullTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensFullTests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+#pragma warning disable format // We want to force explicit column spacing within the collection literals in this file, so we disable formatting.
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SemanticTokens;
+
+public sealed class SemanticTokensFullTests(ITestOutputHelper testOutputHelper) : AbstractSemanticTokensTests(testOutputHelper)
+{
+    [Theory, CombinatorialData]
+    public async Task TestGetSemanticTokensFull_FullDocAsync(bool mutatingLspWorkspace, bool isVS)
+    {
+        var markup =
+@"{|caret:|}// Comment
+static class C { }
+";
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup, mutatingLspWorkspace, GetCapabilities(isVS));
+
+        var results = await RunGetSemanticTokensFullAsync(testLspServer, testLspServer.GetLocations("caret").First());
+
+        var expectedResults = new LSP.SemanticTokens();
+        var tokenTypeToIndex = GetTokenTypeToIndex(testLspServer);
+        if (isVS)
+        {
+            expectedResults.Data =
+            [
+                // Line | Char | Len | Token type                                                               | Modifier
+                   0,     0,     10,   tokenTypeToIndex[SemanticTokenTypes.Comment],      0, // '// Comment'
+                   1,     0,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],      0, // 'static'
+                   0,     7,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],      0, // 'class'
+                   0,     6,     1,    tokenTypeToIndex[ClassificationTypeNames.ClassName],   (int)TokenModifiers.Static, // 'C'
+                   0,     2,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation], 0, // '{'
+                   0,     2,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation], 0, // '}'
+            ];
+        }
+        else
+        {
+            expectedResults.Data =
+            [
+                // Line | Char | Len | Token type                                                               | Modifier
+                   0,     0,     10,   tokenTypeToIndex[SemanticTokenTypes.Comment],      0, // '// Comment'
+                   1,     0,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],      0, // 'static'
+                   0,     7,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],      0, // 'class'
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.Class],   (int)TokenModifiers.Static, // 'C'
+                   0,     2,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation], 0, // '{'
+                   0,     2,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation], 0, // '}'
+            ];
+        }
+
+        await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results.Data).ConfigureAwait(false);
+        AssertEx.Equal(ConvertToReadableFormat(testLspServer.ClientCapabilities, expectedResults.Data), ConvertToReadableFormat(testLspServer.ClientCapabilities, results.Data));
+    }
+}


### PR DESCRIPTION
Solves #70536 (apart from delta). Some editors, such as neovim, don't support textDocument/semanticTokens/range, which means that you currently don't get semantic highlighting for .NET in these editors. Getting semantic tokens for the entire document is of course slower, but the editor can decide what to do anyway.

Tested and working with neovim.