### PR TITLE
Do not allow System.CommandLine to swallow all unhandled exceptions in LSP server

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -312,7 +312,7 @@ static CliConfiguration CreateCommandLineParser()
 
     var config = new CliConfiguration(rootCommand)
     {
-        // By default, SCI will catch all exceptions, log them to the console, and return a non-zero exit code.
+        // By default, System.CommandLine will catch all exceptions, log them to the console, and return a non-zero exit code.
         // Unfortunately this makes .NET's crash dump collection environment variables (e.g. 'DOTNET_DbgEnableMiniDump')
         // entirely useless as it never detects an actual crash.  Disable this behavior so we can collect crash dumps when asked to.
         EnableDefaultExceptionHandler = false

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -312,6 +312,9 @@ static CliConfiguration CreateCommandLineParser()
 
     var config = new CliConfiguration(rootCommand)
     {
+        // By default, SCI will catch all exceptions, log them to the console, and return a non-zero exit code.
+        // Unfortunately this makes .NET's crash dump collection environment variables (e.g. 'DOTNET_DbgEnableMiniDump')
+        // entirely useless as it never detects an actual crash.  Disable this behavior so we can collect crash dumps when asked to.
         EnableDefaultExceptionHandler = false
     };
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -181,7 +181,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     }
 }
 
-static CliRootCommand CreateCommandLineParser()
+static CliConfiguration CreateCommandLineParser()
 {
     var debugOption = new CliOption<bool>("--debug")
     {
@@ -277,6 +277,7 @@ static CliRootCommand CreateCommandLineParser()
         serverPipeNameOption,
         useStdIoOption
     };
+
     rootCommand.SetAction((parseResult, cancellationToken) =>
     {
         var launchDebugger = parseResult.GetValue(debugOption);
@@ -308,7 +309,13 @@ static CliRootCommand CreateCommandLineParser()
 
         return RunAsync(serverConfiguration, cancellationToken);
     });
-    return rootCommand;
+
+    var config = new CliConfiguration(rootCommand)
+    {
+        EnableDefaultExceptionHandler = false
+    };
+
+    return config;
 }
 
 static (string clientPipe, string serverPipe) CreateNewPipeNames()


### PR DESCRIPTION
By default, System.CommandLine will handle all exceptions, print the stack trace, then return a non-zero exit code.  See https://github.com/dotnet/command-line-api/issues/796

Unfortunately, this makes all [dump collection environment variables](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/collect-dumps-crash) mostly useless, as it never detects a process crash.  Instead we can tell SCI to not handle exceptions.  Stack traces still get reported to stderr (and therefore in VSCode logs), but we also can get dumps for them (with our built-in dump collection option).

![image](https://github.com/user-attachments/assets/3d78c1b6-3d23-40ed-920b-bcddb4ef9274)
