### PR TITLE
Make things more strongly typed in compilation tracker

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker.cs
@@ -118,11 +118,14 @@ namespace Microsoft.CodeAnalysis
                 return finalState.RootedSymbolSet.ContainsAssemblyOrModuleOrDynamic(symbol, primary, out compilation, out referencedThrough);
             }
 
+            ICompilationTracker ICompilationTracker.Fork(ProjectState newProjectState, TranslationAction? translate)
+                => Fork(newProjectState, translate);
+
             /// <summary>
             /// Creates a new instance of the compilation info, retaining any already built
             /// compilation state as the now 'old' state
             /// </summary>
-            public ICompilationTracker Fork(
+            public RegularCompilationTracker Fork(
                 ProjectState newProjectState,
                 TranslationAction? translate)
             {
@@ -680,7 +683,10 @@ namespace Microsoft.CodeAnalysis
                 return finalState.HasSuccessfullyLoaded;
             }
 
-            public ICompilationTracker WithCreateCreationPolicy(bool forceRegeneration)
+            ICompilationTracker ICompilationTracker.WithCreateCreationPolicy(bool forceRegeneration)
+                => WithCreateCreationPolicy(forceRegeneration);
+
+            public RegularCompilationTracker WithCreateCreationPolicy(bool forceRegeneration)
             {
                 var state = this.ReadState();
 
@@ -736,7 +742,10 @@ namespace Microsoft.CodeAnalysis
                     skeletonReferenceCacheToClone: _skeletonReferenceCache);
             }
 
-            public ICompilationTracker WithDoNotCreateCreationPolicy()
+            ICompilationTracker ICompilationTracker.WithDoNotCreateCreationPolicy()
+                => WithDoNotCreateCreationPolicy();
+
+            public RegularCompilationTracker WithDoNotCreateCreationPolicy()
             {
                 var state = this.ReadState();
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.WithFrozenSourceGeneratedDocumentsCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.WithFrozenSourceGeneratedDocumentsCompilationTracker.cs
@@ -35,7 +35,7 @@ internal sealed partial class SolutionCompilationState
         [DisallowNull]
         private Compilation? _compilationWithReplacements;
 
-        public ICompilationTracker UnderlyingTracker { get; }
+        public RegularCompilationTracker UnderlyingTracker { get; }
         public ProjectState ProjectState => UnderlyingTracker.ProjectState;
 
         public GeneratorDriver? GeneratorDriver => UnderlyingTracker.GeneratorDriver;
@@ -46,7 +46,7 @@ internal sealed partial class SolutionCompilationState
         private SkeletonReferenceCache _skeletonReferenceCache;
 
         public WithFrozenSourceGeneratedDocumentsCompilationTracker(
-            ICompilationTracker underlyingTracker,
+            RegularCompilationTracker underlyingTracker,
             TextDocumentStates<SourceGeneratedDocumentState> replacementDocumentStates)
         {
             this.UnderlyingTracker = underlyingTracker;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1385,7 +1385,12 @@ internal sealed partial class SolutionCompilationState
                         existingTracker = CreateCompilationTracker(projectId, arg.SolutionState);
                     }
 
-                    trackerMap[projectId] = new WithFrozenSourceGeneratedDocumentsCompilationTracker(existingTracker, new(documentStatesForProject));
+                    // We should never be wrapping a WithFrozenSourceGeneratedDocumentsCompilationTracker with another
+                    // WithFrozenSourceGeneratedDocumentsCompilationTracker.  If we do, that's a straight bug that
+                    // should fail immediately.  So blind casting is here is appropriate.
+                    var regularCompilationTracker = (RegularCompilationTracker)existingTracker;
+                    trackerMap[projectId] = new WithFrozenSourceGeneratedDocumentsCompilationTracker(
+                        regularCompilationTracker, new(documentStatesForProject));
                 }
             },
             (documentStatesByProjectId, this.SolutionState),


### PR DESCRIPTION
Something noticed while reviewing the Razor forking work that David is doing.