### PR TITLE
Avoid computations in AnalyzerAssemblyLoader.AddDependencyLocation

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -144,6 +144,8 @@ namespace Microsoft.CodeAnalysis
         {
             CheckIfDisposed();
 
+            CompilerPathUtilities.RequireAbsolutePath(originalPath, nameof(originalPath));
+
             lock (_guard)
             {
                 if (_originalPathInfoMap.ContainsKey(originalPath))
@@ -152,7 +154,6 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            CompilerPathUtilities.RequireAbsolutePath(originalPath, nameof(originalPath));
             var simpleName = PathUtilities.GetFileName(originalPath, includeExtension: false);
             string resolvedPath = originalPath;
             IAnalyzerPathResolver? resolver = null;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -146,9 +146,8 @@ namespace Microsoft.CodeAnalysis
 
             lock (_guard)
             {
-                if (_originalPathInfoMap.TryGetValue(originalPath, out var originalPathInfo))
+                if (_originalPathInfoMap.ContainsKey(originalPath))
                 {
-                    Debug.Assert(GeneratedPathComparer.Equals(_originalPathInfoMap[originalPath].ResolvedPath, originalPathInfo.ResolvedPath));
                     return;
                 }
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -144,6 +144,15 @@ namespace Microsoft.CodeAnalysis
         {
             CheckIfDisposed();
 
+            lock (_guard)
+            {
+                if (_originalPathInfoMap.TryGetValue(originalPath, out var originalPathInfo))
+                {
+                    Debug.Assert(GeneratedPathComparer.Equals(_originalPathInfoMap[originalPath].ResolvedPath, originalPathInfo.ResolvedPath));
+                    return;
+                }
+            }
+
             CompilerPathUtilities.RequireAbsolutePath(originalPath, nameof(originalPath));
             var simpleName = PathUtilities.GetFileName(originalPath, includeExtension: false);
             string resolvedPath = originalPath;


### PR DESCRIPTION
Currently, this method is calculating some data upfront for the value part of a TryAdd call. Instead, defer calculating that data until after we've determine it's not already in the dictionary.

I saw this accounting for 2.3% of CPU during loading Roslyn.sln. With this change, it was about 0.2%.

*** original CPU usage opening Roslyn.sln ***
![image](https://github.com/user-attachments/assets/f48c9cf4-b70f-40c8-83f3-7e9a4538a705)

*** CPU usage with this change opening Roslyn.sln ***
![image](https://github.com/user-attachments/assets/ccef8441-23f6-49bf-8fe0-2361e593fa7e)
