### PR TITLE
Another attempt to fix the SDK insertion issue related to runtime/apphost downloads

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -44,7 +44,6 @@
     <PublishDir Condition="'$(RuntimeIdentifier)' != ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <PublishDir Condition="'$(RuntimeIdentifier)' == ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/neutral</PublishDir>
 
-
     <!-- List of runtime identifiers that we want to publish an executable for. -->
     <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseOS.
          TargetRid and BaseOS are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
@@ -57,7 +56,7 @@
     <!-- These indicate that the runtime/apphost packages should not be downloaded as part of build/restore -->
     <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
     <EnableAppHostPackDownload>false</EnableAppHostPackDownload>
-    
+
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -44,6 +44,20 @@
     <PublishDir Condition="'$(RuntimeIdentifier)' != ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <PublishDir Condition="'$(RuntimeIdentifier)' == ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/neutral</PublishDir>
 
+
+    <!-- List of runtime identifiers that we want to publish an executable for. -->
+    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseOS.
+         TargetRid and BaseOS are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
+         https://github.com/dotnet/dotnet/blob/main/repo-projects/roslyn.proj. For definitions of the TargetRid
+         and other common properties, see https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
+    <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(TargetRid)' == '' and '$(BaseOS)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+
+    <!-- These indicate that the runtime/apphost packages should not be downloaded as part of build/restore -->
+    <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
+    <EnableAppHostPackDownload>false</EnableAppHostPackDownload>
+    
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
@@ -4,25 +4,6 @@
     <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <_RoslynPublishReadyToRun>false</_RoslynPublishReadyToRun>
     <_RoslynPublishReadyToRun Condition="'$(Configuration)' == 'Release'">true</_RoslynPublishReadyToRun>
-
-    <!-- 
-      List of runtime identifiers that we want to publish an executable for.
-      This cannot be set in the base project as it will cause issues when roslyn is built
-      as a test project for SDK insertions.  The RuntimeIdentifiers property will cause the build to
-      attempt to download unpublished packages, which fails (until the packages eventually get published).
-
-      The test doesn't actually run pack, so we can instead skip setting the RuntimeIdentifiers property unless
-      we're actually trying to build packages.
-    -->
-    <!-- 
-      When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseOS.
-      TargetRid and BaseOS are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
-      https://github.com/dotnet/dotnet/blob/main/repo-projects/roslyn.proj. For definitions of the TargetRid
-      and other common properties, see https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md 
-    -->
-    <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(TargetRid)' == '' and '$(BaseOS)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <Target Name="Pack">
@@ -43,8 +24,11 @@
 
       We also pass the RestoreUseStaticGraphEvaluation=false flag to workaround a long path issue when calling the restore target.
       See https://github.com/NuGet/Home/issues/11968
+
+      We also pass the EnableRuntimePackDownload/EnableAppHostPackDownload flags to indicate we wish for this restore to download
+      the required runtime/apphost packages as those will be needed during the pack.
     -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="PublishReadyToRun=$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="EnableRuntimePackDownload=true;EnableAppHostPackDownload=true;PublishReadyToRun=$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
 
     <MSBuild Projects="@(ProjectToPublish)" Targets="Pack" BuildInParallel="true" />
   </Target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
@@ -25,12 +25,12 @@
       We also pass the RestoreUseStaticGraphEvaluation=false flag to workaround a long path issue when calling the restore target.
       See https://github.com/NuGet/Home/issues/11968
 
-      We also pass the EnableRuntimePackDownload/EnableAppHostPackDownload flags to indicate we wish for this restore to download
+      We also pass the EnableRuntimePackDownload/EnableAppHostPackDownload flags to indicate we wish for this restore/pack to download
       the required runtime/apphost packages as those will be needed during the pack.
     -->
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="EnableRuntimePackDownload=true;EnableAppHostPackDownload=true;PublishReadyToRun=$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
 
-    <MSBuild Projects="@(ProjectToPublish)" Targets="Pack" BuildInParallel="true" />
+    <MSBuild Projects="@(ProjectToPublish)" Targets="Pack" Properties="EnableRuntimePackDownload=true;EnableAppHostPackDownload=true" BuildInParallel="true" />
   </Target>
 
   <!--


### PR DESCRIPTION
It was previously mentioned that instead of modifying the RuntimeIdentifiers property to attempt to avoid downloading the runtime/apphost packages during build, we could use the EnableRuntimePackDownload/EnableAppHostPackDownload flags instead. Earlier attempts to use these failed, very likely due to a poor understanding by me how msbuild propogates properties.

This PR reinstates setting the RuntimeIdentifiers property in all context as we did before, and utilizes the flags instead to indicate that we only want these packages downloaded during the restore/pack that we do when packing.