### PR TITLE
Fix reflection use in integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/FindReferencesWindowInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/FindReferencesWindowInProcess.cs
@@ -82,7 +82,7 @@ internal partial class FindReferencesWindowInProcess
 
         // Dig through to get the Find References control.
         var toolWindowType = toolWindow.GetType();
-        var toolWindowControlField = toolWindowType.GetField("Control");
+        var toolWindowControlField = toolWindowType.GetField("_control") ?? toolWindowType.GetField("Control");
         var toolWindowControl = toolWindowControlField.GetValue(toolWindow);
 
         // Dig further to get the results table (as opposed to the toolbar).


### PR DESCRIPTION
In https://devdiv.visualstudio.com/DevDiv/_git/VSEditor/pullrequest/618447 the field name was changed, so tests will break in future. We just got broken by this in Razor because we test against VS main (https://github.com/dotnet/razor/pull/11640) so figured I'd prevent this breaking Roslyn too, at whatever point in the future the VS image is updated.