### PR TITLE
Cover expression-bodied async methods with generic Task-like return values in implicit object creation analyzer

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationCodeFixProvider.cs
@@ -60,7 +60,7 @@ internal sealed class CSharpUseImplicitObjectCreationCodeFixProvider() : SyntaxE
         await editor.ApplyExpressionLevelSemanticEditsAsync(
             document,
             nodes,
-            (semanticModel, node) => Analyze(semanticModel, options, node, semanticModel.Compilation, cancellationToken),
+            (semanticModel, node) => Analyze(semanticModel, options, node, cancellationToken),
             (semanticModel, root, node) => FixOne(root, node),
             cancellationToken).ConfigureAwait(false);
     }

--- a/src/Analyzers/CSharp/Tests/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationTests.cs
@@ -643,28 +643,31 @@ public class UseImplicitObjectCreationTests
         }.RunAsync();
     }
 
-    [Fact]
-    public async Task TestWithAsyncMethodExpressionBody()
+    [Theory]
+    [InlineData("Task")]
+    [InlineData("ValueTask")]
+    public async Task TestWithAsyncMethodExpressionBody(string taskLike)
     {
         await new VerifyCS.Test
         {
-            TestCode = """
+            TestCode = $$"""
                 using System.Threading.Tasks;
 
                 class C
                 {
-                    async Task<C> Func() => new [|C|]();
+                    async {{taskLike}}<C> Func() => new [|C|]();
                 }
                 """,
-            FixedCode = """
+            FixedCode = $$"""
                 using System.Threading.Tasks;
 
                 class C
                 {
-                    async Task<C> Func() => new();
+                    async {{taskLike}}<C> Func() => new();
                 }
                 """,
             LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
 


### PR DESCRIPTION
This PR covers the following case:

```cs
using System.Threading.Tasks;

class C
{
    async Task<C> Func() => new [|C|]();
}
```

Captured in issue #77670.