### PR TITLE
Change SVsBrokeredServiceContainer retrieval to not use RoslynServiceExtensions

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -83,7 +83,7 @@ internal sealed class RoslynPackage : AbstractPackage
 
         Task PackageInitializationBackgroundThreadAsync(PackageLoadTasks packageInitializationTasks, CancellationToken cancellationToken)
         {
-            return ProfferServiceBrokerServicesAsync();
+            return ProfferServiceBrokerServicesAsync(cancellationToken);
         }
 
         Task PackageInitializationMainThreadAsync(PackageLoadTasks packageInitializationTasks, CancellationToken cancellationToken)
@@ -130,12 +130,12 @@ internal sealed class RoslynPackage : AbstractPackage
         }
     }
 
-    private async Task ProfferServiceBrokerServicesAsync()
+    private async Task ProfferServiceBrokerServicesAsync(CancellationToken cancellationToken)
     {
         // Proffer in-process service broker services
-        var serviceBrokerContainer = await this.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(this.JoinableTaskFactory).ConfigureAwait(false);
+        var serviceBrokerContainer = await this.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(throwOnFailure: true, cancellationToken).ConfigureAwait(false);
 
-        serviceBrokerContainer.Proffer(
+        serviceBrokerContainer!.Proffer(
             WorkspaceProjectFactoryServiceDescriptor.ServiceDescriptor,
             (_, _, _, _) => ValueTaskFactory.FromResult<object?>(new WorkspaceProjectFactoryService(this.ComponentModel.GetService<IWorkspaceProjectContextFactory>())));
 


### PR DESCRIPTION
Use of this RoslynServiceExtensions.GetServiceAsync forces a main thread switch, even when not necessary. Instead, as we're in an AsyncPackage derived class, we can use the base class's GetServiceAsync method which doesn't do the main thread switch unless the requested interface requires it.