### PR TITLE
Move the construction cost of SettingsEditorFactory to when it's used

### DIFF
--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
@@ -3,14 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
@@ -21,45 +20,23 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings;
 
-[Export(typeof(SettingsEditorFactory))]
 [Guid(SettingsEditorFactoryGuidString)]
-internal sealed class SettingsEditorFactory : IVsEditorFactory, IVsEditorFactory4, IDisposable
+internal sealed class SettingsEditorFactory(IComponentModel componentModel) : IVsEditorFactory, IVsEditorFactory4
 {
+    private static SettingsEditorFactory? s_instance;
+
     public static readonly Guid SettingsEditorFactoryGuid = new(SettingsEditorFactoryGuidString);
     public const string SettingsEditorFactoryGuidString = "68b46364-d378-42f2-9e72-37d86c5f4468";
     public const string Extension = ".editorconfig";
 
-    private readonly ISettingsAggregator _settingsDataProviderFactory;
-    private readonly VisualStudioWorkspace _workspace;
-    private readonly IWpfTableControlProvider _controlProvider;
-    private readonly ITableManagerProvider _tableMangerProvider;
-    private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
-    private readonly IThreadingContext _threadingContext;
+    private readonly IComponentModel _componentModel = componentModel;
     private ServiceProvider? _vsServiceProvider;
 
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public SettingsEditorFactory(VisualStudioWorkspace workspace,
-                                 IWpfTableControlProvider controlProvider,
-                                 ITableManagerProvider tableMangerProvider,
-                                 IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
-                                 IThreadingContext threadingContext)
+    public static SettingsEditorFactory GetInstance(IComponentModel componentModel)
     {
-        _settingsDataProviderFactory = workspace.Services.GetRequiredService<ISettingsAggregator>();
-        _workspace = workspace;
-        _controlProvider = controlProvider;
-        _tableMangerProvider = tableMangerProvider;
-        _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
-        _threadingContext = threadingContext;
-    }
+        s_instance ??= new SettingsEditorFactory(componentModel);
 
-    public void Dispose()
-    {
-        if (_vsServiceProvider is not null)
-        {
-            _vsServiceProvider.Dispose();
-            _vsServiceProvider = null;
-        }
+        return s_instance;
     }
 
     public int CreateEditorInstance(uint grfCreateDoc,
@@ -81,14 +58,15 @@ internal sealed class SettingsEditorFactory : IVsEditorFactory, IVsEditorFactory
         pgrfCDW = 0;
         pbstrEditorCaption = null;
 
-        if (!_workspace.CurrentSolution.Projects.Any(p => p.Language is LanguageNames.CSharp or LanguageNames.VisualBasic))
+        var workspace = _componentModel.GetService<VisualStudioWorkspace>();
+        if (!workspace.CurrentSolution.Projects.Any(p => p.Language is LanguageNames.CSharp or LanguageNames.VisualBasic))
         {
             // If there are no VB or C# projects loaded in the solution (so an editorconfig file in a C++ project) then we want their
             // editorfactory to present the file instead of use showing ours
             return VSConstants.VS_E_UNSUPPORTEDFORMAT;
         }
 
-        if (!_workspace.CurrentSolution.Projects.Any(p => p.AnalyzerConfigDocuments.Any(editorconfig => StringComparer.OrdinalIgnoreCase.Equals(editorconfig.FilePath, filePath))))
+        if (!workspace.CurrentSolution.Projects.Any(p => p.AnalyzerConfigDocuments.Any(editorconfig => StringComparer.OrdinalIgnoreCase.Equals(editorconfig.FilePath, filePath))))
         {
             // If the user is simply opening an editorconfig file that does not apply to the current solution we just want to show the text view
             return VSConstants.VS_E_UNSUPPORTEDFORMAT;
@@ -100,11 +78,12 @@ internal sealed class SettingsEditorFactory : IVsEditorFactory, IVsEditorFactory
             return VSConstants.E_INVALIDARG;
         }
 
+        var threadingContext = _componentModel.GetService<IThreadingContext>();
         IVsTextLines? textBuffer = null;
         if (punkDocDataExisting == IntPtr.Zero)
         {
             Assumes.NotNull(_vsServiceProvider);
-            if (_vsServiceProvider.TryGetService<SLocalRegistry, ILocalRegistry>(_threadingContext.JoinableTaskFactory, out var localRegistry))
+            if (_vsServiceProvider.TryGetService<SLocalRegistry, ILocalRegistry>(threadingContext.JoinableTaskFactory, out var localRegistry))
             {
                 var textLinesGuid = typeof(IVsTextLines).GUID;
                 _ = localRegistry.CreateInstance(typeof(VsTextBufferClass).GUID, null, ref textLinesGuid, 1 /*CLSCTX_INPROC_SERVER*/, out var ptr);
@@ -119,7 +98,7 @@ internal sealed class SettingsEditorFactory : IVsEditorFactory, IVsEditorFactory
 
                 if (textBuffer is IObjectWithSite objectWithSite)
                 {
-                    var oleServiceProvider = _vsServiceProvider.GetService<IOleServiceProvider>(_threadingContext.JoinableTaskFactory);
+                    var oleServiceProvider = _vsServiceProvider.GetService<IOleServiceProvider>(threadingContext.JoinableTaskFactory);
                     objectWithSite.SetSite(oleServiceProvider);
                 }
             }
@@ -138,15 +117,20 @@ internal sealed class SettingsEditorFactory : IVsEditorFactory, IVsEditorFactory
             throw new InvalidOperationException("unable to acquire text buffer");
         }
 
+        var settingsDataProviderFactory = workspace.Services.GetRequiredService<ISettingsAggregator>();
+        var tableManagerProvider = _componentModel.GetService<ITableManagerProvider>();
+        var controlProvider = _componentModel.GetService<IWpfTableControlProvider>();
+        var vsEditorAdaptersFactoryService = _componentModel.GetService<IVsEditorAdaptersFactoryService>();
+
         // Create the editor
-        var newEditor = new SettingsEditorPane(_vsEditorAdaptersFactoryService,
-                                               _threadingContext,
-                                               _settingsDataProviderFactory,
-                                               _controlProvider,
-                                               _tableMangerProvider,
+        var newEditor = new SettingsEditorPane(vsEditorAdaptersFactoryService,
+                                               threadingContext,
+                                               settingsDataProviderFactory,
+                                               controlProvider,
+                                               tableManagerProvider,
                                                filePath,
                                                textBuffer,
-                                               _workspace);
+                                               workspace);
         ppunkDocView = Marshal.GetIUnknownForObject(newEditor);
         ppunkDocData = Marshal.GetIUnknownForObject(textBuffer);
         pbstrEditorCaption = "";
@@ -155,6 +139,7 @@ internal sealed class SettingsEditorFactory : IVsEditorFactory, IVsEditorFactory
 
     public int SetSite(IOleServiceProvider psp)
     {
+        // We don't dispose this (as we aren't disposable), but that's fine as it's disposer only clears a field.
         _vsServiceProvider = new ServiceProvider(psp);
         return VSConstants.S_OK;
     }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -88,7 +88,7 @@ internal sealed class RoslynPackage : AbstractPackage
 
         Task PackageInitializationMainThreadAsync(PackageLoadTasks packageInitializationTasks, CancellationToken cancellationToken)
         {
-            var settingsEditorFactory = SettingsEditorFactory.GetInstance(this.ComponentModel);
+            var settingsEditorFactory = SettingsEditorFactory.GetInstance();
             RegisterEditorFactory(settingsEditorFactory);
 
             return Task.CompletedTask;


### PR DESCRIPTION
SettingsEditorFactory was noted in a previous PR as having it's construction and registration separated across threads, having it's construction occur on a background thread due to it's cost. However, all of the data MEF imported by the ctor isn't used until it's CreateEditorInstance method is called, and can thus be deferred until then.

Note that I also moved this to be a singleton exposed through a static method rather than through MEF. I originally coded this to just change all the MEF ctor params to be lazy, but this still showed up as 4 ms of cost (which was an improvement over the 22 ms of cost without using lazys) over multiple runs of release bits. Instead, just putting it into a static had a 0 ms cost over multiple runs.

Also:
1) Got rid of an Assumes.Present as MEF will have already thrown before that point
2) Got rid of some Contract.Throws that were checking things that the containing method would never do.