### PR TITLE
Remove RoslynServiceExtensions.GetServiceAsync

### DIFF
--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -26,8 +26,6 @@ M:Microsoft.CodeAnalysis.Document.GetOptionsAsync(System.Threading.CancellationT
 T:Microsoft.CodeAnalysis.Options.DocumentOptionSet; Use AnalyzerConfigOptions instead
 M:Microsoft.VisualStudio.Shell.ServiceExtensions.GetService``2(System.IServiceProvider); Use RoslynServiceExtensions instead. This extension internally relies on ThreadHelper, which is incompatible with testing.
 M:Microsoft.VisualStudio.Shell.ServiceExtensions.GetService``2(System.IServiceProvider,System.Boolean); Use RoslynServiceExtensions instead. This extension internally relies on ThreadHelper, which is incompatible with testing
-M:Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync``2(Microsoft.VisualStudio.Shell.IAsyncServiceProvider); Use RoslynServiceExtensions instead. This extension internally relies on ThreadHelper, which is incompatible with testing
-M:Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync``2(Microsoft.VisualStudio.Shell.IAsyncServiceProvider,System.Boolean); Use RoslynServiceExtensions instead. This extension internally relies on ThreadHelper, which is incompatible with testing
 P:Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory; Use IThreadingContext.JoinableTaskFactory instead.
 M:Microsoft.CodeAnalysis.Formatting.Formatter.FormatAsync(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.Options.OptionSet,System.Threading.CancellationToken); Use internal overload instead
 M:Microsoft.CodeAnalysis.Formatting.Formatter.FormatAsync(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.Text.TextSpan,Microsoft.CodeAnalysis.Options.OptionSet,System.Threading.CancellationToken); Use overload with SyntaxFormattingOptions instead

--- a/src/EditorFeatures/TestUtilities/StubVsServiceExporter`2.cs
+++ b/src/EditorFeatures/TestUtilities/StubVsServiceExporter`2.cs
@@ -34,7 +34,7 @@ internal class StubVsServiceExporter<TService, TInterface> : IVsService<TService
         [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider2 asyncServiceProvider,
         JoinableTaskContext joinableTaskContext)
     {
-        _serviceGetter = new AsyncLazy<TInterface>(() => asyncServiceProvider.GetServiceAsync<TService, TInterface>(joinableTaskContext.Factory, throwOnFailure: true)!, joinableTaskContext.Factory);
+        _serviceGetter = new AsyncLazy<TInterface>(() => asyncServiceProvider.GetServiceAsync<TService, TInterface>(throwOnFailure: true, CancellationToken.None)!, joinableTaskContext.Factory);
     }
 
     /// <inheritdoc />

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -72,10 +72,10 @@ internal sealed partial class ColorSchemeApplier
 
     private async Task AfterPackageLoadedBackgroundThreadAsync(PackageLoadTasks afterPackageLoadedTasks, CancellationToken cancellationToken)
     {
-        var settingsManager = await _asyncServiceProvider.GetServiceAsync<SVsSettingsPersistenceManager, ISettingsManager>(_threadingContext.JoinableTaskFactory).ConfigureAwait(false);
+        var settingsManager = await _asyncServiceProvider.GetServiceAsync<SVsSettingsPersistenceManager, ISettingsManager>(throwOnFailure: true, cancellationToken).ConfigureAwait(false);
 
         // We need to update the theme whenever the Editor Color Scheme setting changes.
-        settingsManager.GetSubset(ColorSchemeOptionsStorage.ColorSchemeSettingKey).SettingChangedAsync += ColorSchemeChangedAsync;
+        settingsManager!.GetSubset(ColorSchemeOptionsStorage.ColorSchemeSettingKey).SettingChangedAsync += ColorSchemeChangedAsync;
 
         // Try to migrate the `useEnhancedColorsSetting` to the new `ColorSchemeName` setting.
         _settings.MigrateToColorSchemeSetting();

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -62,7 +62,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerService(
         _serviceProvider = (IServiceProvider)serviceProvider;
 
         // Hook up the "Run Code Analysis" menu command for CPS based managed projects.
-        var menuCommandService = await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(false);
+        var menuCommandService = await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(throwOnFailure: false, cancellationToken).ConfigureAwait(false);
         if (menuCommandService != null)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/RuleSetEventHandler.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/RuleSetEventHandler.cs
@@ -41,7 +41,7 @@ internal sealed class RuleSetEventHandler : IVsTrackProjectDocumentsEvents2, IVs
     {
         if (!_eventsHookedUp)
         {
-            var trackProjectDocuments = await serviceProvider.GetServiceAsync<SVsTrackProjectDocuments, IVsTrackProjectDocuments2>(_threadingContext.JoinableTaskFactory).ConfigureAwait(false);
+            var trackProjectDocuments = await serviceProvider.GetServiceAsync<SVsTrackProjectDocuments, IVsTrackProjectDocuments2>(throwOnFailure: true, cancellationToken).ConfigureAwait(false);
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             if (!_eventsHookedUp)

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -924,11 +924,11 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
             return false;
 
         // All checks pass, so let's treat this special.
-        var dte = _threadingContext.JoinableTaskFactory.Run(() => _asyncServiceProvider.GetServiceAsync<SDTE, EnvDTE.DTE>(_threadingContext.JoinableTaskFactory));
+        var dte = _threadingContext.JoinableTaskFactory.Run(() => _asyncServiceProvider.GetServiceAsync<SDTE, EnvDTE.DTE>(throwOnFailure: true, _threadingContext.DisposalToken));
 
         const string SolutionItemsFolderName = "Solution Items";
 
-        var projects = dte.Solution.Projects.OfType<EnvDTE.Project>();
+        var projects = dte!.Solution.Projects.OfType<EnvDTE.Project>();
         var solutionItemsFolder = projects.FirstOrDefault(static p => p.Kind == EnvDTE.Constants.vsProjectKindSolutionItems && p.Name == SolutionItemsFolderName);
 
         if (solutionItemsFolder != null)

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -172,7 +172,7 @@ internal sealed class RoslynPackage : AbstractPackage
 
         // we need to load it as early as possible since we can have errors from
         // package from each language very early
-        await this.ComponentModel.GetService<VisualStudioSuppressionFixService>().InitializeAsync(this).ConfigureAwait(false);
+        await this.ComponentModel.GetService<VisualStudioSuppressionFixService>().InitializeAsync(this, cancellationToken).ConfigureAwait(false);
         await this.ComponentModel.GetService<VisualStudioDiagnosticListSuppressionStateService>().InitializeAsync(this, cancellationToken).ConfigureAwait(false);
 
         await this.ComponentModel.GetService<IVisualStudioDiagnosticAnalyzerService>().InitializeAsync(this, cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/SyncNamespaces/SyncNamespacesCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/SyncNamespaces/SyncNamespacesCommandHandler.cs
@@ -52,7 +52,7 @@ internal sealed class SyncNamespacesCommandHandler
         _serviceProvider = (IServiceProvider)serviceProvider;
 
         // Hook up the "Remove Unused References" menu command for CPS based managed projects.
-        var menuCommandService = await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(false);
+        var menuCommandService = await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(throwOnFailure: false, cancellationToken).ConfigureAwait(false);
         if (menuCommandService != null)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioDiagnosticListSuppressionStateService.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioDiagnosticListSuppressionStateService.cs
@@ -58,8 +58,8 @@ internal class VisualStudioDiagnosticListSuppressionStateService : IVisualStudio
 
     public async Task InitializeAsync(IAsyncServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
-        _shellService = await serviceProvider.GetServiceAsync<SVsUIShell, IVsUIShell>(_threadingContext.JoinableTaskFactory).ConfigureAwait(false);
-        var errorList = await serviceProvider.GetServiceAsync<SVsErrorList, IErrorList>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(false);
+        _shellService = await serviceProvider.GetServiceAsync<SVsUIShell, IVsUIShell>(throwOnFailure: false, cancellationToken).ConfigureAwait(false);
+        var errorList = await serviceProvider.GetServiceAsync<SVsErrorList, IErrorList>(throwOnFailure: false, cancellationToken).ConfigureAwait(false);
         _tableControl = errorList?.TableControl;
 
         await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -64,9 +64,9 @@ internal sealed class VisualStudioSuppressionFixService(
 
     private IWpfTableControl? _tableControl;
 
-    public async Task InitializeAsync(IAsyncServiceProvider serviceProvider)
+    public async Task InitializeAsync(IAsyncServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
-        var errorList = await serviceProvider.GetServiceAsync<SVsErrorList, IErrorList>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(false);
+        var errorList = await serviceProvider.GetServiceAsync<SVsErrorList, IErrorList>(throwOnFailure: false, cancellationToken).ConfigureAwait(false);
         _tableControl = errorList?.TableControl;
     }
 

--- a/src/VisualStudio/Core/Def/UnusedReferences/RemoveUnusedReferencesCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/UnusedReferences/RemoveUnusedReferencesCommandHandler.cs
@@ -65,7 +65,7 @@ internal sealed class RemoveUnusedReferencesCommandHandler
         _serviceProvider = (IServiceProvider)serviceProvider;
 
         // Hook up the "Remove Unused References" menu command for CPS based managed projects.
-        var menuCommandService = await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(false);
+        var menuCommandService = await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(throwOnFailure: false, cancellationToken).ConfigureAwait(false);
         if (menuCommandService != null)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioSourceGeneratorTelemetryCollectorWorkspaceServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioSourceGeneratorTelemetryCollectorWorkspaceServiceFactory.cs
@@ -73,9 +73,9 @@ internal class VisualStudioSourceGeneratorTelemetryCollectorWorkspaceServiceFact
         {
             Task.Run(async () =>
             {
-                var shellService = await _serviceProvider.GetServiceAsync<SVsSolution, IVsSolution>(_threadingContext.JoinableTaskFactory).ConfigureAwait(true);
+                var shellService = await _serviceProvider.GetServiceAsync<SVsSolution, IVsSolution>(throwOnFailure: true, _threadingContext.DisposalToken).ConfigureAwait(true);
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(_threadingContext.DisposalToken);
-                shellService.AdviseSolutionEvents(this, out _);
+                shellService!.AdviseSolutionEvents(this, out _);
             }, _threadingContext.DisposalToken);
         }
     }

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
@@ -77,7 +77,7 @@ internal sealed class VisualStudioWorkspaceStatusServiceFactory(
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _threadingContext.DisposalToken);
 
                 // Make sure the HubClient package is loaded, since we rely on it for proffered OOP services
-                var shell = await _serviceProvider.GetServiceAsync<SVsShell, IVsShell7>(_threadingContext.JoinableTaskFactory).ConfigureAwait(true);
+                var shell = await _serviceProvider.GetServiceAsync<SVsShell, IVsShell7>(throwOnFailure: true, _threadingContext.DisposalToken).ConfigureAwait(true);
                 Assumes.Present(shell);
 
                 await shell.LoadPackageAsync(Guids.GlobalHubClientPackageGuid);
@@ -90,7 +90,7 @@ internal sealed class VisualStudioWorkspaceStatusServiceFactory(
                 using var asyncToken = listener.BeginAsyncOperation("StatusChanged_EventSubscription");
 
                 await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _threadingContext.DisposalToken);
-                var service = await serviceProvider.GetServiceAsync<SVsOperationProgress, IVsOperationProgressStatusService>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(true);
+                var service = await serviceProvider.GetServiceAsync<SVsOperationProgress, IVsOperationProgressStatusService>(throwOnFailure: false, _threadingContext.DisposalToken).ConfigureAwait(true);
                 if (service is null)
                     return null;
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -165,13 +165,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             {
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-                var shell = await _serviceProvider.GetServiceAsync<SVsShell, IVsShell7>(_threadingContext.JoinableTaskFactory).ConfigureAwait(true);
+                var shell = await _serviceProvider.GetServiceAsync<SVsShell, IVsShell7>(throwOnFailure: true, cancellationToken).ConfigureAwait(true);
 
                 // Force the F# package to load; this is necessary because the F# package listens to WorkspaceChanged to 
                 // set up some items, and the F# project system doesn't guarantee that the F# package has been loaded itself
                 // so we're caught in the middle doing this.
                 var packageId = Guids.FSharpPackageId;
-                await shell.LoadPackageAsync(ref packageId);
+                await shell!.LoadPackageAsync(ref packageId);
 
                 await TaskScheduler.Default;
             }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzerItemTracker.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzerItemTracker.cs
@@ -34,7 +34,7 @@ internal sealed class AnalyzerItemsTracker(IThreadingContext threadingContext) :
 
     public async Task RegisterAsync(IAsyncServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
-        _vsMonitorSelection ??= await serviceProvider.GetServiceAsync<SVsShellMonitorSelection, IVsMonitorSelection>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(false);
+        _vsMonitorSelection ??= await serviceProvider.GetServiceAsync<SVsShellMonitorSelection, IVsMonitorSelection>(throwOnFailure: false, cancellationToken).ConfigureAwait(false);
         await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
         _vsMonitorSelection?.AdviseSelectionEvents(this, out _selectionEventsCookie);
     }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzerNodeSetup.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzerNodeSetup.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         {
             await _analyzerTracker.RegisterAsync(serviceProvider, cancellationToken).ConfigureAwait(false);
             await _analyzerCommandHandler.InitializeAsync(
-                await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(_threadingContext.JoinableTaskFactory, throwOnFailure: false).ConfigureAwait(false),
+                await serviceProvider.GetServiceAsync<IMenuCommandService, IMenuCommandService>(throwOnFailure: false, cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/73636

Remove the RoslynServiceExtensions.GetServiceAsync and instead encourage use of the standard IAsyncServiceProvider* methods. The VS implementation of these methods has been changed to better understand which interfaces require a main thread switch for the cast, as opposed to the roslyn implementations which blindly did a main thread switch.