### PR TITLE
Workaround issue related to crossgen and specific .NET 9 runtimes

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -65,7 +65,7 @@
   <Target Name="SetCrossgen2ExtraArgs" BeforeTargets="ResolveReadyToRunCompilers" Condition="'$(PublishReadyToRun)' == 'true'">
     <PropertyGroup>
       <!-- Define extra crossgen2 args.  This must be done in a target as TargetName isn't available in evaluation -->
-      <PublishReadyToRunCrossgen2ExtraArgs>$(PublishReadyToRunCrossgen2ExtraArgs);--opt-cross-module:*;--non-local-generics-module:"$(TargetName)"</PublishReadyToRunCrossgen2ExtraArgs>
+      <PublishReadyToRunCrossgen2ExtraArgs>$(PublishReadyToRunCrossgen2ExtraArgs);--non-local-generics-module:"$(TargetName)"</PublishReadyToRunCrossgen2ExtraArgs>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
Helps resolve https://github.com/dotnet/vscode-csharp/issues/8034?reload=1

Related to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2419950

This arg appears to be triggering crossgen issues in certain .NET 9 runtimes (specifically, 9.0.0 and upcoming 9.0.4), resulting in a BadImageFormatException being thrown loading the language server.

Until we get to the bottom of the issue, we should remove this arg so that the server can function with these existing runtimes.