### PR TITLE
Remove feature flag for SourceGen execution

### DIFF
--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -168,7 +168,8 @@ public sealed class GlobalOptionsTests
              property.DeclaringType == typeof(DocumentFormattingOptions) && property.Name == nameof(DocumentFormattingOptions.InsertFinalNewLine) ||
              property.DeclaringType == typeof(ClassificationOptions) && property.Name == nameof(ClassificationOptions.FrozenPartialSemantics) ||
              property.DeclaringType == typeof(HighlightingOptions) && property.Name == nameof(HighlightingOptions.FrozenPartialSemantics) ||
-             property.DeclaringType == typeof(BlockStructureOptions) && property.Name == nameof(BlockStructureOptions.IsMetadataAsSource));
+             property.DeclaringType == typeof(BlockStructureOptions) && property.Name == nameof(BlockStructureOptions.IsMetadataAsSource) ||
+             property.DeclaringType == typeof(WorkspaceConfigurationOptions) && property.Name == nameof(WorkspaceConfigurationOptions.SourceGeneratorExecution));
 
     /// <summary>
     /// Our mock <see cref="IGlobalOptionService"/> implementation returns a non-default value for each option it reads.

--- a/src/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
@@ -10,9 +10,7 @@ internal static class WorkspaceConfigurationOptionsStorage
 {
     public static WorkspaceConfigurationOptions GetWorkspaceConfigurationOptions(this IGlobalOptionService globalOptions)
         => new(
-            SourceGeneratorExecution:
-                globalOptions.GetOption(SourceGeneratorExecution) ??
-                (globalOptions.GetOption(SourceGeneratorExecutionBalancedFeatureFlag) ? SourceGeneratorExecutionPreference.Balanced : SourceGeneratorExecutionPreference.Automatic),
+            SourceGeneratorExecution: globalOptions.GetOption(SourceGeneratorExecution),
             ReloadChangedAnalyzerReferences:
                 globalOptions.GetOption(ReloadChangedAnalyzerReferences) ?? globalOptions.GetOption(ReloadChangedAnalyzerReferencesFeatureFlag),
             ValidateCompilationTrackerStates: globalOptions.GetOption(ValidateCompilationTrackerStates));
@@ -20,16 +18,13 @@ internal static class WorkspaceConfigurationOptionsStorage
     public static readonly Option2<bool> ValidateCompilationTrackerStates = new(
         "dotnet_validate_compilation_tracker_states", WorkspaceConfigurationOptions.Default.ValidateCompilationTrackerStates);
 
-    public static readonly Option2<SourceGeneratorExecutionPreference?> SourceGeneratorExecution = new(
+    public static readonly Option2<SourceGeneratorExecutionPreference> SourceGeneratorExecution = new(
         "dotnet_source_generator_execution",
-        defaultValue: null,
+        defaultValue: SourceGeneratorExecutionPreference.Balanced,
         isEditorConfigOption: true,
-        serializer: new EditorConfigValueSerializer<SourceGeneratorExecutionPreference?>(
-            s => SourceGeneratorExecutionPreferenceUtilities.Parse(s),
+        serializer: new EditorConfigValueSerializer<SourceGeneratorExecutionPreference>(
+            s => SourceGeneratorExecutionPreferenceUtilities.Parse(s, SourceGeneratorExecutionPreference.Balanced),
             SourceGeneratorExecutionPreferenceUtilities.GetEditorConfigString));
-
-    public static readonly Option2<bool> SourceGeneratorExecutionBalancedFeatureFlag = new(
-        "dotnet_source_generator_execution_balanced_feature_flag", true);
 
     public static readonly Option2<bool?> ReloadChangedAnalyzerReferences = new(
         "dotnet_reload_changed_analyzer_references",

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
@@ -1,4 +1,4 @@
-# Generated, do not update manually
+﻿# Generated, do not update manually
 Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo
 Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo.Equals(Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo)
 Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo.Equals(System.Object)

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
@@ -1,4 +1,4 @@
-# Generated, do not update manually
+﻿# Generated, do not update manually
 Microsoft.CodeAnalysis.Accessibility
 Microsoft.CodeAnalysis.Accessibility.Friend
 Microsoft.CodeAnalysis.Accessibility.Internal

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.Immutable.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.Immutable.txt
@@ -1,4 +1,4 @@
-# Generated, do not update manually
+﻿# Generated, do not update manually
 System.Collections.Frozen.FrozenDictionary
 System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary``2(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``1}},System.Collections.Generic.IEqualityComparer{``0})
 System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.txt
@@ -1,4 +1,4 @@
-# Generated, do not update manually
+﻿# Generated, do not update manually
 System.Collections.BitArray
 System.Collections.BitArray.#ctor(System.Boolean[])
 System.Collections.BitArray.#ctor(System.Byte[])

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Linq.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Linq.txt
@@ -1,4 +1,4 @@
-# Generated, do not update manually
+﻿# Generated, do not update manually
 System.Linq.Enumerable
 System.Linq.Enumerable.Aggregate``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0})
 System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Runtime.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Runtime.txt
@@ -1,4 +1,4 @@
-# Generated, do not update manually
+﻿# Generated, do not update manually
 System.AccessViolationException
 System.AccessViolationException.#ctor
 System.AccessViolationException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -73,18 +73,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer, FeatureOnOffOptions.OfferRemoveUnusedReferences, () => true);
 
             // Source Generators
-            BindToOption(Automatic_Run_generators_after_any_change, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Automatic, () =>
-            {
-                // If the option hasn't been set by the user, then check the feature flag.  If the feature flag has set
-                // us to only run when builds complete, then we're not in automatic mode.  So we `!` the result.
-                return !optionStore.GetOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecutionBalancedFeatureFlag);
-            });
-            BindToOption(Balanced_Run_generators_after_saving_or_building, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Balanced, () =>
-            {
-                // If the option hasn't been set by the user, then check the feature flag.  If the feature flag has set
-                // us to only run when builds complete, then we're in `Balanced_Run_generators_after_saving_or_building` mode and directly return it.
-                return optionStore.GetOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecutionBalancedFeatureFlag);
-            });
+            BindToOption(Automatic_Run_generators_after_any_change, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Automatic);
+            BindToOption(Balanced_Run_generators_after_saving_or_building, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Balanced);
+
             BindToOption(Analyze_source_generated_files, SolutionCrawlerOptionsStorage.EnableDiagnosticsInSourceGeneratedFiles, () =>
             {
                 // If the option has not been set by the user, check if the option is enabled from experimentation. If so, default to that.

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -426,7 +426,6 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_enable_diagnostics_in_source_generated_files", new RoamingProfileStorage("TextEditor.Roslyn.Specific.EnableDiagnosticsInSourceGeneratedFilesExperiment")},
         {"dotnet_enable_diagnostics_in_source_generated_files_feature_flag", new FeatureFlagStorage(@"Roslyn.EnableDiagnosticsInSourceGeneratedFiles")},
         {"dotnet_source_generator_execution", new RoamingProfileStorage("TextEditor.Roslyn.Specific.SourceGeneratorExecution")},
-        {"dotnet_source_generator_execution_balanced_feature_flag", new FeatureFlagStorage(@"Roslyn.SourceGeneratorExecutionBalanced")},
         {"dotnet_reload_changed_analyzer_references", new RoamingProfileStorage("TextEditor.Roslyn.Specific.ReloadChangedAnalyzerReferences")},
         {"dotnet_reload_changed_analyzer_references_feature_flag", new FeatureFlagStorage(@"Roslyn.ReloadChangedAnalyzerReferences")},
         {"xaml_enable_lsp_intellisense", new FeatureFlagStorage(@"Xaml.EnableLspIntelliSense")},

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/StateResetInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/StateResetInProcess.cs
@@ -65,7 +65,6 @@ internal partial class StateResetInProcess
         ResetOption(globalOptions, InlineRenameUIOptionsStorage.UseInlineAdornment);
         ResetOption(globalOptions, MetadataAsSourceOptionsStorage.NavigateToDecompiledSources);
         ResetOption(globalOptions, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution);
-        ResetOption(globalOptions, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecutionBalancedFeatureFlag);
         ResetPerLanguageOption(globalOptions, FormattingOptions2.IndentationSize);
         ResetPerLanguageOption(globalOptions, BlockStructureOptionsStorage.CollapseSourceLinkEmbeddedDecompiledFilesWhenFirstOpened);
         ResetPerLanguageOption(globalOptions, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces);

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -78,19 +78,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
                          End Function)
 
             ' Source Generators
-            BindToOption(Automatic_Run_generators_after_any_change, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Automatic,
-                         Function()
-                             ' If the option hasn't been set by the user, then check the feature flag.  If the feature flag has set
-                             ' us to only run when builds complete, then we're not in automatic mode.  So we `!` the result.
-                             Return Not optionStore.GetOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecutionBalancedFeatureFlag)
-                         End Function)
+            BindToOption(Automatic_Run_generators_after_any_change, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Automatic)
+            BindToOption(Balanced_Run_generators_after_saving_or_building, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Balanced)
 
-            BindToOption(Balanced_Run_generators_after_saving_or_building, WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Balanced,
-                         Function()
-                             ' If the option hasn't been set by the user, then check the feature flag.  If the feature flag has set
-                             ' us to only run when builds complete, then we're in `Balanced_Run_generators_after_saving_or_building` mode and directly return it.
-                             Return optionStore.GetOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecutionBalancedFeatureFlag)
-                         End Function)
             BindToOption(Analyze_source_generated_files, SolutionCrawlerOptionsStorage.EnableDiagnosticsInSourceGeneratedFiles,
                          Function()
                              ' If the option has not been set by the user, check if the option is enabled from experimentation.

--- a/src/Workspaces/Core/Portable/Workspace/SourceGeneratorExecution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/SourceGeneratorExecution.cs
@@ -25,25 +25,24 @@ internal static class SourceGeneratorExecutionPreferenceUtilities
     private const string balanced = "balanced";
 
     // Default to beginning_of_line if we don't know the value.
-    public static string GetEditorConfigString(SourceGeneratorExecutionPreference? value)
+    public static string GetEditorConfigString(SourceGeneratorExecutionPreference value)
     {
         return value switch
         {
             SourceGeneratorExecutionPreference.Automatic => automatic,
             SourceGeneratorExecutionPreference.Balanced => balanced,
-            null => "",
             _ => throw ExceptionUtilities.UnexpectedValue(value),
         };
     }
 
-    public static SourceGeneratorExecutionPreference? Parse(
-        string optionString)
+    public static SourceGeneratorExecutionPreference Parse(
+        string optionString, SourceGeneratorExecutionPreference defaultValue)
     {
         return optionString switch
         {
             automatic => SourceGeneratorExecutionPreference.Automatic,
             balanced => SourceGeneratorExecutionPreference.Balanced,
-            _ => null,
+            _ => defaultValue,
         };
     }
 }


### PR DESCRIPTION
This flag was added back in April 2024 (https://github.com/dotnet/roslyn/pull/72494) when we added 'balanced mode' execution for Source GEnerators.  The flag existed so that if we discovered a major problem, post ship, we could disable the feature.  In other words, an emergency rip cord.

We've had no problems since shipping the feature in all this time, and we haven't had to exercise the flag.  So i'm removing it from Dev18.  