### PR TITLE
Remove unnecessary nullable directives

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
+++ b/src/Analyzers/CSharp/CodeFixes/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Composition;

--- a/src/Analyzers/Core/Analyzers/DiagnosticCustomTags.cs
+++ b/src/Analyzers/Core/Analyzers/DiagnosticCustomTags.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeStyle;

--- a/src/Analyzers/Core/CodeFixes/GenerateEnumMember/AbstractGenerateEnumMemberService.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateEnumMember/AbstractGenerateEnumMemberService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateConversionService.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateConversionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateMethodService.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateMethodService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.AbstractInvocationInfo.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.AbstractInvocationInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.MethodSignatureInfo.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.MethodSignatureInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGeneration;

--- a/src/Analyzers/Core/CodeFixes/GenerateVariable/IGenerateVariableService.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateVariable/IGenerateVariableService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Analyzers/Core/CodeFixes/Naming/FallbackNamingRules.cs
+++ b/src/Analyzers/Core/CodeFixes/Naming/FallbackNamingRules.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;

--- a/src/EditorFeatures/CSharpTest/Intents/IntentTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Intents/IntentTestsBase.cs
@@ -115,7 +115,7 @@ public abstract class IntentTestsBase
         // Get the text change to pass into the API that rewinds the current document to the prior document.
         var currentDocument = currentTextBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
         var textDiffService = workspace.CurrentSolution.Services.GetRequiredService<IDocumentTextDifferencingService>();
-        var changes = await textDiffService.GetTextChangesAsync(currentDocument, priorDocument, CancellationToken.None).ConfigureAwait(false);
+        var changes = await textDiffService.GetTextChangesAsync(currentDocument!, priorDocument, CancellationToken.None).ConfigureAwait(false);
 
         // Get the current snapshot span to pass in.
         var currentSnapshot = new SnapshotSpan(currentTextBuffer.CurrentSnapshot, new Span(0, currentTextBuffer.CurrentSnapshot.Length));

--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/NullResultMetadataAsSourceFileProvider.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/NullResultMetadataAsSourceFileProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PdbSourceDocument;
 internal class NullResultMetadataAsSourceFileProvider : IMetadataAsSourceFileProvider
 {
     // Represents a null result
-    public static MetadataAsSourceFile NullResult = new("", null, null, null);
+    public static MetadataAsSourceFile NullResult = new("", null!, null!, null!);
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/EditorFeatures/Core/AutomaticCompletion/Extensions.cs
+++ b/src/EditorFeatures/Core/AutomaticCompletion/Extensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.BraceCompletion;

--- a/src/EditorFeatures/Core/BraceMatching/BraceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/BraceMatching/BraceHighlightingViewTaggerProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;

--- a/src/EditorFeatures/Core/ChangeSignature/AbstractChangeSignatureCommandHandler.cs
+++ b/src/EditorFeatures/Core/ChangeSignature/AbstractChangeSignatureCommandHandler.cs
@@ -125,7 +125,7 @@ internal abstract class AbstractChangeSignatureCommandHandler(IThreadingContext 
                 string.Format(EditorFeaturesResources.Preview_Changes_0, EditorFeaturesResources.Change_Signature),
                 "vs.csharp.refactoring.preview",
                 EditorFeaturesResources.Change_Signature_colon,
-                result.Name,
+                result.Name!,
                 result.Glyph.GetValueOrDefault(),
                 result.UpdatedSolution,
                 oldSolution);

--- a/src/EditorFeatures/Core/Classification/ClassificationTags.cs
+++ b/src/EditorFeatures/Core/Classification/ClassificationTags.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Classification;

--- a/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
+++ b/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
@@ -186,7 +186,7 @@ internal class DefinitionContextTracker : ITextViewConnectionListener
                     var declarationFile = await _metadataAsSourceFileService.GetGeneratedFileAsync(workspace, document.Project, symbol, signaturesOnly: false, options: options, cancellationToken: cancellationToken).ConfigureAwait(false);
                     var identifierSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
                     locations.Add(new CodeDefinitionWindowLocation(
-                        symbol.ToDisplayString(), declarationFile.FilePath, identifierSpan.Start));
+                        symbol.ToDisplayString(), declarationFile.FilePath!, identifierSpan.Start));
                 }
             }
         }

--- a/src/EditorFeatures/Core/CodeRefactorings/EditorLayerCodeActionHelpersService.cs
+++ b/src/EditorFeatures/Core/CodeRefactorings/EditorLayerCodeActionHelpersService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor;

--- a/src/EditorFeatures/Core/Commanding/LegacyCommandHandlerServiceFactory.cs
+++ b/src/EditorFeatures/Core/Commanding/LegacyCommandHandlerServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;

--- a/src/EditorFeatures/Core/CommentSelection/AbstractToggleBlockCommentBase.cs
+++ b/src/EditorFeatures/Core/CommentSelection/AbstractToggleBlockCommentBase.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/EditorFeatures/Core/CommentSelection/CommentSelectionResult.cs
+++ b/src/EditorFeatures/Core/CommentSelection/CommentSelectionResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;

--- a/src/EditorFeatures/Core/CommentSelection/CommentTrackingSpan.cs
+++ b/src/EditorFeatures/Core/CommentSelection/CommentTrackingSpan.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CommentSelection;

--- a/src/EditorFeatures/Core/CommentSelection/ToggleBlockCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommentSelection/ToggleBlockCommentCommandHandler.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;

--- a/src/EditorFeatures/Core/Editor/ITextBufferAssociatedViewService.cs
+++ b/src/EditorFeatures/Core/Editor/ITextBufferAssociatedViewService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/EditorFeatures/Core/Editor/ITextUndoHistoryWorkspaceService.cs
+++ b/src/EditorFeatures/Core/Editor/ITextUndoHistoryWorkspaceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;

--- a/src/EditorFeatures/Core/Extensibility/Commands/ExportInteractiveCommandAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/ExportInteractiveCommandAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;

--- a/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 
 namespace Microsoft.CodeAnalysis.Editor;

--- a/src/EditorFeatures/Core/Extensibility/Completion/ExportCompletionProviderAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/ExportCompletionProviderAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Completion;

--- a/src/EditorFeatures/Core/Extensibility/Completion/PredefinedCompletionProviderNames.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/PredefinedCompletionProviderNames.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Editor;
 
 internal static class PredefinedCompletionProviderNames

--- a/src/EditorFeatures/Core/Extensibility/Composition/IContentTypeMetadata.cs
+++ b/src/EditorFeatures/Core/Extensibility/Composition/IContentTypeMetadata.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editor;

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarControllerFactoryService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarControllerFactoryService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.Text;
 

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarAutomationStrings.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarAutomationStrings.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Editor;
 
 internal static class NavigationBarAutomationStrings

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/ISignatureHelpPresenterSession.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/ISignatureHelpPresenterSession.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.SignatureHelp;

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/PredefinedSignatureHelpPresenterNames.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/PredefinedSignatureHelpPresenterNames.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Editor;
 
 internal static class PredefinedSignatureHelpPresenterNames

--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItemEventArgs.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/SignatureHelpItemEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.SignatureHelp;
 

--- a/src/EditorFeatures/Core/Extensions/GlyphExtensions.cs
+++ b/src/EditorFeatures/Core/Extensions/GlyphExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Imaging.Interop;
 

--- a/src/EditorFeatures/Core/Extensions/LSPExtensions.cs
+++ b/src/EditorFeatures/Core/Extensions/LSPExtensions.cs
@@ -23,7 +23,7 @@ internal static class VSEditorLSPExtensions
     public static Roslyn.Text.Adornments.ContainerElement ToLSPElement(this VisualStudio.Text.Adornments.ContainerElement element)
         => new((Roslyn.Text.Adornments.ContainerElementStyle)element.Style, element.Elements.Select(ToLSPElement));
 
-    private static object? ToLSPElement(object? value)
+    private static object ToLSPElement(object value)
         => value switch
         {
             VisualStudio.Core.Imaging.ImageId imageId => imageId.ToLSPImageId(),
@@ -31,7 +31,6 @@ internal static class VSEditorLSPExtensions
             VisualStudio.Text.Adornments.ContainerElement element => element.ToLSPElement(),
             VisualStudio.Text.Adornments.ClassifiedTextElement element => element.ToLSPElement(),
             VisualStudio.Text.Adornments.ClassifiedTextRun run => run.ToLSPRun(),
-
             _ => value,
         };
 }

--- a/src/EditorFeatures/Core/ExternalAccess/UnitTesting/UnitTestingReferencesService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/UnitTesting/UnitTestingReferencesService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptEditorInlineRenameService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptInlineRenameReplacementInfo.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptInlineRenameReplacementInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentSpan.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentSpan.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameLocationWrapper.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameLocationWrapper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameReplacementWrapper.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameReplacementWrapper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInlineRenameReplacementKindHelpers.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInlineRenameReplacementKindHelpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 

--- a/src/EditorFeatures/Core/Host/IPreviewDialogService.cs
+++ b/src/EditorFeatures/Core/Host/IPreviewDialogService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Editor.Host;

--- a/src/EditorFeatures/Core/Host/IPreviewPaneService.cs
+++ b/src/EditorFeatures/Core/Host/IPreviewPaneService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;

--- a/src/EditorFeatures/Core/ICommandHandlerServiceFactory.cs
+++ b/src/EditorFeatures/Core/ICommandHandlerServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Editor;

--- a/src/EditorFeatures/Core/IContentTypeLanguageService.cs
+++ b/src/EditorFeatures/Core/IContentTypeLanguageService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.Utilities;
 

--- a/src/EditorFeatures/Core/IIntellisensePresenterSession.cs
+++ b/src/EditorFeatures/Core/IIntellisensePresenterSession.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/src/EditorFeatures/Core/IRefactorNotifyService.cs
+++ b/src/EditorFeatures/Core/IRefactorNotifyService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editor;

--- a/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
 
@@ -34,7 +35,7 @@ internal abstract partial class AbstractEditorInlineRenameService
         private InlineRenameLocation ConvertLocation(RenameLocation location)
         {
             return new InlineRenameLocation(
-                _renameLocationSet.Solution.GetDocument(location.DocumentId), location.Location.SourceSpan);
+                _renameLocationSet.Solution.GetRequiredDocument(location.DocumentId), location.Location.SourceSpan);
         }
 
         public async Task<IInlineRenameReplacementInfo> GetReplacementsAsync(

--- a/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
@@ -160,7 +160,7 @@ internal interface IInlineRenameInfo
     /// Provides the reason that can be displayed to the user if the entity at the selected 
     /// location cannot be renamed.
     /// </summary>
-    string LocalizedErrorMessage { get; }
+    string? LocalizedErrorMessage { get; }
 
     /// <summary>
     /// The span of the entity that is being renamed.

--- a/src/EditorFeatures/Core/IntelliSense/ISession.cs
+++ b/src/EditorFeatures/Core/IntelliSense/ISession.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense;

--- a/src/EditorFeatures/Core/IntelliSense/QuickInfo/Model.cs
+++ b/src/EditorFeatures/Core/IntelliSense/QuickInfo/Model.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;

--- a/src/EditorFeatures/Core/Interactive/ISendToInteractiveSubmissionProvider.cs
+++ b/src/EditorFeatures/Core/Interactive/ISendToInteractiveSubmissionProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding;
 using System.Threading;

--- a/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;

--- a/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Highlighting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.KeywordHighlighting;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -98,7 +99,7 @@ internal sealed class HighlighterViewTaggerProvider(TaggerHost taggerHost, IHigh
         using (Logger.LogBlock(FunctionId.Tagger_Highlighter_TagProducer_ProduceTags, cancellationToken))
         using (s_listPool.GetPooledObject(out var highlights))
         {
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             _highlightingService.AddHighlights(root, position, highlights, cancellationToken);
 

--- a/src/EditorFeatures/Core/KeywordHighlighting/KeywordHighlightTag.cs
+++ b/src/EditorFeatures/Core/KeywordHighlighting/KeywordHighlightTag.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting;

--- a/src/EditorFeatures/Core/ModernCommands/GoToImplementationCommandArgs.cs
+++ b/src/EditorFeatures/Core/ModernCommands/GoToImplementationCommandArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/src/EditorFeatures/Core/ModernCommands/OrganizeDocumentCommandArgs.cs
+++ b/src/EditorFeatures/Core/ModernCommands/OrganizeDocumentCommandArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/src/EditorFeatures/Core/ModernCommands/SortAndRemoveUnnecessaryImportsCommandArgs.cs
+++ b/src/EditorFeatures/Core/ModernCommands/SortAndRemoveUnnecessaryImportsCommandArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/src/EditorFeatures/Core/ModernCommands/SortImportsCommandArgs.cs
+++ b/src/EditorFeatures/Core/ModernCommands/SortImportsCommandArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.	
 
-#nullable disable
-
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/src/EditorFeatures/Core/NavigateTo/DefaultNavigateToLinkService.cs
+++ b/src/EditorFeatures/Core/NavigateTo/DefaultNavigateToLinkService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;

--- a/src/EditorFeatures/Core/NavigateTo/INavigateToLinkService.cs
+++ b/src/EditorFeatures/Core/NavigateTo/INavigateToLinkService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/EditorFeatures/Core/RenameTracking/IRenameTrackingLanguageHeuristicsService.cs
+++ b/src/EditorFeatures/Core/RenameTracking/IRenameTrackingLanguageHeuristicsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking;

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingCancellationCommandHandler.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingCancellationCommandHandler.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTag.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTag.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking;

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingSolutionSet.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingSolutionSet.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking;
 
 internal sealed partial class RenameTrackingTaggerProvider

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.Tagger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Text;

--- a/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Editor.Tagging;

--- a/src/EditorFeatures/Core/Tagging/TaggerCaretChangeBehavior.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerCaretChangeBehavior.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Editor.Tagging;

--- a/src/EditorFeatures/Core/Tagging/TaggerDelay.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerDelay.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Editor.Tagging;
 
 /// <summary>

--- a/src/EditorFeatures/Core/Tags/IImageIdService.cs
+++ b/src/EditorFeatures/Core/Tags/IImageIdService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Core.Imaging;
 

--- a/src/EditorFeatures/Core/TextViewRoles.cs
+++ b/src/EditorFeatures/Core/TextViewRoles.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Editor;
 
 internal static class TextViewRoles

--- a/src/EditorFeatures/Core/TypeForwarders.cs
+++ b/src/EditorFeatures/Core/TypeForwarders.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 
 // Microsoft.CodeAnalysis.Editor.ContentTypeNames has been moved to Microsoft.CodeAnalysis.Editor.Text.dll

--- a/src/EditorFeatures/Core/Undo/IGlobalUndoService.cs
+++ b/src/EditorFeatures/Core/Undo/IGlobalUndoService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Editor.Undo;

--- a/src/EditorFeatures/Core/Undo/ISourceTextUndoService.cs
+++ b/src/EditorFeatures/Core/Undo/ISourceTextUndoService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;

--- a/src/EditorFeatures/Core/Undo/ISourceTextUndoTransaction.cs
+++ b/src/EditorFeatures/Core/Undo/ISourceTextUndoTransaction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/EditorFeatures/Core/Undo/IWorkspaceGlobalUndoTransaction.cs
+++ b/src/EditorFeatures/Core/Undo/IWorkspaceGlobalUndoTransaction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Editor.Undo;

--- a/src/EditorFeatures/Core/Undo/NoOpGlobalUndoServiceFactory.cs
+++ b/src/EditorFeatures/Core/Undo/NoOpGlobalUndoServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/EditorFeatures/Core/Workspaces/TextUndoHistoryWorkspaceServiceFactoryService.cs
+++ b/src/EditorFeatures/Core/Workspaces/TextUndoHistoryWorkspaceServiceFactoryService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
+++ b/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
@@ -35,7 +35,7 @@ internal sealed partial class CSharpReplacePropertyWithMethodsService() :
         Document document,
         IPropertySymbol property,
         SyntaxNode propertyDeclarationNode,
-        IFieldSymbol propertyBackingField,
+        IFieldSymbol? propertyBackingField,
         string desiredGetMethodName,
         string desiredSetMethodName,
         CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddImport/CodeActions/AddImportCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/AddImportCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/AddImport/CodeActions/InstallWithPackageManagerCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/InstallWithPackageManagerCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Features/Core/Portable/AddPackage/InstallWithPackageManagerCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallWithPackageManagerCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Features/Core/Portable/BraceMatching/BraceMatchingService.cs
+++ b/src/Features/Core/Portable/BraceMatching/BraceMatchingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Features/Core/Portable/BraceMatching/ExportBraceMatcherAttribute.cs
+++ b/src/Features/Core/Portable/BraceMatching/ExportBraceMatcherAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Internal.Log;
 

--- a/src/Features/Core/Portable/ChangeSignature/IUnifiedArgumentSyntax.cs
+++ b/src/Features/Core/Portable/ChangeSignature/IUnifiedArgumentSyntax.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.ChangeSignature;
 
 internal interface IUnifiedArgumentSyntax

--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpan.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpan.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Features/Core/Portable/CodeFixes/CodeFixCollection.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Features/Core/Portable/CodeFixes/CodeFixCollection.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixCollection.cs
@@ -15,7 +15,7 @@ internal sealed class CodeFixCollection(
     object provider,
     TextSpan span,
     ImmutableArray<CodeFix> fixes,
-    FixAllState fixAllState,
+    FixAllState? fixAllState,
     ImmutableArray<FixAllScope> supportedScopes,
     Diagnostic firstDiagnostic)
 {
@@ -26,7 +26,7 @@ internal sealed class CodeFixCollection(
     /// <summary>
     /// Optional fix all context, which is non-null if the given <see cref="Provider"/> supports fix all occurrences code fix.
     /// </summary>
-    public FixAllState FixAllState { get; } = fixAllState;
+    public FixAllState? FixAllState { get; } = fixAllState;
     public ImmutableArray<FixAllScope> SupportedScopes { get; } = supportedScopes.NullToEmpty();
     public Diagnostic FirstDiagnostic { get; } = firstDiagnostic;
 }

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelConfigureSeverityCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelConfigureSeverityCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeActions;
 

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixMultipleCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixMultipleCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
 
 namespace Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/IFixMultipleOccurrencesService.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/IFixMultipleOccurrencesService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Features/Core/Portable/CodeFixes/ICodeFixProviderFactory.cs
+++ b/src/Features/Core/Portable/CodeFixes/ICodeFixProviderFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.AbstractSuppressionCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.AbstractSuppressionCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.CodeFixes.Suppression;
 
 internal abstract partial class AbstractSuppressionCodeFixProvider

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.IPragmaBasedCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.IPragmaBasedCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;

--- a/src/Features/Core/Portable/CodeFixes/Suppression/ExportConfigurationFixProviderAttribute.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/ExportConfigurationFixProviderAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/NestedSuppressionCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/NestedSuppressionCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CodeActions;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.Suppression;

--- a/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Globalization;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Features/Core/Portable/CodeFixes/Suppression/TopLevelSuppressionCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/TopLevelSuppressionCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeActions;
 

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesServiceFactory.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Features/Core/Portable/CodeLens/ICodeLensDisplayInfoService.cs
+++ b/src/Features/Core/Portable/CodeLens/ICodeLensDisplayInfoService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.CodeLens;

--- a/src/Features/Core/Portable/CodeLens/IRemoteCodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/IRemoteCodeLensReferencesService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/CodeLens/IRemoteCodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/IRemoteCodeLensReferencesService.cs
@@ -14,5 +14,5 @@ internal interface IRemoteCodeLensReferencesService
     ValueTask<ReferenceCount?> GetReferenceCountAsync(Checksum solutionChecksum, DocumentId documentId, TextSpan textSpan, int maxResultCount, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<ReferenceLocationDescriptor>?> FindReferenceLocationsAsync(Checksum solutionChecksum, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<ReferenceMethodDescriptor>?> FindReferenceMethodsAsync(Checksum solutionChecksum, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
-    ValueTask<string> GetFullyQualifiedNameAsync(Checksum solutionChecksum, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
+    ValueTask<string?> GetFullyQualifiedNameAsync(Checksum solutionChecksum, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 

--- a/src/Features/Core/Portable/CodeLens/ReferenceMethodDescriptor.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceMethodDescriptor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.CodeLens;

--- a/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringProviderFactory.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringProviderFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CodeRefactorings;

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/IMoveTypeService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/IMoveTypeService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/CodeRefactorings/ServicesLayerCodeActionHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ServicesLayerCodeActionHelpersService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Features/Core/Portable/CodeRefactorings/WorkspaceServices/IAddMetadataReferenceCodeActionOperationFactoryWorkspaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/WorkspaceServices/IAddMetadataReferenceCodeActionOperationFactoryWorkspaceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.CodeActions.WorkspaceServices;

--- a/src/Features/Core/Portable/CodeRefactorings/WorkspaceServices/ISymbolRenamedCodeActionOperationFactoryWorkspaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/WorkspaceServices/ISymbolRenamedCodeActionOperationFactoryWorkspaceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.CodeActions.WorkspaceServices;

--- a/src/Features/Core/Portable/Common/GlyphExtensions.cs
+++ b/src/Features/Core/Portable/Common/GlyphExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Tags;
 

--- a/src/Features/Core/Portable/Common/GlyphTags.cs
+++ b/src/Features/Core/Portable/Common/GlyphTags.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Tags;
 

--- a/src/Features/Core/Portable/Common/TextTags.cs
+++ b/src/Features/Core/Portable/Common/TextTags.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 /// <summary>

--- a/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
@@ -54,7 +54,7 @@ internal abstract partial class AbstractKeywordCompletionProvider<TContext> : LS
         TContext context,
         CancellationToken cancellationToken)
     {
-        var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+        var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
         if (syntaxFacts.IsInNonUserCode(syntaxTree, position, cancellationToken))
             return [];

--- a/src/Features/Core/Portable/Completion/Providers/Scripting/AbstractLoadDirectiveCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Scripting/AbstractLoadDirectiveCompletionProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.Collections;

--- a/src/Features/Core/Portable/Completion/Providers/Scripting/GlobalAssemblyCacheCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Scripting/GlobalAssemblyCacheCompletionHelper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/ForEachInfo.cs
+++ b/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/ForEachInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.ConvertLinq.ConvertForEachToLinqQuery;

--- a/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.NameAndArity.cs
+++ b/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.NameAndArity.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Debugging;
 
 internal abstract partial class AbstractBreakpointResolver

--- a/src/Features/Core/Portable/Debugging/IProximityExpressionsService.cs
+++ b/src/Features/Core/Portable/Debugging/IProximityExpressionsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/Features/Core/Portable/Diagnostics/IAnalyzerDriverService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IAnalyzerDriverService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Runtime.Serialization;

--- a/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogger.cs
+++ b/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Internal.Log;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.Log;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/IRegexNodeVisitor.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/IRegexNodeVisitor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions;
 
 internal interface IRegexNodeVisitor

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexCharClass.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexCharClass.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 // LICENSING NOTE: The license for this file is from the originating 
 // source and not the general https://github.com/dotnet/roslyn license.
 // See https://github.com/dotnet/runtime/blob/5b5bd46c03c86f8545f2c4c8628ac25d875210fe/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text.RegularExpressions;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexNode.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexNode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.EmbeddedLanguages.Common;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexNodes.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexNodes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexTree.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexTree.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.Common;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;

--- a/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldResult.cs
+++ b/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/EncapsulateField/IRemoteEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/IRemoteEncapsulateFieldService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingInvocationReasons_Constants.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingInvocationReasons_Constants.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api;
 
 internal readonly partial struct UnitTestingInvocationReasons

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/ExportUnitTestingIncrementalAnalyzerProviderAttribute.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/ExportUnitTestingIncrementalAnalyzerProviderAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingIncrementalAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api;

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptGlyphHelpers.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptGlyphHelpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript;

--- a/src/Features/Core/Portable/ExtractClass/ExtractClassOptions.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.ExtractClass;

--- a/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.cs
+++ b/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TypeParameterCollector.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TypeParameterCollector.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TypeParameterCollector.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TypeParameterCollector.cs
@@ -19,10 +19,10 @@ internal abstract partial class AbstractExtractMethodService<
         {
             private readonly List<ITypeParameterSymbol> _typeParameters = [];
 
-            public static IEnumerable<ITypeParameterSymbol> Collect(ITypeSymbol typeSymbol)
+            public static IEnumerable<ITypeParameterSymbol> Collect(ITypeSymbol? typeSymbol)
             {
                 var collector = new TypeParameterCollector();
-                typeSymbol.Accept(collector);
+                typeSymbol?.Accept(collector);
 
                 return collector._typeParameters;
             }

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod;
 
 internal sealed partial class OperationStatus
 {
-    public OperationStatus(bool succeeded, string reason)
+    public OperationStatus(bool succeeded, string? reason)
     {
         Succeeded = succeeded;
         Reasons = reason == null ? [] : [reason];

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.ExtractMethod;

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.ExtractMethod;
 
 internal sealed partial class OperationStatus

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus`1.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus`1.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.ExtractMethod;
 
 /// <summary>

--- a/src/Features/Core/Portable/ExtractMethod/UniqueNameGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/UniqueNameGenerator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExtractMethod;

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Features/Core/Portable/FindUsages/DefinitionsAndReferences.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionsAndReferences.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using Roslyn.Utilities;

--- a/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
+++ b/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Classification;
 

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
@@ -101,7 +101,7 @@ internal abstract partial class AbstractGenerateTypeService<TService, TSimpleNam
             var generateTypeOptionsService = _document.Project.Solution.Services.GetRequiredService<IGenerateTypeOptionsService>();
             var notificationService = _document.Project.Solution.Services.GetService<INotificationService>();
             var projectManagementService = _document.Project.Solution.Services.GetService<IProjectManagementService>();
-            var syntaxFactsService = _document.GetLanguageService<ISyntaxFactsService>();
+            var syntaxFactsService = _document.GetRequiredLanguageService<ISyntaxFactsService>();
             var typeKindValue = GetTypeKindOption(_state);
             var isPublicOnlyAccessibility = IsPublicOnlyAccessibility(_state, _document.Project);
             return generateTypeOptionsService.GetGenerateTypeOptions(

--- a/src/Features/Core/Portable/GenerateType/GenerateTypeDialogOptions.cs
+++ b/src/Features/Core/Portable/GenerateType/GenerateTypeDialogOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.GenerateType;
 
 internal sealed class GenerateTypeDialogOptions(

--- a/src/Features/Core/Portable/GenerateType/IGenerateTypeOptionService.cs
+++ b/src/Features/Core/Portable/GenerateType/IGenerateTypeOptionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Notification;

--- a/src/Features/Core/Portable/GenerateType/IGenerateTypeOptionService.cs
+++ b/src/Features/Core/Portable/GenerateType/IGenerateTypeOptionService.cs
@@ -15,7 +15,7 @@ internal interface IGenerateTypeOptionsService : IWorkspaceService
         string className,
         GenerateTypeDialogOptions generateTypeDialogOptions,
         Document document,
-        INotificationService notificationService,
-        IProjectManagementService projectManagementService,
+        INotificationService? notificationService,
+        IProjectManagementService? projectManagementService,
         ISyntaxFactsService syntaxFactsService);
 }

--- a/src/Features/Core/Portable/GenerateType/TypeKindOptions.cs
+++ b/src/Features/Core/Portable/GenerateType/TypeKindOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.GenerateType;

--- a/src/Features/Core/Portable/GoToBase/FindBaseHelpers.cs
+++ b/src/Features/Core/Portable/GoToBase/FindBaseHelpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.FindSymbols.FindReferences;

--- a/src/Features/Core/Portable/GoToDefinition/GoToDefinitionFeatureHelpers.cs
+++ b/src/Features/Core/Portable/GoToDefinition/GoToDefinitionFeatureHelpers.cs
@@ -18,6 +18,9 @@ internal static class GoToDefinitionFeatureHelpers
     public static ISymbol? TryGetPreferredSymbol(
         Solution solution, ISymbol? symbol, CancellationToken cancellationToken)
     {
+        if (symbol is null)
+            return null;
+
         // VB global import aliases have a synthesized SyntaxTree.
         // We can't go to the definition of the alias, so use the target type.
 

--- a/src/Features/Core/Portable/Highlighting/ExportHighlighterAttribute.cs
+++ b/src/Features/Core/Portable/Highlighting/ExportHighlighterAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Features/Core/Portable/Highlighting/HighlightingService.cs
+++ b/src/Features/Core/Portable/Highlighting/HighlightingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Features/Core/Portable/Highlighting/IHighlighter.cs
+++ b/src/Features/Core/Portable/Highlighting/IHighlighter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Features/Core/Portable/Highlighting/IHighlightingService.cs
+++ b/src/Features/Core/Portable/Highlighting/IHighlightingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Attribute.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Attribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.IntroduceVariable;
 
 internal abstract partial class AbstractIntroduceVariableService<TService, TExpressionSyntax, TTypeSyntax, TTypeDeclarationSyntax, TQueryExpressionSyntax, TNameSyntax>

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Block.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Block.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_ConstructorInitializer.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_ConstructorInitializer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Field.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Field.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Parameter.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Parameter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Query.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State_Query.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;

--- a/src/Features/Core/Portable/IntroduceVariable/IIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/IIntroduceVariableService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/ISymbolDisplayService.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/ISymbolDisplayService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/SymbolDescriptionGroups.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/SymbolDescriptionGroups.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.LanguageService;

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedNamespaceOrTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedNamespaceOrTypeSymbol.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.DocumentationComments;
 

--- a/src/Features/Core/Portable/MetadataAsSource/DocumentationCommentUtilities.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/DocumentationCommentUtilities.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFile.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFile.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.MetadataAsSource;
 
 internal sealed class MetadataAsSourceFile

--- a/src/Features/Core/Portable/MoveStaticMembers/MoveStaticMembersWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/MoveStaticMembersWithDialogCodeAction.cs
@@ -127,7 +127,7 @@ internal sealed class MoveStaticMembersWithDialogCodeAction(
         var members = memberNodes
             .Select(node => root.GetCurrentNode(node))
             .WhereNotNull()
-            .SelectAsArray(node => (semanticModel.GetDeclaredSymbol(node, cancellationToken), false));
+            .SelectAsArray(node => (semanticModel.GetRequiredDeclaredSymbol(node, cancellationToken), false));
 
         var pullMembersUpOptions = PullMembersUpOptionsBuilder.BuildPullMembersUpOptions(newType, members);
         var movedSolution = await MembersPuller.PullMembersUpAsync(sourceDoc, pullMembersUpOptions, cancellationToken).ConfigureAwait(false);
@@ -202,7 +202,7 @@ internal sealed class MoveStaticMembersWithDialogCodeAction(
         var members = oldMemberNodes
             .Select(node => root.GetCurrentNode(node))
             .WhereNotNull()
-            .SelectAsArray(node => (semanticModel.GetDeclaredSymbol(node, cancellationToken), false));
+            .SelectAsArray(node => (semanticModel.GetRequiredDeclaredSymbol(node, cancellationToken), false));
 
         newTypeDoc = solutionWithFixedReferences.GetRequiredDocument(newTypeDoc.Id);
         newTypeRoot = await newTypeDoc.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
@@ -316,7 +316,7 @@ internal abstract class AbstractMoveToNamespaceService<TCompilationUnitSyntax, T
         string defaultNamespace,
         ImmutableArray<string> namespaces)
     {
-        var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
+        var syntaxFactsService = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
         return OptionsService.GetChangeNamespaceOptions(
             defaultNamespace,

--- a/src/Features/Core/Portable/MoveToNamespace/IMoveToNamespaceOptionsService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/IMoveToNamespaceOptionsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;

--- a/src/Features/Core/Portable/NavigateTo/NavigateToItemKind.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToItemKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.NavigateTo;
 
 internal static class NavigateToItemKind

--- a/src/Features/Core/Portable/Navigation/NavigableItemFactory.cs
+++ b/src/Features/Core/Portable/Navigation/NavigableItemFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Features/Core/Portable/Notification/INotificationServiceCallback.cs
+++ b/src/Features/Core/Portable/Notification/INotificationServiceCallback.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Notification;

--- a/src/Features/Core/Portable/Organizing/AbstractOrganizingService.cs
+++ b/src/Features/Core/Portable/Organizing/AbstractOrganizingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Features/Core/Portable/Organizing/IOrganizingService.cs
+++ b/src/Features/Core/Portable/Organizing/IOrganizingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/Organizing/Organizers/AbstractSyntaxNodeOrganizer.cs
+++ b/src/Features/Core/Portable/Organizing/Organizers/AbstractSyntaxNodeOrganizer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Features/Core/Portable/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
+++ b/src/Features/Core/Portable/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 

--- a/src/Features/Core/Portable/Organizing/Organizers/ISyntaxOrganizer.cs
+++ b/src/Features/Core/Portable/Organizing/Organizers/ISyntaxOrganizer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Features/Core/Portable/PasteTracking/IPasteTrackingService.cs
+++ b/src/Features/Core/Portable/PasteTracking/IPasteTrackingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.PasteTracking;

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -300,7 +300,7 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
             sourceDescription);
         var documentTooltip = navigateDocument.FilePath + Environment.NewLine + dllPath;
 
-        return new MetadataAsSourceFile(navigateDocument.FilePath, navigateLocation, documentName, documentTooltip);
+        return new MetadataAsSourceFile(navigateDocument.FilePath!, navigateLocation, documentName, documentTooltip);
     }
 
     private ProjectInfo? CreateProjectInfo(Workspace workspace, Project project, ImmutableDictionary<string, string> pdbCompilationOptions, string assemblyName, string assemblyVersion, SourceHashAlgorithm checksumAlgorithm)

--- a/src/Features/Core/Portable/PickMembers/IPickMembersService.cs
+++ b/src/Features/Core/Portable/PickMembers/IPickMembersService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host;
 

--- a/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeConstants.cs
+++ b/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeConstants.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CodeAnalysis.PreferFrameworkType;
 internal static class PreferFrameworkTypeConstants
 {
     public const string PreferFrameworkType = nameof(PreferFrameworkType);
-    public static readonly ImmutableDictionary<string, string> Properties =
-        ImmutableDictionary<string, string>.Empty.Add(PreferFrameworkType, "");
+    public static readonly ImmutableDictionary<string, string?> Properties =
+        ImmutableDictionary<string, string?>.Empty.Add(PreferFrameworkType, "");
 }

--- a/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeConstants.cs
+++ b/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeConstants.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.PreferFrameworkType;

--- a/src/Features/Core/Portable/ProjectManagement/IProjectManagementService.cs
+++ b/src/Features/Core/Portable/ProjectManagement/IProjectManagementService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Host;
 

--- a/src/Features/Core/Portable/PullMemberUp/Dialog/IPullMemberUpOptionsService.cs
+++ b/src/Features/Core/Portable/PullMemberUp/Dialog/IPullMemberUpOptionsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PullMemberUp;

--- a/src/Features/Core/Portable/PullMemberUp/MemberAnalysisResult.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MemberAnalysisResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.PullMemberUp;
 
 internal readonly struct MemberAnalysisResult(

--- a/src/Features/Core/Portable/PullMemberUp/PullMembersUpOptions.cs
+++ b/src/Features/Core/Portable/PullMemberUp/PullMembersUpOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Linq;
 

--- a/src/Features/Core/Portable/PullMemberUp/PullMembersUpOptionsBuilder.cs
+++ b/src/Features/Core/Portable/PullMemberUp/PullMembersUpOptionsBuilder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.PullMemberUp;
 

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -28,7 +28,7 @@ internal abstract class AbstractReplaceMethodWithPropertyService<TMethodDeclarat
         return null;
     }
 
-    private static bool OverridesMetadataSymbol(IMethodSymbol method)
+    private static bool OverridesMetadataSymbol(IMethodSymbol? method)
     {
         for (var current = method; current != null; current = current.OverriddenMethod)
         {

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
@@ -27,11 +27,11 @@ internal interface IReplaceMethodWithPropertyService : ILanguageService
 }
 
 internal readonly struct GetAndSetMethods(
-    IMethodSymbol getMethod, IMethodSymbol setMethod,
-    SyntaxNode getMethodDeclaration, SyntaxNode setMethodDeclaration)
+    IMethodSymbol getMethod, IMethodSymbol? setMethod,
+    SyntaxNode getMethodDeclaration, SyntaxNode? setMethodDeclaration)
 {
     public readonly IMethodSymbol GetMethod = getMethod;
-    public readonly IMethodSymbol SetMethod = setMethod;
+    public readonly IMethodSymbol? SetMethod = setMethod;
     public readonly SyntaxNode GetMethodDeclaration = getMethodDeclaration;
-    public readonly SyntaxNode SetMethodDeclaration = setMethodDeclaration;
+    public readonly SyntaxNode? SetMethodDeclaration = setMethodDeclaration;
 }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGeneration;

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -385,7 +385,7 @@ internal sealed class ReplaceMethodWithPropertyCodeRefactoringProvider() : CodeR
             var setMethodDeclaration = await GetMethodDeclarationAsync(setMethod, cancellationToken).ConfigureAwait(false);
 
             var setMethodDocument = updatedSolution.GetDocument(setMethodDeclaration?.SyntaxTree);
-            if (setMethodDocument?.Id == documentId)
+            if (setMethodDocument?.Id == documentId && setMethodDeclaration != null)
             {
                 service.RemoveSetMethod(editor, setMethodDeclaration);
             }

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -26,7 +27,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
 {
     public abstract SyntaxNode GetPropertyNodeToReplace(SyntaxNode propertyDeclaration);
     public abstract Task<ImmutableArray<SyntaxNode>> GetReplacementMembersAsync(
-        Document document, IPropertySymbol property, SyntaxNode propertyDeclaration, IFieldSymbol propertyBackingField, string desiredGetMethodName, string desiredSetMethodName, CancellationToken cancellationToken);
+        Document document, IPropertySymbol property, SyntaxNode propertyDeclaration, IFieldSymbol? propertyBackingField, string desiredGetMethodName, string desiredSetMethodName, CancellationToken cancellationToken);
 
     protected abstract TCrefSyntax? TryGetCrefSyntax(TIdentifierNameSyntax identifierName);
     protected abstract TCrefSyntax CreateCrefSyntax(TCrefSyntax originalCref, SyntaxToken identifierToken, SyntaxNode? parameterType);
@@ -53,7 +54,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
     public async Task ReplaceReferenceAsync(
         Document document,
         SyntaxEditor editor, SyntaxNode identifierName,
-        IPropertySymbol property, IFieldSymbol propertyBackingField,
+        IPropertySymbol property, IFieldSymbol? propertyBackingField,
         string desiredGetMethodName, string desiredSetMethodName,
         CancellationToken cancellationToken)
     {
@@ -78,7 +79,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
         private readonly ISemanticFactsService _semanticFacts;
         private readonly SyntaxEditor _editor;
         private readonly IPropertySymbol _property;
-        private readonly IFieldSymbol _propertyBackingField;
+        private readonly IFieldSymbol? _propertyBackingField;
         private readonly string _desiredGetMethodName;
         private readonly string _desiredSetMethodName;
 
@@ -95,7 +96,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
             SyntaxEditor editor,
             TIdentifierNameSyntax identifierName,
             IPropertySymbol property,
-            IFieldSymbol propertyBackingField,
+            IFieldSymbol? propertyBackingField,
             string desiredGetMethodName,
             string desiredSetMethodName,
             CancellationToken cancellationToken)
@@ -315,12 +316,12 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
             return _service.CreateCrefSyntax(originalCref, newIdentifierToken, parameterType);
         }
 
-        private SyntaxNode QualifyIfAppropriate(SyntaxNode newIdentifierName)
+        private SyntaxNode QualifyIfAppropriate(IFieldSymbol propertyBackingField, SyntaxNode newIdentifierName)
         {
             // See if already qualified appropriate.
             if (_expression is TIdentifierNameSyntax)
             {
-                var container = _propertyBackingField.IsStatic
+                var container = propertyBackingField.IsStatic
                     ? Generator.TypeExpression(_property.ContainingType)
                     : Generator.ThisExpression();
 
@@ -337,7 +338,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
             if (ShouldReadFromBackingField())
             {
                 var newIdentifierToken = AddConflictAnnotation(Generator.Identifier(_propertyBackingField.Name), conflictMessage);
-                var newIdentifierName = QualifyIfAppropriate(Generator.IdentifierName(newIdentifierToken));
+                var newIdentifierName = QualifyIfAppropriate(_propertyBackingField, Generator.IdentifierName(newIdentifierToken));
 
                 if (keepTrivia)
                 {
@@ -360,7 +361,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
             if (ShouldWriteToBackingField())
             {
                 var newIdentifierToken = AddConflictAnnotation(Generator.Identifier(_propertyBackingField.Name), conflictMessage);
-                var newIdentifierName = QualifyIfAppropriate(Generator.IdentifierName(newIdentifierToken));
+                var newIdentifierName = QualifyIfAppropriate(_propertyBackingField, Generator.IdentifierName(newIdentifierToken));
 
                 if (keepTrivia)
                 {
@@ -410,6 +411,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
             return (TExpressionSyntax)invocation;
         }
 
+        [MemberNotNullWhen(true, nameof(_propertyBackingField))]
         private bool ShouldReadFromBackingField()
             => _propertyBackingField != null && _property.GetMethod == null;
 
@@ -422,6 +424,7 @@ internal abstract class AbstractReplacePropertyWithMethodsService<TIdentifierNam
                 conflictMessage: conflictMessage);
         }
 
+        [MemberNotNullWhen(true, nameof(_propertyBackingField))]
         private bool ShouldWriteToBackingField()
             => _propertyBackingField != null && _property.SetMethod == null;
 

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/IReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/IReplacePropertyWithMethodsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/IReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/IReplacePropertyWithMethodsService.cs
@@ -13,19 +13,19 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods;
 
 internal interface IReplacePropertyWithMethodsService : ILanguageService
 {
-    Task<SyntaxNode> GetPropertyDeclarationAsync(CodeRefactoringContext context);
+    Task<SyntaxNode?> GetPropertyDeclarationAsync(CodeRefactoringContext context);
 
     Task ReplaceReferenceAsync(
         Document document,
         SyntaxEditor editor, SyntaxNode identifierName,
-        IPropertySymbol property, IFieldSymbol propertyBackingField,
+        IPropertySymbol property, IFieldSymbol? propertyBackingField,
         string desiredGetMethodName, string desiredSetMethodName,
         CancellationToken cancellationToken);
 
     Task<ImmutableArray<SyntaxNode>> GetReplacementMembersAsync(
         Document document,
         IPropertySymbol property, SyntaxNode propertyDeclaration,
-        IFieldSymbol propertyBackingField,
+        IFieldSymbol? propertyBackingField,
         string desiredGetMethodName,
         string desiredSetMethodName,
         CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/Shared/Extensions/ProjectExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ProjectExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Shared.Extensions;
 
 internal static class ProjectExtensions

--- a/src/Features/Core/Portable/Shared/Extensions/SyntaxTokenListExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/SyntaxTokenListExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Features/Core/Portable/Shared/IDocumentSupportsFeatureService.cs
+++ b/src/Features/Core/Portable/Shared/IDocumentSupportsFeatureService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Features/Core/Portable/Shared/TestHooks/Legacy/ListenerForwarders.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/Legacy/ListenerForwarders.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Microsoft.CodeAnalysis.Shared.TestHooks.AsynchronousOperationListener))]

--- a/src/Features/Core/Portable/Snippets/ISnippetInfoService.cs
+++ b/src/Features/Core/Portable/Snippets/ISnippetInfoService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Host;
 

--- a/src/Features/Core/Portable/Snippets/ISnippetInfoService.cs
+++ b/src/Features/Core/Portable/Snippets/ISnippetInfoService.cs
@@ -10,6 +10,6 @@ namespace Microsoft.CodeAnalysis.Snippets;
 internal interface ISnippetInfoService : ILanguageService
 {
     IEnumerable<SnippetInfo> GetSnippetsIfAvailable();
-    bool SnippetShortcutExists_NonBlocking(string shortcut);
+    bool SnippetShortcutExists_NonBlocking(string? shortcut);
     bool ShouldFormatSnippet(SnippetInfo snippetInfo);
 }

--- a/src/Features/Core/Portable/Snippets/SnippetInfo.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Snippets;
 
 internal sealed class SnippetInfo(string shortcut, string title, string description, string path)

--- a/src/Features/Core/Portable/SplitOrMergeIfStatements/IIfLikeStatementGenerator.cs
+++ b/src/Features/Core/Portable/SplitOrMergeIfStatements/IIfLikeStatementGenerator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Features/Core/Portable/Structure/BlockStructure.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructure.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Structure;

--- a/src/Features/Core/Portable/Structure/BlockTypes.cs
+++ b/src/Features/Core/Portable/Structure/BlockTypes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Structure;
 
 internal static class BlockTypes

--- a/src/Features/Core/Portable/Structure/Syntax/BlockStructureExtensions.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/BlockStructureExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 

--- a/src/Features/Core/Portable/SymbolSearch/Windows/IAddReferenceDatabaseWrapper.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/IAddReferenceDatabaseWrapper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Elfie.Model;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch;

--- a/src/Features/Core/Portable/SymbolSearch/Windows/IPatchService.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/IPatchService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.SymbolSearch;
 
 /// <summary>

--- a/src/Features/Core/Portable/SymbolSearch/Windows/NativePatching.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/NativePatching.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.DelayService.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.DelayService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch;

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.PatchService.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.PatchService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.SymbolSearch;
 
 internal sealed partial class SymbolSearchUpdateEngine

--- a/src/Features/Core/Portable/TaskList/AbstractTaskListService.cs
+++ b/src/Features/Core/Portable/TaskList/AbstractTaskListService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Host
             }
 
             [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
-            public IWorkspaceService? CreateService(HostWorkspaceServices workspaceServices)
+            public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
                 => new CompileTimeSolutionProvider(workspaceServices.Workspace);
         }
 

--- a/src/Features/Core/Portable/Wrapping/ISyntaxWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ISyntaxWrapper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Features/Core/Portable/Wrapping/ISyntaxWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ISyntaxWrapper.cs
@@ -23,6 +23,6 @@ internal interface ISyntaxWrapper
     /// Returns the <see cref="ICodeActionComputer"/> that produces wrapping code actions for the  
     /// node passed in.  Returns <see langword="null"/> if this Wrapper cannot wrap this node.
     /// </summary>
-    Task<ICodeActionComputer> TryCreateComputerAsync(
+    Task<ICodeActionComputer?> TryCreateComputerAsync(
         Document document, int position, SyntaxNode node, SyntaxWrappingOptions options, bool containsSyntaxError, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
+++ b/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/LanguageServer/Protocol.TestUtilities/Diagnostics/DiagnosticProviderTestUtilities.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/Diagnostics/DiagnosticProviderTestUtilities.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;

--- a/src/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -308,14 +308,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static ContainerElement ToLSPElement(this QuickInfoContainerElement element)
             => new((ContainerElementStyle)element.Style, element.Elements.Select(ToLSPElement));
 
-        private static object? ToLSPElement(QuickInfoElement value)
+        private static object ToLSPElement(QuickInfoElement value)
         {
             return value switch
             {
                 QuickInfoGlyphElement element => element.ToLSPElement(),
                 QuickInfoContainerElement element => element.ToLSPElement(),
                 QuickInfoClassifiedTextElement element => element.ToLSPElement(),
-
                 _ => value
             };
         }

--- a/src/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             var fixAllService = document.Project.Solution.Services.GetRequiredService<IFixAllGetFixesService>();
 
             var solution = await fixAllService.GetFixAllChangedSolutionAsync(
-                new FixAllContext(fixCollection.FixAllState, progressTracker, cancellationToken)).ConfigureAwait(false);
+                new FixAllContext(fixCollection.FixAllState!, progressTracker, cancellationToken)).ConfigureAwait(false);
             Contract.ThrowIfNull(solution);
 
             return solution.GetDocument(document.Id) ?? throw new NotSupportedException(FeaturesResources.Removal_of_document_not_supported);

--- a/src/LanguageServer/Protocol/Features/CodeCleanup/EnabledDiagnosticOptions.cs
+++ b/src/LanguageServer/Protocol/Features/CodeCleanup/EnabledDiagnosticOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CodeCleanup

--- a/src/LanguageServer/Protocol/Features/CodeCleanup/OrganizeUsingsSettings.cs
+++ b/src/LanguageServer/Protocol/Features/CodeCleanup/OrganizeUsingsSettings.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.CodeCleanup
 {
     /// <summary>

--- a/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.FixAllPredefinedDiagnosticProvider.cs
+++ b/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.FixAllPredefinedDiagnosticProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             var fixAllService = document.Project.Solution.Services.GetRequiredService<IFixAllGetFixesService>();
 
             var solution = await fixAllService.GetFixAllChangedSolutionAsync(
-                new FixAllContext(fixCollection.FixAllState, progressTracker, cancellationToken)).ConfigureAwait(false);
+                new FixAllContext(fixCollection.FixAllState!, progressTracker, cancellationToken)).ConfigureAwait(false);
             Contract.ThrowIfNull(solution);
 
             return (TDocument)(solution.GetTextDocument(document.Id) ?? throw new NotSupportedException(FeaturesResources.Removal_of_document_not_supported));

--- a/src/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
         private static async Task<UnifiedSuggestedActionSet?> GetUnifiedFixAllSuggestedActionSetAsync(
             CodeAction action,
             int actionCount,
-            IFixAllState fixAllState,
+            IFixAllState? fixAllState,
             ImmutableArray<FixAllScope> supportedScopes,
             Diagnostic firstDiagnostic,
             Workspace workspace,

--- a/src/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     var linePosSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
                     locations.Add(new LSP.Location
                     {
-                        Uri = ProtocolConversions.CreateAbsoluteUri(declarationFile.FilePath),
+                        Uri = ProtocolConversions.CreateAbsoluteUri(declarationFile.FilePath!),
                         Range = ProtocolConversions.LinePositionToRange(linePosSpan),
                     });
                 }

--- a/src/LanguageServer/Protocol/Protocol/Internal/Text/ContainerElement.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Text/ContainerElement.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/LanguageServer/ProtocolUnitTests/InlineCompletions/TestSnippetInfoService.cs
+++ b/src/LanguageServer/ProtocolUnitTests/InlineCompletions/TestSnippetInfoService.cs
@@ -44,7 +44,7 @@ internal class TestSnippetInfoService : ISnippetInfoService
         throw new NotImplementedException();
     }
 
-    public bool SnippetShortcutExists_NonBlocking(string shortcut)
+    public bool SnippetShortcutExists_NonBlocking(string? shortcut)
     {
         throw new NotImplementedException();
     }

--- a/src/VisualStudio/Core/Def/CallHierarchy/FieldInitializerItem.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/FieldInitializerItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Windows.Media;
 using Microsoft.VisualStudio.Language.CallHierarchy;

--- a/src/VisualStudio/Core/Def/CallHierarchy/Finders/BaseMemberFinder.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/Finders/BaseMemberFinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/VisualStudio/Core/Def/CallHierarchy/Finders/CallToOverrideFinder.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/Finders/CallToOverrideFinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/VisualStudio/Core/Def/CallHierarchy/Finders/FieldReferenceFinder.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/Finders/FieldReferenceFinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/VisualStudio/Core/Def/CallHierarchy/Finders/ImplementerFinder.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/Finders/ImplementerFinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/VisualStudio/Core/Def/CallHierarchy/Finders/InterfaceImplementationCallFinder.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/Finders/InterfaceImplementationCallFinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/VisualStudio/Core/Def/CallHierarchy/Finders/MethodCallFinder.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/Finders/MethodCallFinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/VisualStudio/Core/Def/CallHierarchy/Finders/OverridingMemberFinder.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/Finders/OverridingMemberFinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/VisualStudio/Core/Def/CallHierarchy/ICallHierarchyPresenter.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/ICallHierarchyPresenter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy;
 
 namespace Microsoft.CodeAnalysis.Editor.Host;

--- a/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
@@ -122,7 +122,7 @@ internal sealed class RemoteCodeLensReferencesService : ICodeLensReferencesServi
             var client = await RemoteHostClient.TryGetClientAsync(solution.Services, cancellationToken).ConfigureAwait(false);
             if (client != null)
             {
-                var result = await client.TryInvokeAsync<IRemoteCodeLensReferencesService, string>(
+                var result = await client.TryInvokeAsync<IRemoteCodeLensReferencesService, string?>(
                     solution,
                     (service, solutionInfo, cancellationToken) => service.GetFullyQualifiedNameAsync(solutionInfo, documentId, syntaxNode.Span, cancellationToken),
                     cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/CodeModel/ICodeModelInstanceFactory.cs
+++ b/src/VisualStudio/Core/Def/CodeModel/ICodeModelInstanceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 
 internal interface ICodeModelInstanceFactory

--- a/src/VisualStudio/Core/Def/CodeModel/IProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Def/CodeModel/IProjectCodeModelFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;

--- a/src/VisualStudio/Core/Def/CommonControls/MemberSelection.xaml.cs
+++ b/src/VisualStudio/Core/Def/CommonControls/MemberSelection.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows;
 using System.Windows.Controls;
 

--- a/src/VisualStudio/Core/Def/CommonControls/MemberSelectionViewModel.cs
+++ b/src/VisualStudio/Core/Def/CommonControls/MemberSelectionViewModel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;

--- a/src/VisualStudio/Core/Def/CommonControls/MemberSelectionViewModel.cs
+++ b/src/VisualStudio/Core/Def/CommonControls/MemberSelectionViewModel.cs
@@ -19,13 +19,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CommonControls;
 internal class MemberSelectionViewModel : AbstractNotifyPropertyChanged
 {
     private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor;
-    private readonly ImmutableDictionary<ISymbol, Task<ImmutableArray<ISymbol>>> _symbolToDependentsMap;
+    private readonly ImmutableDictionary<ISymbol, Task<ImmutableArray<ISymbol>>>? _symbolToDependentsMap;
     private readonly ImmutableDictionary<ISymbol, MemberSymbolViewModel> _symbolToMemberViewMap;
 
     public MemberSelectionViewModel(
         IUIThreadOperationExecutor uiThreadOperationExecutor,
         ImmutableArray<MemberSymbolViewModel> members,
-        ImmutableDictionary<ISymbol, Task<ImmutableArray<ISymbol>>> dependentsMap,
+        ImmutableDictionary<ISymbol, Task<ImmutableArray<ISymbol>>>? dependentsMap,
         TypeKind destinationTypeKind = TypeKind.Class,
         bool showDependentsButton = true,
         bool showPublicButton = true)
@@ -113,9 +113,10 @@ internal class MemberSelectionViewModel : AbstractNotifyPropertyChanged
                 showProgress: true,
                 context =>
                 {
-                    foreach (var member in Members)
+                    if (_symbolToDependentsMap != null)
                     {
-                        _symbolToDependentsMap[member.Symbol].Wait(context.UserCancellationToken);
+                        foreach (var member in Members)
+                            _symbolToDependentsMap[member.Symbol].Wait(context.UserCancellationToken);
                     }
                 });
 
@@ -178,11 +179,12 @@ internal class MemberSelectionViewModel : AbstractNotifyPropertyChanged
             var currentMember = queue.Dequeue();
             result.Add(currentMember);
             visited.Add(currentMember);
-            foreach (var dependent in _symbolToDependentsMap[currentMember].Result)
+            if (_symbolToDependentsMap != null)
             {
-                if (!visited.Contains(dependent))
+                foreach (var dependent in _symbolToDependentsMap[currentMember].Result)
                 {
-                    queue.Enqueue(dependent);
+                    if (!visited.Contains(dependent))
+                        queue.Enqueue(dependent);
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/CommonControls/NewTypeDestinationSelection.xaml.cs
+++ b/src/VisualStudio/Core/Def/CommonControls/NewTypeDestinationSelection.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/src/VisualStudio/Core/Def/DebuggerIntelliSense/DebuggerIntellisenseHelpers.cs
+++ b/src/VisualStudio/Core/Def/DebuggerIntelliSense/DebuggerIntellisenseHelpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense;

--- a/src/VisualStudio/Core/Def/DebuggerIntelliSense/DebuggerIntellisenseWorkspace.cs
+++ b/src/VisualStudio/Core/Def/DebuggerIntelliSense/DebuggerIntellisenseWorkspace.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.Loader.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.Loader.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Reflection;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Extensions/SnapshotSpanExtensions.cs
+++ b/src/VisualStudio/Core/Def/Extensions/SnapshotSpanExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;

--- a/src/VisualStudio/Core/Def/Extensions/SourceTextExtensions.cs
+++ b/src/VisualStudio/Core/Def/Extensions/SourceTextExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;

--- a/src/VisualStudio/Core/Def/Extensions/VirtualTreePointExtensions.cs
+++ b/src/VisualStudio/Core/Def/Extensions/VirtualTreePointExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
 

--- a/src/VisualStudio/Core/Def/Extensions/VsTextSpanExtensions.cs
+++ b/src/VisualStudio/Core/Def/Extensions/VsTextSpanExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/Api/ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/Api/ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/Api/ILegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/Api/ILegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis.Api;

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/IVsTypeScriptRemoteLanguageServiceWorkspaceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/IVsTypeScriptRemoteLanguageServiceWorkspaceAccessor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Api;

--- a/src/VisualStudio/Core/Def/ExtractClass/ExtractClassDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/ExtractClass/ExtractClassDialog.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows;
 using System.Windows.Input;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialog.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/ExtractInterface/ExtractInterfaceDialogViewModel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/VisualStudio/Core/Def/F1Help/AbstractHelpContextService.cs
+++ b/src/VisualStudio/Core/Def/F1Help/AbstractHelpContextService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/F1Help/AbstractHelpContextService.cs
+++ b/src/VisualStudio/Core/Def/F1Help/AbstractHelpContextService.cs
@@ -43,5 +43,5 @@ internal abstract class AbstractHelpContextService : IHelpContextService
 
     public abstract Task<string> GetHelpTermAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
 
-    public abstract string FormatSymbol(ISymbol symbol);
+    public abstract string? FormatSymbol(ISymbol symbol);
 }

--- a/src/VisualStudio/Core/Def/F1Help/IHelpContextService.cs
+++ b/src/VisualStudio/Core/Def/F1Help/IHelpContextService.cs
@@ -17,5 +17,5 @@ internal interface IHelpContextService : ILanguageService
 
     Task<string> GetHelpTermAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
 
-    string FormatSymbol(ISymbol symbol);
+    string? FormatSymbol(ISymbol symbol);
 }

--- a/src/VisualStudio/Core/Def/FindReferences/ContainingMemberColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/ContainingMemberColumnDefinition.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -83,7 +83,7 @@ internal partial class StreamingFindUsagesPresenter
             var service = documentSpan.Document.DocumentServiceProvider.GetService<ISpanMappingService>();
             if (service == null)
             {
-                return new MappedSpanResult(documentSpan.Document.FilePath, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);
+                return new MappedSpanResult(documentSpan.Document.FilePath!, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);
             }
 
             var results = await service.MapSpansAsync(
@@ -91,7 +91,7 @@ internal partial class StreamingFindUsagesPresenter
 
             if (results.IsDefaultOrEmpty)
             {
-                return new MappedSpanResult(documentSpan.Document.FilePath, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);
+                return new MappedSpanResult(documentSpan.Document.FilePath!, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);
             }
 
             // if span mapping service filtered out the span, make sure

--- a/src/VisualStudio/Core/Def/GenerateType/GenerateTypeDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/GenerateType/GenerateTypeDialog.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;

--- a/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
+++ b/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;

--- a/src/VisualStudio/Core/Def/IAnalyzerNodeSetup.cs
+++ b/src/VisualStudio/Core/Def/IAnalyzerNodeSetup.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;

--- a/src/VisualStudio/Core/Def/ID.CSharpCommands.cs
+++ b/src/VisualStudio/Core/Def/ID.CSharpCommands.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.LanguageServices;
 
 internal static partial class ID

--- a/src/VisualStudio/Core/Def/IInvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/IInvisibleEditor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.Text;
 

--- a/src/VisualStudio/Core/Def/Implementation/ICodeModelNavigationPointService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ICodeModelNavigationPointService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;

--- a/src/VisualStudio/Core/Def/Interactive/LogMessage.cs
+++ b/src/VisualStudio/Core/Def/Interactive/LogMessage.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.LanguageServices.Interactive;
 
 internal static class LogMessage

--- a/src/VisualStudio/Core/Def/Interactive/VsUpdateSolutionEvents.cs
+++ b/src/VisualStudio/Core/Def/Interactive/VsUpdateSolutionEvents.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/VisualStudio/Core/Def/Interop/Feedback.cs
+++ b/src/VisualStudio/Core/Def/Interop/Feedback.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace Microsoft.VisualStudio.Feedback.Interop;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService.IVsAutoOutliningClient.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService.IVsAutoOutliningClient.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo2.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.TextManager.Interop;
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -158,7 +158,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
             var navigationBarClient = new NavigationBarClient(dropdownManager, _codeWindow, _languageService.SystemServiceProvider, _languageService.Workspace);
             var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(buffer);
             var controllerFactoryService = _languageService.Package.ComponentModel.GetService<INavigationBarControllerFactoryService>();
-            var newController = controllerFactoryService.CreateController(navigationBarClient, textBuffer);
+            var newController = controllerFactoryService.CreateController(navigationBarClient, textBuffer!);
             var hr = dropdownManager.AddDropdownBar(cCombos: 3, pClient: navigationBarClient);
 
             if (ErrorHandler.Failed(hr))

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -165,13 +165,13 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         public int IsMappedLocation(IVsTextBuffer pBuffer, int iLine, int iCol)
             => VSConstants.E_NOTIMPL;
 
-        public int ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName? ppNames)
+        public int ResolveName(string? pszName, uint dwFlags, out IVsEnumDebugName? ppNames)
         {
             // In VS, this method frequently get's called with an empty string to test if the language service
             // supports this method (some language services, like F#, implement IVsLanguageDebugInfo but don't
             // implement this method).  In that scenario, there's no sense doing work, so we'll just return
             // S_FALSE (as the old VB language service did).
-            if (string.IsNullOrEmpty(pszName))
+            if (pszName is null or "")
             {
                 ppNames = null;
                 return VSConstants.S_FALSE;
@@ -226,7 +226,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
             if (mappedSpan != null)
                 span = mappedSpan.Value;
 
-            return new VsDebugName(breakpoint.LocationNameOpt, filePath, span);
+            return new VsDebugName(breakpoint.LocationNameOpt, filePath!, span);
         }
 
         public int ValidateBreakpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, VsTextSpan[] pCodeSpan)

--- a/src/VisualStudio/Core/Def/Library/AbstractLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/AbstractLibraryManager.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.ComponentModelHost;

--- a/src/VisualStudio/Core/Def/Library/AbstractLibraryManager_IOleCommandTarget.cs
+++ b/src/VisualStudio/Core/Def/Library/AbstractLibraryManager_IOleCommandTarget.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.OLE.Interop;
 

--- a/src/VisualStudio/Core/Def/Library/AbstractLibraryService.cs
+++ b/src/VisualStudio/Core/Def/Library/AbstractLibraryService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library.VsNavInfo;

--- a/src/VisualStudio/Core/Def/Library/ILibraryService.cs
+++ b/src/VisualStudio/Core/Def/Library/ILibraryService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library.VsNavInfo;
 

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractDescriptionBuilder.LinkFlags.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractDescriptionBuilder.LinkFlags.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser;

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager_Description.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager_Description.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager_ListItems.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager_ListItems.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Helpers.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Helpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/FolderListItem.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/FolderListItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Language.Intellisense;
 

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/MemberListItem.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/MemberListItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/NamespaceListItem.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/NamespaceListItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser.Lists;

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/ProjectListItem.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/ProjectListItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Language.Intellisense;

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/SymbolListItem`1.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/SymbolListItem`1.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser.Lists;

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/TypeListItem.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/TypeListItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser.Lists;

--- a/src/VisualStudio/Core/Def/Library/VsNavInfo/Extensions.cs
+++ b/src/VisualStudio/Core/Def/Library/VsNavInfo/Extensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/VisualStudio/Core/Def/Library/VsNavInfo/NavInfoNode.cs
+++ b/src/VisualStudio/Core/Def/Library/VsNavInfo/NavInfoNode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.VsNavInfo;

--- a/src/VisualStudio/Core/Def/Library/VsNavInfo/NavInfoNodeEnum.cs
+++ b/src/VisualStudio/Core/Def/Library/VsNavInfo/NavInfoNodeEnum.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/VisualStudio/Core/Def/Log/VisualStudioErrorLogger.cs
+++ b/src/VisualStudio/Core/Def/Log/VisualStudioErrorLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.ErrorLogger;

--- a/src/VisualStudio/Core/Def/MoveStaticMembers/VisualStudioMoveStaticMembersOptionsService.cs
+++ b/src/VisualStudio/Core/Def/MoveStaticMembers/VisualStudioMoveStaticMembersOptionsService.cs
@@ -89,7 +89,7 @@ internal sealed class VisualStudioMoveStaticMembersOptionsService(
         INamedTypeSymbol selectedType,
         ImmutableArray<ISymbol> selectedNodeSymbols,
         LinkedList<INamedTypeSymbol> history,
-        IGlyphService? glyphService,
+        IGlyphService glyphService,
         IUIThreadOperationExecutor uiThreadOperationExecutor)
     {
         var membersInType = selectedType.GetMembers().

--- a/src/VisualStudio/Core/Def/MoveToNamespace/MoveToNamespaceDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/MoveToNamespace/MoveToNamespaceDialog.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/src/VisualStudio/Core/Def/MoveToNamespace/NamespaceItem.cs
+++ b/src/VisualStudio/Core/Def/MoveToNamespace/NamespaceItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace;
 
 internal class NamespaceItem

--- a/src/VisualStudio/Core/Def/NavigateTo/VisualStudioNavigateToPreviewService.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/VisualStudioNavigateToPreviewService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo;
 using Microsoft.CodeAnalysis.Navigation;

--- a/src/VisualStudio/Core/Def/NavigateTo/VisualStudioNavigateToPreviewServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/VisualStudioNavigateToPreviewServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo;

--- a/src/VisualStudio/Core/Def/Packaging/Interop/SVsRemoteControlService.cs
+++ b/src/VisualStudio/Core/Def/Packaging/Interop/SVsRemoteControlService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Internal.VisualStudio.Shell.Interop;

--- a/src/VisualStudio/Core/Def/Preview/ChangeList.cs
+++ b/src/VisualStudio/Core/Def/Preview/ChangeList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview;

--- a/src/VisualStudio/Core/Def/Preview/PreviewService.cs
+++ b/src/VisualStudio/Core/Def/Preview/PreviewService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Preview/ReferenceChange.AnalyzerReferenceChange.cs
+++ b/src/VisualStudio/Core/Def/Preview/ReferenceChange.AnalyzerReferenceChange.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/VisualStudio/Core/Def/Preview/ReferenceChange.MetadataReferenceChange.cs
+++ b/src/VisualStudio/Core/Def/Preview/ReferenceChange.MetadataReferenceChange.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview;

--- a/src/VisualStudio/Core/Def/Preview/ReferenceChange.ProjectReferenceChange.cs
+++ b/src/VisualStudio/Core/Def/Preview/ReferenceChange.ProjectReferenceChange.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview;

--- a/src/VisualStudio/Core/Def/Preview/SpanChange.cs
+++ b/src/VisualStudio/Core/Def/Preview/SpanChange.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/VisualStudio/Core/Def/Progression/GraphNodeCreation.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphNodeCreation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/ContainsChildrenGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/ContainsChildrenGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/ContainsGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/ContainsGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/ImplementedByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/ImplementedByGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/ImplementsGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/ImplementsGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritedByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritedByGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritsGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritsGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/IsCalledByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/IsCalledByGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/OverriddenByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/OverriddenByGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/OverridesGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/OverridesGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Progression/IGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/IGraphQuery.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Progression/IProgressionLanguageService.cs
+++ b/src/VisualStudio/Core/Def/Progression/IProgressionLanguageService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Progression/IconHelper.cs
+++ b/src/VisualStudio/Core/Def/Progression/IconHelper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Progression/RoslynGraphCategories.cs
+++ b/src/VisualStudio/Core/Def/Progression/RoslynGraphCategories.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.GraphModel;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression;

--- a/src/VisualStudio/Core/Def/Progression/RoslynGraphProperties.cs
+++ b/src/VisualStudio/Core/Def/Progression/RoslynGraphProperties.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editing;

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/ICodeModelFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/ICodeModelFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 /// <summary>

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/ITempPECompiler.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/ITempPECompiler.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Extensions/ServiceProviderExtensions.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Extensions/ServiceProviderExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.ComponentModelHost;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/IAnalyzerConfigFileHost.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/IAnalyzerConfigFileHost.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/IAnalyzerHost.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/IAnalyzerHost.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/ICompilerOptionsHostObject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/ICompilerOptionsHostObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/IIntPtrReturningVsInvisibleEditorManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/IIntPtrReturningVsInvisibleEditorManager.cs
@@ -22,8 +22,8 @@ internal interface IIntPtrReturningVsInvisibleEditorManager
 {
     int RegisterInvisibleEditor(
         [MarshalAs(UnmanagedType.LPWStr)] string pszMkDocument,
-        IVsProject pProject,
+        IVsProject? pProject,
         uint dwFlags,
-        IVsSimpleDocFactory pFactory,
+        IVsSimpleDocFactory? pFactory,
         out IntPtr ppEditor);
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/IIntPtrReturningVsInvisibleEditorManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/IIntPtrReturningVsInvisibleEditorManager.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/IIntellisenseBuildTarget.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/IIntellisenseBuildTarget.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/IProjectSiteEx.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/IProjectSiteEx.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Interop/IVsUndoState.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Interop/IVsUndoState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerConfigFileHost.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerConfigFileHost.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_ICompilerOptionsHostObject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_ICompilerOptionsHostObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IVsHierarchyEvents.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IVsHierarchyEvents.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IVsReportExternalErrors.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IVsReportExternalErrors.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/SolutionEventsBatchScopeCreator.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/SolutionEventsBatchScopeCreator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;

--- a/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Shared.TestHooks;

--- a/src/VisualStudio/Core/Def/ProjectSystem/ViewEventArgs.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/ViewEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.TextManager.Interop;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectManagementService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectManagementService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -302,7 +302,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
         }
         else
         {
-            return _projectCodeModelFactory.Value.GetOrCreateFileCodeModel(documentId.ProjectId, document.FilePath);
+            return _projectCodeModelFactory.Value.GetOrCreateFileCodeModel(documentId.ProjectId, document.FilePath!);
         }
     }
 
@@ -490,7 +490,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
 
         var originalProject = CurrentSolution.GetRequiredProject(projectId);
         var compilationOptionsService = originalProject.Services.GetRequiredService<ICompilationOptionsChangingService>();
-        var storage = ProjectPropertyStorage.Create(TryGetDTEProject(projectId), ServiceProvider.GlobalProvider);
+        var storage = ProjectPropertyStorage.Create(TryGetDTEProject(projectId)!, ServiceProvider.GlobalProvider);
         compilationOptionsService.Apply(originalProject.CompilationOptions!, options, storage);
     }
 
@@ -507,7 +507,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
         }
 
         var parseOptionsService = CurrentSolution.GetRequiredProject(projectId).Services.GetRequiredService<IParseOptionsChangingService>();
-        var storage = ProjectPropertyStorage.Create(TryGetDTEProject(projectId), ServiceProvider.GlobalProvider);
+        var storage = ProjectPropertyStorage.Create(TryGetDTEProject(projectId)!, ServiceProvider.GlobalProvider);
         parseOptionsService.Apply(options, storage);
     }
 

--- a/src/VisualStudio/Core/Def/PullMemberUp/MainDialog/PullMemberUpDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/PullMemberUp/MainDialog/PullMemberUpDialog.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
 using System.Windows;
 using System.Windows.Input;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/PullMemberUp/WarningDialog/PullMemberUpWarningDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/PullMemberUp/WarningDialog/PullMemberUpWarningDialog.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
 using System.Windows;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.PlatformUI;

--- a/src/VisualStudio/Core/Def/PullMemberUp/WarningDialog/PullMemberUpWarningViewModel.cs
+++ b/src/VisualStudio/Core/Def/PullMemberUp/WarningDialog/PullMemberUpWarningViewModel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Internal.Log;

--- a/src/VisualStudio/Core/Def/RoslynActivityLogger.cs
+++ b/src/VisualStudio/Core/Def/RoslynActivityLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Shared/LogicalStringComparer.cs
+++ b/src/VisualStudio/Core/Def/Shared/LogicalStringComparer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/Shared/VisualStudioImageIdService.cs
+++ b/src/VisualStudio/Core/Def/Shared/VisualStudioImageIdService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/VisualStudio/Core/Def/Snippets/AbstractSnippetInfoService.cs
+++ b/src/VisualStudio/Core/Def/Snippets/AbstractSnippetInfoService.cs
@@ -94,7 +94,7 @@ internal abstract class AbstractSnippetInfoService : ISnippetInfoService, IVsExp
         }
     }
 
-    public bool SnippetShortcutExists_NonBlocking(string shortcut)
+    public bool SnippetShortcutExists_NonBlocking(string? shortcut)
     {
         if (shortcut == null)
         {

--- a/src/VisualStudio/Core/Def/Snippets/IVsContainedLanguageHostInternal.cs
+++ b/src/VisualStudio/Core/Def/Snippets/IVsContainedLanguageHostInternal.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/Snippets/IVsExpansionSessionInternal.cs
+++ b/src/VisualStudio/Core/Def/Snippets/IVsExpansionSessionInternal.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/VisualStudio/Core/Def/Snippets/IVsExpansionSessionInternal.cs
+++ b/src/VisualStudio/Core/Def/Snippets/IVsExpansionSessionInternal.cs
@@ -30,7 +30,7 @@ internal interface IVsExpansionSessionInternal
     /// before leaving the calling method.
     /// </summary>
     [PreserveSig]
-    int GetSnippetNode([MarshalAs(UnmanagedType.BStr)] string bstrNode, out IntPtr pNode);
+    int GetSnippetNode([MarshalAs(UnmanagedType.BStr)] string? bstrNode, out IntPtr pNode);
 
     void Reserved9();
     void Reserved10();

--- a/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/AbstractSnippetFunction.IVsExpansionFunction.cs
+++ b/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/AbstractSnippetFunction.IVsExpansionFunction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.TextManager.Interop;

--- a/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -265,9 +265,9 @@ internal sealed class VisualStudioSuppressionFixService(
                 if (!documentDiagnosticsPerLanguage.IsEmpty)
                 {
                     var suppressionFixer = GetSuppressionFixer(documentDiagnosticsPerLanguage.SelectMany(kvp => kvp.Value), language, _codeFixService);
-                    if (suppressionFixer != null)
+                    var suppressionFixAllProvider = suppressionFixer?.GetFixAllProvider();
+                    if (suppressionFixer != null && suppressionFixAllProvider != null)
                     {
-                        var suppressionFixAllProvider = suppressionFixer.GetFixAllProvider();
                         newSolution = await _fixMultipleOccurencesService.GetFixAsync(
                             documentDiagnosticsPerLanguage,
                             _workspace,
@@ -290,9 +290,9 @@ internal sealed class VisualStudioSuppressionFixService(
                 if (!projectDiagnosticsPerLanguage.IsEmpty)
                 {
                     var suppressionFixer = GetSuppressionFixer(projectDiagnosticsPerLanguage.SelectMany(kvp => kvp.Value), language, _codeFixService);
-                    if (suppressionFixer != null)
+                    var suppressionFixAllProvider = suppressionFixer?.GetFixAllProvider();
+                    if (suppressionFixer != null && suppressionFixAllProvider != null)
                     {
-                        var suppressionFixAllProvider = suppressionFixer.GetFixAllProvider();
                         newSolution = await _fixMultipleOccurencesService.GetFixAsync(
                              projectDiagnosticsPerLanguage,
                              _workspace,

--- a/src/VisualStudio/Core/Def/Telemetry/CodeMarkerLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/CodeMarkerLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/VisualStudio/Core/Def/Utilities/BooleanReverseConverter.cs
+++ b/src/VisualStudio/Core/Def/Utilities/BooleanReverseConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.Windows.Data;

--- a/src/VisualStudio/Core/Def/Utilities/ComEventSink.cs
+++ b/src/VisualStudio/Core/Def/Utilities/ComEventSink.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.OLE.Interop;
 

--- a/src/VisualStudio/Core/Def/Utilities/EnumBoolConverter.cs
+++ b/src/VisualStudio/Core/Def/Utilities/EnumBoolConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.Windows;

--- a/src/VisualStudio/Core/Def/Utilities/GlyphExtensions.cs
+++ b/src/VisualStudio/Core/Def/Utilities/GlyphExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Windows.Media;
 using Microsoft.CodeAnalysis;

--- a/src/VisualStudio/Core/Def/Utilities/IVsEnumDebugName.cs
+++ b/src/VisualStudio/Core/Def/Utilities/IVsEnumDebugName.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TextManager.Interop;
 

--- a/src/VisualStudio/Core/Def/Utilities/IVsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Utilities/IVsLanguageDebugInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 internal interface IVsLanguageDebugInfo
 {
     [PreserveSig]
-    int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR ppEnum);
+    int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR? ppEnum);
 
     [PreserveSig]
     int ValidateBreakpointLocation(
@@ -24,16 +24,16 @@ internal interface IVsLanguageDebugInfo
         [In, Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.Struct)] TextSpan[] pCodeSpan);
 
     [PreserveSig]
-    int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, [MarshalAs(UnmanagedType.BStr)] out string pbstrName, out int piLineOffset);
+    int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, [MarshalAs(UnmanagedType.BStr)] out string? pbstrName, out int piLineOffset);
 
     [PreserveSig]
     int GetLocationOfName(
         [MarshalAs(UnmanagedType.LPWStr)] string pszName,
-        [MarshalAs(UnmanagedType.BStr)] out string pbstrMkDoc,
+        [MarshalAs(UnmanagedType.BStr)] out string? pbstrMkDoc,
         out TextSpan pspanLocation);
 
     [PreserveSig]
-    int ResolveName([MarshalAs(UnmanagedType.LPWStr)] string pszName, uint dwFlags, out IVsEnumDebugName ppNames);
+    int ResolveName([MarshalAs(UnmanagedType.LPWStr)] string? pszName, uint dwFlags, out IVsEnumDebugName? ppNames);
 
     [PreserveSig]
     int GetLanguageID(IVsTextBuffer pBuffer, int iLine, int iCol, out Guid pguidLanguageID);

--- a/src/VisualStudio/Core/Def/Utilities/IVsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Utilities/IVsLanguageDebugInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TextManager.Interop;

--- a/src/VisualStudio/Core/Def/Utilities/ProjectPropertyStorage.cs
+++ b/src/VisualStudio/Core/Def/Utilities/ProjectPropertyStorage.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using EnvDTE;

--- a/src/VisualStudio/Core/Def/Utilities/SymbolViewModel.cs
+++ b/src/VisualStudio/Core/Def/Utilities/SymbolViewModel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows.Media;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/VisualStudio/Core/Def/Utilities/TaskItemsEnum.cs
+++ b/src/VisualStudio/Core/Def/Utilities/TaskItemsEnum.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;

--- a/src/VisualStudio/Core/Def/Utilities/VisualStudioNavigateToLinkService.cs
+++ b/src/VisualStudio/Core/Def/Utilities/VisualStudioNavigateToLinkService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;

--- a/src/VisualStudio/Core/Def/Utilities/VsDebugName.cs
+++ b/src/VisualStudio/Core/Def/Utilities/VsDebugName.cs
@@ -8,11 +8,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 
 internal class VsDebugName : IVsDebugName
 {
-    private readonly string _name;
+    private readonly string? _name;
     private readonly string _document;
     private readonly TextSpan _textSpan;
 
-    public VsDebugName(string name, string document, TextSpan textSpan)
+    public VsDebugName(string? name, string document, TextSpan textSpan)
     {
         _name = name;
         _document = document;
@@ -31,7 +31,7 @@ internal class VsDebugName : IVsDebugName
         return VSConstants.S_OK;
     }
 
-    public int GetName(out string pbstrName)
+    public int GetName(out string? pbstrName)
     {
         pbstrName = _name;
         return VSConstants.S_OK;

--- a/src/VisualStudio/Core/Def/Utilities/VsDebugName.cs
+++ b/src/VisualStudio/Core/Def/Utilities/VsDebugName.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;

--- a/src/VisualStudio/Core/Def/Utilities/VsEnumBSTR.cs
+++ b/src/VisualStudio/Core/Def/Utilities/VsEnumBSTR.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TextManager.Interop;
 

--- a/src/VisualStudio/Core/Def/Utilities/VsEnumDebugName.cs
+++ b/src/VisualStudio/Core/Def/Utilities/VsEnumDebugName.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TextManager.Interop;
 

--- a/src/VisualStudio/Core/Def/Venus/CodeBlockEnumerator.cs
+++ b/src/VisualStudio/Core/Def/Venus/CodeBlockEnumerator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TextManager.Interop;

--- a/src/VisualStudio/Core/Def/Venus/IAdditionalFormattingRuleLanguageService.cs
+++ b/src/VisualStudio/Core/Def/Venus/IAdditionalFormattingRuleLanguageService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host;
 

--- a/src/VisualStudio/Core/Def/Venus/IVsContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Venus/IVsContainedLanguageCodeSupport.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/VisualStudio/Core/Def/Venus/IVsContainedLanguageStaticEventBinding.cs
+++ b/src/VisualStudio/Core/Def/Venus/IVsContainedLanguageStaticEventBinding.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/VisualStudio/Core/Def/Venus/VenusCommandFilter`2.cs
+++ b/src/VisualStudio/Core/Def/Venus/VenusCommandFilter`2.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.VisualStudio.Editor;

--- a/src/VisualStudio/Core/Def/Venus/VenusTaskExtensions.cs
+++ b/src/VisualStudio/Core/Def/Venus/VenusTaskExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Roslyn.Utilities;
 using System.Threading;

--- a/src/VisualStudio/Core/Def/Workspace/GlobalUndoServiceFactory.WorkspaceGlobalUndoTransaction.cs
+++ b/src/VisualStudio/Core/Def/Workspace/GlobalUndoServiceFactory.WorkspaceGlobalUndoTransaction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/VisualStudio/Core/Def/Workspace/GlobalUndoServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/GlobalUndoServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioAddMetadataReferenceCodeActionOperationFactoryWorkspaceService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioAddMetadataReferenceCodeActionOperationFactoryWorkspaceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolRenamedCodeActionOperationFactoryWorkspaceService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolRenamedCodeActionOperationFactoryWorkspaceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -399,17 +399,16 @@ internal sealed class CSharpRenameConflictLanguageService() : AbstractRenameRewr
 
                 var isMemberGroupReference = _semanticFactsService.IsInsideNameOfExpression(_semanticModel, token.Parent, _cancellationToken);
 
-                var renameAnnotation =
-                        new RenameActionAnnotation(
-                            token.Span,
-                            isRenameLocation,
-                            prefix,
-                            suffix,
-                            renameDeclarationLocations: renameDeclarationLocations,
-                            isOriginalTextLocation: isOldText,
-                            isNamespaceDeclarationReference: isNamespaceDeclarationReference,
-                            isInvocationExpression: false,
-                            isMemberGroupReference: isMemberGroupReference);
+                var renameAnnotation = new RenameActionAnnotation(
+                    token.Span,
+                    isRenameLocation,
+                    prefix,
+                    suffix,
+                    renameDeclarationLocations: renameDeclarationLocations,
+                    isOriginalTextLocation: isOldText,
+                    isNamespaceDeclarationReference: isNamespaceDeclarationReference,
+                    isInvocationExpression: false,
+                    isMemberGroupReference: isMemberGroupReference);
 
                 newToken = _renameAnnotations.WithAdditionalAnnotations(newToken, renameAnnotation, new RenameTokenSimplificationAnnotation() { OriginalTextSpan = token.Span });
 

--- a/src/Workspaces/Core/Desktop/TypeForwarders.cs
+++ b/src/Workspaces/Core/Desktop/TypeForwarders.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 
 // Microsoft.CodeAnalysis.FileTextLoader has been moved to Microsoft.CodeAnalysis.Workspaces.dll.

--- a/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// This delegate allows test code to override the behavior of <see cref="Create(IEnumerable{Assembly})"/>.
         /// </summary>
         /// <seealso cref="TestAccessor.HookServiceCreation"/>
-        private static CreationHook s_CreationHook;
+        private static CreationHook? s_CreationHook;
 
         // the export provider for the MEF composition
         private readonly ExportProvider _exportProvider;
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// </summary>
         public IEnumerable<Lazy<TExtension, TMetadata>> GetExports<TExtension, TMetadata>()
         {
-            var key = new ExportKey(typeof(TExtension).AssemblyQualifiedName, typeof(TMetadata).AssemblyQualifiedName);
+            var key = new ExportKey(typeof(TExtension).AssemblyQualifiedName!, typeof(TMetadata).AssemblyQualifiedName!);
             if (!_exportsMap.TryGetValue(key, out var exports))
             {
                 exports = ImmutableInterlocked.GetOrAdd(ref _exportsMap, key, _ =>
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// </summary>
         public IEnumerable<Lazy<TExtension>> GetExports<TExtension>()
         {
-            var key = new ExportKey(typeof(TExtension).AssemblyQualifiedName, "");
+            var key = new ExportKey(typeof(TExtension).AssemblyQualifiedName!, "");
             if (!_exportsMap.TryGetValue(key, out var exports))
             {
                 exports = ImmutableInterlocked.GetOrAdd(ref _exportsMap, key, _ =>
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
                     && string.Compare(this.MetadataTypeName, other.MetadataTypeName, StringComparison.OrdinalIgnoreCase) == 0;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
                 => obj is ExportKey exportKey && this.Equals(exportKey);
 
             public override int GetHashCode()

--- a/src/Workspaces/Core/Portable/CodeStyle/NotificationOption.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/NotificationOption.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -248,7 +248,7 @@ internal sealed class DiagnosticData(
     private static ImmutableDictionary<string, string?>? GetAdditionalProperties(TextDocument document, Diagnostic diagnostic)
     {
         var service = document.Project.GetLanguageService<IDiagnosticPropertiesService>();
-        return service?.GetAdditionalProperties(diagnostic);
+        return service?.GetAdditionalProperties(diagnostic)!;
     }
 
     private static ImmutableArray<DiagnosticDataLocation> GetAdditionalLocations(TextDocument document, Diagnostic diagnostic)

--- a/src/Workspaces/Core/Portable/Diagnostics/DocumentDiagnosticAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DocumentDiagnosticAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Workspaces/Core/Portable/Diagnostics/FileContentLoadAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/FileContentLoadAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Workspaces/Core/Portable/Diagnostics/IDiagnosticPropertiesService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IDiagnosticPropertiesService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host;
 

--- a/src/Workspaces/Core/Portable/Diagnostics/IWorkspaceVenusSpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IWorkspaceVenusSpanMappingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Workspaces/Core/Portable/Diagnostics/ProjectDiagnosticAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/ProjectDiagnosticAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Workspaces/Core/Portable/Diagnostics/WellKnownDiagnosticPropertyNames.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/WellKnownDiagnosticPropertyNames.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal static class WellKnownDiagnosticPropertyNames

--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonImmutableArraySubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonImmutableArraySubsequence.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 

--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubstring.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubstring.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Differencing;

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editing;

--- a/src/Workspaces/Core/Portable/Editing/TypeConstraintKind.cs
+++ b/src/Workspaces/Core/Portable/Editing/TypeConstraintKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Editing;

--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaObjectPool.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaObjectPool.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaSyntaxFactsServiceWrapper.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaSyntaxFactsServiceWrapper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 

--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingFatalErrorAccessor.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/Api/UnitTestingFatalErrorAccessor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.ErrorReporting;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
@@ -24,7 +24,7 @@ internal abstract class AbstractMethodOrPropertyOrEventSymbolReferenceFinder<TSy
 
             // the only accessor method referenced in a foreach-statement is the .Current's
             // get-accessor
-            return symbols.CurrentProperty.GetMethod == null
+            return symbols.CurrentProperty?.GetMethod == null
                 ? []
                 : [symbols.CurrentProperty.GetMethod];
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/ReferencedSymbol.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/ReferencedSymbol.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Workspaces/Core/Portable/FindSymbols/StreamingProgressCollector.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/StreamingProgressCollector.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Workspaces/Core/Portable/Log/EmptyLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/EmptyLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Internal.Log;

--- a/src/Workspaces/Core/Portable/Log/EtwLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/EtwLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics.Tracing;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/Log/IErrorLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/IErrorLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Host;
 

--- a/src/Workspaces/Core/Portable/Log/InteractionClass.cs
+++ b/src/Workspaces/Core/Portable/Log/InteractionClass.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Internal.Log;

--- a/src/Workspaces/Core/Portable/Log/WorkspaceErrorLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/WorkspaceErrorLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatchKind.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatchKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.PatternMatching;

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.PatternSegment.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.PatternSegment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.PatternMatching;

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.TextChunk.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.TextChunk.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Utilities;

--- a/src/Workspaces/Core/Portable/Serialization/IOptionsSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/IOptionsSerializationService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Roslyn.Utilities;

--- a/src/Workspaces/Core/Portable/Shared/Utilities/ExtensionOrderer.Node.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/ExtensionOrderer.Node.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.SolutionCrawler;
 
 internal readonly partial struct InvocationReasons

--- a/src/Workspaces/Core/Portable/SolutionCrawler/PredefinedInvocationReasons.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/PredefinedInvocationReasons.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.SolutionCrawler;
 
 internal static class PredefinedInvocationReasons

--- a/src/Workspaces/Core/Portable/Workspace/DocumentActiveContextChangedEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/DocumentActiveContextChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Workspaces/Core/Portable/Workspace/DocumentEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/DocumentEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Caching/IWorkspaceCacheService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Caching/IWorkspaceCacheService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentExcerptService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentExcerptService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentOperationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentOperationService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host;
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISpanMappingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/Workspace/Host/EventListener/IWorkspaceEventListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/EventListener/IWorkspaceEventListenerProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostServices.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host;
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ILanguageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ILanguageServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host.Mef;
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/IWorkspaceServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/IWorkspaceServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host.Mef;
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/DefaultAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/DefaultAnalyzerService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IAnalyzerService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host;
 
 // Obsolete - used only for MSBuild workspace extensibility,

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IMetadataService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IMetadataService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host;
 
 internal interface IMetadataService : IWorkspaceService

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IPersistentStorageFaultInjectionService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IPersistentStorageFaultInjectionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IRuleSetFile.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IRuleSetFile.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentDiagnostic.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentDiagnostic.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 public class DocumentDiagnostic(WorkspaceDiagnosticKind kind, string message, DocumentId documentId) : WorkspaceDiagnostic(kind, message)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.EquivalenceResult.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.EquivalenceResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 internal partial class DocumentState

--- a/src/Workspaces/Core/Portable/Workspace/Solution/IDocumentTextDifferencingService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/IDocumentTextDifferencingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/PreservationMode.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/PreservationMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.EquivalenceResult.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.EquivalenceResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 public partial class Project

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDiagnostic.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDiagnostic.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 public class ProjectDiagnostic(WorkspaceDiagnosticKind kind, string message, ProjectId projectId) : WorkspaceDiagnostic(kind, message)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDifferenceTypes.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDifferenceTypes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis;

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 public enum WorkspaceChangeKind

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnostic.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnostic.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 public class WorkspaceDiagnostic(WorkspaceDiagnosticKind kind, string message)

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticDescriptors.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticDescriptors.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis;
 
 internal sealed class WorkspaceDiagnosticDescriptors

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnosticEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis;

--- a/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Text;
 using Xunit;

--- a/src/Workspaces/CoreTest/Differencing/MatchTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/MatchTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Roslyn.Utilities;
 using Xunit;

--- a/src/Workspaces/CoreTest/Differencing/TestTreeComparer.cs
+++ b/src/Workspaces/CoreTest/Differencing/TestTreeComparer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.TestSolutionsAndProject.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.TestSolutionsAndProject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Workspaces/CoreTest/FunctionIdTests.cs
+++ b/src/Workspaces/CoreTest/FunctionIdTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Internal.Log;

--- a/src/Workspaces/CoreTest/Options/NamingStylePreferencesTests.cs
+++ b/src/Workspaces/CoreTest/Options/NamingStylePreferencesTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Xml.Linq;

--- a/src/Workspaces/CoreTest/Shared/Extensions/TelemetryExtensions/TelemetryExtensionTests.cs
+++ b/src/Workspaces/CoreTest/Shared/Extensions/TelemetryExtensions/TelemetryExtensionTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Xunit;

--- a/src/Workspaces/CoreTest/Shared/Extensions/TextSpanExtensions/SubtractTests.cs
+++ b/src/Workspaces/CoreTest/Shared/Extensions/TextSpanExtensions/SubtractTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;

--- a/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using Roslyn.Utilities;
 using Xunit;

--- a/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Text.Json;
 using Microsoft.CodeAnalysis.ErrorReporting;

--- a/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;

--- a/src/Workspaces/CoreTest/UtilityTest/FormattingRangeHelperTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/FormattingRangeHelperTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Roslyn.Test.Utilities;

--- a/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading;

--- a/src/Workspaces/CoreTest/UtilityTest/SpellCheckerTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SpellCheckerTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Roslyn.Utilities;
 using Xunit;
 

--- a/src/Workspaces/CoreTest/UtilityTest/StringEscapingTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/StringEscapingTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Roslyn.Utilities;
 using Xunit;
 

--- a/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/src/Workspaces/CoreTest/WorkspaceTests/DynamicFileInfoProviderMefTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/DynamicFileInfoProviderMefTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/CoreTestUtilities/Fakes/MockWorkspaceEventListenerProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/MockWorkspaceEventListenerProvider.cs
@@ -19,6 +19,6 @@ internal sealed class MockWorkspaceEventListenerProvider() : IWorkspaceServiceFa
 {
     public IEnumerable<IEventListener>? EventListeners;
 
-    public IWorkspaceService? CreateService(HostWorkspaceServices workspaceServices)
-        => EventListeners != null ? new DefaultWorkspaceEventListenerServiceFactory.Service(workspaceServices.Workspace, EventListeners) : null;
+    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+        => EventListeners != null ? new DefaultWorkspaceEventListenerServiceFactory.Service(workspaceServices.Workspace, EventListeners) : null!;
 }

--- a/src/Workspaces/CoreTestUtilities/MEF/IMefHostExportProviderExtensions.cs
+++ b/src/Workspaces/CoreTestUtilities/MEF/IMefHostExportProviderExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Host.Mef;

--- a/src/Workspaces/CoreTestUtilities/TestTextLoader.cs
+++ b/src/Workspaces/CoreTestUtilities/TestTextLoader.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/Workspaces/CoreTestUtilities/Workspaces/AbstractTestHostProject.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/AbstractTestHostProject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestHostSolution.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestHostSolution.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.CollectTypeParameterSymbolsVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.CollectTypeParameterSymbolsVisitor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.CompilationTypeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.CompilationTypeGenerator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Shared.Extensions;
 
 internal static partial class ITypeSymbolExtensions

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/DataFlowAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/DataFlowAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/FlowCaptureKind.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/FlowCaptureKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.FlowAnalysis;
 
 /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.OperationTreeAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.OperationTreeAnalysisData.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageResult.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Naming/IdentifierNameParts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Naming/IdentifierNameParts.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.NamingStyles;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.WordSpanEnumerable.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.WordSpanEnumerable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.NamingStyles;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.WordSpanEnumerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.WordSpanEnumerator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyleRules.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyleRules.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/Precedence/IPrecedenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/Precedence/IPrecedenceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Precedence;
 
 internal interface IPrecedenceService

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SemanticFacts/ForEachSymbols.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SemanticFacts/ForEachSymbols.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.LanguageService;
 
 internal readonly struct ForEachSymbols

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SemanticFacts/ForEachSymbols.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SemanticFacts/ForEachSymbols.cs
@@ -4,25 +4,16 @@
 
 namespace Microsoft.CodeAnalysis.LanguageService;
 
-internal readonly struct ForEachSymbols
+internal readonly struct ForEachSymbols(
+    IMethodSymbol? getEnumeratorMethod,
+    IMethodSymbol? moveNextMethod,
+    IPropertySymbol? currentProperty,
+    IMethodSymbol? disposeMethod,
+    ITypeSymbol? elementType)
 {
-    public readonly IMethodSymbol GetEnumeratorMethod;
-    public readonly IMethodSymbol MoveNextMethod;
-    public readonly IPropertySymbol CurrentProperty;
-    public readonly IMethodSymbol DisposeMethod;
-    public readonly ITypeSymbol ElementType;
-
-    internal ForEachSymbols(IMethodSymbol getEnumeratorMethod,
-                            IMethodSymbol moveNextMethod,
-                            IPropertySymbol currentProperty,
-                            IMethodSymbol disposeMethod,
-                            ITypeSymbol elementType)
-        : this()
-    {
-        this.GetEnumeratorMethod = getEnumeratorMethod;
-        this.MoveNextMethod = moveNextMethod;
-        this.CurrentProperty = currentProperty;
-        this.DisposeMethod = disposeMethod;
-        this.ElementType = elementType;
-    }
+    public readonly IMethodSymbol? GetEnumeratorMethod = getEnumeratorMethod;
+    public readonly IMethodSymbol? MoveNextMethod = moveNextMethod;
+    public readonly IPropertySymbol? CurrentProperty = currentProperty;
+    public readonly IMethodSymbol? DisposeMethod = disposeMethod;
+    public readonly ITypeSymbol? ElementType = elementType;
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractDocumentationCommentService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractDocumentationCommentService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using Roslyn.Utilities;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractDocumentationCommentService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/AbstractDocumentationCommentService.cs
@@ -56,8 +56,11 @@ internal abstract class AbstractDocumentationCommentService<
     }
 
     public string GetBannerText(
-        TDocumentationCommentTriviaSyntax documentationComment, int maxBannerLength, CancellationToken cancellationToken)
+        TDocumentationCommentTriviaSyntax? documentationComment, int maxBannerLength, CancellationToken cancellationToken)
     {
+        if (documentationComment is null)
+            return "";
+
         // TODO: Consider unifying code to extract text from an Xml Documentation Comment (https://github.com/dotnet/roslyn/issues/2290)
         var summaryElement =
             documentationComment.ChildNodes().OfType<TXmlElementSyntax>()
@@ -184,6 +187,6 @@ internal abstract class AbstractDocumentationCommentService<
     private static bool HasTrailingWhitespace(string tokenText)
         => tokenText.Length > 0 && char.IsWhiteSpace(tokenText[^1]);
 
-    public string GetBannerText(SyntaxNode documentationCommentTriviaSyntax, int maxBannerLength, CancellationToken cancellationToken)
-        => GetBannerText((TDocumentationCommentTriviaSyntax)documentationCommentTriviaSyntax, maxBannerLength, cancellationToken);
+    public string GetBannerText(SyntaxNode? documentationCommentTriviaSyntax, int maxBannerLength, CancellationToken cancellationToken)
+        => GetBannerText((TDocumentationCommentTriviaSyntax?)documentationCommentTriviaSyntax, maxBannerLength, cancellationToken);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ExternalSourceInfo.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ExternalSourceInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.LanguageService;
 
 internal readonly struct ExternalSourceInfo(int? startLine, bool ends)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/IDocumentationCommentService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/IDocumentationCommentService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.LanguageService;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/IDocumentationCommentService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/IDocumentationCommentService.cs
@@ -8,5 +8,5 @@ namespace Microsoft.CodeAnalysis.LanguageService;
 
 internal interface IDocumentationCommentService
 {
-    string GetBannerText(SyntaxNode documentationCommentTriviaSyntax, int bannerLength, CancellationToken cancellationToken);
+    string GetBannerText(SyntaxNode? documentationCommentTriviaSyntax, int bannerLength, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AnonymousTypeSymbolKey.cs
@@ -20,7 +20,7 @@ internal partial struct SymbolKey
 
             var properties = symbol.GetMembers().OfType<IPropertySymbol>().ToImmutableArray();
             var propertyTypes = properties.SelectAsArray(p => p.Type);
-            var propertyNames = properties.SelectAsArray(p => p.Name);
+            var propertyNames = properties.SelectAsArray(p => (string?)p.Name);
             var propertyIsReadOnly = properties.SelectAsArray(p => p.SetMethod == null);
             var propertyLocations = properties.SelectAsArray(p => p.Locations.FirstOrDefault());
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -16,12 +16,12 @@ internal partial struct SymbolKey
 {
     private static class BodyLevelSymbolKey
     {
-        public static ImmutableArray<Location> GetBodyLevelSourceLocations(ISymbol symbol, CancellationToken cancellationToken)
+        public static ImmutableArray<Location?> GetBodyLevelSourceLocations(ISymbol symbol, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(IsBodyLevelSymbol(symbol));
             Contract.ThrowIfTrue(symbol.DeclaringSyntaxReferences.IsEmpty && symbol.Locations.IsEmpty);
 
-            using var _ = ArrayBuilder<Location>.GetInstance(out var result);
+            using var _ = ArrayBuilder<Location?>.GetInstance(out var result);
 
             foreach (var location in symbol.Locations)
             {
@@ -62,7 +62,7 @@ internal partial struct SymbolKey
 
             var locations = GetBodyLevelSourceLocations(symbol, cancellationToken);
 
-            Contract.ThrowIfFalse(locations.All(loc => loc.IsInSource));
+            Contract.ThrowIfFalse(locations.All(loc => loc != null && loc.IsInSource));
             visitor.WriteLocationArray(locations.Distinct());
 
             // and the containingSymbol/ordinal for resilience
@@ -74,7 +74,7 @@ internal partial struct SymbolKey
 
             int GetOrdinal()
             {
-                var syntaxTree = locations[0].SourceTree;
+                var syntaxTree = locations[0]!.SourceTree;
                 var compilation = ((ISourceAssemblySymbol)symbol.ContainingAssembly).Compilation;
 
                 // See if we can find an appropriate container for this local and attempt to find this local's index

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
@@ -49,9 +49,9 @@ internal partial struct SymbolKey
         /// For a symbol like <c>System.Collections.Generic.IEnumerable</c>, this would produce <c>"Generic",
         /// "Collections", "System"</c>
         /// </summary>
-        private static ImmutableArray<string> GetContainingNamespaceNamesInReverse(INamespaceSymbol namespaceSymbol)
+        private static ImmutableArray<string?> GetContainingNamespaceNamesInReverse(INamespaceSymbol namespaceSymbol)
         {
-            using var _ = ArrayBuilder<string>.GetInstance(out var builder);
+            using var _ = ArrayBuilder<string?>.GetInstance(out var builder);
             while (namespaceSymbol != null && namespaceSymbol.Name != "")
             {
                 builder.Add(namespaceSymbol.Name);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -289,8 +289,6 @@ internal partial struct SymbolKey
         // annotating WriteStringArray and WriteLocationArray as allowing null elements
         // then causes issues where we can't pass ImmutableArrays of non-null elements
 
-#nullable disable
-
         internal void WriteStringArray(ImmutableArray<string> strings)
             => WriteArray(strings, _writeString);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -289,10 +289,10 @@ internal partial struct SymbolKey
         // annotating WriteStringArray and WriteLocationArray as allowing null elements
         // then causes issues where we can't pass ImmutableArrays of non-null elements
 
-        internal void WriteStringArray(ImmutableArray<string> strings)
+        internal void WriteStringArray(ImmutableArray<string?> strings)
             => WriteArray(strings, _writeString);
 
-        internal void WriteLocationArray(ImmutableArray<Location> array)
+        internal void WriteLocationArray(ImmutableArray<Location?> array)
             => WriteArray(array, _writeLocation);
 
 #nullable enable

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
@@ -22,7 +22,7 @@ internal partial struct SymbolKey
             var isError = symbol.TupleUnderlyingType!.TypeKind == TypeKind.Error;
 
             using var _1 = ArrayBuilder<string?>.GetInstance(out var friendlyNames);
-            using var _2 = ArrayBuilder<Location>.GetInstance(out var locations);
+            using var _2 = ArrayBuilder<Location?>.GetInstance(out var locations);
 
             foreach (var element in symbol.TupleElements)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
@@ -148,13 +148,14 @@ internal partial struct SymbolKey(string data) : IEquatable<SymbolKey>
         if (IsBodyLevelSymbol(symbol))
         {
             var locations = BodyLevelSymbolKey.GetBodyLevelSourceLocations(symbol, cancellationToken);
-            if (locations.Length == 0)
+            var firstNonNull = locations.FirstOrDefault(l => l != null);
+            if (firstNonNull is null)
                 return false;
 
             // Ensure that the tree we're looking at is actually in this compilation.  It may not be in the
             // compilation in the case of work done with a speculative model.
             var compilation = ((ISourceAssemblySymbol)symbol.ContainingAssembly).Compilation;
-            return compilation.SyntaxTrees.Contains(locations.First().SourceTree);
+            return compilation.SyntaxTrees.Contains(firstNonNull.SourceTree);
         }
 
         return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/RoslynParallel.NetFramework.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/RoslynParallel.NetFramework.cs
@@ -10,7 +10,6 @@
 #pragma warning disable IDE2004 // Blank line not allowed after constructor initializer colon
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
 
-#nullable disable
 
 // Ported from
 // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/RoslynParallel.NetFramework.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/RoslynParallel.NetFramework.cs
@@ -10,6 +10,7 @@
 #pragma warning disable IDE2004 // Blank line not allowed after constructor initializer colon
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
 
+#nullable disable
 
 // Ported from
 // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/InternalExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/InternalExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using System.Threading;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpCommandLineParserService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpCommandLineParserService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpCommandLineParserService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpCommandLineParserService.cs
@@ -19,7 +19,7 @@ internal sealed class CSharpCommandLineParserService : ICommandLineParserService
     {
     }
 
-    public CommandLineArguments Parse(IEnumerable<string> arguments, string baseDirectory, bool isInteractive, string sdkDirectory)
+    public CommandLineArguments Parse(IEnumerable<string> arguments, string? baseDirectory, bool isInteractive, string? sdkDirectory)
     {
 #if SCRIPTING
         var parser = isInteractive ? CSharpCommandLineParser.Interactive : CSharpCommandLineParser.Default;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpGeneratedCodeRecognitionService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpGeneratedCodeRecognitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.GeneratedCodeRecognition;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpReplaceDiscardDeclarationsWithAssignmentsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpReplaceDiscardDeclarationsWithAssignmentsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Diagnostics;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsServiceFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSemanticFactsServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSymbolDeclarationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSymbolDeclarationService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Composition;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsServiceFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxFactsServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxKindsServiceFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxKindsServiceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 #if CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Editing;
 namespace Microsoft.CodeAnalysis.CodeGeneration;
 
 internal sealed class CodeGenerationConstructorSymbol(
-    INamedTypeSymbol containingType,
+    INamedTypeSymbol? containingType,
     ImmutableArray<AttributeData> attributes,
     Accessibility accessibility,
     DeclarationModifiers modifiers,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 #if CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Editing;
 namespace Microsoft.CodeAnalysis.CodeGeneration;
 
 internal sealed class CodeGenerationConversionSymbol(
-    INamedTypeSymbol containingType,
+    INamedTypeSymbol? containingType,
     ImmutableArray<AttributeData> attributes,
     Accessibility declaredAccessibility,
     DeclarationModifiers modifiers,
@@ -21,7 +21,7 @@ internal sealed class CodeGenerationConversionSymbol(
     IParameterSymbol fromType,
     bool isImplicit,
     ImmutableArray<AttributeData> toTypeAttributes,
-    string documentationCommentXml) : CodeGenerationMethodSymbol(containingType,
+    string? documentationCommentXml) : CodeGenerationMethodSymbol(containingType,
           attributes,
           declaredAccessibility,
           modifiers,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationDestructorSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationDestructorSymbol.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CodeGeneration;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationDestructorSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationDestructorSymbol.cs
@@ -7,7 +7,7 @@ using System.Collections.Immutable;
 namespace Microsoft.CodeAnalysis.CodeGeneration;
 
 internal sealed class CodeGenerationDestructorSymbol(
-    INamedTypeSymbol containingType,
+    INamedTypeSymbol? containingType,
     ImmutableArray<AttributeData> attributes) : CodeGenerationMethodSymbol(containingType,
          attributes,
          Accessibility.NotApplicable,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationNamespaceOrTypeSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationNamespaceOrTypeSymbol.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 #if CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 #if CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Editing;
 namespace Microsoft.CodeAnalysis.CodeGeneration;
 
 internal sealed class CodeGenerationOperatorSymbol(
-    INamedTypeSymbol containingType,
+    INamedTypeSymbol? containingType,
     ImmutableArray<AttributeData> attributes,
     Accessibility accessibility,
     DeclarationModifiers modifiers,
@@ -21,7 +21,7 @@ internal sealed class CodeGenerationOperatorSymbol(
     CodeGenerationOperatorKind operatorKind,
     ImmutableArray<IParameterSymbol> parameters,
     ImmutableArray<AttributeData> returnTypeAttributes,
-    string documentationCommentXml) : CodeGenerationMethodSymbol(containingType,
+    string? documentationCommentXml) : CodeGenerationMethodSymbol(containingType,
          attributes,
          accessibility,
          modifiers,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/CommandLine/ICommandLineParserService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/CommandLine/ICommandLineParserService.cs
@@ -8,5 +8,5 @@ namespace Microsoft.CodeAnalysis.Host;
 
 internal interface ICommandLineParserService : ILanguageService
 {
-    CommandLineArguments Parse(IEnumerable<string> arguments, string baseDirectory, bool isInteractive, string sdkDirectory);
+    CommandLineArguments Parse(IEnumerable<string> arguments, string? baseDirectory, bool isInteractive, string? sdkDirectory);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/CommandLine/ICommandLineParserService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/CommandLine/ICommandLineParserService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/GeneratedCodeRecognition/IGeneratedCodeRecognitionService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/GeneratedCodeRecognition/IGeneratedCodeRecognitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/MoveDeclarationNearReference/IMoveDeclarationNearReferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/MoveDeclarationNearReference/IMoveDeclarationNearReferenceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/ReplaceDiscardDeclarationsWithAssignments/IReplaceDiscardDeclarationsWithAssignmentsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/ReplaceDiscardDeclarationsWithAssignments/IReplaceDiscardDeclarationsWithAssignmentsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.cs
@@ -13,7 +13,7 @@ internal abstract partial class AbstractTypeInferenceService : ITypeInferenceSer
     protected abstract AbstractTypeInferrer CreateTypeInferrer(SemanticModel semanticModel, CancellationToken cancellationToken);
 
     private static ImmutableArray<ITypeSymbol> InferTypeBasedOnNameIfEmpty(
-        SemanticModel semanticModel, ImmutableArray<ITypeSymbol> result, string nameOpt)
+        SemanticModel semanticModel, ImmutableArray<ITypeSymbol> result, string? nameOpt)
     {
         if (result.IsEmpty && nameOpt != null)
         {
@@ -24,7 +24,7 @@ internal abstract partial class AbstractTypeInferenceService : ITypeInferenceSer
     }
 
     private static ImmutableArray<TypeInferenceInfo> InferTypeBasedOnNameIfEmpty(
-        SemanticModel semanticModel, ImmutableArray<TypeInferenceInfo> result, string nameOpt)
+        SemanticModel semanticModel, ImmutableArray<TypeInferenceInfo> result, string? nameOpt)
     {
         if (result.IsEmpty && nameOpt != null)
         {
@@ -78,7 +78,7 @@ internal abstract partial class AbstractTypeInferenceService : ITypeInferenceSer
 
     public ImmutableArray<ITypeSymbol> InferTypes(
         SemanticModel semanticModel, int position,
-        string nameOpt, CancellationToken cancellationToken)
+        string? nameOpt, CancellationToken cancellationToken)
     {
         var result = CreateTypeInferrer(semanticModel, cancellationToken)
             .InferTypes(position)
@@ -90,7 +90,7 @@ internal abstract partial class AbstractTypeInferenceService : ITypeInferenceSer
 
     public ImmutableArray<ITypeSymbol> InferTypes(
         SemanticModel semanticModel, SyntaxNode expression,
-        string nameOpt, CancellationToken cancellationToken)
+        string? nameOpt, CancellationToken cancellationToken)
     {
         var result = CreateTypeInferrer(semanticModel, cancellationToken)
             .InferTypes(expression)
@@ -102,7 +102,7 @@ internal abstract partial class AbstractTypeInferenceService : ITypeInferenceSer
 
     public ImmutableArray<TypeInferenceInfo> GetTypeInferenceInfo(
         SemanticModel semanticModel, int position,
-        string nameOpt, CancellationToken cancellationToken)
+        string? nameOpt, CancellationToken cancellationToken)
     {
         var result = CreateTypeInferrer(semanticModel, cancellationToken).InferTypes(position);
         return InferTypeBasedOnNameIfEmpty(semanticModel, result, nameOpt);
@@ -110,7 +110,7 @@ internal abstract partial class AbstractTypeInferenceService : ITypeInferenceSer
 
     public ImmutableArray<TypeInferenceInfo> GetTypeInferenceInfo(
         SemanticModel semanticModel, SyntaxNode expression,
-        string nameOpt, CancellationToken cancellationToken)
+        string? nameOpt, CancellationToken cancellationToken)
     {
         var result = CreateTypeInferrer(semanticModel, cancellationToken).InferTypes(expression);
         return InferTypeBasedOnNameIfEmpty(semanticModel, result, nameOpt);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/ITypeInferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/ITypeInferenceService.cs
@@ -24,11 +24,11 @@ namespace Microsoft.CodeAnalysis.LanguageService;
 /// </summary>
 internal interface ITypeInferenceService : ILanguageService
 {
-    ImmutableArray<ITypeSymbol> InferTypes(SemanticModel semanticModel, SyntaxNode expression, string nameOpt, CancellationToken cancellationToken);
-    ImmutableArray<ITypeSymbol> InferTypes(SemanticModel semanticModel, int position, string nameOpt, CancellationToken cancellationToken);
+    ImmutableArray<ITypeSymbol> InferTypes(SemanticModel semanticModel, SyntaxNode expression, string? nameOpt, CancellationToken cancellationToken);
+    ImmutableArray<ITypeSymbol> InferTypes(SemanticModel semanticModel, int position, string? nameOpt, CancellationToken cancellationToken);
 
-    ImmutableArray<TypeInferenceInfo> GetTypeInferenceInfo(SemanticModel semanticModel, int position, string nameOpt, CancellationToken cancellationToken);
-    ImmutableArray<TypeInferenceInfo> GetTypeInferenceInfo(SemanticModel semanticModel, SyntaxNode expression, string nameOpt, CancellationToken cancellationToken);
+    ImmutableArray<TypeInferenceInfo> GetTypeInferenceInfo(SemanticModel semanticModel, int position, string? nameOpt, CancellationToken cancellationToken);
+    ImmutableArray<TypeInferenceInfo> GetTypeInferenceInfo(SemanticModel semanticModel, SyntaxNode expression, string? nameOpt, CancellationToken cancellationToken);
 }
 
 internal readonly record struct TypeInferenceInfo(ITypeSymbol InferredType, bool IsParams)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/ITypeInferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/ITypeInferenceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameActionAnnotation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameActionAnnotation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Rename.ConflictEngine;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameActionAnnotation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameActionAnnotation.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine;
 internal sealed class RenameActionAnnotation(
     TextSpan originalSpan,
     bool isRenameLocation,
-    string prefix,
-    string suffix,
+    string? prefix,
+    string? suffix,
     bool isOriginalTextLocation,
     RenameDeclarationLocationReference[] renameDeclarationLocations,
     bool isNamespaceDeclarationReference,
@@ -42,13 +42,13 @@ internal sealed class RenameActionAnnotation(
     /// When replacing the annotated token this string will be prepended to the token's value. This is used when renaming compiler 
     /// generated fields and methods backing properties (e.g. "get_X" or "_X" for property "X").
     /// </summary>
-    public readonly string Prefix = prefix;
+    public readonly string? Prefix = prefix;
 
     /// <summary>
     /// When replacing the annotated token this string will be appended to the token's value. This is used when renaming compiler 
     /// generated types whose names are derived from user given names (e.g. "XEventHandler" for event "X").
     /// </summary>
-    public readonly string Suffix = suffix;
+    public readonly string? Suffix = suffix;
 
     /// <summary>
     /// A single dimensional array of annotations to verify after rename.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameAnnotation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameAnnotation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Rename.ConflictEngine;
 
 internal class RenameAnnotation

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameInvalidIdentifierAnnotation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Rename/Annotations/RenameInvalidIdentifierAnnotation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Rename.ConflictEngine;
 
 internal sealed class RenameInvalidIdentifierAnnotation : RenameAnnotation

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractReducer.IExpressionRewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractReducer.IExpressionRewriter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractReducer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractReducer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Simplification;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractSimplificationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractSimplificationService.cs
@@ -196,7 +196,7 @@ internal abstract class AbstractSimplificationService<
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using var rewriter = reducer.GetOrCreateRewriter();
-                rewriter.Initialize(document.Project.ParseOptions, options, cancellationToken);
+                rewriter.Initialize(document.Project.ParseOptions!, options, cancellationToken);
 
                 do
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/ILanguageMetadata.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/ILanguageMetadata.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host.Mef;
 
 /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/ILanguagesMetadata.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/ILanguagesMetadata.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Host.Mef;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/IMefHostExportProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/IMefHostExportProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefConstruction.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefConstruction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Host.Mef;
 
 internal static class MefConstruction


### PR DESCRIPTION
We've nullable disabled a bunch of files in the IDE, for reasons i don't understand.  Our code should be nullable safe.  And if not, we should fix it.  I'm enabling nullability on roslyn ide.