### PR TITLE
Remove unnecessary flag in diagnostics subsystem

### DIFF
--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/InProcOrRemoteHostAnalyzerRunner.cs
@@ -22,16 +22,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal sealed class InProcOrRemoteHostAnalyzerRunner
 {
-    private readonly bool _enabled;
     private readonly IAsynchronousOperationListener _asyncOperationListener;
     public DiagnosticAnalyzerInfoCache AnalyzerInfoCache { get; }
 
     public InProcOrRemoteHostAnalyzerRunner(
-        bool enabled,
         DiagnosticAnalyzerInfoCache analyzerInfoCache,
         IAsynchronousOperationListener? operationListener = null)
     {
-        _enabled = enabled;
         AnalyzerInfoCache = analyzerInfoCache;
         _asyncOperationListener = operationListener ?? AsynchronousOperationListenerProvider.NullListener;
     }
@@ -64,9 +61,6 @@ internal sealed class InProcOrRemoteHostAnalyzerRunner
         bool getTelemetryInfo,
         CancellationToken cancellationToken)
     {
-        if (!_enabled)
-            return DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty;
-
         var result = await AnalyzeCoreAsync().ConfigureAwait(false);
         Debug.Assert(getTelemetryInfo || result.TelemetryInfo.IsEmpty);
         return result;
@@ -89,9 +83,6 @@ internal sealed class InProcOrRemoteHostAnalyzerRunner
 
     public async Task<ImmutableArray<Diagnostic>> GetSourceGeneratorDiagnosticsAsync(Project project, CancellationToken cancellationToken)
     {
-        if (!_enabled)
-            return [];
-
         var options = project.Solution.Services.GetRequiredService<IWorkspaceConfigurationService>().Options;
         var remoteHostClient = await RemoteHostClient.TryGetClientAsync(project, cancellationToken).ConfigureAwait(false);
         if (remoteHostClient != null)


### PR DESCRIPTION
This flag is unneeded, due to all pull diagnostics handler running this code first:

```c#
    public async Task<TReturn?> HandleRequestAsync(
        TDiagnosticsParams diagnosticsParams, RequestContext context, CancellationToken cancellationToken)
    {
        // The progress object we will stream reports to.
        using var progress = BufferedProgress.Create(diagnosticsParams.PartialResultToken);

        // We only support this option to disable crawling in internal speedometer and ddrit perf runs to lower
        // noise.  It is not exposed to the user.
        if (!this.GlobalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
        {
            context.TraceInformation($"{this.GetType()}. Skipping due to {nameof(SolutionCrawlerRegistrationService.EnableSolutionCrawler)}={false}");
        }
```