### PR TITLE
Remove unnecessary cancellation of diagnostics requests.

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -693,7 +693,7 @@ public sealed class DiagnosticAnalyzerServiceTests
         var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
             document, project, Checksum.Null, span: null, projectAnalyzerIds: [], analyzerIdsToRequestDiagnostics,
             AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
-            isExplicit: false, logPerformanceInfo: false, getTelemetryInfo: false,
+            logPerformanceInfo: false, getTelemetryInfo: false,
             cancellationToken: CancellationToken.None);
         Assert.False(analyzer2.ReceivedSymbolCallback);
 
@@ -762,7 +762,7 @@ public sealed class DiagnosticAnalyzerServiceTests
             _ = await DiagnosticComputer.GetDiagnosticsAsync(
                 documentToAnalyze, project, Checksum.Null, filterSpan, analyzerIdsToRequestDiagnostics, hostAnalyzerIds: [],
                 analysisKind, new DiagnosticAnalyzerInfoCache(), workspace.Services,
-                isExplicit: false, logPerformanceInfo: false, getTelemetryInfo: false,
+                logPerformanceInfo: false, getTelemetryInfo: false,
                 CancellationToken.None);
             Assert.Equal(filterSpan, analyzer.CallbackFilterSpan);
             if (kind == FilterSpanTestAnalyzer.AnalysisKind.AdditionalFile)
@@ -817,7 +817,7 @@ public sealed class DiagnosticAnalyzerServiceTests
         try
         {
             _ = await DiagnosticComputer.GetDiagnosticsAsync(document, project, Checksum.Null, span: null,
-                projectAnalyzerIds: [], analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, isExplicit: false,
+                projectAnalyzerIds: [], analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services,
                 logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: analyzer.CancellationToken);
 
             throw ExceptionUtilities.Unreachable();
@@ -830,7 +830,7 @@ public sealed class DiagnosticAnalyzerServiceTests
 
         // Then invoke analysis without cancellation token, and verify non-cancelled diagnostic.
         var diagnosticsMap = await DiagnosticComputer.GetDiagnosticsAsync(document, project, Checksum.Null, span: null,
-            projectAnalyzerIds: [], analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, isExplicit: false,
+            projectAnalyzerIds: [], analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services,
             logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: CancellationToken.None);
         var builder = diagnosticsMap.Diagnostics.Single().diagnosticMap;
         var diagnostic = kind == AnalysisKind.Syntax ? builder.Syntax.Single().Item2.Single() : builder.Semantic.Single().Item2.Single();

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
@@ -77,8 +77,7 @@ internal sealed class DiagnosticArguments
         AnalysisKind? documentAnalysisKind,
         ProjectId projectId,
         ImmutableArray<string> projectAnalyzerIds,
-        ImmutableArray<string> hostAnalyzerIds,
-        bool isExplicit)
+        ImmutableArray<string> hostAnalyzerIds)
     {
         Debug.Assert(documentId != null || documentSpan == null);
         Debug.Assert(documentId != null || documentAnalysisKind == null);

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
@@ -69,13 +69,6 @@ internal sealed class DiagnosticArguments
     [DataMember(Order = 7)]
     public ImmutableArray<string> HostAnalyzerIds;
 
-    /// <summary>
-    /// Indicates diagnostic computation for an explicit user-invoked request,
-    /// such as a user-invoked Ctrl + Dot operation to bring up the light bulb.
-    /// </summary>
-    [DataMember(Order = 8)]
-    public bool IsExplicit;
-
     public DiagnosticArguments(
         bool logPerformanceInfo,
         bool getTelemetryInfo,
@@ -101,6 +94,5 @@ internal sealed class DiagnosticArguments
         ProjectId = projectId;
         ProjectAnalyzerIds = projectAnalyzerIds;
         HostAnalyzerIds = hostAnalyzerIds;
-        IsExplicit = isExplicit;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -80,7 +80,6 @@ internal interface IDiagnosticAnalyzerService
         TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic,
         ICodeActionRequestPriorityProvider priorityProvider,
         DiagnosticKind diagnosticKind,
-        bool isExplicit,
         CancellationToken cancellationToken);
 }
 
@@ -99,7 +98,8 @@ internal static class IDiagnosticAnalyzerServiceExtensions
             document, range,
             diagnosticId: null,
             priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
-            diagnosticKind, isExplicit: false, cancellationToken);
+            diagnosticKind,
+            cancellationToken);
 
     /// <summary>
     /// Return up to date diagnostics for the given <paramref name="range"/> and parameters for the given <paramref name="document"/>.
@@ -113,11 +113,10 @@ internal static class IDiagnosticAnalyzerServiceExtensions
         TextDocument document, TextSpan? range, string? diagnosticId,
         ICodeActionRequestPriorityProvider priorityProvider,
         DiagnosticKind diagnosticKind,
-        bool isExplicit,
         CancellationToken cancellationToken)
     {
         Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
         return service.GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
-            priorityProvider, diagnosticKind, isExplicit, cancellationToken);
+            priorityProvider, diagnosticKind, cancellationToken);
     }
 }

--- a/src/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -203,7 +203,7 @@ internal abstract class AbstractCodeCleanupService : ICodeCleanupService
         var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(document, range,
             shouldIncludeDiagnostic: static diagnosticId => !(IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId)),
             priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
-            DiagnosticKind.All, isExplicit: false,
+            DiagnosticKind.All,
             cancellationToken).ConfigureAwait(false);
 
         // We don't want code cleanup automatically cleaning suppressed diagnostics.

--- a/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.FixAllDiagnosticProvider.cs
+++ b/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.FixAllDiagnosticProvider.cs
@@ -58,7 +58,7 @@ internal sealed partial class CodeFixService
             var diagnostics = Filter(await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, fixAllSpan, shouldIncludeDiagnostic,
                 priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
-                DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false));
+                DiagnosticKind.All, cancellationToken).ConfigureAwait(false));
             Contract.ThrowIfFalse(diagnostics.All(d => d.DocumentId != null));
             return await diagnostics.ToDiagnosticsAsync(document.Project, cancellationToken).ConfigureAwait(false);
         }

--- a/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -109,7 +109,7 @@ internal sealed partial class CodeFixService : ICodeFixService
         {
             allDiagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, GetShouldIncludeDiagnosticPredicate(document, priorityProvider),
-                priorityProvider, DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false);
+                priorityProvider, DiagnosticKind.All, cancellationToken).ConfigureAwait(false);
 
             // NOTE(cyrusn): We do not include suppressed diagnostics here as they are effectively hidden from the
             // user in the editor.  As far as the user is concerned, there is no squiggle for it and no lightbulb
@@ -199,7 +199,7 @@ internal sealed partial class CodeFixService : ICodeFixService
         {
             diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, GetShouldIncludeDiagnosticPredicate(document, priorityProvider),
-                priorityProvider, DiagnosticKind.All, isExplicit: true, cancellationToken).ConfigureAwait(false);
+                priorityProvider, DiagnosticKind.All, cancellationToken).ConfigureAwait(false);
             if (!includeSuppressionFixes)
                 diagnostics = diagnostics.WhereAsArray(d => !d.IsSuppressed);
         }
@@ -299,7 +299,7 @@ internal sealed partial class CodeFixService : ICodeFixService
         {
             diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, diagnosticId, priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
-                DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false);
+                DiagnosticKind.All, cancellationToken).ConfigureAwait(false);
 
             // NOTE(cyrusn): We do not include suppressed diagnostics here as they are effectively hidden from the
             // user in the editor.  As far as the user is concerned, there is no squiggle for it and no lightbulb

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
@@ -83,7 +83,6 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
         Func<string, bool>? shouldIncludeDiagnostic,
         ICodeActionRequestPriorityProvider priorityProvider,
         DiagnosticKind diagnosticKinds,
-        bool isExplicit,
         CancellationToken cancellationToken)
     {
         var analyzer = CreateIncrementalAnalyzer(document.Project.Solution.Workspace);
@@ -93,7 +92,7 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
         priorityProvider ??= new DefaultCodeActionRequestPriorityProvider();
 
         return await analyzer.GetDiagnosticsForSpanAsync(
-            document, range, shouldIncludeDiagnostic, priorityProvider, diagnosticKinds, isExplicit, cancellationToken).ConfigureAwait(false);
+            document, range, shouldIncludeDiagnostic, priorityProvider, diagnosticKinds, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ImmutableArray<DiagnosticData>> ForceAnalyzeProjectAsync(Project project, CancellationToken cancellationToken)

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
@@ -27,7 +27,6 @@ internal sealed partial class DocumentAnalysisExecutor
 {
     private readonly CompilationWithAnalyzersPair? _compilationWithAnalyzers;
     private readonly InProcOrRemoteHostAnalyzerRunner _diagnosticAnalyzerRunner;
-    private readonly bool _isExplicit;
     private readonly bool _logPerformanceInfo;
     private readonly Action? _onAnalysisException;
 
@@ -41,14 +40,12 @@ internal sealed partial class DocumentAnalysisExecutor
         DocumentAnalysisScope analysisScope,
         CompilationWithAnalyzersPair? compilationWithAnalyzers,
         InProcOrRemoteHostAnalyzerRunner diagnosticAnalyzerRunner,
-        bool isExplicit,
         bool logPerformanceInfo,
         Action? onAnalysisException = null)
     {
         AnalysisScope = analysisScope;
         _compilationWithAnalyzers = compilationWithAnalyzers;
         _diagnosticAnalyzerRunner = diagnosticAnalyzerRunner;
-        _isExplicit = isExplicit;
         _logPerformanceInfo = logPerformanceInfo;
         _onAnalysisException = onAnalysisException;
 
@@ -66,7 +63,7 @@ internal sealed partial class DocumentAnalysisExecutor
     public DocumentAnalysisScope AnalysisScope { get; }
 
     public DocumentAnalysisExecutor With(DocumentAnalysisScope analysisScope)
-        => new(analysisScope, _compilationWithAnalyzers, _diagnosticAnalyzerRunner, _isExplicit, _logPerformanceInfo, _onAnalysisException);
+        => new(analysisScope, _compilationWithAnalyzers, _diagnosticAnalyzerRunner, _logPerformanceInfo, _onAnalysisException);
 
     /// <summary>
     /// Return all local diagnostics (syntax, semantic) that belong to given document for the given analyzer by calculating them.
@@ -185,8 +182,8 @@ internal sealed partial class DocumentAnalysisExecutor
 
         try
         {
-            var resultAndTelemetry = await _diagnosticAnalyzerRunner.AnalyzeDocumentAsync(analysisScope, _compilationWithAnalyzers,
-                _isExplicit, _logPerformanceInfo, getTelemetryInfo: false, cancellationToken).ConfigureAwait(false);
+            var resultAndTelemetry = await _diagnosticAnalyzerRunner.AnalyzeDocumentAsync(
+                analysisScope, _compilationWithAnalyzers, _logPerformanceInfo, getTelemetryInfo: false, cancellationToken).ConfigureAwait(false);
             return resultAndTelemetry.AnalysisResult;
         }
         catch when (_onAnalysisException != null)

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -54,7 +54,6 @@ internal sealed partial class DiagnosticAnalyzerService
             Func<string, bool>? shouldIncludeDiagnostic,
             ICodeActionRequestPriorityProvider priorityProvider,
             DiagnosticKind diagnosticKind,
-            bool isExplicit,
             CancellationToken cancellationToken)
         {
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
@@ -236,7 +235,7 @@ internal sealed partial class DiagnosticAnalyzerService
                 var projectAnalyzers = analyzers.WhereAsArray(static (a, info) => !info.IsHostAnalyzer(a), hostAnalyzerInfo);
                 var hostAnalyzers = analyzers.WhereAsArray(static (a, info) => info.IsHostAnalyzer(a), hostAnalyzerInfo);
                 var analysisScope = new DocumentAnalysisScope(document, span, projectAnalyzers, hostAnalyzers, kind);
-                var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, isExplicit, logPerformanceInfo);
+                var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, logPerformanceInfo);
                 var version = await GetDiagnosticVersionAsync(document.Project, cancellationToken).ConfigureAwait(false);
 
                 ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> diagnosticsMap;

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/InProcOrRemoteHostAnalyzerRunner.cs
@@ -39,12 +39,10 @@ internal sealed class InProcOrRemoteHostAnalyzerRunner
     public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeDocumentAsync(
         DocumentAnalysisScope documentAnalysisScope,
         CompilationWithAnalyzersPair compilationWithAnalyzers,
-        bool isExplicit,
         bool logPerformanceInfo,
         bool getTelemetryInfo,
         CancellationToken cancellationToken)
-        => AnalyzeAsync(documentAnalysisScope, documentAnalysisScope.TextDocument.Project, compilationWithAnalyzers,
-            isExplicit, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+        => AnalyzeAsync(documentAnalysisScope, documentAnalysisScope.TextDocument.Project, compilationWithAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
 
     public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeProjectAsync(
         Project project,
@@ -52,14 +50,12 @@ internal sealed class InProcOrRemoteHostAnalyzerRunner
         bool logPerformanceInfo,
         bool getTelemetryInfo,
         CancellationToken cancellationToken)
-        => AnalyzeAsync(documentAnalysisScope: null, project, compilationWithAnalyzers,
-            isExplicit: false, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+        => AnalyzeAsync(documentAnalysisScope: null, project, compilationWithAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
 
     private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeAsync(
         DocumentAnalysisScope? documentAnalysisScope,
         Project project,
         CompilationWithAnalyzersPair compilationWithAnalyzers,
-        bool isExplicit,
         bool logPerformanceInfo,
         bool getTelemetryInfo,
         CancellationToken cancellationToken)
@@ -79,7 +75,7 @@ internal sealed class InProcOrRemoteHostAnalyzerRunner
             if (remoteHostClient != null)
             {
                 return await AnalyzeOutOfProcAsync(documentAnalysisScope, project, compilationWithAnalyzers, remoteHostClient,
-                    isExplicit, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
+                    logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
             }
 
             return await AnalyzeInProcAsync(documentAnalysisScope, project, compilationWithAnalyzers,
@@ -192,7 +188,6 @@ internal sealed class InProcOrRemoteHostAnalyzerRunner
         Project project,
         CompilationWithAnalyzersPair compilationWithAnalyzers,
         RemoteHostClient client,
-        bool isExplicit,
         bool logPerformanceInfo,
         bool getTelemetryInfo,
         CancellationToken cancellationToken)
@@ -221,8 +216,7 @@ internal sealed class InProcOrRemoteHostAnalyzerRunner
             documentAnalysisScope?.Kind,
             project.Id,
             [.. projectAnalyzerMap.Keys],
-            [.. hostAnalyzerMap.Keys],
-            isExplicit);
+            [.. hostAnalyzerMap.Keys]);
 
         var result = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, SerializableDiagnosticAnalysisResults>(
             project.Solution,

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -312,7 +312,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public Sub RequestDiagnosticRefresh() Implements IDiagnosticAnalyzerService.RequestDiagnosticRefresh
             End Sub
 
-            Public Function GetDiagnosticsForSpanAsync(document As TextDocument, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), priority As ICodeActionRequestPriorityProvider, diagnosticKinds As DiagnosticKind, isExplicit As Boolean, cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+            Public Function GetDiagnosticsForSpanAsync(document As TextDocument, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), priority As ICodeActionRequestPriorityProvider, diagnosticKinds As DiagnosticKind, cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
             End Function
 

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -27,48 +27,23 @@ internal sealed class DiagnosticComputer
 {
     /// <summary>
     /// Cache of <see cref="CompilationWithAnalyzers"/> and a map from analyzer IDs to <see cref="DiagnosticAnalyzer"/>s
-    /// for all analyzers for the last project to be analyzed.
-    /// The <see cref="CompilationWithAnalyzers"/> instance is shared between all the following document analyses modes for the project:
-    ///  1. Span-based analysis for active document (lightbulb)
-    ///  2. Background analysis for active and open documents.
-    ///
-    /// NOTE: We do not re-use this cache for project analysis as it leads to significant memory increase in the OOP process.
-    /// Additionally, we only store the cache entry for the last project to be analyzed instead of maintaining a CWT keyed off
-    /// each project in the solution, as the CWT does not seem to drop entries until ForceGC happens, leading to significant memory
-    /// pressure when there are large number of open documents across different projects to be analyzed by background analysis.
+    /// for all analyzers for the last project to be analyzed. The <see cref="CompilationWithAnalyzers"/> instance is
+    /// shared between all the following document analyses modes for the project:
+    /// <list type="number">
+    /// <item>Span-based analysis for active document (lightbulb)</item>
+    /// <item>Background analysis for active and open documents.</item>
+    /// </list>
+    /// NOTE: We do not re-use this cache for project analysis as it leads to significant memory increase in the OOP
+    /// process. Additionally, we only store the cache entry for the last project to be analyzed instead of maintaining
+    /// a CWT keyed off each project in the solution, as the CWT does not seem to drop entries until ForceGC happens,
+    /// leading to significant memory pressure when there are large number of open documents across different projects
+    /// to be analyzed by background analysis.
     /// </summary>
     private static CompilationWithAnalyzersCacheEntry? s_compilationWithAnalyzersCache = null;
 
     /// <summary>
-    /// Set of high priority diagnostic computation tasks which are currently executing.
-    /// Any new high priority diagnostic request is added to this set before the core diagnostics
-    /// compute call is performed, and removed from this list after the computation finishes.
-    /// Any new normal priority diagnostic request first waits for all the high priority tasks in this set
-    /// to complete, and moves ahead only after this list becomes empty.
-    /// </summary>
-    /// <remarks>
-    /// Read/write access to this field is guarded by <see cref="s_gate"/>.
-    /// </remarks>
-    private static ImmutableHashSet<Task> s_highPriorityComputeTasks = [];
-
-    /// <summary>
-    /// Set of cancellation token sources for normal priority diagnostic computation tasks which are currently executing.
-    /// For any new normal priority diagnostic request, a new cancellation token source is created and added to this set
-    /// before the core diagnostics compute call is performed, and removed from this set after the computation finishes.
-    /// Any new high priority diagnostic request first fires cancellation on all the cancellation token sources in this set
-    /// to avoid resource contention between normal and high priority requests.
-    /// Canceled normal priority diagnostic requests are re-attempted from scratch after all the high priority requests complete.
-    /// </summary>
-    /// <remarks>
-    /// Read/write access to this field is guarded by <see cref="s_gate"/>.
-    /// </remarks>
-    private static ImmutableHashSet<CancellationTokenSource> s_normalPriorityCancellationTokenSources = [];
-
-    /// <summary>
     /// Static gate controlling access to following static fields:
     /// - <see cref="s_compilationWithAnalyzersCache"/>
-    /// - <see cref="s_highPriorityComputeTasks"/>
-    /// - <see cref="s_normalPriorityCancellationTokenSources"/>
     /// </summary>
     private static readonly object s_gate = new();
 
@@ -116,7 +91,6 @@ internal sealed class DiagnosticComputer
         AnalysisKind? analysisKind,
         DiagnosticAnalyzerInfoCache analyzerInfoCache,
         HostWorkspaceServices hostWorkspaceServices,
-        bool isExplicit,
         bool logPerformanceInfo,
         bool getTelemetryInfo,
         CancellationToken cancellationToken)
@@ -144,174 +118,8 @@ internal sealed class DiagnosticComputer
         // We execute explicit, user-invoked diagnostics requests with higher priority compared to implicit requests
         // from clients such as editor diagnostic tagger to show squiggles, background analysis to populate the error list, etc.
         var diagnosticsComputer = new DiagnosticComputer(document, project, solutionChecksum, span, analysisKind, analyzerInfoCache, hostWorkspaceServices);
-        return isExplicit
-            ? diagnosticsComputer.GetHighPriorityDiagnosticsAsync(projectAnalyzerIds, hostAnalyzerIds, logPerformanceInfo, getTelemetryInfo, cancellationToken)
-            : diagnosticsComputer.GetNormalPriorityDiagnosticsAsync(projectAnalyzerIds, hostAnalyzerIds, logPerformanceInfo, getTelemetryInfo, cancellationToken);
-    }
-
-    private async Task<SerializableDiagnosticAnalysisResults> GetHighPriorityDiagnosticsAsync(
-        ImmutableArray<string> projectAnalyzerIds,
-        ImmutableArray<string> hostAnalyzerIds,
-        bool logPerformanceInfo,
-        bool getTelemetryInfo,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        // Step 1:
-        //  - Create the core 'computeTask' for computing diagnostics.
-        var computeTask = GetDiagnosticsAsync(projectAnalyzerIds, hostAnalyzerIds, logPerformanceInfo, getTelemetryInfo, cancellationToken);
-
-        // Step 2:
-        //  - Add this computeTask to the set of currently executing high priority tasks.
-        //    This set of high priority tasks is used in 'GetNormalPriorityDiagnosticsAsync'
-        //    method to ensure that any new or cancelled normal priority task waits for all
-        //    the executing high priority tasks before starting its execution.
-        //  - Note that it is critical to do this step prior to Step 3 below to ensure that
-        //    any canceled normal priority tasks in Step 3 do not resume execution prior to
-        //    completion of this high priority computeTask.
-        lock (s_gate)
-        {
-            Debug.Assert(!s_highPriorityComputeTasks.Contains(computeTask));
-            s_highPriorityComputeTasks = s_highPriorityComputeTasks.Add(computeTask);
-        }
-
-        try
-        {
-            // Step 3:
-            //  - Force cancellation of all the executing normal priority tasks
-            //    to minimize resource and CPU contention between normal priority tasks
-            //    and the high priority computeTask in Step 4 below.
-            CancelNormalPriorityTasks();
-
-            // Step 4:
-            //  - Execute the core 'computeTask' for diagnostic computation.
-            return await computeTask.ConfigureAwait(false);
-        }
-        finally
-        {
-            // Step 5:
-            //  - Remove the 'computeTask' from the set of current executing high priority tasks.
-            lock (s_gate)
-            {
-                Debug.Assert(s_highPriorityComputeTasks.Contains(computeTask));
-                s_highPriorityComputeTasks = s_highPriorityComputeTasks.Remove(computeTask);
-            }
-        }
-
-        static void CancelNormalPriorityTasks()
-        {
-            ImmutableHashSet<CancellationTokenSource> cancellationTokenSources;
-            lock (s_gate)
-            {
-                cancellationTokenSources = s_normalPriorityCancellationTokenSources;
-            }
-
-            foreach (var cancellationTokenSource in cancellationTokenSources)
-            {
-                try
-                {
-                    cancellationTokenSource.Cancel();
-                }
-                catch (ObjectDisposedException)
-                {
-                    // CancellationTokenSource might get disposed if the normal priority
-                    // task completes while we were executing this foreach loop.
-                    // Gracefully handle this case and ignore this exception.
-                }
-            }
-        }
-    }
-
-    private async Task<SerializableDiagnosticAnalysisResults> GetNormalPriorityDiagnosticsAsync(
-        ImmutableArray<string> projectAnalyzerIds,
-        ImmutableArray<string> hostAnalyzerIds,
-        bool logPerformanceInfo,
-        bool getTelemetryInfo,
-        CancellationToken cancellationToken)
-    {
-        while (true)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Step 1:
-            //  - Normal priority task must wait for all the executing high priority tasks to complete
-            //    before beginning execution.
-            await WaitForHighPriorityTasksAsync(cancellationToken).ConfigureAwait(false);
-
-            // Step 2:
-            //  - Create a custom 'cancellationTokenSource' associated with the current normal priority
-            //    request and add it to the tracked set of normal priority cancellation token sources.
-            //    This token source allows normal priority computeTasks to be cancelled when
-            //    a subsequent high priority diagnostic request is received.
-            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            lock (s_gate)
-            {
-                s_normalPriorityCancellationTokenSources = s_normalPriorityCancellationTokenSources.Add(cancellationTokenSource);
-            }
-
-            try
-            {
-                // Step 3:
-                //  - Execute the core compute task for diagnostic computation.
-                return await GetDiagnosticsAsync(projectAnalyzerIds, hostAnalyzerIds, logPerformanceInfo, getTelemetryInfo,
-                    cancellationTokenSource.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationTokenSource.Token)
-            {
-                // Step 4:
-                //  - Attempt to re-execute this cancelled normal priority task by running the loop again.
-                continue;
-            }
-            finally
-            {
-                // Step 5:
-                //  - Remove the 'cancellationTokenSource' for completed or cancelled task.
-                //    For the case where the computeTask was cancelled, we will create a new
-                //    'cancellationTokenSource' for the retry.
-                lock (s_gate)
-                {
-                    Debug.Assert(s_normalPriorityCancellationTokenSources.Contains(cancellationTokenSource));
-                    s_normalPriorityCancellationTokenSources = s_normalPriorityCancellationTokenSources.Remove(cancellationTokenSource);
-                }
-            }
-        }
-
-        static async Task WaitForHighPriorityTasksAsync(CancellationToken cancellationToken)
-        {
-            // We loop continuously until we have an empty high priority task queue.
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                ImmutableHashSet<Task> highPriorityTasksToAwait;
-                lock (s_gate)
-                {
-                    highPriorityTasksToAwait = s_highPriorityComputeTasks;
-                }
-
-                if (highPriorityTasksToAwait.IsEmpty)
-                {
-                    return;
-                }
-
-                // Wait for all the high priority tasks, ignoring all exceptions from it. Loop directly to avoid
-                // expensive allocations in Task.WhenAll.
-                foreach (var task in highPriorityTasksToAwait)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    if (task.IsCompleted)
-                    {
-                        // Make sure to yield so continuations of 'task' can make progress.
-                        await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-                    }
-                    else
-                    {
-                        await task.WithCancellation(cancellationToken).NoThrowAwaitable(false);
-                    }
-                }
-            }
-        }
+        return diagnosticsComputer.GetDiagnosticsAsync(
+            projectAnalyzerIds, hostAnalyzerIds, logPerformanceInfo, getTelemetryInfo, cancellationToken);
     }
 
     private async Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -63,7 +63,6 @@ internal sealed class RemoteDiagnosticAnalyzerService : BrokeredServiceBase, IRe
                         documentSpan,
                         arguments.ProjectAnalyzerIds, arguments.HostAnalyzerIds, documentAnalysisKind,
                         _analyzerInfoCache, hostWorkspaceServices,
-                        isExplicit: arguments.IsExplicit,
                         logPerformanceInfo: arguments.LogPerformanceInfo,
                         getTelemetryInfo: arguments.GetTelemetryInfo,
                         cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This code originally existed for TypeScript.   The TS impl could only handle one request at a time.  So if they were queried for lightbulbs while diags were computing, they were blocked.  This is no longer the case.  And TS doesn't even use us for diags anymore (they use LSP).  So we don't need this code to try to cancel diags when lightbulbs are queried. 