### PR TITLE
Set PackageProjectUrl

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <Copyright>$(CopyrightMicrosoft)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/dotnet/roslyn</PackageProjectUrl>
 
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</PackageTags>
     <ThirdPartyNoticesFilePath>$(MSBuildThisFileDirectory)..\..\src\NuGet\ThirdPartyNotices.rtf</ThirdPartyNoticesFilePath>


### PR DESCRIPTION
Avoids the SDK setting this to dotnet/dotnet automatically, which is generally not useful for customers.