### PR TITLE
Update the link to the file Portable PDB v1.0: Format Specification

### DIFF
--- a/docs/specs/PortablePdb-Metadata.md
+++ b/docs/specs/PortablePdb-Metadata.md
@@ -1,4 +1,4 @@
 # Portable PDB v1.0: Format Specification
 
-Moved to 
-https://github.com/dotnet/corefx/blob/main/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md
+Moved to
+https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md


### PR DESCRIPTION
Fixes #77910 

Update the broken link to https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md