### PR TITLE
Ensure we don't put as an input to the VSIX build outputs

### DIFF
--- a/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
+++ b/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
@@ -11,4 +11,16 @@
 
   <Target Name="CollectVsixUpToDateCheckBuilt">
   </Target>
+
+  <PropertyGroup>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);RemoveBuildOutputSourceItems</CollectUpToDateCheckInputDesignTimeDependsOn>
+  </PropertyGroup>
+
+  <!-- Add a workaround for https://github.com/dotnet/project-system/issues/9651 until we decide what we want to do there long term. -->
+  <Target Name="RemoveBuildOutputSourceItems" DependsOnTargets="AddUpToDateCheckVSIXSourceItems" Condition="'$(CreateVsixContainer)' == 'true'">
+    <ItemGroup>
+      <_ItemsInObjDirectory Include="$(IntermediateOutputPath)\**\*" Set="VsixItems" />
+      <UpToDateCheckInput Remove="@(_ItemsInObjDirectory)" MatchOnMetadata="Set" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
This can screw up the comparison to the check where we compare the timestamp of each input in any set to the last build start time.

Works around https://github.com/dotnet/project-system/issues/9651