### PR TITLE
Collection expression arguments: parse `with()` based on language version

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
@@ -292,6 +292,25 @@ unsafe record struct R(
 }
 ```
 
+## `with()` as a collection expression element is treated as collection *arguments*
+
+***Introduced in Visual Studio 2022 version 17.14***
+
+`with(...)` when used as an element in a collection expression is bound as arguments passed to constructor or
+factory method used to create the collection, rather than as an invocation expression of a method named `with`.
+
+To bind to a method named `with`, use `@with` instead.
+
+```cs
+object x, y, z = ...;
+object[] items;
+
+items = [with(x, y), z];  // C#13: call to with() method; C#14: error args not supported for object[]
+items = [@with(x, y), z]; // call to with() method
+
+object with(object a, object b) { ... }
+```
+
 ## Emitting metadata-only executables requires an entrypoint
 
 ***Introduced in Visual Studio 2022 version 17.14***

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -12760,10 +12760,13 @@ done:
 
         private CollectionElementSyntax ParseCollectionElement()
         {
-            // PROTOTYPE: This is technically a breaking change.  Ensure this is discussed with LDM and we codify any
-            // desired outcome.  If we decide on a breaking change, add to documentation.
-            if (this.CurrentToken.ContextualKind == SyntaxKind.WithKeyword && this.PeekToken(1).Kind == SyntaxKind.OpenParenToken)
+            if (this.CurrentToken.ContextualKind == SyntaxKind.WithKeyword &&
+                this.PeekToken(1).Kind == SyntaxKind.OpenParenToken &&
+                IsFeatureEnabled(MessageID.IDS_FeatureCollectionExpressionArguments))
+            {
+                // PROTOTYPE: Document breaking change.
                 return _syntaxFactory.WithElement(this.EatContextualToken(SyntaxKind.WithKeyword), this.ParseParenthesizedArgumentList());
+            }
 
             if (this.IsAtDotDotToken())
                 return _syntaxFactory.SpreadElement(this.EatDotDotToken(), this.ParseExpressionCore());

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -12764,7 +12764,6 @@ done:
                 this.PeekToken(1).Kind == SyntaxKind.OpenParenToken &&
                 IsFeatureEnabled(MessageID.IDS_FeatureCollectionExpressionArguments))
             {
-                // PROTOTYPE: Document breaking change.
                 return _syntaxFactory.WithElement(this.EatContextualToken(SyntaxKind.WithKeyword), this.ParseParenthesizedArgumentList());
             }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionArgumentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionArgumentTests.cs
@@ -32,9 +32,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             if (languageVersion == LanguageVersion.CSharp13)
             {
                 comp.VerifyEmitDiagnostics(
-                    // (1,12): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // (1,12): error CS0103: The name 'with' does not exist in the current context
                     // int[] a = [with()];
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(1, 12));
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(1, 12));
             }
             else
             {
@@ -54,18 +54,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             if (languageVersion == LanguageVersion.CSharp13)
             {
                 comp.VerifyEmitDiagnostics(
-                    // (2,19): error CS9275: Collection argument element must be the first element.
+                    // (2,19): error CS0103: The name 'with' does not exist in the current context
                     // List<int> l = [1, with(), 3, with(capacity: 4)];
-                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 19),
-                    // (2,19): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 19),
+                    // (2,30): error CS0103: The name 'with' does not exist in the current context
                     // List<int> l = [1, with(), 3, with(capacity: 4)];
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(2, 19),
-                    // (2,30): error CS9275: Collection argument element must be the first element.
-                    // List<int> l = [1, with(), 3, with(capacity: 4)];
-                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 30),
-                    // (2,30): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    // List<int> l = [1, with(), 3, with(capacity: 4)];
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(2, 30));
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 30));
             }
             else
             {
@@ -91,21 +85,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             if (languageVersion == LanguageVersion.CSharp13)
             {
                 comp.VerifyEmitDiagnostics(
-                    // (2,16): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // (2,16): error CS0103: The name 'with' does not exist in the current context
                     // List<int> l = [with(x: 1), with(y: 2)];
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(2, 16),
-                    // (2,21): error CS1739: The best overload for 'List' does not have a parameter named 'x'
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 16),
+                    // (2,28): error CS0103: The name 'with' does not exist in the current context
                     // List<int> l = [with(x: 1), with(y: 2)];
-                    Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("List", "x").WithLocation(2, 21),
-                    // (2,28): error CS9275: Collection argument element must be the first element.
-                    // List<int> l = [with(x: 1), with(y: 2)];
-                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 28),
-                    // (2,28): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    // List<int> l = [with(x: 1), with(y: 2)];
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(2, 28),
-                    // (2,33): error CS1739: The best overload for 'List' does not have a parameter named 'y'
-                    // List<int> l = [with(x: 1), with(y: 2)];
-                    Diagnostic(ErrorCode.ERR_BadNamedArgument, "y").WithArguments("List", "y").WithLocation(2, 33));
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 28));
             }
             else
             {
@@ -155,24 +140,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             if (languageVersion == LanguageVersion.CSharp13)
             {
                 comp.VerifyEmitDiagnostics(
-                    // (2,5): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // (2,5): error CS0103: The name 'with' does not exist in the current context
                     //     with(),
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(2, 5),
-                    // (3,5): error CS9275: Collection argument element must be the first element.
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 5),
+                    // (3,5): error CS0103: The name 'with' does not exist in the current context
                     //     with(arg: 0),
-                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(3, 5),
-                    // (3,5): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    //     with(arg: 0),
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(3, 5),
-                    // (4,5): error CS9275: Collection argument element must be the first element.
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(3, 5),
+                    // (4,5): error CS0103: The name 'with' does not exist in the current context
                     //     with(unknown: 1)];
-                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(4, 5),
-                    // (4,5): error CS8652: The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    //     with(unknown: 1)];
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "with").WithArguments("collection expression arguments").WithLocation(4, 5),
-                    // (4,10): error CS1739: The best overload for 'Create' does not have a parameter named 'unknown'
-                    //     with(unknown: 1)];
-                    Diagnostic(ErrorCode.ERR_BadNamedArgument, "unknown").WithArguments("Create", "unknown").WithLocation(4, 10));
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(4, 5));
             }
             else
             {
@@ -187,6 +163,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     //     with(unknown: 1)];
                     Diagnostic(ErrorCode.ERR_BadNamedArgument, "unknown").WithArguments("Create", "unknown").WithLocation(4, 10));
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersion_05(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                List<string> list;
+                list = [with(capacity: 1), "one"];
+                list.Report();
+                list = [@with(capacity: 2), "two"];
+                list.Report();
+                string with(int capacity) => $"with({capacity})";
+                """;
+            var verifier = CompileAndVerify([source, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: (languageVersion == LanguageVersion.CSharp13 ? "[with(1), one], [with(2), two], " : "[one], [with(2), two], "));
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionExpressionParsingTests.cs
@@ -18758,11 +18758,38 @@ class C
         }
         EOF();
     }
+}
 
-    [Fact]
-    public void NotWithElement1()
+public class CollectionArgumentsParsingTests : ParsingTests
+{
+    public CollectionArgumentsParsingTests(ITestOutputHelper output) : base(output)
     {
-        UsingExpression("[with]");
+    }
+
+    public static readonly TheoryData<LanguageVersion> CollectionArgumentsLanguageVersions = new([LanguageVersion.CSharp13, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
+
+    private void CollectionArgumentsOrInvocation(LanguageVersion languageVersion)
+    {
+        if (languageVersion > LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.WithElement);
+            N(SyntaxKind.WithKeyword);
+        }
+        else
+        {
+            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.InvocationExpression);
+            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.IdentifierToken, "with");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement1(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18779,10 +18806,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement2()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement2(LanguageVersion languageVersion)
     {
-        UsingExpression("[with: with]");
+        UsingExpression("[with: with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18804,10 +18833,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement3()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement3(LanguageVersion languageVersion)
     {
-        UsingExpression("[.. with]");
+        UsingExpression("[.. with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18825,10 +18856,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement4()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement4(LanguageVersion languageVersion)
     {
-        UsingExpression("[with + with]");
+        UsingExpression("[with + with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18853,10 +18886,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement5()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement5(LanguageVersion languageVersion)
     {
-        UsingExpression("[with.X]");
+        UsingExpression("[with.X]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18881,10 +18916,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement6()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement6(LanguageVersion languageVersion)
     {
-        UsingExpression("[with[X]]");
+        UsingExpression("[with[X]]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18916,10 +18953,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement7()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement7(LanguageVersion languageVersion)
     {
-        UsingExpression("[with ? with : with]");
+        UsingExpression("[with ? with : with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18949,10 +18988,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement8()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement8(LanguageVersion languageVersion)
     {
-        UsingExpression("[with?.with]");
+        UsingExpression("[with?.with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -18981,10 +19022,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement9()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement9(LanguageVersion languageVersion)
     {
-        UsingExpression("[with++]");
+        UsingExpression("[with++]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -19005,10 +19048,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement10()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement10(LanguageVersion languageVersion)
     {
         UsingExpression("[with)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,6): error CS1003: Syntax error, ',' expected
             // [with)]
             Diagnostic(ErrorCode.ERR_SyntaxError, ")").WithArguments(",").WithLocation(1, 6));
@@ -19028,10 +19073,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement11()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement11(LanguageVersion languageVersion)
     {
-        UsingExpression("[with..with]");
+        UsingExpression("[with..with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -19056,10 +19103,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement12()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement12(LanguageVersion languageVersion)
     {
-        UsingExpression("[with..with()]");
+        UsingExpression("[with..with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -19092,10 +19141,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement13()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement13(LanguageVersion languageVersion)
     {
-        UsingExpression("[@with()]");
+        UsingExpression("[@with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -19120,10 +19171,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement14()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement14(LanguageVersion languageVersion)
     {
-        UsingExpression("with()");
+        UsingExpression("with()",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.InvocationExpression);
         {
@@ -19140,10 +19193,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement15()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement15(LanguageVersion languageVersion)
     {
         UsingExpression("a with()",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,1): error CS1073: Unexpected token 'with'
             // a with()
             Diagnostic(ErrorCode.ERR_UnexpectedToken, "a").WithArguments("with").WithLocation(1, 1));
@@ -19155,10 +19210,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement16()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement16(LanguageVersion languageVersion)
     {
-        UsingExpression("[with()] a => b");
+        UsingExpression("[with()] a => b",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.SimpleLambdaExpression);
         {
@@ -19192,10 +19249,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement17()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement17(LanguageVersion languageVersion)
     {
-        UsingExpression("[with()] async a => b");
+        UsingExpression("[with()] async a => b",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.SimpleLambdaExpression);
         {
@@ -19230,10 +19289,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void NotWithElement18()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement18(LanguageVersion languageVersion)
     {
-        UsingExpression("[with()] (a) => b");
+        UsingExpression("[with()] (a) => b",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.ParenthesizedLambdaExpression);
         {
@@ -19272,10 +19333,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement1()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement1(LanguageVersion languageVersion)
     {
         UsingExpression("[with(]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,7): error CS1026: ) expected
             // [with(]
             Diagnostic(ErrorCode.ERR_CloseParenExpected, "]").WithLocation(1, 7),
@@ -19286,46 +19349,44 @@ class C
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    M(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                M(SyntaxKind.CloseParenToken);
             }
             M(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement2()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement2(LanguageVersion languageVersion)
     {
-        UsingExpression("[with()]");
+        UsingExpression("[with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement3()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement3(LanguageVersion languageVersion)
     {
         UsingExpression("[with(,)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,7): error CS0839: Argument missing
             // [with(,)]
             Diagnostic(ErrorCode.ERR_MissingArgument, ",").WithLocation(1, 7),
@@ -19336,271 +19397,260 @@ class C
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                M(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    M(SyntaxKind.Argument);
+                    M(SyntaxKind.IdentifierName);
                     {
-                        M(SyntaxKind.IdentifierName);
-                        {
-                            M(SyntaxKind.IdentifierToken);
-                        }
+                        M(SyntaxKind.IdentifierToken);
                     }
-                    N(SyntaxKind.CommaToken);
-                    M(SyntaxKind.Argument);
-                    {
-                        M(SyntaxKind.IdentifierName);
-                        {
-                            M(SyntaxKind.IdentifierToken);
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CommaToken);
+                M(SyntaxKind.Argument);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement4()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement4(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(a)]");
+        UsingExpression("[with(a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement5(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(ref a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement6(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(out a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.OutKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement7(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(out var a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.OutKeyword);
+                    N(SyntaxKind.DeclarationExpression);
                     {
                         N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "var");
+                        }
+                        N(SyntaxKind.SingleVariableDesignation);
                         {
                             N(SyntaxKind.IdentifierToken, "a");
                         }
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement5()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement8(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(ref a)]");
+        UsingExpression("[with(name: value)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.RefKeyword);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "a");
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement6()
-    {
-        UsingExpression("[with(out a)]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.OutKeyword);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "a");
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement7()
-    {
-        UsingExpression("[with(out var a)]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.OutKeyword);
-                        N(SyntaxKind.DeclarationExpression);
-                        {
-                            N(SyntaxKind.IdentifierName);
-                            {
-                                N(SyntaxKind.IdentifierToken, "var");
-                            }
-                            N(SyntaxKind.SingleVariableDesignation);
-                            {
-                                N(SyntaxKind.IdentifierToken, "a");
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement8()
-    {
-        UsingExpression("[with(name: value)]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.NameColon);
-                        {
-                            N(SyntaxKind.IdentifierName);
-                            {
-                                N(SyntaxKind.IdentifierToken, "name");
-                            }
-                            N(SyntaxKind.ColonToken);
-                        }
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "value");
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement9()
-    {
-        UsingExpression("[with(a, b)]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.NameColon);
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken, "a");
+                            N(SyntaxKind.IdentifierToken, "name");
                         }
+                        N(SyntaxKind.ColonToken);
                     }
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "b");
-                        }
+                        N(SyntaxKind.IdentifierToken, "value");
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement10()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement9(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(), with()]");
+        UsingExpression("[with(a, b)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
                 }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement10(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(), with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CommaToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement11()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement11(LanguageVersion languageVersion)
     {
-        UsingExpression("[a, with()]");
+        UsingExpression("[a, with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -19613,24 +19663,23 @@ class C
                 }
             }
             N(SyntaxKind.CommaToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement12()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement12(LanguageVersion languageVersion)
     {
-        UsingExpression("[a:b, with()]");
+        UsingExpression("[a:b, with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -19648,24 +19697,23 @@ class C
                 }
             }
             N(SyntaxKind.CommaToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement13()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement13(LanguageVersion languageVersion)
     {
-        UsingExpression("[..a, with()]");
+        UsingExpression("[..a, with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -19679,36 +19727,32 @@ class C
                 }
             }
             N(SyntaxKind.CommaToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement14()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement14(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(), a]");
+        UsingExpression("[with(), a]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CommaToken);
             N(SyntaxKind.ExpressionElement);
@@ -19723,22 +19767,21 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement15()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement15(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(), a:b]");
+        UsingExpression("[with(), a:b]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CommaToken);
             N(SyntaxKind.KeyValuePairElement);
@@ -19758,22 +19801,21 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement16()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement16(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(), ..a]");
+        UsingExpression("[with(), ..a]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CommaToken);
             N(SyntaxKind.SpreadElement);
@@ -19789,459 +19831,534 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement17()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement17(LanguageVersion languageVersion)
     {
-        UsingExpression("[with([])]");
+        UsingExpression("[with([])]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.CollectionExpression);
                     {
-                        N(SyntaxKind.CollectionExpression);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.CloseBracketToken);
-                        }
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.CloseBracketToken);
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement18()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement18(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(() => {})]");
+        UsingExpression("[with(() => {})]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.ParenthesizedLambdaExpression);
                     {
-                        N(SyntaxKind.ParenthesizedLambdaExpression);
+                        N(SyntaxKind.ParameterList);
                         {
-                            N(SyntaxKind.ParameterList);
-                            {
-                                N(SyntaxKind.OpenParenToken);
-                                N(SyntaxKind.CloseParenToken);
-                            }
-                            N(SyntaxKind.EqualsGreaterThanToken);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
                         }
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement19()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement19(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(async () => {})]");
+        UsingExpression("[with(async () => {})]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.ParenthesizedLambdaExpression);
                     {
-                        N(SyntaxKind.ParenthesizedLambdaExpression);
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.ParameterList);
                         {
-                            N(SyntaxKind.AsyncKeyword);
-                            N(SyntaxKind.ParameterList);
-                            {
-                                N(SyntaxKind.OpenParenToken);
-                                N(SyntaxKind.CloseParenToken);
-                            }
-                            N(SyntaxKind.EqualsGreaterThanToken);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
                         }
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement20()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement20(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(from x in y select x)]");
+        UsingExpression("[with(from x in y select x)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.QueryExpression);
                     {
-                        N(SyntaxKind.QueryExpression);
+                        N(SyntaxKind.FromClause);
                         {
-                            N(SyntaxKind.FromClause);
+                            N(SyntaxKind.FromKeyword);
+                            N(SyntaxKind.IdentifierToken, "x");
+                            N(SyntaxKind.InKeyword);
+                            N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.FromKeyword);
-                                N(SyntaxKind.IdentifierToken, "x");
-                                N(SyntaxKind.InKeyword);
+                                N(SyntaxKind.IdentifierToken, "y");
+                            }
+                        }
+                        N(SyntaxKind.QueryBody);
+                        {
+                            N(SyntaxKind.SelectClause);
+                            {
+                                N(SyntaxKind.SelectKeyword);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "y");
-                                }
-                            }
-                            N(SyntaxKind.QueryBody);
-                            {
-                                N(SyntaxKind.SelectClause);
-                                {
-                                    N(SyntaxKind.SelectKeyword);
-                                    N(SyntaxKind.IdentifierName);
-                                    {
-                                        N(SyntaxKind.IdentifierToken, "x");
-                                    }
+                                    N(SyntaxKind.IdentifierToken, "x");
                                 }
                             }
                         }
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement21()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement21(LanguageVersion languageVersion)
     {
-        UsingExpression("[with([with()])]");
+        UsingExpression("[with([with()])]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.CollectionExpression);
                     {
-                        N(SyntaxKind.CollectionExpression);
+                        N(SyntaxKind.OpenBracketToken);
+                        CollectionArgumentsOrInvocation(languageVersion);
+                        N(SyntaxKind.ArgumentList);
                         {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.WithElement);
-                            {
-                                N(SyntaxKind.WithKeyword);
-                                N(SyntaxKind.ArgumentList);
-                                {
-                                    N(SyntaxKind.OpenParenToken);
-                                    N(SyntaxKind.CloseParenToken);
-                                }
-                            }
-                            N(SyntaxKind.CloseBracketToken);
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
                         }
                     }
-                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.CloseBracketToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement22()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement22(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(with: with)]");
+        UsingExpression("[with(with: with)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.NameColon);
                     {
-                        N(SyntaxKind.NameColon);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement23(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(out _)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.OutKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "_");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement24(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(in a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.InKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement25(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(name: ref a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.NameColon);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "name");
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement26(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(ref int () => { })]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.ParenthesizedLambdaExpression);
+                    {
+                        N(SyntaxKind.RefType);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                        }
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement27(LanguageVersion languageVersion)
+    {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with()..x]
+                Diagnostic(ErrorCode.ERR_SyntaxError, ".").WithArguments(",").WithLocation(1, 8)
+            };
+        UsingExpression("[with()..x]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
+
+        if (languageVersion == LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.RangeExpression);
+                    {
+                        N(SyntaxKind.InvocationExpression);
                         {
                             N(SyntaxKind.IdentifierName);
                             {
                                 N(SyntaxKind.IdentifierToken, "with");
                             }
-                            N(SyntaxKind.ColonToken);
-                        }
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "with");
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement23()
-    {
-        UsingExpression("[with(out _)]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.OutKeyword);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "_");
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement24()
-    {
-        UsingExpression("[with(in a)]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.InKeyword);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "a");
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement25()
-    {
-        UsingExpression("[with(name: ref a)]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.NameColon);
-                        {
-                            N(SyntaxKind.IdentifierName);
-                            {
-                                N(SyntaxKind.IdentifierToken, "name");
-                            }
-                            N(SyntaxKind.ColonToken);
-                        }
-                        N(SyntaxKind.RefKeyword);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "a");
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement26()
-    {
-        UsingExpression("[with(ref int () => { })]");
-
-        N(SyntaxKind.CollectionExpression);
-        {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
-            {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
-                    {
-                        N(SyntaxKind.ParenthesizedLambdaExpression);
-                        {
-                            N(SyntaxKind.RefType);
-                            {
-                                N(SyntaxKind.RefKeyword);
-                                N(SyntaxKind.PredefinedType);
-                                {
-                                    N(SyntaxKind.IntKeyword);
-                                }
-                            }
-                            N(SyntaxKind.ParameterList);
+                            N(SyntaxKind.ArgumentList);
                             {
                                 N(SyntaxKind.OpenParenToken);
                                 N(SyntaxKind.CloseParenToken);
                             }
-                            N(SyntaxKind.EqualsGreaterThanToken);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
+                        }
+                        N(SyntaxKind.DotDotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "x");
                         }
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseBracketToken);
             }
-            N(SyntaxKind.CloseBracketToken);
+            EOF();
         }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement27()
-    {
-        UsingExpression("[with()..x]",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // [with()..x]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ".").WithArguments(",").WithLocation(1, 8));
-
-        N(SyntaxKind.CollectionExpression);
+        else
         {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            N(SyntaxKind.CollectionExpression);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.SpreadElement);
-            {
-                N(SyntaxKind.DotDotToken);
-                N(SyntaxKind.IdentifierName);
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.SpreadElement);
                 {
-                    N(SyntaxKind.IdentifierToken, "x");
+                    N(SyntaxKind.DotDotToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
                 }
+                N(SyntaxKind.CloseBracketToken);
             }
-            N(SyntaxKind.CloseBracketToken);
+            EOF();
         }
-        EOF();
     }
 
-    [Fact]
-    public void WithElement28()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement28(LanguageVersion languageVersion)
     {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with().x]
+                Diagnostic(ErrorCode.ERR_SyntaxError, ".").WithArguments(",").WithLocation(1, 8),
+                // (1,9): error CS1003: Syntax error, ',' expected
+                // [with().x]
+                Diagnostic(ErrorCode.ERR_SyntaxError, "x").WithArguments(",").WithLocation(1, 9)
+            };
         UsingExpression("[with().x]",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // [with().x]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ".").WithArguments(",").WithLocation(1, 8),
-            // (1,9): error CS1003: Syntax error, ',' expected
-            // [with().x]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "x").WithArguments(",").WithLocation(1, 9));
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
 
-        N(SyntaxKind.CollectionExpression);
+        if (languageVersion == LanguageVersion.CSharp13)
         {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            N(SyntaxKind.CollectionExpression);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.SimpleMemberAccessExpression);
+                    {
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "with");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "x");
+                        }
+                    }
                 }
+                N(SyntaxKind.CloseBracketToken);
             }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "x");
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
+            EOF();
         }
-        EOF();
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
     }
 
-    [Fact]
-    public void WithElement29()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement29(LanguageVersion languageVersion)
     {
         UsingExpression("[with()",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,8): error CS1003: Syntax error, ']' expected
             // [with()
             Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(1, 8));
@@ -20249,24 +20366,23 @@ class C
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             M(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement30()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement30(LanguageVersion languageVersion)
     {
         UsingExpression("[with(),",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,9): error CS1003: Syntax error, ']' expected
             // [with(),
             Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(1, 9));
@@ -20274,14 +20390,11 @@ class C
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CommaToken);
             M(SyntaxKind.CloseBracketToken);
@@ -20289,39 +20402,40 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement31()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement31(LanguageVersion languageVersion)
     {
-        UsingExpression("[with(_)]");
+        UsingExpression("[with(_)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "_");
-                        }
+                        N(SyntaxKind.IdentifierToken, "_");
                     }
-                    N(SyntaxKind.CloseParenToken);
                 }
+                N(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
     }
 
-    [Fact]
-    public void WithElement32()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement32(LanguageVersion languageVersion)
     {
         UsingExpression("[with(a,)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,9): error CS1525: Invalid expression term ')'
             // [with(a,)]
             Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 9));
@@ -20329,18 +20443,15 @@ class C
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Argument);
+                    N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "a");
-                        }
+                        N(SyntaxKind.IdentifierToken, "a");
                     }
                     N(SyntaxKind.CommaToken);
                     M(SyntaxKind.Argument);
@@ -20358,10 +20469,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement33()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement33(LanguageVersion languageVersion)
     {
         UsingExpression("[with(,a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (1,7): error CS0839: Argument missing
             // [with(,a)]
             Diagnostic(ErrorCode.ERR_MissingArgument, ",").WithLocation(1, 7));
@@ -20369,18 +20482,15 @@ class C
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenParenToken);
+                M(SyntaxKind.Argument);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    M(SyntaxKind.Argument);
+                    M(SyntaxKind.IdentifierName);
                     {
-                        M(SyntaxKind.IdentifierName);
-                        {
-                            M(SyntaxKind.IdentifierToken);
-                        }
+                        M(SyntaxKind.IdentifierToken);
                     }
                     N(SyntaxKind.CommaToken);
                     N(SyntaxKind.Argument);
@@ -20398,51 +20508,93 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement34()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement34(LanguageVersion languageVersion)
     {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with():y]
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 8),
+                // (1,8): error CS1525: Invalid expression term ':'
+                // [with():y]
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 8)
+            };
         UsingExpression("[with():y]",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // [with():y]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 8),
-            // (1,8): error CS1525: Invalid expression term ':'
-            // [with():y]
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 8));
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
 
-        N(SyntaxKind.CollectionExpression);
+        if (languageVersion == LanguageVersion.CSharp13)
         {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            N(SyntaxKind.CollectionExpression);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.KeyValuePairElement);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.InvocationExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                    N(SyntaxKind.ColonToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
                 }
+                N(SyntaxKind.CloseBracketToken);
             }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.KeyValuePairElement);
-            {
-                M(SyntaxKind.IdentifierName);
-                {
-                    M(SyntaxKind.IdentifierToken);
-                }
-                N(SyntaxKind.ColonToken);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "y");
-                }
-            }
-            N(SyntaxKind.CloseBracketToken);
+            EOF();
         }
-        EOF();
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.KeyValuePairElement);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.ColonToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
     }
 
-    [Fact]
-    public void WithElement35()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement35(LanguageVersion languageVersion)
     {
-        UsingExpression("[x:with()]");
+        UsingExpression("[x:with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -20472,10 +20624,12 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement36()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement36(LanguageVersion languageVersion)
     {
-        UsingExpression("[..with()]");
+        UsingExpression("[..with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CollectionExpression);
         {
@@ -20501,89 +20655,179 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement37()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement37(LanguageVersion languageVersion)
     {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with()++]
+                Diagnostic(ErrorCode.ERR_SyntaxError, "++").WithArguments(",").WithLocation(1, 8),
+                // (1,10): error CS1525: Invalid expression term ']'
+                // [with()++]
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "]").WithArguments("]").WithLocation(1, 10),
+            };
         UsingExpression("[with()++]",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // [with()++]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "++").WithArguments(",").WithLocation(1, 8),
-            // (1,10): error CS1525: Invalid expression term ']'
-            // [with()++]
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "]").WithArguments("]").WithLocation(1, 10));
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
 
-        N(SyntaxKind.CollectionExpression);
+        if (languageVersion == LanguageVersion.CSharp13)
         {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            N(SyntaxKind.CollectionExpression);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
-                N(SyntaxKind.PreIncrementExpression);
-                {
-                    N(SyntaxKind.PlusPlusToken);
-                    M(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.PostIncrementExpression);
                     {
-                        M(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "with");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.PlusPlusToken);
                     }
                 }
+                N(SyntaxKind.CloseBracketToken);
             }
-            N(SyntaxKind.CloseBracketToken);
+            EOF();
         }
-        EOF();
-    }
-
-    [Fact]
-    public void WithElement38()
-    {
-        UsingExpression("[with()[0]]",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // [with()[0]]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "[").WithArguments(",").WithLocation(1, 8));
-
-        N(SyntaxKind.CollectionExpression);
+        else
         {
-            N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.WithElement);
+            N(SyntaxKind.CollectionExpression);
             {
-                N(SyntaxKind.WithKeyword);
-                N(SyntaxKind.ArgumentList);
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
-                }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
-                N(SyntaxKind.CollectionExpression);
-                {
-                    N(SyntaxKind.OpenBracketToken);
-                    N(SyntaxKind.ExpressionElement);
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
                     {
-                        N(SyntaxKind.NumericLiteralExpression);
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.PreIncrementExpression);
+                    {
+                        N(SyntaxKind.PlusPlusToken);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.NumericLiteralToken, "0");
+                            M(SyntaxKind.IdentifierToken);
                         }
                     }
-                    N(SyntaxKind.CloseBracketToken);
                 }
+                N(SyntaxKind.CloseBracketToken);
             }
-            N(SyntaxKind.CloseBracketToken);
+            EOF();
         }
-        EOF();
     }
 
-    [Fact]
-    public void WithElement39()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement38(LanguageVersion languageVersion)
+    {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with()[0]]
+                Diagnostic(ErrorCode.ERR_SyntaxError, "[").WithArguments(",").WithLocation(1, 8)
+            };
+        UsingExpression("[with()[0]]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
+
+        if (languageVersion == LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.ElementAccessExpression);
+                    {
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "with");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.BracketedArgumentList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.CollectionExpression);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.ExpressionElement);
+                        {
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "0");
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement39(LanguageVersion languageVersion)
     {
         UsingTree("""
             void M()
@@ -20591,6 +20835,7 @@ class C
                 var v = [await with()];
             }
             """,
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
             // (3,20): error CS1003: Syntax error, ',' expected
             //     var v = [await with()];
             Diagnostic(ErrorCode.ERR_SyntaxError, "with").WithArguments(",").WithLocation(3, 20));
@@ -20639,14 +20884,11 @@ class C
                                                 }
                                             }
                                             M(SyntaxKind.CommaToken);
-                                            N(SyntaxKind.WithElement);
+                                            CollectionArgumentsOrInvocation(languageVersion);
+                                            N(SyntaxKind.ArgumentList);
                                             {
-                                                N(SyntaxKind.WithKeyword);
-                                                N(SyntaxKind.ArgumentList);
-                                                {
-                                                    N(SyntaxKind.OpenParenToken);
-                                                    N(SyntaxKind.CloseParenToken);
-                                                }
+                                                N(SyntaxKind.OpenParenToken);
+                                                N(SyntaxKind.CloseParenToken);
                                             }
                                             N(SyntaxKind.CloseBracketToken);
                                         }
@@ -20664,15 +20906,17 @@ class C
         EOF();
     }
 
-    [Fact]
-    public void WithElement40()
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement40(LanguageVersion languageVersion)
     {
         UsingTree("""
             async void M()
             {
                 var v = [await with()];
             }
-            """);
+            """,
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.CompilationUnit);
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
@@ -526,7 +526,7 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
         await VerifyProviderCommitAsync(markup, "args:", expected, ':');
     }
 
-    [Theory]
+    [Theory(Skip = "PROTOTYPE: Collection arguments require language version preview")]
     [InlineData("IList<int>")]
     [InlineData("ICollection<int>")]
     public async Task TestMutableInterfaces(string type)
@@ -569,7 +569,7 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
         await VerifyItemIsAbsentAsync(markup, "capacity", displayTextSuffix: ":");
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
     public async Task TestConstructibleType1()
     {
         var markup = $$"""
@@ -589,7 +589,7 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
         await VerifyItemExistsAsync(markup, "collection", displayTextSuffix: ":");
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
     public async Task TestConstructibleType2()
     {
         var markup = $$"""
@@ -609,7 +609,7 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
         await VerifyItemExistsAsync(markup, "collection", displayTextSuffix: ":");
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
     public async Task TestBuilder1()
     {
         var markup = $$"""

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
@@ -560,6 +560,9 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
     public async Task TestReadOnlyInterfaces(string type)
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System;
             using System.Collections.Generic;
 
@@ -569,7 +572,9 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
                 {
                     {{type}} list = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
 
         await VerifyItemIsAbsentAsync(markup, "capacity", displayTextSuffix: ":");

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -526,12 +527,15 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
         await VerifyProviderCommitAsync(markup, "args:", expected, ':');
     }
 
-    [Theory(Skip = "PROTOTYPE: Collection arguments require language version preview")]
+    [Theory]
     [InlineData("IList<int>")]
     [InlineData("ICollection<int>")]
     public async Task TestMutableInterfaces(string type)
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System.Collections.Generic;
 
             class C
@@ -540,7 +544,9 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
                 {
                     {{type}} list = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
 
         await VerifyItemExistsAsync(markup, "capacity", displayTextSuffix: ":");
@@ -569,10 +575,13 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
         await VerifyItemIsAbsentAsync(markup, "capacity", displayTextSuffix: ":");
     }
 
-    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
+    [Fact]
     public async Task TestConstructibleType1()
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System;
             using System.Collections.Generic;
 
@@ -582,17 +591,22 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
                 {
                     HashSet<int> set = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
 
         await VerifyItemExistsAsync(markup, "comparer", displayTextSuffix: ":");
         await VerifyItemExistsAsync(markup, "collection", displayTextSuffix: ":");
     }
 
-    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
+    [Fact]
     public async Task TestConstructibleType2()
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System;
             using System.Collections.Generic;
 
@@ -602,17 +616,22 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
                 {
                     HashSet<int> set = [with(comparer: null, $$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
 
         await VerifyItemIsAbsentAsync(markup, "comparer", displayTextSuffix: ":");
         await VerifyItemExistsAsync(markup, "collection", displayTextSuffix: ":");
     }
 
-    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
+    [Fact]
     public async Task TestBuilder1()
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System;
             using System.Collections;
             using System.Collections.Generic;
@@ -651,7 +670,9 @@ public sealed class NamedParameterCompletionProviderTests : AbstractCSharpComple
                 {
                     MyCollection<int> z = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
         await VerifyItemExistsAsync(markup, "capacity", displayTextSuffix: ":");
         await VerifyItemExistsAsync(markup, "extra", displayTextSuffix: ":");

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
@@ -50,7 +50,7 @@ public sealed class ObjectCreationExpressionSignatureHelpProviderTests : Abstrac
         var markup = """
             <Workspace>
                 <Project Language="C#" LanguageVersion="Preview" CommonReferences="true">
-                    <Document FilePath="SourceDocument"><![CDATA[
+                    <Document FilePath="SourceDocument">
             class C
             {
                 void M()
@@ -63,12 +63,7 @@ public sealed class ObjectCreationExpressionSignatureHelpProviderTests : Abstrac
             </Workspace>
             """;
 
-        var expectedOrderedItems = new List<SignatureHelpTestItem>
-        {
-            new SignatureHelpTestItem("C()", string.Empty, null, currentParameterIndex: 0)
-        };
-
-        await TestAsync(markup, expectedOrderedItems);
+        await TestAsync(markup, [new("C()", string.Empty, null, currentParameterIndex: 0)]);
     }
 
     [Fact]

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
@@ -16,12 +17,15 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
     internal override Type GetSignatureHelpProviderType()
         => typeof(WithElementSignatureHelpProvider);
 
-    [Theory(Skip = "PROTOTYPE: Collection arguments require language version preview")]
+    [Theory]
     [InlineData("IList<int>")]
     [InlineData("ICollection<int>")]
     public async Task TestMutableInterfaces(string type)
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System.Collections.Generic;
 
             class C
@@ -30,7 +34,9 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
                 {
                     {{type}} list = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
 
         await TestAsync(markup, [new("List<int>(int capacity)", string.Empty, null, currentParameterIndex: 0)]);
@@ -59,10 +65,13 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
         await TestAsync(markup, []);
     }
 
-    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
+    [Fact]
     public async Task TestConstructibleType()
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System;
             using System.Collections.Generic;
 
@@ -72,7 +81,9 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
                 {
                     HashSet<int> set = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
 
         await TestAsync(markup, [
@@ -82,10 +93,13 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
             new("HashSet<int>(IEnumerable<int> collection, IEqualityComparer<int> comparer)", string.Empty, null, currentParameterIndex: 0)]);
     }
 
-    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
+    [Fact]
     public async Task TestBuilder1()
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System;
             using System.Collections;
             using System.Collections.Generic;
@@ -124,7 +138,9 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
                 {
                     MyCollection<int> z = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
         await TestAsync(markup, [
             new("MyCollection<int> MyCollectionBuilder.Create<T>(int capacity, int extra)", string.Empty, null, currentParameterIndex: 0),

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
@@ -50,6 +50,9 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
     public async Task TestReadOnlyInterfaces(string type)
     {
         var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
             using System;
             using System.Collections.Generic;
 
@@ -59,7 +62,9 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
                 {
                     {{type}} list = [with($$)];
                 }
-            }
+            }]]></Document>
+                </Project>
+            </Workspace>
             """;
 
         await TestAsync(markup, []);

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
@@ -16,7 +16,7 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
     internal override Type GetSignatureHelpProviderType()
         => typeof(WithElementSignatureHelpProvider);
 
-    [Theory]
+    [Theory(Skip = "PROTOTYPE: Collection arguments require language version preview")]
     [InlineData("IList<int>")]
     [InlineData("ICollection<int>")]
     public async Task TestMutableInterfaces(string type)
@@ -59,7 +59,7 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
         await TestAsync(markup, []);
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
     public async Task TestConstructibleType()
     {
         var markup = $$"""
@@ -82,7 +82,7 @@ public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignat
             new("HashSet<int>(IEnumerable<int> collection, IEqualityComparer<int> comparer)", string.Empty, null, currentParameterIndex: 0)]);
     }
 
-    [Fact]
+    [Fact(Skip = "PROTOTYPE: Collection arguments require language version preview")]
     public async Task TestBuilder1()
     {
         var markup = $$"""

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
@@ -6,8 +6,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
 
@@ -17,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         public int Position;
         public string Code;
+        public ImmutableArray<TextSpan> Spans;
 
         private EditorTestWorkspace _workspace;
         private EditorTestHostDocument _currentDocument;
@@ -42,12 +45,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _workspace = EditorTestWorkspace.CreateWorkspace(XElement.Parse(markup), composition: composition, workspaceKind: workspaceKind);
                 _currentDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);
                 Position = _currentDocument.CursorPosition.Value;
+                Spans = [.. CurrentDocument.SelectedSpans];
                 Code = _currentDocument.GetTextBuffer().CurrentSnapshot.GetText();
                 return _workspace;
             }
             else
             {
-                MarkupTestFile.GetPosition(markup.NormalizeLineEndings(), out Code, out Position);
+                MarkupTestFile.GetPositionAndSpans(markup.NormalizeLineEndings(), out Code, out Position, out Spans);
                 var workspace = GetWorkspace(composition);
                 _currentDocument = workspace.Documents.Single();
                 return workspace;


### PR DESCRIPTION
See [LDM-2025-03-17](https://github.com/dotnet/csharplang/blob/main/meetings/2025/LDM-2025-03-17.md#conclusion).

Relates to test plan https://github.com/dotnet/roslyn/issues/76310