### PR TITLE
Fix multi-threaded bug in compilations in MONO.

### DIFF
--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/MonoGlobalAssemblyCache.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/MonoGlobalAssemblyCache.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Roslyn.Utilities;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis
 {


### PR DESCRIPTION
Fix multi-threaded bug in compilations in MONO.(Script.CreateDelegate)

```
0x00007FF827E1AB6A (KERNELBASE) RaiseException
0x00007FFF69CB0C1C (mono-2.0-bdwgc) [X\mono\mono\utils\mono-log-common.c:143] mono_log_write_logfile 
0x00007FFF69C9C822 (mono-2.0-bdwgc) [X\mono\mono\eglib\goutput.c:172] monoeg_g_logv_nofree 
0x00007FFF69C9C888 (mono-2.0-bdwgc) [X\mono\mono\eglib\goutput.c:187] monoeg_g_log 
0x00007FFF69D8C1E7 (mono-2.0-bdwgc) [X\mono\mono\metadata\image.c:1632] mono_image_storage_tryaddref 
0x00007FFF69D8C4B8 (mono-2.0-bdwgc) [X\mono\mono\metadata\image.c:1697] mono_image_storage_open 
0x00007FFF69D8C8BB (mono-2.0-bdwgc) [X\mono\mono\metadata\image.c:1777] do_mono_image_open 
0x00007FFF69D4BBFB (mono-2.0-bdwgc) [X\mono\mono\metadata\icall.c:6209] ves_icall_System_Reflection_Assembly_InternalGetAssemblyName 
0x00007FFF69D652E0 (mono-2.0-bdwgc) [X\mono\mono\metadata\icall-def.h:608] ves_icall_System_Reflection_Assembly_InternalGetAssemblyName_raw 
0x0000021F5FB8E2E6 (Mono JIT Code) (wrapper managed-to-native) System.Reflection.Assembly:InternalGetAssemblyName (string,Mono.MonoAssemblyName&,string&)
0x0000021F5FB8E00B (Mono JIT Code) System.Reflection.AssemblyName:GetAssemblyName (string)
0x0000021F5FB8DD73 (Mono JIT Code) Microsoft.CodeAnalysis.MonoGlobalAssemblyCache:CreateAssemblyNameFromFile (string)
0x0000021F5FB84AE3 (Mono JIT Code) Microsoft.CodeAnalysis.MonoGlobalAssemblyCache:ResolvePartialName (string,string&,System.Collections.Immutable.ImmutableArray`1<System.Reflection.ProcessorArchitecture>,System.Globalization.CultureInfo)
0x0000021F5FB83AB2 (Mono JIT Code) Microsoft.CodeAnalysis.Scripting.Hosting.GacFileResolver:Resolve (string)
0x0000021F5FB7C03B (Mono JIT Code) Microsoft.CodeAnalysis.Scripting.Hosting.RuntimeMetadataReferenceResolver:ResolveMissingAssembly (Microsoft.CodeAnalysis.MetadataReference,Microsoft.CodeAnalysis.AssemblyIdentity)
0x0000021F5FB7BE1E (Mono JIT Code) Microsoft.CodeAnalysis.Scripting.ScriptMetadataResolver:ResolveMissingAssembly (Microsoft.CodeAnalysis.MetadataReference,Microsoft.CodeAnalysis.AssemblyIdentity)
0x0000021F5FB78E44 (Mono JIT Code) Microsoft.CodeAnalysis.CommonReferenceManager`2<TCompilation_REF, TAssemblySymbol_REF>:TryResolveMissingReference 
```
