### PR TITLE
Reduce main thread switches in VisualStudioProjectFactory.CreateAndAddToWorkspaceAsync

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
@@ -77,6 +77,8 @@ internal sealed class VisualStudioProjectFactory : IVsTypeScriptVisualStudioProj
                 // HACK: Fetch this service to ensure it's still created on the UI thread; once this is
                 // moved off we'll need to fix up it's constructor to be free-threaded.
 
+                // yield if on the main thread, as the VisualStudioMetadataReferenceManager construction can be fairly expensive
+                // and we don't want the case where VisualStudioProjectFactory is constructed on the main thread to block on that.
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
                 _visualStudioWorkspaceImpl.Services.GetRequiredService<VisualStudioMetadataReferenceManager>();
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
@@ -96,13 +96,10 @@ internal sealed class VisualStudioProjectFactory : IVsTypeScriptVisualStudioProj
 
     private async ValueTask UpdateUIContextsAsync(ImmutableSegmentedList<string> list, CancellationToken cancellationToken)
     {
-        // This is not cancellable as we have already mutated the solution.
-        cancellationToken = CancellationToken.None;
-
         await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         foreach (var language in list)
-            await _visualStudioWorkspaceImpl.RefreshProjectExistsUIContextForLanguageAsync(language, cancellationToken).ConfigureAwait(false);
+            await _visualStudioWorkspaceImpl.RefreshProjectExistsUIContextForLanguageAsync(language, cancellationToken).ConfigureAwait(true);
     }
 
     public Task<ProjectSystemProject> CreateAndAddToWorkspaceAsync(string projectSystemName, string language, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Workspaces.AnalyzerRedirecting;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
@@ -49,8 +48,7 @@ internal sealed class VisualStudioProjectFactory : IVsTypeScriptVisualStudioProj
         [ImportMany] IEnumerable<Lazy<IDynamicFileInfoProvider, FileExtensionsMetadata>> fileInfoProviders,
         IVisualStudioDiagnosticAnalyzerProviderFactory vsixAnalyzerProviderFactory,
         [ImportMany] IEnumerable<IAnalyzerAssemblyRedirector> analyzerAssemblyRedirectors,
-        IVsService<SVsBackgroundSolution, IVsBackgroundSolution> solution,
-        IAsynchronousOperationListenerProvider listenerProvider)
+        IVsService<SVsBackgroundSolution, IVsBackgroundSolution> solution)
     {
         _threadingContext = threadingContext;
         _visualStudioWorkspaceImpl = visualStudioWorkspaceImpl;

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
@@ -94,12 +94,10 @@ internal sealed class VisualStudioProjectFactory : IVsTypeScriptVisualStudioProj
             await TaskScheduler.Default;
         }
 
-        // From this point on, we start mutating the solution.  So make us non cancellable.
-#pragma warning disable IDE0059 // Unnecessary assignment of a value
-        cancellationToken = CancellationToken.None;
-#pragma warning restore IDE0059 // Unnecessary assignment of a value
-
         var solution = await _solution.GetValueOrNullAsync(cancellationToken).ConfigureAwait(true);
+
+        // From this point on, we start mutating the solution.  So make us non cancellable.
+        cancellationToken = CancellationToken.None;
 
         _visualStudioWorkspaceImpl.ProjectSystemProjectFactory.SolutionPath = solution?.SolutionFileName;
         _visualStudioWorkspaceImpl.ProjectSystemProjectFactory.SolutionTelemetryId = GetSolutionSessionId();

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1582,12 +1582,15 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
             {
                 _languageToProjectExistsUIContextState[language] = projectExistsWithLanguage;
 
+                // Create a task to update the UI context, and add it to the task collection that all callers to 
+                // this method will wait on before returning.
                 var joinableTask = _threadingContext.JoinableTaskFactory.RunAsync(() => UpdateUIContextAsync(language, cancellationToken));
 
                 _updateUIContextJoinableTasks.Add(joinableTask);
             }
         }
 
+        // Ensure any pending ui context updates have occurred before returning
         await _updateUIContextJoinableTasks.JoinTillEmptyAsync(cancellationToken).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
This method is called once for each project in the solution during solution open, and each call was essentially switching to the main thread twice (once explicitly, once via call to _visualStudioWorkspaceImpl.RefreshProjectExistsUIContextForLanguageAsync). For my testing of opening Roslyn.sln, this removed over 600 main thread switches.

Instead:

1) Move the first main thread switch to just occur once in an initialization task. This task is joined when CreateAndAddToWorkspaceAsync is invoked to ensure that that initialization is completed.
2) Move the second main thread switch to instead only occur when the known uicontext state would have it's active state changed. This essentially only happens when opening the first or closing the last project for a language.