### PR TITLE
Support using k:v syntax when converting collection expressions.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
@@ -313,11 +313,12 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
                             memberAccess.Expression.WithoutTrailingTrivia(),
                             memberAccess.OperatorToken.WithoutTrivia(),
                             memberAccess.Name.WithoutLeadingTrivia()))),
-                    UseSpread: true));
+                    UseSpread: true,
+                    UseKeyValue: false));
                 return;
             }
 
-            postMatchesInReverse.Add(new(Argument(expression), UseSpread: true));
+            postMatchesInReverse.Add(new(Argument(expression), UseSpread: true, UseKeyValue: false));
         }
 
         // We only want to offer this feature when the original collection was list-like (as opposed to being something
@@ -362,7 +363,7 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
             return;
 
         for (var i = arguments.Count - 1; i >= 0; i--)
-            matchesInReverse.Add(new(arguments[i], useSpread));
+            matchesInReverse.Add(new(arguments[i], useSpread, UseKeyValue: false));
     }
 
     /// <summary>
@@ -406,7 +407,8 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
             var name = memberAccess.Name.Identifier.ValueText;
 
             // Check for Add/AddRange/Concat
-            if (state.TryAnalyzeInvocationForCollectionExpression(invocation, allowLinq, cancellationToken, out _, out var useSpread))
+            if (state.TryAnalyzeInvocationForCollectionExpression(
+                    invocation, allowLinq, cancellationToken, out _, out var useSpread, out _))
             {
                 AddArgumentsInReverse(matchesInReverse, invocation.ArgumentList.Arguments, useSpread);
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -575,7 +575,7 @@ internal static class UseCollectionExpressionHelpers
                 if (keyValuePairOnSingleLine && valueExpression.GetTrailingTrivia() is [.., (kind: SyntaxKind.WhitespaceTrivia)] trailingTrivia)
                     valueExpression = valueExpression.WithTrailingTrivia(trailingTrivia.Take(trailingTrivia.Count - 1));
 
-                KeyValuePairElement(keyExpression, ColonToken.WithTriviaFrom(initializer.Expressions.GetSeparator(0)), valueExpression);
+                return KeyValuePairElement(keyExpression, ColonToken.WithTriviaFrom(initializer.Expressions.GetSeparator(0)), valueExpression);
             }
 
             return ExpressionElement(expression);

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -788,7 +788,7 @@ internal static class UseCollectionExpressionHelpers
 
                         // this looks like a good statement, add to the right size of the assignment to track as that's what
                         // we'll want to put in the final collection expression.
-                        matches.Add(new(expressionStatement, UseSpread: false));
+                        matches.Add(new(expressionStatement, UseSpread: false, UseKeyValue: false));
                         currentStatement = currentStatement.GetNextStatement();
                     }
                 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -90,7 +90,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
         // Otherwise, if we're in C#14 or above, we can use the 'with(args)' argument trivially.
         if (supportsWithArgument)
         {
-            preMatches.Add(new(argumentList, UseSpread: false));
+            preMatches.Add(new(argumentList, UseSpread: false, UseKeyValue: false));
             return true;
         }
 
@@ -129,7 +129,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
                 if (Equals(firstParameter.Type.OriginalDefinition, ienumerableOfTType) ||
                     firstParameter.Type.AllInterfaces.Any(i => Equals(i.OriginalDefinition, ienumerableOfTType)))
                 {
-                    preMatches.Add(new(argumentList.Arguments[0].Expression, UseSpread: true));
+                    preMatches.Add(new(argumentList.Arguments[0].Expression, UseSpread: true, UseKeyValue: false));
                     return true;
                 }
             }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -32,8 +32,19 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
     protected override bool IsInitializerOfLocalDeclarationStatement(LocalDeclarationStatementSyntax localDeclarationStatement, BaseObjectCreationExpressionSyntax rootExpression, [NotNullWhen(true)] out VariableDeclaratorSyntax? variableDeclarator)
         => CSharpObjectCreationHelpers.IsInitializerOfLocalDeclarationStatement(localDeclarationStatement, rootExpression, out variableDeclarator);
 
-    protected override bool IsComplexElementInitializer(SyntaxNode expression)
-        => expression.IsKind(SyntaxKind.ComplexElementInitializerExpression);
+    protected override bool IsComplexElementInitializer(SyntaxNode expression, out int initializerElementCount)
+    {
+        if (expression is InitializerExpressionSyntax(SyntaxKind.ComplexElementInitializerExpression) initializer)
+        {
+            initializerElementCount = initializer.Expressions.Count;
+            return true;
+        }
+        else
+        {
+            initializerElementCount = 0;
+            return false;
+        }
+    }
 
     protected override bool HasExistingInvalidInitializerForCollection()
     {

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -83,7 +83,11 @@ internal sealed class CSharpUseCollectionInitializerDiagnosticAnalyzer :
             if (initializer != null)
             {
                 foreach (var expression in initializer.Expressions)
-                    yield return ExpressionElement(expression);
+                {
+                    yield return expression is InitializerExpressionSyntax { Expressions: [var keyExpression, var valueExpression] }
+                        ? KeyValuePairElement(keyExpression, valueExpression)
+                        : ExpressionElement(expression);
+                }
             }
         }
     }

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -484,17 +484,17 @@ internal static class CSharpCollectionExpressionRewriter
                     {
                         var arguments = invocation.ArgumentList.Arguments;
                         yield return KeyValuePairElement(
-                            IndentNode(expressionStatement, arguments[0].Expression, preferredIndentation),
+                            IndentExpression(expressionStatement, arguments[0].Expression, preferredIndentation),
                             ColonToken.WithTriviaFrom(arguments.GetSeparator(0)),
-                            IndentNode(expressionStatement, arguments[1].Expression, preferredIndentation));
+                            IndentExpression(expressionStatement, arguments[1].Expression, preferredIndentation));
                     }
                     else if (expressionStatement.Expression is AssignmentExpressionSyntax assignment)
                     {
                         var elementAccess = (ElementAccessExpressionSyntax)assignment.Left;
                         yield return KeyValuePairElement(
-                            IndentNode(expressionStatement, elementAccess.ArgumentList.Arguments[0].Expression, preferredIndentation),
+                            IndentExpression(expressionStatement, elementAccess.ArgumentList.Arguments[0].Expression, preferredIndentation),
                             ColonToken.WithTrailingTrivia(assignment.OperatorToken.TrailingTrivia),
-                            IndentNode(expressionStatement, assignment.Right, preferredIndentation));
+                            IndentExpression(expressionStatement, assignment.Right, preferredIndentation));
                     }
                     else
                     {
@@ -503,7 +503,7 @@ internal static class CSharpCollectionExpressionRewriter
                 }
                 else
                 {
-                    var expressions = ConvertExpressions(expressionStatement.Expression, expr => IndentNode(expressionStatement, expr, preferredIndentation));
+                    var expressions = ConvertExpressions(expressionStatement.Expression, expr => IndentExpression(expressionStatement, expr, preferredIndentation));
 
                     Contract.ThrowIfTrue(expressions.Length >= 2 && match.UseSpread);
 
@@ -535,11 +535,11 @@ internal static class CSharpCollectionExpressionRewriter
                 // Create: `.. x` for `foreach (var v in x) collection.Add(v)`
                 yield return CreateCollectionElement(
                     match.UseSpread,
-                    IndentNode(foreachStatement, foreachStatement.Expression, preferredIndentation));
+                    IndentExpression(foreachStatement, foreachStatement.Expression, preferredIndentation));
             }
             else if (node is IfStatementSyntax ifStatement)
             {
-                var condition = IndentNode(ifStatement, ifStatement.Condition, preferredIndentation).Parenthesize(includeElasticTrivia: false);
+                var condition = IndentExpression(ifStatement, ifStatement.Condition, preferredIndentation).Parenthesize(includeElasticTrivia: false);
                 var trueStatement = (ExpressionStatementSyntax)UnwrapEmbeddedStatement(ifStatement.Statement);
 
                 if (ifStatement.Else is null)
@@ -565,7 +565,7 @@ internal static class CSharpCollectionExpressionRewriter
             }
             else if (node is ExpressionSyntax expression)
             {
-                yield return CreateCollectionElement(match.UseSpread, IndentNode(parentStatement: null, expression, preferredIndentation));
+                yield return CreateCollectionElement(match.UseSpread, IndentExpression(parentStatement: null, expression, preferredIndentation));
             }
             else if (node is ArgumentListSyntax argumentList)
             {
@@ -577,10 +577,10 @@ internal static class CSharpCollectionExpressionRewriter
             }
         }
 
-        TNode IndentNode<TNode>(
+        ExpressionSyntax IndentExpression(
             StatementSyntax? parentStatement,
-            TNode node,
-            string? preferredIndentation) where TNode : SyntaxNode
+            ExpressionSyntax node,
+            string? preferredIndentation)
         {
             // This must be called from an expression from the original tree.  Not something we're already transforming.
             // Otherwise, we'll have no idea how to apply the preferredIndentation if present.
@@ -688,10 +688,10 @@ internal static class CSharpCollectionExpressionRewriter
                 : preferredIndentation);
         }
 
-        static TNode TransferParentStatementComments<TNode>(
+        static ExpressionSyntax TransferParentStatementComments(
             StatementSyntax? parentStatement,
-            TNode expression,
-            string preferredIndentation) where TNode : SyntaxNode
+            ExpressionSyntax expression,
+            string preferredIndentation)
         {
             if (parentStatement is null)
                 return expression;

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -579,21 +579,21 @@ internal static class CSharpCollectionExpressionRewriter
 
         ExpressionSyntax IndentExpression(
             StatementSyntax? parentStatement,
-            ExpressionSyntax node,
+            ExpressionSyntax expression,
             string? preferredIndentation)
         {
             // This must be called from an expression from the original tree.  Not something we're already transforming.
             // Otherwise, we'll have no idea how to apply the preferredIndentation if present.
-            Contract.ThrowIfNull(node.Parent);
+            Contract.ThrowIfNull(expression.Parent);
             if (preferredIndentation is null)
-                return node.WithoutLeadingTrivia();
+                return expression.WithoutLeadingTrivia();
 
-            var startLine = document.Text.Lines.GetLineFromPosition(GetAnchorNode(node).SpanStart);
+            var startLine = document.Text.Lines.GetLineFromPosition(GetAnchorNode(expression).SpanStart);
             var firstTokenOnLineIndentationString = GetIndentationStringForToken(document.Root.FindToken(startLine.Start));
 
-            var expressionFirstToken = node.GetFirstToken();
-            var updatedExpression = node.ReplaceTokens(
-                node.DescendantTokens(),
+            var expressionFirstToken = expression.GetFirstToken();
+            var updatedExpression = expression.ReplaceTokens(
+                expression.DescendantTokens(),
                 (currentToken, _) =>
                 {
                     // Ensure the first token has the indentation we're moving the entire node to

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -231,7 +231,7 @@ internal static class CSharpCollectionExpressionRewriter
                 // braces (and initial elements) match whatever the initializer correct looks like.
 
                 var initialCollection = UseCollectionExpressionHelpers.ConvertInitializerToCollectionExpression(
-                    initializer, wasOnSingleLine: false);
+                    document.Text, initializer, wasOnSingleLine: false);
 
                 if (!makeMultiLineCollectionExpression &&
                     document.Text.AreOnSameLine(initializer.Expressions.First().GetFirstToken(), initializer.Expressions.Last().GetLastToken()))
@@ -270,7 +270,7 @@ internal static class CSharpCollectionExpressionRewriter
                 // end.
 
                 var initialCollection = UseCollectionExpressionHelpers.ConvertInitializerToCollectionExpression(
-                    initializer, wasOnSingleLine: false);
+                    document.Text, initializer, wasOnSingleLine: false);
 
                 if (document.Text.AreOnSameLine(initializer.OpenBraceToken.GetPreviousToken(), initializer.OpenBraceToken))
                 {
@@ -319,7 +319,7 @@ internal static class CSharpCollectionExpressionRewriter
                 // First, convert the existing initializer (and its expressions) into a corresponding collection
                 // expression.  This will fixup the braces properly for the collection expression.
                 var initialCollection = UseCollectionExpressionHelpers.ConvertInitializerToCollectionExpression(
-                    initializer, wasOnSingleLine: true);
+                    document.Text, initializer, wasOnSingleLine: true);
 
                 // now, add all the matches in after the existing elements.
                 var finalCollection = AddMatchesToExistingNonEmptyCollectionExpression(initialCollection, preferredIndentation: null);

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -472,11 +472,11 @@ internal static class CSharpCollectionExpressionRewriter
             {
                 // Create:
                 //
-                //      `x: y` for `collection.Add(x, y)`
-                //      `x: y` for `collection[x] = y`
-                //      `x` for `collection.Add(x)`
-                //      `.. x` for `collection.AddRange(x)` // when useSpread=true
-                //      `x, y, z` for `collection.AddRange(x, y, z)` // when useSpread=false
+                //      `x: y` for `collection.Add(x, y)`               // when useKeyValue=true
+                //      `x: y` for `collection[x] = y`                  // when useKeyValue=true
+                //      `x` for `collection.Add(x)`                     // when useSpread=false
+                //      `.. x` for `collection.AddRange(x)`             // when useSpread=true
+                //      `x, y, z` for `collection.AddRange(x, y, z)`    // when useSpread=false
 
                 if (match.UseKeyValue)
                 {

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -481,10 +481,10 @@ internal static class CSharpCollectionExpressionRewriter
                 {
                     var invocation = (InvocationExpressionSyntax)expressionStatement.Expression;
                     var arguments = invocation.ArgumentList.Arguments;
-                    yield return IndentNode(
-                        expressionStatement,
-                        KeyValuePairElement(arguments[0].Expression, ColonToken.WithTriviaFrom(arguments.GetSeparator(0)), arguments[1].Expression),
-                        preferredIndentation);
+                    yield return KeyValuePairElement(
+                        IndentNode(expressionStatement, arguments[0].Expression, preferredIndentation),
+                        ColonToken.WithTriviaFrom(arguments.GetSeparator(0)),
+                        IndentNode(expressionStatement, arguments[1].Expression, preferredIndentation));
                 }
                 else
                 {

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
@@ -57,6 +57,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayCodeFixProvid
             editor.ReplaceNode(
                 initializer,
                 ConvertInitializerToCollectionExpression(
+                    text,
                     initializer,
                     IsOnSingleLine(text, initializer)));
         }

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderCodeFixProvider.cs
@@ -74,7 +74,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderCodeFixProv
         var subEditor = new SyntaxEditor(root, document.Project.Solution.Services);
 
         // Remove all the nodes mutating the builder.
-        foreach (var (statement, _) in analysisResult.Matches)
+        foreach (var (statement, _, _) in analysisResult.Matches)
             subEditor.RemoveNode(statement);
 
         // Remove the actual declaration of the builder.  Keep any comments on the builder declaration in case they're
@@ -97,7 +97,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderCodeFixProv
             => new(analysisResult.DiagnosticLocation,
                    root.GetCurrentNode(analysisResult.LocalDeclarationStatement)!,
                    root.GetCurrentNode(analysisResult.CreationExpression)!,
-                   analysisResult.Matches.SelectAsArray(m => new CollectionMatch<SyntaxNode>(root.GetCurrentNode(m.Node)!, m.UseSpread)),
+                   analysisResult.Matches.SelectAsArray(m => new CollectionMatch<SyntaxNode>(root.GetCurrentNode(m.Node)!, m.UseSpread, m.UseKeyValue)),
                    analysisResult.ChangesSemantics);
 
         // Creates a new document with all of the relevant nodes in analysisResult tracked so that we can find them
@@ -114,7 +114,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderCodeFixProv
 
             nodesToTrack.Add(analysisResult.LocalDeclarationStatement);
             nodesToTrack.Add(analysisResult.CreationExpression);
-            foreach (var (statement, _) in analysisResult.Matches)
+            foreach (var (statement, _, _) in analysisResult.Matches)
                 nodesToTrack.Add(statement);
 
             var newRoot = root.TrackNodes(nodesToTrack);

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
@@ -64,7 +64,7 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateCodeFixProvi
             semanticDocument.Root.ReplaceNode(invocationExpression, dummyObjectCreation), cancellationToken).ConfigureAwait(false);
         dummyObjectCreation = (ImplicitObjectCreationExpressionSyntax)newSemanticDocument.Root.GetAnnotatedNodes(dummyObjectAnnotation).Single();
         var expressions = dummyObjectCreation.ArgumentList.Arguments.Select(a => a.Expression);
-        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread));
+        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread, UseKeyValue: false));
 
         var collectionExpression = await CreateCollectionExpressionAsync(
             newSemanticDocument.Document,

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
@@ -8,7 +8,6 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,13 +21,12 @@ using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.UseCollectionExpression;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 
 using static CSharpCollectionExpressionRewriter;
-using static CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer;
 using static CSharpSyntaxTokens;
+using static CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer;
 using static SyntaxFactory;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.UseCollectionExpressionForFluent), Shared]
@@ -61,10 +59,10 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentCodeFixProvi
 
         // We want to replace `new[] { 1, 2, 3 }.Concat(x).Add(y).ToArray()` with the new collection expression.  To do
         // this, we go through the following steps.  First, we replace the whole expression with `new(x, y) { 1, 2, 3 }`
-        // (a dummy object creation expression). We then call into our helper which replaces expressions with
-        // collection expressions.  The reason for the dummy object creation expression is that it serves as an actual
-        // node the rewriting code can attach an initializer to, by which it can figure out appropriate wrapping and
-        // indentation for the collection expression elements.
+        // (a dummy object creation expression). We then call into our helper which replaces expressions with collection
+        // expressions.  The reason for the dummy object creation expression is that it serves as an actual node the
+        // rewriting code can attach an initializer to, by which it can figure out appropriate wrapping and indentation
+        // for the collection expression elements.
 
         var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
@@ -119,17 +119,17 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentCodeFixProvi
                     {
                         if (element is SpreadElementSyntax spreadElement)
                         {
-                            result.Add(new(spreadElement.Expression, UseSpread: true));
+                            result.Add(new(spreadElement.Expression, UseSpread: true, UseKeyValue: false));
                         }
                         else if (element is ExpressionElementSyntax expressionElement)
                         {
-                            result.Add(new(expressionElement.Expression, UseSpread: false));
+                            result.Add(new(expressionElement.Expression, UseSpread: false, UseKeyValue: false));
                         }
                     }
                 }
                 else
                 {
-                    result.Add(new(argument.Expression, match.UseSpread));
+                    result.Add(new(argument.Expression, match.UseSpread, UseKeyValue: false));
                 }
             }
 

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForNewCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForNewCodeFixProvider.cs
@@ -63,7 +63,7 @@ internal sealed partial class CSharpUseCollectionExpressionForNewCodeFixProvider
             semanticDocument.Root.ReplaceNode(objectCreationExpression, dummyObjectCreation), cancellationToken).ConfigureAwait(false);
         dummyObjectCreation = (ImplicitObjectCreationExpressionSyntax)newSemanticDocument.Root.GetAnnotatedNodes(dummyObjectAnnotation).Single();
         var expressions = dummyObjectCreation.ArgumentList.Arguments.Select(a => a.Expression);
-        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread));
+        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread, UseKeyValue: false));
 
         var collectionExpression = await CreateCollectionExpressionAsync(
             newSemanticDocument.Document,

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -6354,7 +6354,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     void M(int[] values)
                     {
-                        Dictionary<int, string> map = [with(StringComparer.Ordinal), "x": "y"];
+                        Dictionary<string, string> map = [with(StringComparer.Ordinal), "x": "y"];
                     }
                 }
                 """,

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -6270,7 +6270,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                     void M(int[] values)
                     {
                         Dictionary<int, string> map = [|new|] Dictionary<int, string>();
-                        map.Add(1, "x");
+                        [|map.Add(|]1, "x");
                     }
                 }
                 """,

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -6282,10 +6282,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     void M(int[] values)
                     {
-                        Dictionary<int, string> map =
-                        [
-                            1: "x"
-                        ];
+                        Dictionary<int, string> map = [1: "x"];
                     }
                 }
                 """,

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
@@ -6094,6 +6096,275 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                     void M(int[] values)
                     {
                         List<int> list = [with(capacity: 0), 1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair1_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>() { { 1, "x" } };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [1: "x"];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair2_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>()
+                        {
+                            { 1, "x" },
+                            { 2, "y" },
+                        };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map =
+                        [
+                            1: "x",
+                            2: "y",
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair3_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>() { [1] = "x" };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [1: "x"];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair4_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>()
+                        {
+                            [1] = "x",
+                            [2] = "y",
+                        };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map =
+                        [
+                            1: "x",
+                            2: "y",
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair5_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>();
+                        map.Add(1, "x");
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map =
+                        [
+                            1: "x"
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair6_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>();
+                        map[1] = "x";
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map =
+                        [
+                            1: "x"
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair7_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<string, string> map = [|new|] Dictionary<string, string>(StringComparer.Ordinal);
+                        map["x"] = "y";
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map =
+                        [
+                            with(StringComparer.Ordinal),
+                            "x": "y"
+                        ];
                     }
                 }
                 """,

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -6317,10 +6317,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     void M(int[] values)
                     {
-                        Dictionary<int, string> map =
-                        [
-                            1: "x"
-                        ];
+                        Dictionary<int, string> map = [1: "x"];
                     }
                 }
                 """,
@@ -6357,11 +6354,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     void M(int[] values)
                     {
-                        Dictionary<int, string> map =
-                        [
-                            with(StringComparer.Ordinal),
-                            "x": "y"
-                        ];
+                        Dictionary<int, string> map = [with(StringComparer.Ordinal), "x": "y"];
                     }
                 }
                 """,

--- a/src/Analyzers/Core/Analyzers/UseCollectionExpression/CollectionExpressionMatch.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionExpression/CollectionExpressionMatch.cs
@@ -16,4 +16,5 @@ namespace Microsoft.CodeAnalysis.UseCollectionExpression;
 /// what form it is.</param>
 internal readonly record struct CollectionMatch<TMatchNode>(
     TMatchNode Node,
-    bool UseSpread) where TMatchNode : SyntaxNode;
+    bool UseSpread,
+    bool UseKeyValue) where TMatchNode : SyntaxNode;

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
@@ -47,7 +47,6 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
         TVariableDeclaratorSyntax,
         TAnalyzer>, new()
 {
-    protected abstract bool SupportsKeyValuePairElement();
     protected abstract bool IsComplexElementInitializer(SyntaxNode expression, out int initializerElementCount);
     protected abstract bool HasExistingInvalidInitializerForCollection();
     protected abstract bool AnalyzeMatchesAndCollectionConstructorForCollectionExpression(

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
@@ -165,11 +165,12 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
                     requiredArgumentName: null,
                     forCollectionExpression: false,
                     cancellationToken,
-                    out var instance) &&
+                    out var instance,
+                    out var useKeyValue) &&
                 this.State.ValuePatternMatches(instance))
             {
                 seenInvocation = true;
-                return new(expressionStatement, UseSpread: false);
+                return new(expressionStatement, UseSpread: false, useKeyValue);
             }
         }
 
@@ -179,7 +180,7 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
                 this.State.ValuePatternMatches(instance))
             {
                 seenIndexAssignment = true;
-                return new(expressionStatement, UseSpread: false);
+                return new(expressionStatement, UseSpread: false, UseKeyValue: true);
             }
         }
 

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
@@ -446,6 +446,7 @@ internal readonly struct UpdateExpressionState<
                 return new(expressionStatement, useSpread, useKeyValue);
             }
 
+            // `x[y] = z` can be converted to `y:z` element if the destination type has an indexer with exactly 1 arg.
             if (@this.SyntaxFacts.SupportsKeyValuePairElement(expression.SyntaxTree.Options) &&
                 @this.TryAnalyzeIndexAssignment(expressionStatement, cancellationToken, out instance, supportedArgumentCount: 1) &&
                 @this.ValuePatternMatches(instance))

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
@@ -363,6 +363,50 @@ internal readonly struct UpdateExpressionState<
         return instance != null;
     }
 
+    public bool TryAnalyzeIndexAssignment(
+        TStatementSyntax statement,
+        CancellationToken cancellationToken,
+        [NotNullWhen(true)] out TExpressionSyntax? instance)
+    {
+        instance = null;
+        if (!this.SyntaxFacts.SupportsIndexingInitializer(statement.SyntaxTree.Options))
+            return false;
+
+        if (!this.SyntaxFacts.IsSimpleAssignmentStatement(statement))
+            return false;
+
+        this.SyntaxFacts.GetPartsOfAssignmentStatement(statement, out var left, out var right);
+
+        if (!this.SyntaxFacts.IsElementAccessExpression(left))
+            return false;
+
+        // If we're initializing a variable, then we can't reference that variable on the right 
+        // side of the initialization.  Rewriting this into a collection initializer would lead
+        // to a definite-assignment error.
+        if (this.NodeContainsValuePatternOrReferencesInitializedSymbol(right, cancellationToken))
+            return false;
+
+        // Can't reference the variable being initialized in the arguments of the indexing expression.
+        this.SyntaxFacts.GetPartsOfElementAccessExpression(left, out var elementInstance, out var argumentList);
+        var elementAccessArguments = this.SyntaxFacts.GetArgumentsOfArgumentList(argumentList);
+        foreach (var argument in elementAccessArguments)
+        {
+            if (this.NodeContainsValuePatternOrReferencesInitializedSymbol(argument, cancellationToken))
+                return false;
+
+            // An index/range expression implicitly references the value being initialized.  So it cannot be used in the
+            // indexing expression.
+            var argExpression = this.SyntaxFacts.GetExpressionOfArgument(argument);
+            argExpression = this.SyntaxFacts.WalkDownParentheses(argExpression);
+
+            if (this.SyntaxFacts.IsIndexExpression(argExpression) || this.SyntaxFacts.IsRangeExpression(argExpression))
+                return false;
+        }
+
+        instance = elementInstance as TExpressionSyntax;
+        return instance != null;
+    }
+
     /// <summary>
     /// Analyze an statement to see if it it could be converted into elements for a new collection-expression.  This
     /// includes calls to <c>.Add</c> and <c>.AddRange</c>, as well as <c>foreach</c> statements that update the

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             Return VisualBasicObjectCreationHelpers.IsInitializerOfLocalDeclarationStatement(localDeclarationStatement, rootExpression, variableDeclarator)
         End Function
 
-        Protected Overrides Function IsComplexElementInitializer(expression As SyntaxNode) As Boolean
+        Protected Overrides Function IsComplexElementInitializer(expression As SyntaxNode, ByRef initializerElementCount As Integer) As Boolean
             ' Only called for collection expressions, which VB does not support
             Throw ExceptionUtilities.Unreachable()
         End Function

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
@@ -1,4 +1,4 @@
-﻿# Generated, do not update manually
+# Generated, do not update manually
 Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo
 Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo.Equals(Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo)
 Microsoft.CodeAnalysis.CSharp.AwaitExpressionInfo.Equals(System.Object)

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
@@ -1,4 +1,4 @@
-﻿# Generated, do not update manually
+# Generated, do not update manually
 Microsoft.CodeAnalysis.Accessibility
 Microsoft.CodeAnalysis.Accessibility.Friend
 Microsoft.CodeAnalysis.Accessibility.Internal

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.Immutable.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.Immutable.txt
@@ -1,4 +1,4 @@
-﻿# Generated, do not update manually
+# Generated, do not update manually
 System.Collections.Frozen.FrozenDictionary
 System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary``2(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``1}},System.Collections.Generic.IEqualityComparer{``0})
 System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Collections.txt
@@ -1,4 +1,4 @@
-﻿# Generated, do not update manually
+# Generated, do not update manually
 System.Collections.BitArray
 System.Collections.BitArray.#ctor(System.Boolean[])
 System.Collections.BitArray.#ctor(System.Byte[])

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Linq.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Linq.txt
@@ -1,4 +1,4 @@
-﻿# Generated, do not update manually
+# Generated, do not update manually
 System.Linq.Enumerable
 System.Linq.Enumerable.Aggregate``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0})
 System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Runtime.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/System.Runtime.txt
@@ -1,4 +1,4 @@
-﻿# Generated, do not update manually
+# Generated, do not update manually
 System.AccessViolationException
 System.AccessViolationException.#ctor
 System.AccessViolationException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -77,6 +77,9 @@ internal class CSharpSyntaxFacts : AbstractSyntaxFacts, ISyntaxFacts
     public bool SupportsFieldExpression(ParseOptions options)
         => options.LanguageVersion() >= LanguageVersionExtensions.CSharpNext;
 
+    public bool SupportsKeyValuePairElement(ParseOptions options)
+        => options.LanguageVersion() >= LanguageVersionExtensions.CSharpNext;
+
     public SyntaxToken ParseToken(string text)
         => SyntaxFactory.ParseToken(text);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -98,6 +98,7 @@ internal interface ISyntaxFacts
     bool SupportsImplicitImplementationOfNonPublicInterfaceMembers(ParseOptions options);
     bool SupportsIndexingInitializer(ParseOptions options);
     bool SupportsIsNotTypeExpression(ParseOptions options);
+    bool SupportsKeyValuePairElement(ParseOptions options);
     bool SupportsLocalFunctionDeclaration(ParseOptions options);
     bool SupportsNotPattern(ParseOptions options);
     bool SupportsRecord(ParseOptions options);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -86,6 +86,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return False
         End Function
 
+        Public Function SupportsKeyValuePairElement(options As ParseOptions) As Boolean Implements ISyntaxFacts.SupportsKeyValuePairElement
+            Return False
+        End Function
+
         Public Function ParseToken(text As String) As SyntaxToken Implements ISyntaxFacts.ParseToken
             Return SyntaxFactory.ParseToken(text, startStatement:=True)
         End Function


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/77922

This is to support the cases of:

1. `new Dictionary<int, string> { { 1, "x" } }` into `[1: "x"]`
2. `new Dictionary<int, string> { [1] = "x" }` into `[1: "x"]`
3. `new Dictionary<int, string>(); d.Add(1, "x");` into `[1: "x"]`
4. `new Dictionary<int, string>(); d[1] = "x";` into `[1: "x"]`

Later PRs will update things like our fluent matcher and builder matcher to handle dictionaries there as well.  