### PR TITLE
Add GetOptionAsync calls to IGlobalOptionService

### DIFF
--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.BraceMatching;
 using Microsoft.CodeAnalysis.Classification;
@@ -60,6 +61,9 @@ public sealed class GlobalOptionsTests
         public T GetOption<T>(Option2<T> option)
             => GetOption<T>(new OptionKey2(option));
 
+        public ValueTask<T> GetOptionAsync<T>(Option2<T> option)
+            => GetOptionAsync<T>(new OptionKey2(option));
+
         public T GetOption<T>(PerLanguageOption2<T> option, string languageName)
             => GetOption<T>(new OptionKey2(option, languageName));
 
@@ -67,6 +71,12 @@ public sealed class GlobalOptionsTests
         {
             OnOptionAccessed(optionKey);
             return (T)OptionsTestHelpers.GetDifferentValue(typeof(T), optionKey.Option.DefaultValue)!;
+        }
+
+        public ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey)
+        {
+            OnOptionAccessed(optionKey);
+            return new ValueTask<T>((T)OptionsTestHelpers.GetDifferentValue(typeof(T), optionKey.Option.DefaultValue)!);
         }
 
         #region Unused

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.BraceMatching;
@@ -61,8 +62,8 @@ public sealed class GlobalOptionsTests
         public T GetOption<T>(Option2<T> option)
             => GetOption<T>(new OptionKey2(option));
 
-        public ValueTask<T> GetOptionAsync<T>(Option2<T> option)
-            => GetOptionAsync<T>(new OptionKey2(option));
+        public ValueTask<T> GetOptionAsync<T>(Option2<T> option, CancellationToken cancellationToken)
+            => GetOptionAsync<T>(new OptionKey2(option), cancellationToken);
 
         public T GetOption<T>(PerLanguageOption2<T> option, string languageName)
             => GetOption<T>(new OptionKey2(option, languageName));
@@ -73,7 +74,7 @@ public sealed class GlobalOptionsTests
             return (T)OptionsTestHelpers.GetDifferentValue(typeof(T), optionKey.Option.DefaultValue)!;
         }
 
-        public ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey)
+        public ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey, CancellationToken cancellationToken)
         {
             OnOptionAccessed(optionKey);
             return new ValueTask<T>((T)OptionsTestHelpers.GetDifferentValue(typeof(T), optionKey.Option.DefaultValue)!);

--- a/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
@@ -54,9 +55,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                 => default!;
 
             public T GetOption<T>(Option2<T> option) => throw new NotImplementedException();
-            public ValueTask<T> GetOptionAsync<T>(Option2<T> option) => throw new NotImplementedException();
+            public ValueTask<T> GetOptionAsync<T>(Option2<T> option, CancellationToken cancellationToken) => throw new NotImplementedException();
             public T GetOption<T>(OptionKey2 optionKey) => throw new NotImplementedException();
-            public ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey) => throw new NotImplementedException();
+            public ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey, CancellationToken cancellationToken) => throw new NotImplementedException();
             public ImmutableArray<object?> GetOptions(ImmutableArray<OptionKey> optionKeys) => throw new NotImplementedException();
             public bool RefreshOption(OptionKey2 optionKey, object? newValue) => throw new NotImplementedException();
             public ImmutableArray<object?> GetOptions(ImmutableArray<OptionKey2> optionKeys) => throw new NotImplementedException();

--- a/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
@@ -3,15 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Composition;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Formatting;
-using System.Linq;
-using System.Collections.Immutable;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
 using System.Diagnostics.CodeAnalysis;
-using Roslyn.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
@@ -56,7 +54,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                 => default!;
 
             public T GetOption<T>(Option2<T> option) => throw new NotImplementedException();
+            public ValueTask<T> GetOptionAsync<T>(Option2<T> option) => throw new NotImplementedException();
             public T GetOption<T>(OptionKey2 optionKey) => throw new NotImplementedException();
+            public ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey) => throw new NotImplementedException();
             public ImmutableArray<object?> GetOptions(ImmutableArray<OptionKey> optionKeys) => throw new NotImplementedException();
             public bool RefreshOption(OptionKey2 optionKey, object? newValue) => throw new NotImplementedException();
             public ImmutableArray<object?> GetOptions(ImmutableArray<OptionKey2> optionKeys) => throw new NotImplementedException();

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.Settings.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.Settings.cs
@@ -111,18 +111,18 @@ internal partial class ColorSchemeApplier
             itemKey.Flush();
         }
 
-        public ColorSchemeName GetConfiguredColorScheme()
+        public async Task<ColorSchemeName> GetConfiguredColorSchemeAsync()
         {
-            var schemeName = _globalOptions.GetOption(ColorSchemeOptionsStorage.ColorScheme);
+            var schemeName = await _globalOptions.GetOptionAsync(ColorSchemeOptionsStorage.ColorScheme).ConfigureAwait(false);
             return schemeName != ColorSchemeName.None
                 ? schemeName
                 : ColorSchemeOptionsStorage.ColorScheme.Definition.DefaultValue;
         }
 
-        public void MigrateToColorSchemeSetting()
+        public async Task MigrateToColorSchemeSettingAsync()
         {
             // Get the preview feature flag value.
-            var useEnhancedColorsSetting = _globalOptions.GetOption(ColorSchemeOptionsStorage.LegacyUseEnhancedColors);
+            var useEnhancedColorsSetting = await _globalOptions.GetOptionAsync(ColorSchemeOptionsStorage.LegacyUseEnhancedColors).ConfigureAwait(false);
 
             // Return if we have already migrated.
             if (useEnhancedColorsSetting == ColorSchemeOptionsStorage.UseEnhancedColors.Migrated)

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.Settings.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.Settings.cs
@@ -111,18 +111,18 @@ internal partial class ColorSchemeApplier
             itemKey.Flush();
         }
 
-        public async Task<ColorSchemeName> GetConfiguredColorSchemeAsync()
+        public async Task<ColorSchemeName> GetConfiguredColorSchemeAsync(CancellationToken cancellationToken)
         {
-            var schemeName = await _globalOptions.GetOptionAsync(ColorSchemeOptionsStorage.ColorScheme).ConfigureAwait(false);
+            var schemeName = await _globalOptions.GetOptionAsync(ColorSchemeOptionsStorage.ColorScheme, cancellationToken).ConfigureAwait(false);
             return schemeName != ColorSchemeName.None
                 ? schemeName
                 : ColorSchemeOptionsStorage.ColorScheme.Definition.DefaultValue;
         }
 
-        public async Task MigrateToColorSchemeSettingAsync()
+        public async Task MigrateToColorSchemeSettingAsync(CancellationToken cancellationToken)
         {
             // Get the preview feature flag value.
-            var useEnhancedColorsSetting = await _globalOptions.GetOptionAsync(ColorSchemeOptionsStorage.LegacyUseEnhancedColors).ConfigureAwait(false);
+            var useEnhancedColorsSetting = await _globalOptions.GetOptionAsync(ColorSchemeOptionsStorage.LegacyUseEnhancedColors, cancellationToken).ConfigureAwait(false);
 
             // Return if we have already migrated.
             if (useEnhancedColorsSetting == ColorSchemeOptionsStorage.UseEnhancedColors.Migrated)

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -78,7 +78,7 @@ internal sealed partial class ColorSchemeApplier
         settingsManager.GetSubset(ColorSchemeOptionsStorage.ColorSchemeSettingKey).SettingChangedAsync += ColorSchemeChangedAsync;
 
         // Try to migrate the `useEnhancedColorsSetting` to the new `ColorSchemeName` setting.
-        _settings.MigrateToColorSchemeSetting();
+        await _settings.MigrateToColorSchemeSettingAsync().ConfigureAwait(false);
 
         // Since the Roslyn colors are now defined in the Roslyn repo and no longer applied by the VS pkgdef built from EditorColors.xml,
         // We attempt to apply a color scheme when the Roslyn package is loaded. This is our chance to update the configuration registry
@@ -125,7 +125,7 @@ internal sealed partial class ColorSchemeApplier
         var appliedColorScheme = await _settings.GetAppliedColorSchemeAsync(cancellationToken).ConfigureAwait(false);
 
         // The color scheme configured in VS settings.
-        var configuredColorScheme = _settings.GetConfiguredColorScheme();
+        var configuredColorScheme = await _settings.GetConfiguredColorSchemeAsync().ConfigureAwait(false);
 
         if (appliedColorScheme == configuredColorScheme)
             return null;

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -78,7 +78,7 @@ internal sealed partial class ColorSchemeApplier
         settingsManager.GetSubset(ColorSchemeOptionsStorage.ColorSchemeSettingKey).SettingChangedAsync += ColorSchemeChangedAsync;
 
         // Try to migrate the `useEnhancedColorsSetting` to the new `ColorSchemeName` setting.
-        await _settings.MigrateToColorSchemeSettingAsync().ConfigureAwait(false);
+        await _settings.MigrateToColorSchemeSettingAsync(cancellationToken).ConfigureAwait(false);
 
         // Since the Roslyn colors are now defined in the Roslyn repo and no longer applied by the VS pkgdef built from EditorColors.xml,
         // We attempt to apply a color scheme when the Roslyn package is loaded. This is our chance to update the configuration registry
@@ -125,7 +125,7 @@ internal sealed partial class ColorSchemeApplier
         var appliedColorScheme = await _settings.GetAppliedColorSchemeAsync(cancellationToken).ConfigureAwait(false);
 
         // The color scheme configured in VS settings.
-        var configuredColorScheme = await _settings.GetConfiguredColorSchemeAsync().ConfigureAwait(false);
+        var configuredColorScheme = await _settings.GetConfiguredColorSchemeAsync(cancellationToken).ConfigureAwait(false);
 
         if (appliedColorScheme == configuredColorScheme)
             return null;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -72,11 +72,12 @@ internal abstract class AbstractPackage : AsyncPackage
     {
         afterPackageLoadedTasks.AddTask(
             isMainThreadTask: false,
-            task: (afterPackageLoadedTasks, cancellationToken) =>
+            task: async (afterPackageLoadedTasks, cancellationToken) =>
             {
                 // TODO: remove, workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1985204
                 var globalOptions = ComponentModel.GetService<IGlobalOptionService>();
-                if (globalOptions.GetOption(SemanticSearchFeatureFlag.Enabled))
+                var isSemanticSearchEnabled = await globalOptions.GetOptionAsync(SemanticSearchFeatureFlag.Enabled).ConfigureAwait(false);
+                if (isSemanticSearchEnabled)
                 {
                     afterPackageLoadedTasks.AddTask(
                         isMainThreadTask: true,
@@ -87,8 +88,6 @@ internal abstract class AbstractPackage : AsyncPackage
                             return Task.CompletedTask;
                         });
                 }
-
-                return Task.CompletedTask;
             });
     }
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -76,7 +76,7 @@ internal abstract class AbstractPackage : AsyncPackage
             {
                 // TODO: remove, workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1985204
                 var globalOptions = ComponentModel.GetService<IGlobalOptionService>();
-                var isSemanticSearchEnabled = await globalOptions.GetOptionAsync(SemanticSearchFeatureFlag.Enabled).ConfigureAwait(false);
+                var isSemanticSearchEnabled = await globalOptions.GetOptionAsync(SemanticSearchFeatureFlag.Enabled, cancellationToken).ConfigureAwait(false);
                 if (isSemanticSearchEnabled)
                 {
                     afterPackageLoadedTasks.AddTask(

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -39,44 +39,48 @@ internal sealed class GlobalOptionService(
 
     private ImmutableArray<IOptionPersister> GetOptionPersisters()
     {
-        if (_lazyOptionPersisters.IsDefault)
+        if (!_lazyOptionPersisters.IsDefault)
         {
-            // Option persisters cannot be initialized while holding the global options lock
-            // https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1353715
-            Debug.Assert(!Monitor.IsEntered(_gate));
-
-            ImmutableInterlocked.InterlockedInitialize(
-                ref _lazyOptionPersisters,
-                GetOptionPersistersSlow(workspaceThreadingService, _optionPersisterProviders, CancellationToken.None));
+            return _lazyOptionPersisters;
         }
 
-        return _lazyOptionPersisters;
-
-        // Local functions
-        static ImmutableArray<IOptionPersister> GetOptionPersistersSlow(
-            IWorkspaceThreadingService? workspaceThreadingService,
-            ImmutableArray<Lazy<IOptionPersisterProvider>> persisterProviders,
-            CancellationToken cancellationToken)
+        var result = GetOptionPersistersImplAsync(CancellationToken.None);
+        if (workspaceThreadingService is not null)
         {
-            if (workspaceThreadingService is not null && workspaceThreadingService.IsOnMainThread)
-            {
-                // speedometer tests report jtf.run calls from background threads, so we try to avoid those.
-                return workspaceThreadingService.Run(() => GetOptionPersistersAsync(persisterProviders, cancellationToken));
-            }
-            else
-            {
-                return GetOptionPersistersAsync(persisterProviders, cancellationToken).WaitAndGetResult_CanCallOnBackground(cancellationToken);
-            }
+            // Synchronous codepath through GetOption has potential JTF.Run invocation if it's the first option requested.
+            return workspaceThreadingService.Run(() => result);
+        }
+        else
+        {
+            return result.WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+        }
+    }
+
+    private ValueTask<ImmutableArray<IOptionPersister>> GetOptionPersistersAsync(CancellationToken cancellationToken)
+    {
+        if (!_lazyOptionPersisters.IsDefault)
+        {
+            return new ValueTask<ImmutableArray<IOptionPersister>>(_lazyOptionPersisters);
         }
 
-        static async Task<ImmutableArray<IOptionPersister>> GetOptionPersistersAsync(
-            ImmutableArray<Lazy<IOptionPersisterProvider>> persisterProviders,
-            CancellationToken cancellationToken)
-        {
-            return await persisterProviders.SelectAsArrayAsync(
-                static (lazyProvider, cancellationToken) => lazyProvider.Value.GetOrCreatePersisterAsync(cancellationToken),
-                cancellationToken).ConfigureAwait(false);
-        }
+        return new ValueTask<ImmutableArray<IOptionPersister>>(GetOptionPersistersImplAsync(cancellationToken));
+    }
+
+    private async Task<ImmutableArray<IOptionPersister>> GetOptionPersistersImplAsync(CancellationToken cancellationToken)
+    {
+        // Option persisters cannot be initialized while holding the global options lock
+        // https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1353715
+        Debug.Assert(!Monitor.IsEntered(_gate));
+
+        var lazyOptionPersisters = await _optionPersisterProviders.SelectAsArrayAsync(
+            static (lazyProvider, cancellationToken) => lazyProvider.Value.GetOrCreatePersisterAsync(cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+
+        ImmutableInterlocked.InterlockedInitialize(
+            ref _lazyOptionPersisters,
+            lazyOptionPersisters);
+
+        return lazyOptionPersisters;
     }
 
     private static object? LoadOptionFromPersisterOrGetDefault(OptionKey2 optionKey, ImmutableArray<IOptionPersister> persisters)
@@ -103,14 +107,14 @@ internal sealed class GlobalOptionService(
     public T GetOption<T>(Option2<T> option)
         => GetOption<T>(new OptionKey2(option));
 
+    public ValueTask<T> GetOptionAsync<T>(Option2<T> option)
+        => GetOptionAsync<T>(new OptionKey2(option));
+
     public T GetOption<T>(PerLanguageOption2<T> option, string language)
         => GetOption<T>(new OptionKey2(option, language));
 
     public T GetOption<T>(OptionKey2 optionKey)
     {
-        // Ensure the option persisters are available before taking the global lock
-        var persisters = GetOptionPersisters();
-
         // Performance: This is called very frequently, with the vast majority (> 99%) of calls requesting a previously
         //  added key. In those cases, we can avoid taking the lock as _currentValues is an immutable structure.
         if (_currentValues.TryGetValue(optionKey, out var value))
@@ -118,9 +122,35 @@ internal sealed class GlobalOptionService(
             return (T)value!;
         }
 
+        // Ensure the option persisters are available before taking the global lock
+        var persisters = GetOptionPersisters();
+
         lock (_gate)
         {
             return (T)GetOption_NoLock(ref _currentValues, optionKey, persisters)!;
+        }
+    }
+
+    public ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey)
+    {
+        // Performance: This is called very frequently, with the vast majority (> 99%) of calls requesting a previously
+        //  added key. In those cases, we can avoid taking the lock as _currentValues is an immutable structure.
+        if (_currentValues.TryGetValue(optionKey, out var value))
+        {
+            return new ValueTask<T>((T)value!);
+        }
+
+        return GetOptionSlowAsync(optionKey);
+
+        async ValueTask<T> GetOptionSlowAsync(OptionKey2 optionKey)
+        {
+            // Ensure the option persisters are available before taking the global lock
+            var persisters = await GetOptionPersistersAsync(CancellationToken.None).ConfigureAwait(false);
+
+            lock (_gate)
+            {
+                return (T)GetOption_NoLock(ref _currentValues, optionKey, persisters)!;
+            }
         }
     }
 

--- a/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Options;
 
@@ -21,12 +22,22 @@ internal interface IGlobalOptionService : IOptionsReader
     /// <summary>
     /// Gets the current value of the specific option.
     /// </summary>
+    ValueTask<T> GetOptionAsync<T>(Option2<T> option);
+
+    /// <summary>
+    /// Gets the current value of the specific option.
+    /// </summary>
     T GetOption<T>(PerLanguageOption2<T> option, string language);
 
     /// <summary>
     /// Gets the current value of the specific option.
     /// </summary>
     T GetOption<T>(OptionKey2 optionKey);
+
+    /// <summary>
+    /// Gets the current value of the specific option.
+    /// </summary>
+    ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey);
 
     /// <summary>
     /// Gets the current values of specified options.

--- a/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Options;
@@ -22,7 +23,7 @@ internal interface IGlobalOptionService : IOptionsReader
     /// <summary>
     /// Gets the current value of the specific option.
     /// </summary>
-    ValueTask<T> GetOptionAsync<T>(Option2<T> option);
+    ValueTask<T> GetOptionAsync<T>(Option2<T> option, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the current value of the specific option.
@@ -37,7 +38,7 @@ internal interface IGlobalOptionService : IOptionsReader
     /// <summary>
     /// Gets the current value of the specific option.
     /// </summary>
-    ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey);
+    ValueTask<T> GetOptionAsync<T>(OptionKey2 optionKey, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the current values of specified options.


### PR DESCRIPTION
This is a potentially better way to address the speedometer regression "fixed" by https://github.com/dotnet/roslyn/pull/77788.

That PR just replaced a JTF.Run on a bg thread with a .Result call (which doesn't get flagged by speedometer). Instead, go ahead and make there be an async path through this code that avoids the JTF.Run/Result code altogether.

Note that only the first call to GetOption would hit this path, thus why I went down the expediant fix before. However, PR feedback has expressed a strong desire to not go that route, and thus the change here to add an async path to getting an option through IGlobalOptionService. There are *many* synchronous calls to GetOption, and this PR doesn't remove that codepath as that's outside the scope of the change that I'd like to make at this time. This PR only changes the GetOption calls that occur during package load as those were fairly easy to change and the most likely to cause the async work to occur.