### PR TITLE
Move various bits of code to the after package load code in RoslynPackage

### DIFF
--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -67,10 +67,10 @@ internal sealed partial class ColorSchemeApplier
             _isInitialized = true;
         }
 
-        packageInitializationTasks.AddTask(isMainThreadTask: false, task: PackageInitializationBackgroundThreadAsync);
+        packageInitializationTasks.AddTask(isMainThreadTask: false, task: AfterPackageLoadedBackgroundThreadAsync);
     }
 
-    private async Task PackageInitializationBackgroundThreadAsync(PackageLoadTasks packageInitializationTasks, CancellationToken cancellationToken)
+    private async Task AfterPackageLoadedBackgroundThreadAsync(PackageLoadTasks afterPackageLoadedTasks, CancellationToken cancellationToken)
     {
         var settingsManager = await _asyncServiceProvider.GetServiceAsync<SVsSettingsPersistenceManager, ISettingsManager>(_threadingContext.JoinableTaskFactory).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -58,6 +58,9 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
             RegisterEditorFactory(editorFactory);
         }
 
+        // Misc workspace has to be up and running by the time our package is usable so that it can track running
+        // doc events and appropriately map files to/from it and other relevant workspaces (like the
+        // metadata-as-source workspace).
         var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
 
         // awaiting an IVsTask guarantees to return on the captured context

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
             packageInitializationTasks.AddTask(
                 isMainThreadTask:=False,
-                task:=Function(packageInitializationTasks2, cancellationToken) As Task
+                task:=Function() As Task
                           Try
                               RegisterLanguageService(GetType(IVbCompilerService), Function() Task.FromResult(_comAggregate))
 


### PR DESCRIPTION
1) Move the *very expensive* color schema applier initialization code to occur after package load. I talked with Joey about this and he indicated this could (quite infrequently) cause a recolorization in the editor upon open, but only when the user had previously changed themes or the very first open of a C# file after install.

2) Move the global notification service construction to happen on a bg thread, bright before it's use.

3) Move the SolutionEventMonitor construction and bulk file notification registration to occur after solution load. The bulk notification for the solution open would have already been initiated if the package load occurs during solution load, so this shouldn't affect that notification.

4) A bit of cleanup from earlier PRs: (VB lambda param cleanup, removing duplicated MiscellaneousFilesWorkspace service retrieval)