### PR TITLE
Implement name and signature conflict check across extension containers with the same receiver type

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
@@ -9,7 +9,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal sealed class ConversionSignatureComparer : IEqualityComparer<SourceUserDefinedConversionSymbol>
+    internal sealed class ConversionSignatureComparer : IEqualityComparer<MethodSymbol>
     {
         private static readonly ConversionSignatureComparer s_comparer = new ConversionSignatureComparer();
         public static ConversionSignatureComparer Comparer
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
-        public bool Equals(SourceUserDefinedConversionSymbol member1, SourceUserDefinedConversionSymbol member2)
+        public bool Equals(MethodSymbol member1, MethodSymbol member2)
         {
             if (ReferenceEquals(member1, member2))
             {
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 && (member1.Name == WellKnownMemberNames.ImplicitConversionName || member2.Name == WellKnownMemberNames.ImplicitConversionName || member1.Name == member2.Name);
         }
 
-        public int GetHashCode(SourceUserDefinedConversionSymbol member)
+        public int GetHashCode(MethodSymbol member)
         {
             if ((object)member == null)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1812,12 +1812,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 CheckExtensionMembers(this.GetMembers(), diagnostics);
             }
 
-            CheckMemberNamesDistinctFromType(diagnostics);
+            CheckMemberNamesDistinctFromType(diagnostics); // PROTOTYPE: Should this check "see through" extensions?
             CheckMemberNameConflicts(diagnostics);
             CheckRecordMemberNames(diagnostics);
             CheckSpecialMemberErrors(diagnostics);
             CheckTypeParameterNameConflicts(diagnostics);
-            CheckAccessorNameConflicts(diagnostics);
 
             bool unused = KnownCircularStruct;
 
@@ -1964,17 +1963,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private void CheckMemberNameConflicts(BindingDiagnosticBag diagnostics)
+        private static void CheckMemberNameConflicts(
+            SourceMemberContainerTypeSymbol containerForDiagnostics,
+            bool mightHaveMembersFromDistinctNonPartialDeclarations,
+            Dictionary<ReadOnlyMemory<char>, ImmutableArray<NamedTypeSymbol>>? typesByName,
+            Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName,
+            BindingDiagnosticBag diagnostics)
         {
-            Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName = GetMembersByName();
 
             // Collisions involving indexers are handled specially.
-            CheckIndexerNameConflicts(diagnostics, membersByName);
+            CheckIndexerNameConflicts(containerForDiagnostics, mightHaveMembersFromDistinctNonPartialDeclarations, diagnostics, membersByName);
 
             // key and value will be the same object in these dictionaries.
             var methodsBySignature = new Dictionary<MethodSymbol, MethodSymbol>(MemberSignatureComparer.DuplicateSourceComparer);
-            var conversionsAsMethods = new Dictionary<MethodSymbol, SourceMemberMethodSymbol>(MemberSignatureComparer.DuplicateSourceComparer);
-            var conversionsAsConversions = new HashSet<SourceUserDefinedConversionSymbol>(ConversionSignatureComparer.Comparer);
+            var conversionsAsMethods = new Dictionary<MethodSymbol, MethodSymbol>(MemberSignatureComparer.DuplicateSourceComparer);
+            var conversionsAsConversions = new HashSet<MethodSymbol>(ConversionSignatureComparer.Comparer);
 
             // SPEC: The signature of an operator must differ from the signatures of all other
             // SPEC: operators declared in the same class.
@@ -2013,7 +2016,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var pair in membersByName)
             {
                 var name = pair.Key;
-                Symbol? lastSym = GetTypeMembers(name).FirstOrDefault();
+                Symbol? lastSym = typesByName?.TryGetValue(name, out var types) == true ? types.FirstOrDefault() : null;
                 methodsBySignature.Clear();
                 // Conversion collisions do not consider the name of the conversion,
                 // so do not clear that dictionary.
@@ -2021,7 +2024,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     if (symbol.Kind == SymbolKind.NamedType ||
                         symbol.IsAccessor() ||
-                        symbol.IsIndexer())
+                        symbol.IsIndexer() ||
+                        symbol.OriginalDefinition is SynthesizedExtensionMarker)
                     {
                         continue;
                     }
@@ -2067,9 +2071,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (symbol.Kind != SymbolKind.Field || !symbol.IsImplicitlyDeclared)
                             {
                                 // The type '{0}' already contains a definition for '{1}'
-                                if (Locations.Length == 1 || IsPartial)
+                                if (!mightHaveMembersFromDistinctNonPartialDeclarations)
                                 {
-                                    diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, symbol.GetFirstLocation(), this, symbol.Name);
+                                    diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, symbol.GetFirstLocation(), containerForDiagnostics, symbol.Name);
                                 }
                             }
 
@@ -2087,10 +2091,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // That takes care of the first category of conflict; we detect the
                     // second and third categories as follows:
 
-                    var conversion = symbol as SourceUserDefinedConversionSymbol;
-
                     // We don't want to consider explicit interface implementations
-                    if (conversion is { MethodKind: MethodKind.Conversion })
+                    if (symbol is MethodSymbol { MethodKind: MethodKind.Conversion } conversion)
                     {
                         // Does this conversion collide *as a conversion* with any previously-seen
                         // conversion?
@@ -2098,7 +2100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         if (!conversionsAsConversions.Add(conversion))
                         {
                             // CS0557: Duplicate user-defined conversion in type 'C'
-                            diagnostics.Add(ErrorCode.ERR_DuplicateConversionInClass, conversion.GetFirstLocation(), this);
+                            diagnostics.Add(ErrorCode.ERR_DuplicateConversionInClass, conversion.GetFirstLocation(), containerForDiagnostics);
                         }
                         else
                         {
@@ -2115,19 +2117,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         if (methodsBySignature.TryGetValue(conversion, out var previousMethod))
                         {
-                            ReportMethodSignatureCollision(diagnostics, conversion, previousMethod);
+                            ReportMethodSignatureCollision(containerForDiagnostics, diagnostics, conversion, previousMethod);
                         }
                         // Do not add the conversion to the set of previously-seen methods; that set
                         // is only non-conversion methods.
                     }
-                    else if (symbol is MethodSymbol method && method is (SourceMemberMethodSymbol or SourceExtensionImplementationMethodSymbol))
+                    else if (symbol is MethodSymbol method)
                     {
                         // Does this method collide *as a method* with any previously-seen
                         // conversion?
 
                         if (conversionsAsMethods.TryGetValue(method, out var previousConversion))
                         {
-                            ReportMethodSignatureCollision(diagnostics, method, previousConversion);
+                            ReportMethodSignatureCollision(containerForDiagnostics, diagnostics, method, previousConversion);
                         }
                         // Do not add the method to the set of previously-seen conversions.
 
@@ -2136,7 +2138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         if (methodsBySignature.TryGetValue(method, out var previousMethod))
                         {
-                            ReportMethodSignatureCollision(diagnostics, method, previousMethod);
+                            ReportMethodSignatureCollision(containerForDiagnostics, diagnostics, method, previousMethod);
                         }
                         else
                         {
@@ -2151,7 +2153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // Report a name conflict; the error is reported on the location of method1.
         // UNDONE: Consider adding a secondary location pointing to the second method.
-        private void ReportMethodSignatureCollision(BindingDiagnosticBag diagnostics, MethodSymbol method1, MethodSymbol method2)
+        private static void ReportMethodSignatureCollision(SourceMemberContainerTypeSymbol containerForDiagnostics, BindingDiagnosticBag diagnostics, MethodSymbol method1, MethodSymbol method2)
         {
             switch (method1, method2)
             {
@@ -2167,16 +2169,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // If method1 is a constructor only because its return type is missing, then
             // we've already produced a diagnostic for the missing return type and we suppress the
             // diagnostic about duplicate signature.
-            if (method1 is SourceMemberMethodSymbol { MethodKind: MethodKind.Constructor } constructor &&
-                ((ConstructorDeclarationSyntax)constructor.SyntaxRef.GetSyntax()).Identifier.ValueText != this.Name)
+            if (method1.OriginalDefinition is SourceMemberMethodSymbol { MethodKind: MethodKind.Constructor } constructor &&
+                ((ConstructorDeclarationSyntax)constructor.SyntaxRef.GetSyntax()).Identifier.ValueText != method1.ContainingType.Name)
             {
                 return;
             }
 
             if (method1 is SourceExtensionImplementationMethodSymbol { UnderlyingMethod: var underlying1 } &&
                 method2 is SourceExtensionImplementationMethodSymbol { UnderlyingMethod: var underlying2 } &&
-                (object)underlying1.ContainingType == underlying2.ContainingType &&
-                underlying1.IsStatic == underlying2.IsStatic)
+                underlying1.IsStatic == underlying2.IsStatic &&
+                ((object)underlying1.ContainingType == underlying2.ContainingType ||
+                 new ExtensionGroupingKey(underlying1.ContainingType).Equals(new ExtensionGroupingKey(underlying2.ContainingType))) &&
+                diagnostics.DiagnosticBag?.AsEnumerableWithoutResolution().Any(
+                    static (d, arg) =>
+                        (d.Code is (int)ErrorCode.ERR_OverloadRefKind or (int)ErrorCode.ERR_MemberAlreadyExists or
+                                   (int)ErrorCode.ERR_DuplicateNameInClass or (int)ErrorCode.ERR_MemberReserved) &&
+                        (d.Location == arg.method1.GetFirstLocation() || d.Location == arg.underlying1.AssociatedSymbol?.TryGetFirstLocation() ||
+                            d.Location == arg.method2.GetFirstLocation() || d.Location == arg.underlying2.AssociatedSymbol?.TryGetFirstLocation()),
+                    (method1, underlying1, method2, underlying2)) == true)
             {
                 return; // The conflict is reported in context of extension declaration
             }
@@ -2192,7 +2202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // '{0}' cannot define an overloaded {1} that differs only on parameter modifiers '{2}' and '{3}'
                     var methodKind = method1.MethodKind == MethodKind.Constructor ? MessageID.IDS_SK_CONSTRUCTOR : MessageID.IDS_SK_METHOD;
-                    diagnostics.Add(ErrorCode.ERR_OverloadRefKind, method1.GetFirstLocation(), this, methodKind.Localize(), refKind1.ToParameterDisplayString(), refKind2.ToParameterDisplayString());
+                    diagnostics.Add(ErrorCode.ERR_OverloadRefKind, method1.GetFirstLocation(), containerForDiagnostics, methodKind.Localize(), refKind1.ToParameterDisplayString(), refKind2.ToParameterDisplayString());
 
                     return;
                 }
@@ -2205,24 +2215,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Special case: if there are two destructors, use the destructor syntax instead of "Finalize"
             var methodName = (method1.MethodKind == MethodKind.Destructor && method2.MethodKind == MethodKind.Destructor) ?
-                "~" + this.Name :
-                (method1.IsConstructor() ? this.Name : method1.Name);
+                "~" + method1.ContainingType.Name :
+                (method1.IsConstructor() ? method1.ContainingType.Name : method1.Name);
 
             // Type '{1}' already defines a member called '{0}' with the same parameter types
-            diagnostics.Add(ErrorCode.ERR_MemberAlreadyExists, method1.GetFirstLocation(), methodName, this);
+            diagnostics.Add(ErrorCode.ERR_MemberAlreadyExists, method1.GetFirstLocation(), methodName, containerForDiagnostics);
         }
 
-        private void CheckIndexerNameConflicts(BindingDiagnosticBag diagnostics, Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName)
+        private static void CheckIndexerNameConflicts(
+            SourceMemberContainerTypeSymbol containerForDiagnostics,
+            bool mightHaveMembersFromDistinctNonPartialDeclarations,
+            BindingDiagnosticBag diagnostics, Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName)
         {
             PooledHashSet<string>? typeParameterNames = null;
-            if (this.Arity > 0 && !IsExtension)
-            {
-                typeParameterNames = PooledHashSet<string>.GetInstance();
-                foreach (TypeParameterSymbol typeParameter in this.TypeParameters)
-                {
-                    typeParameterNames.Add(typeParameter.Name);
-                }
-            }
+            bool checkCollisionWithTypeParameters = true;
 
             var indexersBySignature = new Dictionary<PropertySymbol, PropertySymbol>(MemberSignatureComparer.DuplicateSourceComparer);
 
@@ -2238,6 +2244,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         PropertySymbol indexer = (PropertySymbol)symbol;
                         CheckIndexerSignatureCollisions(
+                            containerForDiagnostics,
+                            mightHaveMembersFromDistinctNonPartialDeclarations,
                             indexer,
                             diagnostics,
                             membersByName,
@@ -2246,12 +2254,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         // Also check for collisions with type parameters, which aren't in the member map.
                         // NOTE: Accessors have normal names and are handled in CheckTypeParameterNameConflicts.
+
+                        if (checkCollisionWithTypeParameters && typeParameterNames == null)
+                        {
+                            if (!indexer.GetIsNewExtensionMember() && indexer.ContainingType.Arity > 0)
+                            {
+                                typeParameterNames = PooledHashSet<string>.GetInstance();
+                                foreach (TypeParameterSymbol typeParameter in indexer.ContainingType.TypeParameters)
+                                {
+                                    typeParameterNames.Add(typeParameter.Name);
+                                }
+                            }
+                            else
+                            {
+                                checkCollisionWithTypeParameters = false;
+                            }
+                        }
+
+                        Debug.Assert(checkCollisionWithTypeParameters || typeParameterNames == null);
+
                         if (typeParameterNames != null)
                         {
                             string indexerName = indexer.MetadataName;
                             if (typeParameterNames.Contains(indexerName))
                             {
-                                diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, indexer.GetFirstLocation(), this, indexerName);
+                                diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, indexer.GetFirstLocation(), containerForDiagnostics, indexerName);
                                 continue;
                             }
                         }
@@ -2262,7 +2289,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             typeParameterNames?.Free();
         }
 
-        private void CheckIndexerSignatureCollisions(
+        private static void CheckIndexerSignatureCollisions(
+            SourceMemberContainerTypeSymbol containerForDiagnostics,
+            bool mightHaveMembersFromDistinctNonPartialDeclarations,
             PropertySymbol indexer,
             BindingDiagnosticBag diagnostics,
             Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName,
@@ -2287,7 +2316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 lastIndexerName = indexerName;
 
-                if (Locations.Length == 1 || IsPartial)
+                if (!mightHaveMembersFromDistinctNonPartialDeclarations)
                 {
 #pragma warning disable CA1854 //Prefer a 'TryGetValue' call over a Dictionary indexer access guarded by a 'ContainsKey' check to avoid double lookup
                     if (membersByName.ContainsKey(indexerName.AsMemory()))
@@ -2295,7 +2324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         // The name of the indexer is reserved - it can only be used by other indexers.
                         Debug.Assert(!membersByName[indexerName.AsMemory()].Any(SymbolExtensions.IsIndexer));
-                        diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, indexer.GetFirstLocation(), this, indexerName);
+                        diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, indexer.GetFirstLocation(), containerForDiagnostics, indexerName);
                     }
                 }
             }
@@ -2304,11 +2333,186 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // Type '{1}' already defines a member called '{0}' with the same parameter types
                 // NOTE: Dev10 prints "this" as the name of the indexer.
-                diagnostics.Add(ErrorCode.ERR_MemberAlreadyExists, indexer.GetFirstLocation(), SyntaxFacts.GetText(SyntaxKind.ThisKeyword), this);
+                diagnostics.Add(ErrorCode.ERR_MemberAlreadyExists, indexer.GetFirstLocation(), SyntaxFacts.GetText(SyntaxKind.ThisKeyword), containerForDiagnostics);
             }
             else
             {
                 indexersBySignature[indexer] = indexer;
+            }
+        }
+
+        private void CheckMemberNameConflicts(BindingDiagnosticBag diagnostics)
+        {
+            if (IsExtension)
+            {
+                return; // Conflicts are checked in context of the enclosing type
+            }
+
+            if (this.declaration.ContainsExtensionDeclarations)
+            {
+                checkMemberNameConflictsInExtensions(diagnostics);
+            }
+
+            checkMemberNameConflicts(GetMembersByName(), GetTypeMembersDictionary(), GetMembersUnordered(), diagnostics);
+            return;
+
+            void checkMemberNameConflicts(
+                Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName,
+                Dictionary<ReadOnlyMemory<char>, ImmutableArray<NamedTypeSymbol>>? typesByName,
+                ImmutableArray<Symbol> membersUnordered,
+                BindingDiagnosticBag diagnostics)
+            {
+                bool mightHaveMembersFromDistinctNonPartialDeclarations = !(Locations.Length == 1 || IsPartial);
+                CheckMemberNameConflicts(this, mightHaveMembersFromDistinctNonPartialDeclarations, typesByName, membersByName, diagnostics);
+                CheckAccessorNameConflicts(this, mightHaveMembersFromDistinctNonPartialDeclarations, membersByName, membersUnordered, diagnostics);
+            }
+
+            void checkMemberNameConflictsInExtensions(BindingDiagnosticBag diagnostics)
+            {
+                IEnumerable<IGrouping<ExtensionGroupingKey, NamedTypeSymbol>> extensionsByReceiverType = GetTypeMembers("").Where(static t => t.IsExtension).GroupBy(static t => new ExtensionGroupingKey(t));
+
+                foreach (var grouping in extensionsByReceiverType)
+                {
+                    Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>>? membersByName;
+                    ImmutableArray<Symbol> membersUnordered;
+
+                    (membersByName, membersUnordered) = mergeMembersInGroup(grouping);
+
+                    if (membersByName is not null)
+                    {
+                        checkMemberNameConflicts(membersByName, typesByName: null /* nested types not supported */, membersUnordered, diagnostics);
+                    }
+                }
+            }
+
+            static (Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>>? membersByName, ImmutableArray<Symbol> membersUnordered) mergeMembersInGroup(IGrouping<ExtensionGroupingKey, NamedTypeSymbol> grouping)
+            {
+                Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>>? membersByName = null;
+                ImmutableArray<Symbol> membersUnordered = [];
+                NamedTypeSymbol? masterExtension = null;
+                bool cloneMembersByName = true;
+
+                foreach (NamedTypeSymbol item in grouping)
+                {
+                    var extension = item;
+                    Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByNameToMerge = ((SourceMemberContainerTypeSymbol)extension).GetMembersByName();
+
+                    if (membersByNameToMerge.Count == 0 ||
+                        (membersByNameToMerge.Count == 1 && membersByNameToMerge.Values.Single() is [SynthesizedExtensionMarker]))
+                    {
+                        continue; // This is an optimization
+                    }
+
+                    if (membersByName == null)
+                    {
+                        membersByName = membersByNameToMerge;
+                        membersUnordered = extension.GetMembersUnordered();
+                        masterExtension = extension;
+                        Debug.Assert(cloneMembersByName);
+                    }
+                    else
+                    {
+                        Debug.Assert(masterExtension is not null);
+
+                        if (cloneMembersByName)
+                        {
+                            membersByName = new Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>>(membersByName, ReadOnlyMemoryOfCharComparer.Instance);
+                            cloneMembersByName = false;
+                        }
+
+                        if (extension.Arity != 0)
+                        {
+                            extension = extension.Construct(masterExtension.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
+                        }
+                        else
+                        {
+                            membersUnordered = membersUnordered.Concat(extension.GetMembersUnordered());
+                        }
+
+                        foreach (var pair in membersByNameToMerge)
+                        {
+                            if (membersByName.TryGetValue(pair.Key, out var members))
+                            {
+                                membersByName[pair.Key] = concatMembers(members, extension, pair.Value, ref membersUnordered);
+                            }
+                            else
+                            {
+                                membersByName.Add(pair.Key, concatMembers([], extension, pair.Value, ref membersUnordered));
+                            }
+                        }
+                    }
+                }
+
+                return (membersByName, membersUnordered);
+            }
+
+            static ImmutableArray<Symbol> concatMembers(ImmutableArray<Symbol> existingMembers, NamedTypeSymbol extension, ImmutableArray<Symbol> newMembers, ref ImmutableArray<Symbol> membersUnordered)
+            {
+                Debug.Assert(!newMembers.IsEmpty);
+
+                if (extension.IsDefinition)
+                {
+                    Debug.Assert(newMembers.All(static (m, membersUnordered) => membersUnordered.Contains(m), membersUnordered));
+                    return existingMembers.Concat(newMembers);
+                }
+
+                var membersBuilder = ArrayBuilder<Symbol>.GetInstance(existingMembers.Length + newMembers.Length);
+                var membersUnorderedBuilder = ArrayBuilder<Symbol>.GetInstance(membersUnordered.Length + newMembers.Length);
+
+                membersBuilder.AddRange(existingMembers);
+                membersUnorderedBuilder.AddRange(membersUnordered);
+
+                foreach (var member in newMembers)
+                {
+                    Symbol toAdd = member.SymbolAsMember(extension);
+                    membersBuilder.Add(toAdd);
+                    membersUnorderedBuilder.Add(toAdd);
+                }
+
+                membersUnordered = membersUnorderedBuilder.ToImmutableAndFree();
+                return membersBuilder.ToImmutableAndFree();
+            }
+        }
+
+        private readonly struct ExtensionGroupingKey : IEquatable<ExtensionGroupingKey>
+        {
+            public readonly int ExtensionArity;
+            public readonly TypeSymbol ReceiverType;
+
+            public ExtensionGroupingKey(NamedTypeSymbol extension)
+            {
+                ExtensionArity = extension.Arity;
+
+                if (extension.Arity != 0)
+                {
+                    extension = extension.Construct(IndexedTypeParameterSymbol.Take(extension.Arity));
+                }
+
+                if (extension.ExtensionParameter is { } receiverParameter)
+                {
+                    ReceiverType = receiverParameter.Type;
+                }
+                else
+                {
+                    ReceiverType = ErrorTypeSymbol.UnknownResultType;
+                }
+            }
+
+            public bool Equals(ExtensionGroupingKey other)
+            {
+                return ExtensionArity == other.ExtensionArity &&
+                       ReceiverType.Equals(other.ReceiverType, TypeCompareKind.AllIgnoreOptions);
+            }
+
+            public override bool Equals([NotNullWhen(true)] object? obj)
+            {
+                Debug.Assert(false); // Usage of this method is unexpected
+                return Equals((ExtensionGroupingKey)obj!);
+            }
+
+            public override int GetHashCode()
+            {
+                return ReceiverType.GetHashCode();
             }
         }
 
@@ -2344,11 +2548,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private void CheckAccessorNameConflicts(BindingDiagnosticBag diagnostics)
+        private static void CheckAccessorNameConflicts(
+            SourceMemberContainerTypeSymbol containerForDiagnostics,
+            bool mightHaveMembersFromDistinctNonPartialDeclarations,
+            Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName,
+            ImmutableArray<Symbol> membersUnordered,
+            BindingDiagnosticBag diagnostics)
         {
             // Report errors where property and event accessors
             // conflict with other members of the same name.
-            foreach (Symbol symbol in this.GetMembersUnordered())
+            foreach (Symbol symbol in membersUnordered)
             {
                 if (symbol.IsExplicitInterfaceImplementation())
                 {
@@ -2361,15 +2570,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case SymbolKind.Property:
                         {
                             var propertySymbol = (PropertySymbol)symbol;
-                            this.CheckForMemberConflictWithPropertyAccessor(propertySymbol, getNotSet: true, diagnostics: diagnostics);
-                            this.CheckForMemberConflictWithPropertyAccessor(propertySymbol, getNotSet: false, diagnostics: diagnostics);
+                            CheckForMemberConflictWithPropertyAccessor(containerForDiagnostics, mightHaveMembersFromDistinctNonPartialDeclarations, membersByName, propertySymbol, getNotSet: true, diagnostics: diagnostics);
+                            CheckForMemberConflictWithPropertyAccessor(containerForDiagnostics, mightHaveMembersFromDistinctNonPartialDeclarations, membersByName, propertySymbol, getNotSet: false, diagnostics: diagnostics);
                             break;
                         }
                     case SymbolKind.Event:
                         {
                             var eventSymbol = (EventSymbol)symbol;
-                            this.CheckForMemberConflictWithEventAccessor(eventSymbol, isAdder: true, diagnostics: diagnostics);
-                            this.CheckForMemberConflictWithEventAccessor(eventSymbol, isAdder: false, diagnostics: diagnostics);
+                            CheckForMemberConflictWithEventAccessor(containerForDiagnostics, mightHaveMembersFromDistinctNonPartialDeclarations, membersByName, eventSymbol, isAdder: true, diagnostics: diagnostics);
+                            CheckForMemberConflictWithEventAccessor(containerForDiagnostics, mightHaveMembersFromDistinctNonPartialDeclarations, membersByName, eventSymbol, isAdder: false, diagnostics: diagnostics);
                             break;
                         }
                 }
@@ -4120,7 +4329,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Report an error if a member (other than a method) exists with the same name
         /// as the property accessor, or if a method exists with the same name and signature.
         /// </summary>
-        private void CheckForMemberConflictWithPropertyAccessor(
+        private static void CheckForMemberConflictWithPropertyAccessor(
+            SourceMemberContainerTypeSymbol containerForDiagnostics,
+            bool mightHaveMembersFromDistinctNonPartialDeclarations,
+            Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName,
             PropertySymbol propertySymbol,
             bool getNotSet,
             BindingDiagnosticBag diagnostics)
@@ -4141,13 +4353,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     propertySymbol.IsCompilationOutputWinMdObj());
             }
 
-            foreach (var symbol in GetMembers(accessorName))
+            foreach (var symbol in membersByName.TryGetValue(accessorName.AsMemory(), out var members) ? members : [])
             {
                 if (symbol.Kind != SymbolKind.Method)
                 {
                     // The type '{0}' already contains a definition for '{1}'
-                    if (Locations.Length == 1 || IsPartial)
-                        diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, GetAccessorOrPropertyLocation(propertySymbol, getNotSet), this, accessorName);
+                    if (!mightHaveMembersFromDistinctNonPartialDeclarations)
+                        diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, GetAccessorOrPropertyLocation(propertySymbol, getNotSet), containerForDiagnostics, accessorName);
                     return;
                 }
                 else
@@ -4157,7 +4369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         ParametersMatchPropertyAccessor(propertySymbol, getNotSet, methodSymbol.Parameters))
                     {
                         // Type '{1}' already reserves a member called '{0}' with the same parameter types
-                        diagnostics.Add(ErrorCode.ERR_MemberReserved, GetAccessorOrPropertyLocation(propertySymbol, getNotSet), accessorName, this);
+                        diagnostics.Add(ErrorCode.ERR_MemberReserved, GetAccessorOrPropertyLocation(propertySymbol, getNotSet), accessorName, containerForDiagnostics);
                         return;
                     }
                 }
@@ -4168,7 +4380,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Report an error if a member (other than a method) exists with the same name
         /// as the event accessor, or if a method exists with the same name and signature.
         /// </summary>
-        private void CheckForMemberConflictWithEventAccessor(
+        private static void CheckForMemberConflictWithEventAccessor(
+            SourceMemberContainerTypeSymbol containerForDiagnostics,
+            bool mightHaveMembersFromDistinctNonPartialDeclarations,
+            Dictionary<ReadOnlyMemory<char>, ImmutableArray<Symbol>> membersByName,
             EventSymbol eventSymbol,
             bool isAdder,
             BindingDiagnosticBag diagnostics)
@@ -4177,13 +4392,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             string accessorName = SourceEventSymbol.GetAccessorName(eventSymbol.Name, isAdder);
 
-            foreach (var symbol in GetMembers(accessorName))
+            foreach (var symbol in membersByName.TryGetValue(accessorName.AsMemory(), out var members) ? members : [])
             {
                 if (symbol.Kind != SymbolKind.Method)
                 {
                     // The type '{0}' already contains a definition for '{1}'
-                    if (Locations.Length == 1 || IsPartial)
-                        diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, GetAccessorOrEventLocation(eventSymbol, isAdder), this, accessorName);
+                    if (!mightHaveMembersFromDistinctNonPartialDeclarations)
+                        diagnostics.Add(ErrorCode.ERR_DuplicateNameInClass, GetAccessorOrEventLocation(eventSymbol, isAdder), containerForDiagnostics, accessorName);
                     return;
                 }
                 else
@@ -4193,7 +4408,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         ParametersMatchEventAccessor(eventSymbol, methodSymbol.Parameters))
                     {
                         // Type '{1}' already reserves a member called '{0}' with the same parameter types
-                        diagnostics.Add(ErrorCode.ERR_MemberReserved, GetAccessorOrEventLocation(eventSymbol, isAdder), accessorName, this);
+                        diagnostics.Add(ErrorCode.ERR_MemberReserved, GetAccessorOrEventLocation(eventSymbol, isAdder), accessorName, containerForDiagnostics);
                         return;
                     }
                 }
@@ -4567,6 +4782,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(ctor is object);
                 members.Add(ctor);
 
+                if (!memberSignatures.ContainsKey(ctor))
+                {
+                    memberSignatures.Add(ctor, ctor);
+                }
+
                 if (ctor.ParameterCount != 0)
                 {
                     // properties and Deconstruct
@@ -4582,7 +4802,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (isRecordClass)
             {
-                addCopyCtor(primaryAndCopyCtorAmbiguity);
+                addCopyCtor(primaryAndCopyCtorAmbiguity, declaredMembersAndInitializers);
                 addCloneMethod();
             }
 
@@ -4669,7 +4889,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            void addCopyCtor(bool primaryAndCopyCtorAmbiguity)
+            void addCopyCtor(bool primaryAndCopyCtorAmbiguity, DeclaredMembersAndInitializers declaredMembersAndInitializers)
             {
                 Debug.Assert(isRecordClass);
                 var targetMethod = new SignatureOnlyMethodSymbol(
@@ -4706,7 +4926,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     var constructor = (MethodSymbol)existingConstructor;
 
-                    if (!this.IsSealed && (constructor.DeclaredAccessibility != Accessibility.Public && constructor.DeclaredAccessibility != Accessibility.Protected))
+                    if ((object)constructor == declaredMembersAndInitializers.PrimaryConstructor && primaryAndCopyCtorAmbiguity)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_RecordAmbigCtor, this.GetFirstLocation());
+                    }
+                    else if (!this.IsSealed && (constructor.DeclaredAccessibility != Accessibility.Public && constructor.DeclaredAccessibility != Accessibility.Protected))
                     {
                         diagnostics.Add(ErrorCode.ERR_CopyConstructorWrongAccessibility, constructor.GetFirstLocation(), constructor);
                     }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -23015,7 +23015,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_01()
+    public void MemberNameAndSignatureConflict_01()
     {
         var src = """
 static class Extensions
@@ -23110,18 +23110,18 @@ static class Extensions
             // (10,21): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
             //         public void M1() {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "Extensions").WithLocation(10, 21),
-
-            // PROTOTYPE: The error might be somewhat confusing in this scenario because there are no parameters and we complain about ref-ness of the receiver.
-
-            // (30,21): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'ref' and 'in'
+            // (20,21): error CS0111: Type 'Extensions' already defines a member called 'M2' with the same parameter types
+            //         public void M2() {}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M2").WithArguments("M2", "Extensions").WithLocation(20, 21),
+            // (30,21): error CS0111: Type 'Extensions' already defines a member called 'M3' with the same parameter types
             //         public void M3() {}
-            Diagnostic(ErrorCode.ERR_OverloadRefKind, "M3").WithArguments("Extensions", "method", "ref", "in").WithLocation(30, 21),
-            // (40,21): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'ref' and 'ref readonly'
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M3").WithArguments("M3", "Extensions").WithLocation(30, 21),
+            // (40,21): error CS0111: Type 'Extensions' already defines a member called 'M4' with the same parameter types
             //         public void M4() {}
-            Diagnostic(ErrorCode.ERR_OverloadRefKind, "M4").WithArguments("Extensions", "method", "ref", "ref readonly").WithLocation(40, 21),
-            // (50,21): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'in' and 'ref readonly'
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M4").WithArguments("M4", "Extensions").WithLocation(40, 21),
+            // (50,21): error CS0111: Type 'Extensions' already defines a member called 'M5' with the same parameter types
             //         public void M5() {}
-            Diagnostic(ErrorCode.ERR_OverloadRefKind, "M5").WithArguments("Extensions", "method", "in", "ref readonly").WithLocation(50, 21),
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M5").WithArguments("M5", "Extensions").WithLocation(50, 21),
             // (59,24): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'ref' and 'in'
             //     static public void M7(this ref int receiver) {}
             Diagnostic(ErrorCode.ERR_OverloadRefKind, "M7").WithArguments("Extensions", "method", "ref", "in").WithLocation(59, 24),
@@ -23131,9 +23131,9 @@ static class Extensions
             // (67,24): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'in' and 'ref readonly'
             //     static public void M9(this in int receiver) {}
             Diagnostic(ErrorCode.ERR_OverloadRefKind, "M9").WithArguments("Extensions", "method", "in", "ref readonly").WithLocation(67, 24),
-            // (72,21): error CS0111: Type 'Extensions.extension(object)' already defines a member called 'M10' with the same parameter types
+            // (72,21): error CS0111: Type 'Extensions' already defines a member called 'M10' with the same parameter types
             //         public void M10() {}
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M10").WithArguments("M10", "Extensions.extension(object)").WithLocation(72, 21),
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M10").WithArguments("M10", "Extensions").WithLocation(72, 21),
             // (82,21): error CS0111: Type 'Extensions' already defines a member called 'M13' with the same parameter types
             //         public void M13() {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M13").WithArguments("M13", "Extensions").WithLocation(82, 21)
@@ -23144,51 +23144,12 @@ static class Extensions
 {
     static void Main()
     {
-        1.M2();
-    }
-
-    extension(int receiver)
-    {
-        public void M2() {}
-    }
-
-    extension(ref int receiver)
-    {
-        public void M2() {}
-    }
-}
-""");
-
-        comp.VerifyDiagnostics(
-            // (5,11): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions.extension(int).M2()' and 'Extensions.extension(ref int).M2()'
-            //         1.M2();
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M2").WithArguments("Extensions.extension(int).M2()", "Extensions.extension(ref int).M2()").WithLocation(5, 11)
-            );
-
-        comp = CreateCompilation("""
-static class Extensions
-{
-    static void Main()
-    {
         int i = 0;
-        M2(i);
-        M2(ref i);
-
         i.M11();
         "".M11();
 
         ((long)i).M12(i);
         ((long)i).M12(ref i);
-    }
-
-    extension(int receiver)
-    {
-        public void M2() {}
-    }
-
-    extension(ref int receiver)
-    {
-        public void M2() {}
     }
 
     extension(int receiver)
@@ -23217,7 +23178,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_02()
+    public void MemberNameAndSignatureConflict_02()
     {
         var src = """
 static class Extensions
@@ -23346,9 +23307,9 @@ static class Extensions
             // (40,28): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'in' and 'ref'
             //         static public void M4(in int x) {}
             Diagnostic(ErrorCode.ERR_OverloadRefKind, "M4").WithArguments("Extensions", "method", "in", "ref").WithLocation(40, 28),
-            // (46,28): error CS0111: Type 'Extensions.extension(object)' already defines a member called 'M5' with the same parameter types
+            // (46,28): error CS0111: Type 'Extensions' already defines a member called 'M5' with the same parameter types
             //         static public void M5() {}
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M5").WithArguments("M5", "Extensions.extension(object)").WithLocation(46, 28),
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M5").WithArguments("M5", "Extensions").WithLocation(46, 28),
 
             // PROTOTYPE: It feels unfortunate that we generate conflicting signatures, the methods extend different types (refer to M6 and M7 cases)
 
@@ -23422,7 +23383,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_03()
+    public void MemberNameAndSignatureConflict_03()
     {
         var src = """
 static class Extensions
@@ -23441,14 +23402,14 @@ static class Extensions
         var comp = CreateCompilation(src);
 
         comp.VerifyDiagnostics(
-            // (10,26): error CS0111: Type 'Extensions' already defines a member called 'get_P1' with the same parameter types
+            // (10,20): error CS0102: The type 'Extensions' already contains a definition for 'P1'
             //         public int P1 => 4;
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "4").WithArguments("get_P1", "Extensions").WithLocation(10, 26)
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "P1").WithArguments("Extensions", "P1").WithLocation(10, 20)
             );
     }
 
     [Fact]
-    public void SignatureConflict_04()
+    public void MemberNameAndSignatureConflict_04()
     {
         var src = """
 static class Extensions
@@ -23467,14 +23428,14 @@ static class Extensions
         var comp = CreateCompilation(src);
 
         comp.VerifyDiagnostics(
-            // (10,33): error CS0111: Type 'Extensions' already defines a member called 'get_P1' with the same parameter types
+            // (10,27): error CS0102: The type 'Extensions' already contains a definition for 'P1'
             //         static public int P1 => 4;
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "4").WithArguments("get_P1", "Extensions").WithLocation(10, 33)
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "P1").WithArguments("Extensions", "P1").WithLocation(10, 27)
             );
     }
 
     [Fact]
-    public void SignatureConflict_05()
+    public void MemberNameAndSignatureConflict_05()
     {
         var src = """
 static class Extensions
@@ -23491,24 +23452,117 @@ static class Extensions
         public int P2 => 4;
     }
 }
+
+static class Extensions2
+{
+    extension(object receiver)
+    {
+        public int P3 => 1;
+        public int get_P4() => 2;
+        public int get_P3() => 3;
+        public int P4 => 4;
+    }
+}
+
+static class Extensions3
+{
+    extension(object receiver)
+    {
+        public int P1 => 1;
+        public int set_P2(int x) => 2;
+    }
+
+    extension(object receiver)
+    {
+        public int set_P1(int y) => 3;
+        public int P2 => 4;
+    }
+}
+
+static class Extensions4
+{
+    extension(object receiver)
+    {
+        public int P3 => 1;
+        public int set_P4(int z) => 2;
+        public int set_P3(int z) => 3;
+        public int P4 => 4;
+    }
+}
+
+static class Extensions5
+{
+    extension(object receiver)
+    {
+        public int this[int x] => 1;
+        public int get_Item(long y) => 2;
+    }
+
+    extension(object receiver)
+    {
+        public int get_Item(int a) => 3;
+        public int this[long b] => 4;
+    }
+}
+
+static class Extensions6
+{
+    extension(object receiver)
+    {
+        [System.Runtime.CompilerServices.IndexerName("Indexer")]
+        public int this[int x] => 1;
+    }
+
+    extension(object receiver)
+    {
+        public int get_Indexer(int a) => 3;
+    }
+}
 """;
         var comp = CreateCompilation(src);
 
         comp.VerifyDiagnostics(
-            // (11,20): error CS0111: Type 'Extensions' already defines a member called 'get_P1' with the same parameter types
-            //         public int get_P1() => 3;
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "get_P1").WithArguments("get_P1", "Extensions").WithLocation(11, 20),
-            // (12,26): error CS0111: Type 'Extensions' already defines a member called 'get_P2' with the same parameter types
+            // (5,26): error CS0082: Type 'Extensions' already reserves a member called 'get_P1' with the same parameter types
+            //         public int P1 => 1;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "1").WithArguments("get_P1", "Extensions").WithLocation(5, 26),
+            // (12,26): error CS0082: Type 'Extensions' already reserves a member called 'get_P2' with the same parameter types
             //         public int P2 => 4;
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "4").WithArguments("get_P2", "Extensions").WithLocation(12, 26)
+            Diagnostic(ErrorCode.ERR_MemberReserved, "4").WithArguments("get_P2", "Extensions").WithLocation(12, 26),
+            // (20,26): error CS0082: Type 'Extensions2' already reserves a member called 'get_P3' with the same parameter types
+            //         public int P3 => 1;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "1").WithArguments("get_P3", "Extensions2").WithLocation(20, 26),
+            // (23,26): error CS0082: Type 'Extensions2' already reserves a member called 'get_P4' with the same parameter types
+            //         public int P4 => 4;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "4").WithArguments("get_P4", "Extensions2").WithLocation(23, 26),
+            // (31,20): error CS0082: Type 'Extensions3' already reserves a member called 'set_P1' with the same parameter types
+            //         public int P1 => 1;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "P1").WithArguments("set_P1", "Extensions3").WithLocation(31, 20),
+            // (38,20): error CS0082: Type 'Extensions3' already reserves a member called 'set_P2' with the same parameter types
+            //         public int P2 => 4;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "P2").WithArguments("set_P2", "Extensions3").WithLocation(38, 20),
+            // (46,20): error CS0082: Type 'Extensions4' already reserves a member called 'set_P3' with the same parameter types
+            //         public int P3 => 1;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "P3").WithArguments("set_P3", "Extensions4").WithLocation(46, 20),
+            // (49,20): error CS0082: Type 'Extensions4' already reserves a member called 'set_P4' with the same parameter types
+            //         public int P4 => 4;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "P4").WithArguments("set_P4", "Extensions4").WithLocation(49, 20),
+            // (57,35): error CS0082: Type 'Extensions5' already reserves a member called 'get_Item' with the same parameter types
+            //         public int this[int x] => 1;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "1").WithArguments("get_Item", "Extensions5").WithLocation(57, 35),
+            // (64,36): error CS0082: Type 'Extensions5' already reserves a member called 'get_Item' with the same parameter types
+            //         public int this[long b] => 4;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "4").WithArguments("get_Item", "Extensions5").WithLocation(64, 36),
+            // (73,35): error CS0082: Type 'Extensions6' already reserves a member called 'get_Indexer' with the same parameter types
+            //         public int this[int x] => 1;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "1").WithArguments("get_Indexer", "Extensions6").WithLocation(73, 35)
             );
     }
 
     [Fact]
-    public void SignatureConflict_06()
+    public void MemberNameAndSignatureConflict_06()
     {
         var src = """
-static class Extensions
+static class Extensions1
 {
     extension(object receiver)
     {
@@ -23520,15 +23574,34 @@ static class Extensions
         public int P1 {set{}}
     }
 }
+
+static class Extensions2
+{
+    extension(object receiver1)
+    {
+        public int this[int x] => 1;
+    }
+
+    extension(object receiver2)
+    {
+        public int this[int y] {set{}}
+    }
+}
 """;
         var comp = CreateCompilation(src);
 
-        // PROTOTYPE: Should be complain about a conflict like this?
-        CompileAndVerify(comp).VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (10,20): error CS0102: The type 'Extensions1' already contains a definition for 'P1'
+            //         public int P1 {set{}}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "P1").WithArguments("Extensions1", "P1").WithLocation(10, 20),
+            // (23,20): error CS0111: Type 'Extensions2' already defines a member called 'this' with the same parameter types
+            //         public int this[int y] {set{}}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Extensions2").WithLocation(23, 20)
+            );
     }
 
     [Fact]
-    public void SignatureConflict_07()
+    public void MemberNameAndSignatureConflict_07()
     {
         var src = """
 static class Extensions
@@ -23554,7 +23627,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_08()
+    public void MemberNameAndSignatureConflict_08()
     {
         var src = """
 static class Extensions
@@ -23683,7 +23756,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_09()
+    public void MemberNameAndSignatureConflict_09()
     {
         var src = """
 static class Extensions
@@ -23780,7 +23853,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_10()
+    public void MemberNameAndSignatureConflict_10()
     {
         var src = """
 static class Extensions
@@ -23906,7 +23979,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_11()
+    public void MemberNameAndSignatureConflict_11()
     {
         var src = """
 static class Extensions
@@ -23995,7 +24068,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_12()
+    public void MemberNameAndSignatureConflict_12()
     {
         var src = """
 static class Extensions
@@ -24028,7 +24101,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_13()
+    public void MemberNameAndSignatureConflict_13()
     {
         var src = """
 static class Extensions
@@ -24061,7 +24134,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_14()
+    public void MemberNameAndSignatureConflict_14()
     {
         var src = """
 static class Extensions
@@ -24094,7 +24167,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_15()
+    public void MemberNameAndSignatureConflict_15()
     {
         var src = """
 static class Extensions
@@ -24113,7 +24186,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_16()
+    public void MemberNameAndSignatureConflict_16()
     {
         var src = """
 static class Extensions
@@ -24145,7 +24218,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_17()
+    public void MemberNameAndSignatureConflict_17()
     {
         var src = """
 static class Extensions
@@ -24177,7 +24250,7 @@ static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_18()
+    public void MemberNameAndSignatureConflict_18()
     {
         var src = """
 public static class Extensions
@@ -24221,7 +24294,7 @@ public static class Extensions
     }
 
     [Fact]
-    public void SignatureConflict_19()
+    public void MemberNameAndSignatureConflict_19()
     {
         var src = """
 public static class Extensions
@@ -24261,6 +24334,541 @@ public static class Extensions
             // (22,28): error CS0102: The type 'Extensions' already contains a definition for 'M3'
             //         static public void M3(int x) {}
             Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "M3").WithArguments("Extensions", "M3").WithLocation(22, 28)
+            );
+    }
+
+    [Fact]
+    public void MemberNameAndSignatureConflict_20_ReceiverType_TupleNameDifference()
+    {
+        var src = """
+public static class Extensions
+{
+    extension((int a, int b) receiver)
+    {
+        void M1() {}
+    }
+
+    extension((int c, int d))
+    {
+        static void M1() {}
+    }
+
+    extension(int receiver)
+    {
+        void M1() {}
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (10,21): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
+            //         static void M1() {}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "Extensions").WithLocation(10, 21)
+            );
+    }
+
+    [Fact]
+    public void MemberNameAndSignatureConflict_21_ReceiverType_NativeIntDifference()
+    {
+        var src = """
+public static class Extensions
+{
+    extension(System.IntPtr receiver)
+    {
+        void M1() {}
+    }
+
+    extension(nint)
+    {
+        static void M1() {}
+    }
+
+    extension(int receiver)
+    {
+        void M1() {}
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+
+        comp.VerifyDiagnostics(
+            // (10,21): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
+            //         static void M1() {}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "Extensions").WithLocation(10, 21)
+            );
+    }
+
+    [Fact]
+    public void MemberNameAndSignatureConflict_22_ReceiverType_NullabilityDifference()
+    {
+        var src = """
+#nullable enable
+
+public static class Extensions
+{
+    extension(string[])
+    {
+        static void M1() {}
+    }
+
+    extension(string?[] receiver)
+    {
+        void M1() {}
+    }
+
+    extension(int receiver)
+    {
+        void M1() {}
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (12,14): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
+            //         void M1() {}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "Extensions").WithLocation(12, 14)
+            );
+    }
+
+    [Fact]
+    public void MemberNameAndSignatureConflict_23_Receiver_TypeDifference()
+    {
+        var src = """
+public static class Extensions
+{
+    extension(int receiver)
+    {
+        void M1() {}
+    }
+
+    extension(long)
+    {
+        static void M1() {}
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_24_Genericity(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[]) where T : class
+    {
+        static void M1(T x) {}
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver) where U : struct
+    {
+#line 17
+        void M1(U y) {}
+        void M2(U y) {}
+        static void M2(U x) {}
+    }
+
+    extension(int[] receiver)
+    {
+        void M1(int a) {}
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (17,14): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
+            //         void M1(U y) {}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "Extensions").WithLocation(17, 14),
+            // (19,21): error CS0111: Type 'Extensions' already defines a member called 'M2' with the same parameter types
+            //         static void M2(U x) {}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M2").WithArguments("M2", "Extensions").WithLocation(19, 21)
+            );
+    }
+
+    [Fact]
+    public void MemberNameAndSignatureConflict_25_Genericity_DifferentArity()
+    {
+        var src = """
+public static class Extensions1
+{
+    extension<T1>(T1)
+    {
+        static void M1(T1 x) {}
+    }
+
+    extension<T1, U1>(T1)
+    {
+        static void M1(T1 x) {}
+    }
+}
+
+public static class Extensions2
+{
+    extension<T2, U2>(T2)
+    {
+        static void M1(T2 x) {}
+    }
+
+    extension<T2>(T2)
+    {
+        static void M1(T2 x) {}
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MemberNameAndSignatureConflict_26_Genericity()
+    {
+        var src = """
+public static class Extensions1
+{
+    extension<T, S>(C<T, S>)
+    {
+        static void M1() {}
+    }
+
+    extension<T, S>(C<S, T>)
+    {
+        static void M1() {}
+    }
+}
+
+class C<T, S> {}
+""";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (10,21): error CS0111: Type 'Extensions1' already defines a member called 'M1' with the same parameter types
+            //         static void M1() {}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "Extensions1").WithLocation(10, 21)
+            );
+    }
+
+    [Fact]
+    public void MemberNameAndSignatureConflict_27_Genericity()
+    {
+        var src = """
+public static class Extensions1
+{
+    extension<T, S>(C<T, S>)
+    {
+        void M1() {}
+    }
+
+    extension<T, S>(C<S, T>)
+    {
+        void M1() {}
+    }
+}
+
+class C<T, S> {}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_28_Genericity(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(ref int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[])
+    {
+        static void M1(ref T x) {}
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver)
+    {
+#line 17
+        void M1(in U y) {}
+        void M2(ref U y) {}
+        static void M2(in U x) {}
+    }
+
+    extension(int[] receiver)
+    {
+        void M1(ref int a) {}
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (17,14): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'in' and 'ref'
+            //         void M1(in U y) {}
+            Diagnostic(ErrorCode.ERR_OverloadRefKind, "M1").WithArguments("Extensions", "method", "in", "ref").WithLocation(17, 14),
+            // (19,21): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'in' and 'ref'
+            //         static void M2(in U x) {}
+            Diagnostic(ErrorCode.ERR_OverloadRefKind, "M2").WithArguments("Extensions", "method", "in", "ref").WithLocation(19, 21)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_29_Indexers(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[])
+    {
+#line 8
+        int this[T x] => default;
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver)
+    {
+        void Item(U x) {}
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (8,13): error CS0102: The type 'Extensions' already contains a definition for 'Item'
+            //         int this[T x] => default;
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "this").WithArguments("Extensions", "Item").WithLocation(8, 13)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_30_Indexers(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[])
+    {
+        int this[T x] => default;
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver)
+    {
+#line 18
+        int this[U x] { set{}}
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (18,13): error CS0111: Type 'Extensions' already defines a member called 'this' with the same parameter types
+            //         int this[U x] { set{}}
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Extensions").WithLocation(18, 13)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_31_Indexers(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[])
+    {
+        int this[T x] => default;
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver)
+    {
+#line 18
+        [System.Runtime.CompilerServices.IndexerName(""NotItem"")]
+        int this[int x] { set{}}
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        // PROTOTYPE: The "within a type" part of the message might be somewhat misleading
+        comp.VerifyDiagnostics(
+            // (19,13): error CS0668: Two indexers have different names; the IndexerName attribute must be used with the same name on every indexer within a type
+            //         int this[int x] { set{}}
+            Diagnostic(ErrorCode.ERR_InconsistentIndexerNames, "this").WithLocation(19, 13)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_32_Properties(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[])
+    {
+        T P => default;
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver)
+    {
+#line 18
+        void P(U x) {}
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (18,14): error CS0102: The type 'Extensions' already contains a definition for 'P'
+            //         void P(U x) {}
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "P").WithArguments("Extensions", "P").WithLocation(18, 14)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_33_Properties(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[])
+    {
+#line 8
+        T P => default;
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver)
+    {
+        static void set_P(U x) {}
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (8,11): error CS0082: Type 'Extensions' already reserves a member called 'set_P' with the same parameter types
+            //         T P => default;
+            Diagnostic(ErrorCode.ERR_MemberReserved, "P").WithArguments("set_P", "Extensions").WithLocation(8, 11)
+            );
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void MemberNameAndSignatureConflict_34_Properties(bool insertAtTheBeginning)
+    {
+        var insert = """
+    extension<S>(S[])
+    {
+        static void M1(int z) {}
+    }
+""";
+
+        var src = @"
+public static class Extensions
+{
+" + (insertAtTheBeginning ? insert : "") + @"
+
+    extension<T>(T[])
+    {
+#line 8
+        T P => default;
+    }
+
+" + (!insertAtTheBeginning ? insert : "") + @"
+
+    extension<U>(U[] receiver)
+    {
+        U[] get_P => null;
+    }
+}
+";
+        var comp = CreateCompilation(src);
+
+        comp.VerifyDiagnostics(
+            // (8,16): error CS0102: The type 'Extensions' already contains a definition for 'get_P'
+            //         T P => default;
+            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "default").WithArguments("Extensions", "get_P").WithLocation(8, 16)
             );
     }
 
@@ -26213,12 +26821,15 @@ static class E
         var src = """
 System.Console.Write(42.P);
 
-static class E
+static class E1
 {
     extension(int i)
     {
         public int P => 42;
     }
+}
+static class E2
+{
     extension(in int i)
     {
         public int P => throw null;
@@ -26232,7 +26843,7 @@ static class E
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.P");
-        Assert.Equal("System.Int32 E.<>E__0.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal("System.Int32 E1.<>E__0.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
     }
 
@@ -27492,14 +28103,16 @@ public static class E
     public void LookupSymbols_StaticAndInstance()
     {
         var src = """
-
-public static class E
+public static class E1
 {
     extension(object)
     {
         public static void M() => throw null;
         public static int Property => throw null;
     }
+}
+public static class E2
+{
     extension(object)
     {
         public void M() => throw null;
@@ -27515,17 +28128,17 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertEqualAndNoDuplicates(["void E.<>E__0.M()", "void E.<>E__1.M()"],
+        AssertEqualAndNoDuplicates(["void E1.<>E__0.M()", "void E2.<>E__0.M()"],
             model.LookupSymbols(position: 0, o, name: "M", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertEqualAndNoDuplicates(["System.Int32 E.<>E__0.Property { get; }", "System.Int32 E.<>E__1.Property { get; }"],
+        AssertEqualAndNoDuplicates(["System.Int32 E1.<>E__0.Property { get; }", "System.Int32 E2.<>E__0.Property { get; }"],
             model.LookupSymbols(position: 0, o, name: "Property", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
         AssertEqualAndNoDuplicates([
-            "void E.<>E__0.M()",
-            "System.Int32 E.<>E__0.Property { get; }",
-            "void E.<>E__1.M()",
-            "System.Int32 E.<>E__1.Property { get; }",
+            "void E1.<>E__0.M()",
+            "System.Int32 E1.<>E__0.Property { get; }",
+            "void E2.<>E__0.M()",
+            "System.Int32 E2.<>E__0.Property { get; }",
             .. _objectMembers], model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
@@ -27533,13 +28146,15 @@ public static class E
     public void LookupSymbols_MethodAndProperty()
     {
         var src = """
-
-public static class E
+public static class E1
 {
     extension(object)
     {
         public static void MP() => throw null;
     }
+}
+public static class E2
+{
     extension(object)
     {
         public int MP => throw null;
@@ -27554,10 +28169,10 @@ public static class E
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
-        AssertEqualAndNoDuplicates(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }"],
+        AssertEqualAndNoDuplicates(["void E1.<>E__0.MP()", "System.Int32 E2.<>E__0.MP { get; }"],
             model.LookupSymbols(position: 0, o, name: "MP", includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertEqualAndNoDuplicates(["void E.<>E__0.MP()", "System.Int32 E.<>E__1.MP { get; }", .. _objectMembers],
+        AssertEqualAndNoDuplicates(["void E1.<>E__0.MP()", "System.Int32 E2.<>E__0.MP { get; }", .. _objectMembers],
             model.LookupSymbols(position: 0, o, name: null, includeReducedExtensionMethods: true).ToTestDisplayStrings());
     }
 
@@ -28085,13 +28700,16 @@ static class E2
 int i = object.P;
 System.Console.Write(i);
 
-static class E
+static class E1
 {
     extension<T>(T) where T : struct
     {
         public static void P() { }
     }
+}
 
+static class E2
+{
     extension<T>(T) where T : class
     {
         public static int P => 42;
@@ -28104,7 +28722,7 @@ static class E
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "object.P");
-        Assert.Equal("System.Int32 E.<>E__1<System.Object>.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal("System.Int32 E2.<>E__0<System.Object>.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
         Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE handle GetMemberGroup on a property access
     }


### PR DESCRIPTION
Implements the following rule from the spec:
"Within a given enclosing static class, the set of extension member declarations with the same receiver type (modulo identity conversion and type parameter name substitution) are treated as a single declaration space similar to the members within a class or struct declaration, and are subject to the same rules about uniqueness."

Relates to test plan https://github.com/dotnet/roslyn/issues/76130