### PR TITLE
Dictionary expressions: support user-defined and dynamic conversions for expression and spread elements for dictionary target types

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
@@ -292,7 +292,7 @@ unsafe record struct R(
 }
 ```
 
-## `with()` as a collection expression element is treated as collection *arguments*
+## `with()` as a collection expression element is treated as collection construction *arguments*
 
 ***Introduced in Visual Studio 2022 version 17.14***
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1111,26 +1111,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int conversionIndex = 0;
                 foreach (var element in elements)
                 {
+                    if (element is BoundCollectionExpressionWithElement)
+                    {
+                        continue;
+                    }
+                    var elementConversion = elementConversions[conversionIndex++];
                     BoundNode convertedElement;
                     switch (element)
                     {
-                        case BoundCollectionExpressionWithElement:
-                            continue;
                         case BoundExpression expressionElement:
                             {
                                 BoundExpression convertedExpression;
-                                Conversion keyConversion;
-                                Conversion valueConversion;
-                                if (expressionElement.Type is { })
+                                if (elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
                                 {
                                     Debug.Assert(ConversionsBase.IsKeyValuePairType(Compilation, expressionElement.Type, out _, out _));
                                     convertedExpression = BindToNaturalType(expressionElement, diagnostics);
-                                    keyConversion = elementConversions[conversionIndex++];
-                                    valueConversion = elementConversions[conversionIndex++];
                                 }
                                 else
                                 {
-                                    convertedExpression = CreateConversion(expressionElement, elementConversions[conversionIndex++], elementType, diagnostics);
+                                    convertedExpression = CreateConversion(expressionElement, elementConversion, elementType, diagnostics);
                                     keyConversion = Conversion.Identity;
                                     valueConversion = Conversion.Identity;
                                 }
@@ -1161,26 +1160,40 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 implicitReceiver,
                                 static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
                                 {
-                                    Debug.Assert(ConversionsBase.IsKeyValuePairType(binder.Compilation, item.Type, out _, out _));
+                                    BoundExpression convertedExpression;
+                                    if (arg.elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
+                                    {
+                                        Debug.Assert(ConversionsBase.IsKeyValuePairType(binder.Compilation, item.Type, out _, out _));
+                                        convertedExpression = item;
+                                    }
+                                    else
+                                    {
+                                        convertedExpression = binder.CreateConversion(item, arg.elementConversion, arg.elementType, diagnostics);
+                                        keyConversion = Conversion.Identity;
+                                        valueConversion = Conversion.Identity;
+                                    }
                                     return binder.BindDictionaryItemAssignment(
                                         syntax,
                                         implicitReceiver,
                                         arg.getKeyMethod,
                                         arg.getValueMethod,
                                         arg.setMethod,
-                                        item,
-                                        arg.keyConversion,
+                                        convertedExpression,
+                                        keyConversion,
                                         arg.elementKeyType,
-                                        arg.valueConversion,
+                                        valueConversion,
                                         arg.elementValueType,
                                         diagnostics);
                                 },
-                                (getKeyMethod, getValueMethod, setMethod, keyConversion: elementConversions[conversionIndex], elementKeyType, valueConversion: elementConversions[conversionIndex + 1], elementValueType),
+                                (getKeyMethod, getValueMethod, setMethod, elementType, elementConversion: elementConversion, elementKeyType, elementValueType),
                                 diagnostics);
-                            conversionIndex += 2;
                             break;
                         case BoundKeyValuePairElement keyValuePairElement:
                             {
+                                if (!elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
+                                {
+                                    throw ExceptionUtilities.UnexpectedValue(elementConversion);
+                                }
                                 var keyValuePairSyntax = (KeyValuePairElementSyntax)keyValuePairElement.Syntax;
                                 var key = keyValuePairElement.Key;
                                 var value = keyValuePairElement.Value;
@@ -1188,8 +1201,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 var valuePlaceholder = new BoundValuePlaceholder(keyValuePairSyntax.ValueExpression, elementValueType);
                                 convertedElement = new BoundKeyValuePairElement(
                                     keyValuePairSyntax,
-                                    CreateConversion(key, elementConversions[conversionIndex], elementKeyType, diagnostics),
-                                    CreateConversion(value, elementConversions[conversionIndex + 1], elementValueType, diagnostics),
+                                    CreateConversion(key, keyConversion, elementKeyType, diagnostics),
+                                    CreateConversion(value, valueConversion, elementValueType, diagnostics),
                                     keyPlaceholder,
                                     valuePlaceholder,
                                     BindDictionaryItemAssignment(
@@ -1198,7 +1211,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         setMethod,
                                         keyPlaceholder,
                                         valuePlaceholder));
-                                conversionIndex += 2;
                             }
                             break;
                         default:
@@ -2205,25 +2217,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
+                // Compare with similar loop in Conversions.GetCollectionExpressionConversion().
                 bool usesKeyValuePairs = ConversionsBase.CollectionUsesKeyValuePairs(Compilation, collectionTypeKind, elementType, out var keyType, out var valueType);
                 var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 foreach (var element in elements)
                 {
                     switch (element)
                     {
-                        case BoundCollectionExpressionWithElement:
-                            // Collection arguments do not affect convertibility.
-                            break;
-                        case BoundExpression expressionElement:
-                            if (usesKeyValuePairs && expressionElement.Type is { })
-                            {
-                                generateImplicitConversionFromTypeToKeyValuePairTypeErrors(diagnostics, expressionElement.Syntax, expressionElement.Type, elementType, ref useSiteInfo, ref reportedErrors);
-                            }
-                            else
-                            {
-                                generateImplicitConversionFromExpressionError(diagnostics, expressionElement, elementType, ref useSiteInfo, ref reportedErrors);
-                            }
-                            break;
                         case BoundCollectionExpressionSpreadElement spreadElement:
                             {
                                 var expressionSyntax = spreadElement.Expression.Syntax;
@@ -2233,16 +2233,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     Error(diagnostics, ErrorCode.ERR_NoImplicitConv, expressionSyntax, spreadElement.Expression.Display, elementType);
                                     reportedErrors = true;
                                 }
-                                else if (usesKeyValuePairs && enumeratorInfo.ElementType is { })
-                                {
-                                    generateImplicitConversionFromTypeToKeyValuePairTypeErrors(diagnostics, expressionSyntax, enumeratorInfo.ElementType, elementType, ref useSiteInfo, ref reportedErrors);
-                                }
                                 else
                                 {
-                                    Conversion elementConversion = Conversions.GetCollectionExpressionSpreadElementConversion(spreadElement, elementType, ref useSiteInfo);
-                                    if (!elementConversion.Exists)
+                                    var elementConversion = Conversions.GetCollectionExpressionSpreadElementConversion(expressionSyntax, elementType, enumeratorInfo, ref useSiteInfo);
+                                    if (elementConversion.Exists)
                                     {
-                                        GenerateImplicitConversionError(diagnostics, this.Compilation, expressionSyntax, elementConversion, enumeratorInfo.ElementType, elementType);
+                                        continue;
+                                    }
+                                    else if (usesKeyValuePairs &&
+                                        ConversionsBase.IsKeyValuePairType(Compilation, enumeratorInfo.ElementType, out var itemKeyType, out var itemValueType))
+                                    {
+                                        Debug.Assert(keyType is { });
+                                        Debug.Assert(valueType is { });
+                                        generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, itemKeyType, keyType, ref useSiteInfo, ref reportedErrors);
+                                        generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, itemValueType, valueType, ref useSiteInfo, ref reportedErrors);
+                                    }
+                                    else
+                                    {
+                                        GenerateImplicitConversionError(diagnostics, Compilation, expressionSyntax, elementConversion, enumeratorInfo.ElementType, elementType);
                                         reportedErrors = true;
                                     }
                                 }
@@ -2260,6 +2268,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 Error(diagnostics, ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, keyValuePairElement.Syntax, targetType);
                                 reportedErrors = true;
+                            }
+                            break;
+                        case BoundCollectionExpressionWithElement:
+                            // Collection arguments do not affect convertibility.
+                            break;
+                        case BoundExpression expressionElement:
+                            {
+                                var expressionSyntax = expressionElement.Syntax;
+                                var elementConversion = Conversions.ClassifyImplicitConversionFromExpression(expressionElement, elementType, ref useSiteInfo);
+                                if (elementConversion.Exists)
+                                {
+                                    continue;
+                                }
+                                else if (expressionElement.Type is { } &&
+                                    usesKeyValuePairs &&
+                                    ConversionsBase.IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
+                                {
+                                    Debug.Assert(keyType is { });
+                                    Debug.Assert(valueType is { });
+                                    generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, elementKeyType, keyType, ref useSiteInfo, ref reportedErrors);
+                                    generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, elementValueType, valueType, ref useSiteInfo, ref reportedErrors);
+                                }
+                                else
+                                {
+                                    GenerateImplicitConversionError(diagnostics, expressionSyntax, elementConversion, expressionElement, elementType);
+                                    reportedErrors = true;
+                                }
                             }
                             break;
                         default:
@@ -2304,31 +2339,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!elementConversion.Exists)
                 {
                     GenerateImplicitConversionError(diagnostics, Compilation, syntax, elementConversion, sourceType, targetType);
-                    reportedErrors = true;
-                }
-            }
-
-            void generateImplicitConversionFromTypeToKeyValuePairTypeErrors(
-                BindingDiagnosticBag diagnostics,
-                SyntaxNode syntax,
-                TypeSymbol sourceType,
-                TypeSymbol targetType,
-                ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
-                ref bool reportedErrors)
-            {
-                if (ConversionsBase.IsKeyValuePairType(Compilation, sourceType, out var elementKeyType, out var elementValueType))
-                {
-                    ConversionsBase.IsKeyValuePairType(Compilation, targetType, out var keyType, out var valueType);
-                    Debug.Assert(keyType is { });
-                    Debug.Assert(valueType is { });
-                    generateImplicitConversionFromTypeError(diagnostics, syntax, elementKeyType, keyType, ref useSiteInfo, ref reportedErrors);
-                    generateImplicitConversionFromTypeError(diagnostics, syntax, elementValueType, valueType, ref useSiteInfo, ref reportedErrors);
-                }
-                else
-                {
-                    // PROTOTYPE: We should use a specific error here, to avoid confusion in cases where there
-                    // actually is a user-defined conversion from the source type to KeyValuePair<,>.
-                    Error(diagnostics, ErrorCode.ERR_NoImplicitConv, syntax, sourceType, targetType);
                     reportedErrors = true;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -136,6 +136,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new CollectionExpressionUncommonData(collectionExpressionTypeKind, elementType, constructor, constructorUsedInExpandedForm, elementConversions));
         }
 
+        internal static Conversion CreateKeyValuePairConversion(Conversion keyConversion, Conversion valueConversion)
+        {
+            return new Conversion(
+                ConversionKind.KeyValuePair,
+                new NestedUncommonData([keyConversion, valueConversion]));
+        }
+
         private Conversion(
             ConversionKind kind,
             UncommonData? uncommonData = null)
@@ -558,6 +565,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             constructor = null;
             isExpanded = false;
             return CollectionExpressionTypeKind.None;
+        }
+
+        internal bool TryGetKeyValueConversions(out Conversion keyConversion, out Conversion valueConversion)
+        {
+            if (Kind == ConversionKind.KeyValuePair)
+            {
+                Debug.Assert(_uncommonData is NestedUncommonData { _nestedConversionsOpt: [_, _] });
+                var nestedConversions = ((NestedUncommonData)_uncommonData)._nestedConversionsOpt;
+                keyConversion = nestedConversions[0];
+                valueConversion = nestedConversions[1];
+                return true;
+            }
+
+            keyConversion = NoConversion;
+            valueConversion = NoConversion;
+            return false;
         }
 
         // CONSIDER: public?

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         DefaultLiteral, // a conversion from a `default` literal to any type
         ObjectCreation, // a conversion from a `new()` expression to any type
         CollectionExpression, // a conversion from a collection expression to any type
+        KeyValuePair, // A pair of Key and Value conversions for converting from one KeyValuePair<,> type to another. The conversion is not part of the language, it is an implementation detail.
 
         InterpolatedStringHandler, // A conversion from an interpolated string literal to a type attributed with InterpolatedStringBuilderAttribute
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -204,138 +204,115 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ImmutableArray<Conversion> elementConversions;
-            if (CollectionUsesKeyValuePairs(Compilation, collectionTypeKind, elementType, out var keyType, out var valueType))
+            bool usesKeyValuePairs = CollectionUsesKeyValuePairs(Compilation, collectionTypeKind, elementType, out var keyType, out var valueType);
+            var builder = ArrayBuilder<Conversion>.GetInstance(elements.Length);
+            foreach (var element in elements)
             {
-                var builder = ArrayBuilder<Conversion>.GetInstance(elements.Length * 2);
-                foreach (var element in elements)
+                if (element is BoundCollectionExpressionWithElement)
                 {
-                    switch (element)
-                    {
-                        case BoundCollectionExpressionWithElement:
-                            // Collection arguments do not affect convertibility.
-                            continue;
-                        case BoundCollectionExpressionSpreadElement spreadElement:
-                            {
-                                var enumeratorInfo = spreadElement.EnumeratorInfoOpt;
-                                if (enumeratorInfo is { })
-                                {
-                                    if (IsKeyValuePairType(Compilation, enumeratorInfo.ElementType, out var itemKeyType, out var itemValueType))
-                                    {
-                                        var keyConversion = ClassifyImplicitConversionFromType(itemKeyType, keyType, ref useSiteInfo);
-                                        var valueConversion = ClassifyImplicitConversionFromType(itemValueType, valueType, ref useSiteInfo);
-                                        if (keyConversion.Exists && valueConversion.Exists)
-                                        {
-                                            builder.Add(keyConversion);
-                                            builder.Add(valueConversion);
-                                            continue;
-                                        }
-                                    }
-                                }
-                            }
-                            break;
-                        case BoundKeyValuePairElement keyValuePairElement:
-                            {
-                                var keyConversion = ClassifyImplicitConversionFromExpression(keyValuePairElement.Key, keyType, ref useSiteInfo);
-                                var valueConversion = ClassifyImplicitConversionFromExpression(keyValuePairElement.Value, valueType, ref useSiteInfo);
-                                if (keyConversion.Exists && valueConversion.Exists)
-                                {
-                                    builder.Add(keyConversion);
-                                    builder.Add(valueConversion);
-                                    continue;
-                                }
-                            }
-                            break;
-                        case BoundExpression expressionElement:
-                            {
-                                if (expressionElement.Type is { })
-                                {
-                                    if (IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
-                                    {
-                                        var keyConversion = ClassifyImplicitConversionFromType(elementKeyType, keyType, ref useSiteInfo);
-                                        var valueConversion = ClassifyImplicitConversionFromType(elementValueType, valueType, ref useSiteInfo);
-                                        if (keyConversion.Exists && valueConversion.Exists)
-                                        {
-                                            builder.Add(keyConversion);
-                                            builder.Add(valueConversion);
-                                            continue;
-                                        }
-                                    }
-                                }
-                                else
-                                {
-                                    var expressionConversion = ClassifyImplicitConversionFromExpression(expressionElement, elementType, ref useSiteInfo);
-                                    if (expressionConversion.Exists)
-                                    {
-                                        builder.Add(expressionConversion);
-                                        continue;
-                                    }
-                                }
-                            }
-                            break;
-                    }
+                    // Collection arguments do not affect convertibility.
+                    continue;
+                }
+                Conversion elementConversion = GetCollectionExpressionElementConversion(element, elementType, usesKeyValuePairs, keyType, valueType, ref useSiteInfo);
+                if (!elementConversion.Exists)
+                {
                     builder.Free();
                     return Conversion.NoConversion;
                 }
-                elementConversions = builder.ToImmutableAndFree();
-            }
-            else
-            {
-                var builder = ArrayBuilder<Conversion>.GetInstance(elements.Length);
-                foreach (var element in elements)
-                {
-                    switch (element)
-                    {
-                        case BoundCollectionExpressionWithElement:
-                            // Collection arguments do not affect convertibility.
-                            continue;
-                        case BoundCollectionExpressionSpreadElement spreadElement:
-                            {
-                                var elementConversion = GetCollectionExpressionSpreadElementConversion(spreadElement, elementType, ref useSiteInfo);
-                                if (elementConversion.Exists)
-                                {
-                                    builder.Add(elementConversion);
-                                    continue;
-                                }
-                            }
-                            break;
-                        case BoundExpression expressionElement:
-                            {
-                                var elementConversion = ClassifyImplicitConversionFromExpression(expressionElement, elementType, ref useSiteInfo);
-                                if (elementConversion.Exists)
-                                {
-                                    builder.Add(elementConversion);
-                                    continue;
-                                }
-                            }
-                            break;
-                    }
-                    builder.Free();
-                    return Conversion.NoConversion;
-                }
-                elementConversions = builder.ToImmutableAndFree();
+                builder.Add(elementConversion);
             }
 
+            var elementConversions = builder.ToImmutableAndFree();
             return Conversion.CreateCollectionExpressionConversion(collectionTypeKind, elementType, constructor, isExpanded, elementConversions);
         }
 
-        internal Conversion GetCollectionExpressionSpreadElementConversion(
-            BoundCollectionExpressionSpreadElement element,
-            TypeSymbol targetType,
+        private Conversion GetCollectionExpressionElementConversion(
+            BoundNode element,
+            TypeSymbol elementType,
+            bool usesKeyValuePairs,
+            TypeSymbol? keyType,
+            TypeSymbol? valueType,
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            var enumeratorInfo = element.EnumeratorInfoOpt;
-            if (enumeratorInfo is null)
+            switch (element)
             {
-                return Conversion.NoConversion;
+                case BoundCollectionExpressionSpreadElement spreadElement:
+                    {
+                        var enumeratorInfo = spreadElement.EnumeratorInfoOpt;
+                        if (enumeratorInfo is { })
+                        {
+                            var elementConversion = GetCollectionExpressionSpreadElementConversion(spreadElement.Syntax, elementType, enumeratorInfo, ref useSiteInfo);
+                            if (elementConversion.Exists)
+                            {
+                                return elementConversion;
+                            }
+                            else if (usesKeyValuePairs &&
+                                IsKeyValuePairType(Compilation, enumeratorInfo.ElementType, out var itemKeyType, out var itemValueType))
+                            {
+                                Debug.Assert(keyType is { });
+                                Debug.Assert(valueType is { });
+                                var keyConversion = ClassifyImplicitConversionFromType(itemKeyType, keyType, ref useSiteInfo);
+                                var valueConversion = ClassifyImplicitConversionFromType(itemValueType, valueType, ref useSiteInfo);
+                                if (keyConversion.Exists && valueConversion.Exists)
+                                {
+                                    return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                                }
+                            }
+                        }
+                    }
+                    break;
+                case BoundKeyValuePairElement keyValuePairElement:
+                    if (usesKeyValuePairs)
+                    {
+                        Debug.Assert(keyType is { });
+                        Debug.Assert(valueType is { });
+                        var keyConversion = ClassifyImplicitConversionFromExpression(keyValuePairElement.Key, keyType, ref useSiteInfo);
+                        var valueConversion = ClassifyImplicitConversionFromExpression(keyValuePairElement.Value, valueType, ref useSiteInfo);
+                        if (keyConversion.Exists && valueConversion.Exists)
+                        {
+                            return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                        }
+                    }
+                    break;
+                case BoundExpression expressionElement:
+                    {
+                        var elementConversion = ClassifyImplicitConversionFromExpression(expressionElement, elementType, ref useSiteInfo);
+                        if (elementConversion.Exists)
+                        {
+                            return elementConversion;
+                        }
+                        else if (expressionElement.Type is { } &&
+                            usesKeyValuePairs &&
+                            IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
+                        {
+                            Debug.Assert(keyType is { });
+                            Debug.Assert(valueType is { });
+                            var keyConversion = ClassifyImplicitConversionFromType(elementKeyType, keyType, ref useSiteInfo);
+                            var valueConversion = ClassifyImplicitConversionFromType(elementValueType, valueType, ref useSiteInfo);
+                            if (keyConversion.Exists && valueConversion.Exists)
+                            {
+                                return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                            }
+                        }
+                    }
+                    break;
             }
+            return Conversion.NoConversion;
+        }
+
+        internal Conversion GetCollectionExpressionSpreadElementConversion(
+            SyntaxNode syntax,
+            TypeSymbol targetType,
+            ForEachEnumeratorInfo enumeratorInfo,
+            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
             // This should be conversion from type rather than conversion from expression.
             // The difference is in handling of dynamic, and fixing this would be a breaking
             // change for that case. For instance, the following would become an error:
             // dynamic[] x = [1, 2, 3];
             // int[] y = [.. x];
             return ClassifyImplicitConversionFromExpression(
-                new BoundValuePlaceholder(element.Syntax, enumeratorInfo.ElementType),
+                new BoundValuePlaceholder(syntax, enumeratorInfo.ElementType),
                 targetType,
                 ref useSiteInfo);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1769,23 +1769,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        internal static bool CollectionUsesKeyValuePairs(
+        internal static (TypeSymbol Key, TypeSymbol Value)? TryGetCollectionKeyValuePairTypes(
             CSharpCompilation compilation,
             CollectionExpressionTypeKind collectionTypeKind,
-            TypeSymbol elementType,
-            [NotNullWhen(true)] out TypeSymbol? keyType,
-            [NotNullWhen(true)] out TypeSymbol? valueType)
+            TypeSymbol elementType)
         {
             // PROTOTYPE: Should apply to any collection of KeyValuePair<,>, not just dictionaries.
             if (collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer or CollectionExpressionTypeKind.DictionaryInterface)
             {
-                bool usesKeyValuePairs = IsKeyValuePairType(compilation, elementType, out keyType, out valueType);
-                Debug.Assert(usesKeyValuePairs);
-                return usesKeyValuePairs;
+                if (IsKeyValuePairType(compilation, elementType, out var keyType, out var valueType))
+                {
+                    return (keyType, valueType);
+                }
+                Debug.Assert(false);
             }
-            keyType = null;
-            valueType = null;
-            return false;
+            return null;
         }
 #nullable disable
 


### PR DESCRIPTION
From [LDM-2025-03-17](https://github.com/dotnet/csharplang/blob/main/meetings/2025/LDM-2025-03-17.md#conclusion-2) **emphasis added**:
> **We will allow all standard element type conversions that we allow in normal collection expressions** when the element type is a KVP. We will allow KVP covariance in all collection expressions.