### PR TITLE
Add build utils to simplify local package sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # User-specific files
 *.suo
 *.user
+*.user.props
 *.userprefs
 *.sln.docstates
 *.svclog

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -286,6 +286,14 @@
     <Warning Condition="'%(RestrictedInternalsVisibleTo.Partner)' == '' and '%(RestrictedInternalsVisibleTo.Namespace)' == ''" Text="RestrictedInternalsVisibleTo items must specify the 'Partner' or 'Namespace' attribute. Target assembly: %(Identity)" />
   </Target>
 
+  <!--
+    Deletes the package built by this project from local NuGet cache (if present).
+    Allows refreshing locally built Roslyn packages consumed by another local repo.
+  -->
+  <Target Name="NuGetCacheCleanup" AfterTargets="Pack" Condition="'$(IsPackable)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'">
+    <RemoveDir Directories="$(NuGetPackageRoot)\$(PackageId)\$(Version)" />
+  </Target>
+
   <!-- Make sure expected compile items are included -->
   <ItemGroup>
     <UnexpectedCompileExcludes Include="@(ExpectedCompile)" Exclude="@(Compile)" />

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -241,4 +241,7 @@
     <DefineConstants Condition="'$(DefineConstants)' != ''">DOTNET_BUILD_FROM_SOURCE;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(DefineConstants)' == ''">DOTNET_BUILD_FROM_SOURCE</DefineConstants>
   </PropertyGroup>
+
+  <!-- Allow devs to locally override settings (the file is gitignore'd) -->
+  <Import Project="Settings.user.props" Condition="Exists('Settings.user.props')" />
 </Project>


### PR DESCRIPTION
Automatically deletes package built by a project from NuGet cache. This allows build from another repo to use Roslyn package output dir as a package source without manually cleaning up packages for every Roslyn change.

Imports `Settings.user.props` from `Settings.props` to allow devs to locally override properties, such as `VSSDKTargetPlatformRegRootSuffix`.
Adds `*.user.props` to `.gitignore` to keep it local.