### PR TITLE
Merge features/dictionary-expressions into release/dev17.14

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 10.md
@@ -292,6 +292,47 @@ unsafe record struct R(
 }
 ```
 
+## `with()` as a collection expression element is treated as collection construction *arguments*
+
+***Introduced in Visual Studio 2022 version 17.14***
+
+`with(...)` when used as an element in a collection expression is bound as arguments passed to constructor or
+factory method used to create the collection, rather than as an invocation expression of a method named `with`.
+
+To bind to a method named `with`, use `@with` instead.
+
+```cs
+object x, y, z = ...;
+object[] items;
+
+items = [with(x, y), z];  // C#13: call to with() method; C#14: error args not supported for object[]
+items = [@with(x, y), z]; // call to with() method
+
+object with(object a, object b) { ... }
+```
+
+## Collection expression uses indexer rather than `Add()` for `KeyValuePair<K, V>` collections
+
+***Introduced in Visual Studio 2022 version 17.14***
+
+For a collection expression where the target type is a `struct` or `class` type where the *iteration type* of the target type
+is `KeyValuePair<K, V>`, and where the target type provides an indexer of the form `public V this[K key] { get; set; }`,
+the collection instance will be constructed using the indexer `set` accessor rather than applicable `Add()` methods.
+
+```csharp
+KeyValuePair<string, int> x = ...;
+IReadOnlyDictionary<string, int> y = ...;
+
+MyDictionary<string, int> z = [x, ..y]; // previously used Add(), now uses this[K].set
+
+class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+{
+    public IEnumerator<KeyValuePair<K, V>> GetEnumerator();
+    public V this[K key] { get; set; }
+    public void Add(KeyValuePair<K, V> kvp);
+}
+```
+
 ## Emitting metadata-only executables requires an entrypoint
 
 ***Introduced in Visual Studio 2022 version 17.14***

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
@@ -105,7 +105,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
             if (ienumerableType is null)
                 return default;
 
-            if (!IsConstructibleCollectionType(
+            if (!CollectionExpressionUtilities.IsConstructibleCollectionType(
                     semanticModel.Compilation, ienumerableType.TypeArguments.Single()))
             {
                 return default;

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
@@ -307,17 +307,18 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
                     .All(static t => t.IsWhitespaceOrEndOfLine()))
             {
                 // Remove any whitespace around the `.`, making the singly-wrapped fluent expression into a single line.
-                postMatchesInReverse.Add(new CollectionMatch<ArgumentSyntax>(
+                postMatchesInReverse.Add(new(
                     Argument(innerInvocation.WithExpression(
                         memberAccess.Update(
                             memberAccess.Expression.WithoutTrailingTrivia(),
                             memberAccess.OperatorToken.WithoutTrivia(),
                             memberAccess.Name.WithoutLeadingTrivia()))),
-                    UseSpread: true));
+                    UseSpread: true,
+                    UseKeyValue: false));
                 return;
             }
 
-            postMatchesInReverse.Add(new CollectionMatch<ArgumentSyntax>(Argument(expression), UseSpread: true));
+            postMatchesInReverse.Add(new(Argument(expression), UseSpread: true, UseKeyValue: false));
         }
 
         // We only want to offer this feature when the original collection was list-like (as opposed to being something
@@ -362,7 +363,7 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
             return;
 
         for (var i = arguments.Count - 1; i >= 0; i--)
-            matchesInReverse.Add(new(arguments[i], useSpread));
+            matchesInReverse.Add(new(arguments[i], useSpread, UseKeyValue: false));
     }
 
     /// <summary>
@@ -406,7 +407,8 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
             var name = memberAccess.Name.Identifier.ValueText;
 
             // Check for Add/AddRange/Concat
-            if (state.TryAnalyzeInvocationForCollectionExpression(invocation, allowLinq, cancellationToken, out _, out var useSpread))
+            if (state.TryAnalyzeInvocationForCollectionExpression(
+                    invocation, allowLinq, cancellationToken, out _, out var useSpread, out _))
             {
                 AddArgumentsInReverse(matchesInReverse, invocation.ArgumentList.Arguments, useSpread);
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -116,7 +116,7 @@ internal static class UseCollectionExpressionHelpers
         if (originalTypeInfo.ConvertedType is null or IErrorTypeSymbol)
             return false;
 
-        if (!IsConstructibleCollectionType(compilation, originalTypeInfo.ConvertedType.OriginalDefinition))
+        if (!CollectionExpressionUtilities.IsConstructibleCollectionType(compilation, originalTypeInfo.ConvertedType.OriginalDefinition))
             return false;
 
         if (expression.IsInExpressionTree(semanticModel, expressionType, cancellationToken))
@@ -143,7 +143,7 @@ internal static class UseCollectionExpressionHelpers
         // expression will always succeed, and there's no need to actually validate semantics there.
         // Tracked by https://github.com/dotnet/roslyn/issues/68826
         if (parent is CastExpressionSyntax)
-            return IsConstructibleCollectionType(compilation, semanticModel.GetTypeInfo(parent, cancellationToken).Type);
+            return CollectionExpressionUtilities.IsConstructibleCollectionType(compilation, semanticModel.GetTypeInfo(parent, cancellationToken).Type);
 
         // Looks good as something to replace.  Now check the semantics of making the replacement to see if there would
         // any issues.
@@ -232,7 +232,7 @@ internal static class UseCollectionExpressionHelpers
 
             // It's always safe to convert List<X> to ICollection<X> or IList<X> as the language guarantees that it will
             // continue emitting a List<X> for those target types.
-            var isWellKnownCollectionReadWriteInterface = IsWellKnownCollectionReadWriteInterface(convertedType);
+            var isWellKnownCollectionReadWriteInterface = CollectionExpressionUtilities.IsWellKnownCollectionReadWriteInterface(convertedType);
             if (isWellKnownCollectionReadWriteInterface &&
                 Equals(type.OriginalDefinition, compilation.ListOfTType()) &&
                 type.AllInterfaces.Contains(convertedType))
@@ -258,7 +258,7 @@ internal static class UseCollectionExpressionHelpers
             //
             // `IEnumerable<object> obj = Array.Empty<object>();` or
             // `IEnumerable<string> obj = new[] { "" };`
-            if (IsWellKnownCollectionInterface(convertedType) && type.AllInterfaces.Contains(convertedType))
+            if (CollectionExpressionUtilities.IsWellKnownCollectionInterface(convertedType) && type.AllInterfaces.Contains(convertedType))
             {
                 // The observable collections are known to have significantly different behavior than List<T>.  So
                 // disallow converting those types to ensure semantics are preserved.  We do this even though
@@ -293,91 +293,6 @@ internal static class UseCollectionExpressionHelpers
 
             // Add more cases to support here.
             return false;
-        }
-    }
-
-    public static bool IsWellKnownCollectionInterface(ITypeSymbol type)
-        => IsWellKnownCollectionReadOnlyInterface(type) || IsWellKnownCollectionReadWriteInterface(type);
-
-    public static bool IsWellKnownCollectionReadOnlyInterface(ITypeSymbol type)
-    {
-        return type.OriginalDefinition.SpecialType
-            is SpecialType.System_Collections_Generic_IEnumerable_T
-            or SpecialType.System_Collections_Generic_IReadOnlyCollection_T
-            or SpecialType.System_Collections_Generic_IReadOnlyList_T;
-    }
-
-    public static bool IsWellKnownCollectionReadWriteInterface(ITypeSymbol type)
-    {
-        return type.OriginalDefinition.SpecialType
-            is SpecialType.System_Collections_Generic_ICollection_T
-            or SpecialType.System_Collections_Generic_IList_T;
-    }
-
-    public static bool IsConstructibleCollectionType(Compilation compilation, ITypeSymbol? type)
-    {
-        if (type is null)
-            return false;
-
-        // Arrays are always a valid collection expression type.
-        if (type is IArrayTypeSymbol)
-            return true;
-
-        // Has to be a real named type at this point.
-        if (type is INamedTypeSymbol namedType)
-        {
-            // Span<T> and ReadOnlySpan<T> are always valid collection expression types.
-            if (namedType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
-                namedType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))
-            {
-                return true;
-            }
-
-            // If it has a [CollectionBuilder] attribute on it, it is a valid collection expression type.
-            if (namedType.GetAttributes().Any(a => a.AttributeClass.IsCollectionBuilderAttribute()))
-                return true;
-
-            if (IsWellKnownCollectionInterface(namedType))
-                return true;
-
-            // At this point, all that is left are collection-initializer types.  These need to derive from
-            // System.Collections.IEnumerable, and have an invokable no-arg constructor.
-
-            // Abstract type don't have invokable constructors at all.
-            if (namedType.IsAbstract)
-                return false;
-
-            if (namedType.AllInterfaces.Contains(compilation.IEnumerableType()!))
-            {
-                // If they have an accessible `public C(int capacity)` constructor, the lang prefers calling that.
-                var constructors = namedType.Constructors;
-                var capacityConstructor = GetAccessibleInstanceConstructor(constructors, c => c.Parameters is [{ Name: "capacity", Type.SpecialType: SpecialType.System_Int32 }]);
-                if (capacityConstructor != null)
-                    return true;
-
-                var noArgConstructor =
-                    GetAccessibleInstanceConstructor(constructors, c => c.Parameters.IsEmpty) ??
-                    GetAccessibleInstanceConstructor(constructors, c => c.Parameters.All(p => p.IsOptional || p.IsParams));
-                if (noArgConstructor != null)
-                {
-                    // If we have a struct, and the constructor we find is implicitly declared, don't consider this
-                    // a constructible type.  It's likely the user would just get the `default` instance of the
-                    // collection (like with ImmutableArray<T>) which would then not actually work.  If the struct
-                    // does have an explicit constructor though, that's a good sign it can actually be constructed
-                    // safely with the no-arg `new S()` call.
-                    if (!(namedType.TypeKind == TypeKind.Struct && noArgConstructor.IsImplicitlyDeclared))
-                        return true;
-                }
-            }
-        }
-
-        // Anything else is not constructible.
-        return false;
-
-        IMethodSymbol? GetAccessibleInstanceConstructor(ImmutableArray<IMethodSymbol> constructors, Func<IMethodSymbol, bool> predicate)
-        {
-            var constructor = constructors.FirstOrDefault(c => !c.IsStatic && predicate(c));
-            return constructor is not null && constructor.IsAccessibleWithin(compilation.Assembly) ? constructor : null;
         }
     }
 
@@ -627,12 +542,12 @@ internal static class UseCollectionExpressionHelpers
     }
 
     public static CollectionExpressionSyntax ConvertInitializerToCollectionExpression(
-        InitializerExpressionSyntax initializer, bool wasOnSingleLine)
+        SourceText text, InitializerExpressionSyntax initializer, bool wasOnSingleLine)
     {
         // if the initializer is already on multiple lines, keep it that way.  otherwise, squash from `{ 1, 2, 3 }` to `[1, 2, 3]`
         var openBracket = OpenBracketToken.WithTriviaFrom(initializer.OpenBraceToken);
         var elements = initializer.Expressions.GetWithSeparators().SelectAsArray(
-            i => i.IsToken ? i : ExpressionElement((ExpressionSyntax)i.AsNode()!));
+            i => i.IsToken ? i : CreateElement((ExpressionSyntax)i.AsNode()!));
         var closeBracket = CloseBracketToken.WithTriviaFrom(initializer.CloseBraceToken);
 
         // If it was on a single line to begin with, then remove the inner spaces on the `{ ... }` to create `[...]`. If
@@ -648,6 +563,43 @@ internal static class UseCollectionExpressionHelpers
         }
 
         return CollectionExpression(openBracket, SeparatedList<CollectionElementSyntax>(elements), closeBracket);
+
+        CollectionElementSyntax CreateElement(ExpressionSyntax expression)
+        {
+            if (expression is InitializerExpressionSyntax { Expressions: [var keyExpression1, var valueExpression1] } initializer)
+            {
+                // If we have `{ key, ... }` we want to move the leading trivia of the `{` to the key so that it is
+                // properly indented to the same level the `{` was.
+                var openBraceAndKeyOnSingleLine = wasOnSingleLine || text.AreOnSameLine(initializer.OpenBraceToken, keyExpression1.GetLastToken());
+                if (openBraceAndKeyOnSingleLine)
+                    keyExpression1 = keyExpression1.WithLeadingTrivia(initializer.OpenBraceToken.LeadingTrivia);
+
+                // If we have `{ ..., value }` we want to move the trailing trivia of the `}` to the value to preserve trailing comments.
+                var valueAndCloseBraceOnSingleLine = wasOnSingleLine || text.AreOnSameLine(valueExpression1.GetLastToken(), initializer.CloseBraceToken);
+                if (valueAndCloseBraceOnSingleLine)
+                    valueExpression1 = valueExpression1.WithTrailingTrivia(initializer.CloseBraceToken.TrailingTrivia);
+
+                return KeyValuePairElement(keyExpression1, ColonToken.WithTriviaFrom(initializer.Expressions.GetSeparator(0)), valueExpression1);
+            }
+            else if (expression is AssignmentExpressionSyntax
+            {
+                Left: ImplicitElementAccessSyntax { ArgumentList.Arguments: [var argument] } implicitElementAccess,
+                OperatorToken: var equalsToken,
+                Right: var valueExpression2,
+            })
+            {
+                // If we have `[key] = value` we want to move the leading trivia of the `[` to the key.
+                var keyExpression2 = argument.Expression.WithLeadingTrivia(implicitElementAccess.GetLeadingTrivia());
+                return KeyValuePairElement(
+                    keyExpression2,
+                    ColonToken.WithTrailingTrivia(equalsToken.TrailingTrivia),
+                    valueExpression2);
+            }
+            else
+            {
+                return ExpressionElement(expression);
+            }
+        }
     }
 
     public static CollectionExpressionSyntax ReplaceWithCollectionExpression(
@@ -836,7 +788,7 @@ internal static class UseCollectionExpressionHelpers
 
                         // this looks like a good statement, add to the right size of the assignment to track as that's what
                         // we'll want to put in the final collection expression.
-                        matches.Add(new(expressionStatement, UseSpread: false));
+                        matches.Add(new(expressionStatement, UseSpread: false, UseKeyValue: false));
                         currentStatement = currentStatement.GetNextStatement();
                     }
                 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -31,18 +32,44 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
     protected override bool IsInitializerOfLocalDeclarationStatement(LocalDeclarationStatementSyntax localDeclarationStatement, BaseObjectCreationExpressionSyntax rootExpression, [NotNullWhen(true)] out VariableDeclaratorSyntax? variableDeclarator)
         => CSharpObjectCreationHelpers.IsInitializerOfLocalDeclarationStatement(localDeclarationStatement, rootExpression, out variableDeclarator);
 
-    protected override bool IsComplexElementInitializer(SyntaxNode expression)
-        => expression.IsKind(SyntaxKind.ComplexElementInitializerExpression);
+    protected override bool IsComplexElementInitializer(SyntaxNode expression, out int initializerElementCount)
+    {
+        if (expression is InitializerExpressionSyntax(SyntaxKind.ComplexElementInitializerExpression) initializer)
+        {
+            initializerElementCount = initializer.Expressions.Count;
+            return true;
+        }
+        else
+        {
+            initializerElementCount = 0;
+            return false;
+        }
+    }
 
     protected override bool HasExistingInvalidInitializerForCollection()
     {
-        // Can't convert to a collection expression if it already has an object-initializer.  Note, we do allow
-        // conversion of empty `{ }` initializer.  So we only block if the expression count is more than zero.
-        return _objectCreationExpression.Initializer is InitializerExpressionSyntax
+        // Can't convert to a collection expression if it already has a { X = ... } object-initializer.
+        //
+        // Note 1: we do allow conversion of empty `{ }` initializer.  So we only block if the expression count is more than zero.
+        if (_objectCreationExpression.Initializer is InitializerExpressionSyntax(SyntaxKind.ObjectInitializerExpression)
+            {
+                Expressions: [var firstExpression, ..],
+            })
         {
-            RawKind: (int)SyntaxKind.ObjectInitializerExpression,
-            Expressions.Count: > 0,
-        };
+            // Note 2: we do allow `{ [k] = v }` initializers if k:v elements are supported.
+            if (firstExpression is AssignmentExpressionSyntax
+                {
+                    Left: ImplicitElementAccessSyntax { ArgumentList.Arguments.Count: 1 }
+                } &&
+                this.SyntaxFacts.SupportsKeyValuePairElement(_objectCreationExpression.SyntaxTree.Options))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     protected override bool AnalyzeMatchesAndCollectionConstructorForCollectionExpression(
@@ -58,147 +85,177 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
         if (argumentList is null || argumentList.Arguments.Count == 0)
             return true;
 
-        // Anything beyond just a single capacity argument (or single value to populate the collection with) isn't
-        // anything we can handle.
-        if (argumentList.Arguments.Count != 1)
-            return false;
-
-        if (this.SemanticModel.GetSymbolInfo(_objectCreationExpression, cancellationToken).Symbol is not IMethodSymbol
-            {
-                MethodKind: MethodKind.Constructor,
-                Parameters: [var firstParameter],
-            } constructor)
-        {
-            return false;
-        }
-
-        if (CanSpreadFirstParameter(constructor.ContainingType, firstParameter))
-        {
-            // Took a single argument that implements IEnumerable<T>.  We handle this by spreading that argument as the
-            // first thing added to the collection.
-            preMatches.Add(new(argumentList.Arguments[0].Expression, UseSpread: true));
-
-            // Can't be certain that spreading the elements will be the same as passing to the constructor.  So pass
-            // that uncertainty up to the caller so they can inform the user.
-            mayChangeSemantics = true;
+        // See if we can specialize a single argument, by potentially spreading it, or dropping it entirely if redundant.
+        var supportsWithArgument = _objectCreationExpression.SyntaxTree.Options.LanguageVersion().IsCSharp14OrAbove();
+        if (TrySpecializeSingleArgument(out mayChangeSemantics))
             return true;
-        }
-        else if (firstParameter is { Type.SpecialType: SpecialType.System_Int32, Name: "capacity" })
+
+        // Otherwise, if we're in C#14 or above, we can use the 'with(args)' argument trivially.
+        if (supportsWithArgument)
         {
-            // is a single `int capacity` constructor.
-
-            // The original collection could have been passed elements explicitly in its initializer.  Ensure we account for
-            // that as well.
-            var individualElementCount = _objectCreationExpression.Initializer?.Expressions.Count ?? 0;
-
-            // Walk the matches, determining what individual elements are added as-is, as well as what values are going to
-            // be spread into the final collection.  We'll then ensure a correspondance between both and the expression the
-            // user is currently passing to the 'capacity' argument to make sure they're entirely congruent.
-            using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var spreadElements);
-            foreach (var match in postMatches)
-            {
-                switch (match.Node)
-                {
-                    case ExpressionStatementSyntax { Expression: InvocationExpressionSyntax invocation } expressionStatement:
-                        // x.AddRange(y).  Have to make sure we see y.Count in the capacity list.
-                        // x.Add(y, z).  Increment the total number of elements by the arg count.
-                        if (match.UseSpread)
-                            spreadElements.Add(invocation.ArgumentList.Arguments[0].Expression);
-                        else
-                            individualElementCount += invocation.ArgumentList.Arguments.Count;
-
-                        continue;
-
-                    case ForEachStatementSyntax foreachStatement:
-                        // foreach (var v in expr) x.Add(v).  Have to make sure we see expr.Count in the capacity list.
-                        spreadElements.Add(foreachStatement.Expression);
-                        continue;
-
-                    default:
-                        // Something we don't support (yet).
-                        return false;
-                }
-            }
-
-            // Now, break up an expression like `1 + x.Length + y.Count` into the parts separated by the +'s
-            var currentArgumentExpression = argumentList.Arguments[0].Expression;
-            using var _2 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var expressionPieces);
-
-            while (true)
-            {
-                if (currentArgumentExpression is BinaryExpressionSyntax binaryExpression)
-                {
-                    if (binaryExpression.Kind() != SyntaxKind.AddExpression)
-                        return false;
-
-                    expressionPieces.Add(binaryExpression.Right);
-                    currentArgumentExpression = binaryExpression.Left;
-                }
-                else
-                {
-                    expressionPieces.Add(currentArgumentExpression);
-                    break;
-                }
-            }
-
-            // Determine the total constant value provided in the expression.  For each constant we see, remove that
-            // constant from the pieces list.  That way the pieces list only corresponds to the values to spread.
-            var totalConstantValue = 0;
-            for (var i = expressionPieces.Count - 1; i >= 0; i--)
-            {
-                var piece = expressionPieces[i];
-                var constant = this.SemanticModel.GetConstantValue(piece, cancellationToken);
-                if (constant.Value is int value)
-                {
-                    totalConstantValue += value;
-                    expressionPieces.RemoveAt(i);
-                }
-            }
-
-            // If the constant didn't match the number of individual elements to add, we can't update this code.
-            if (totalConstantValue != individualElementCount)
-                return false;
-
-            // After removing the constants, we should have an expression for each value we're going to spread.
-            if (expressionPieces.Count != spreadElements.Count)
-                return false;
-
-            // Now make sure we have a match for each part of `x.Length + y.Length` to an element being spread
-            // into the collection.
-            foreach (var piece in expressionPieces)
-            {
-                // we support x.Length, x.Count, and x.Count()
-                var current = piece;
-                if (piece is InvocationExpressionSyntax invocationExpression)
-                {
-                    if (invocationExpression.ArgumentList.Arguments.Count != 0)
-                        return false;
-
-                    current = invocationExpression.Expression;
-                }
-
-                if (current is not MemberAccessExpressionSyntax(SyntaxKind.SimpleMemberAccessExpression) { Name.Identifier.ValueText: "Length" or "Count" } memberAccess)
-                    return false;
-
-                current = memberAccess.Expression;
-
-                // Now see if we have an item we're spreading matching 'x'.
-                var matchIndex = spreadElements.FindIndex(SyntaxFacts.AreEquivalent, current);
-                if (matchIndex < 0)
-                    return false;
-
-                spreadElements.RemoveAt(matchIndex);
-            }
-
-            // If we had any spread elements remaining we can't proceed.
-            if (spreadElements.Count > 0)
-                return false;
-
-            // We're all good.  The items we found matches up precisely to the capacity provided!
+            preMatches.Add(new(argumentList, UseSpread: false, UseKeyValue: false));
             return true;
         }
 
         return false;
+
+        bool TrySpecializeSingleArgument(out bool mayChangeSemantics)
+        {
+            mayChangeSemantics = false;
+
+            // Anything beyond just a single capacity argument (or single value to populate the collection with) isn't
+            // anything we can handle.
+            if (argumentList.Arguments.Count != 1)
+                return false;
+
+            // We have one argument.  We can do a few special things here.  First, if it's a capacity argument, that matches
+            // up with the number of elements we're adding to the collection, we can drop the capacity argument entirely.
+            // Otherwise, if we're passing a collection to the constructor, we can spread that collection into the final
+            // collection.  Finally, if we're in C#14 or above, we can use the 'with(args)' argument trivially.
+
+            if (this.SemanticModel.GetSymbolInfo(_objectCreationExpression, cancellationToken).Symbol is not IMethodSymbol
+                {
+                    MethodKind: MethodKind.Constructor,
+                    Parameters: [var firstParameter],
+                } constructor)
+            {
+                return false;
+            }
+
+            // If it took a single argument that implements IEnumerable<T>.  We handle this by spreading that argument
+            // as the first thing added to the collection.  Note: if we support 'with()', we prefer to use that as we know
+            // it preserves the semantics here perfectly.
+            if (!supportsWithArgument)
+            {
+                if (CanSpreadFirstParameter(constructor.ContainingType, firstParameter))
+                {
+                    preMatches.Add(new(argumentList.Arguments[0].Expression, UseSpread: true, UseKeyValue: false));
+
+                    // Can't be certain that spreading the elements will be the same as passing to the constructor.  So pass
+                    // that uncertainty up to the caller so they can inform the user.
+                    mayChangeSemantics = true;
+                    return true;
+                }
+            }
+
+            // Otherwise, if it's a single `int capacity` constructor, we can try to see if the capacity matches up with
+            // the number of elements we're adding to the collection.  If so, we can drop the capacity argument
+            // entirely.
+            if (firstParameter is { Type.SpecialType: SpecialType.System_Int32, Name: "capacity" })
+            {
+                // The original collection could have been passed elements explicitly in its initializer.  Ensure we account for
+                // that as well.
+                var individualElementCount = _objectCreationExpression.Initializer?.Expressions.Count ?? 0;
+
+                // Walk the matches, determining what individual elements are added as-is, as well as what values are going to
+                // be spread into the final collection.  We'll then ensure a correspondance between both and the expression the
+                // user is currently passing to the 'capacity' argument to make sure they're entirely congruent.
+                using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var spreadElements);
+                foreach (var match in postMatches)
+                {
+                    switch (match.Node)
+                    {
+                        case ExpressionStatementSyntax { Expression: InvocationExpressionSyntax invocation } expressionStatement:
+                            // x.AddRange(y).  Have to make sure we see y.Count in the capacity list.
+                            // x.Add(y, z).  Increment the total number of elements by the arg count.
+                            if (match.UseSpread)
+                                spreadElements.Add(invocation.ArgumentList.Arguments[0].Expression);
+                            else
+                                individualElementCount += invocation.ArgumentList.Arguments.Count;
+
+                            continue;
+
+                        case ForEachStatementSyntax foreachStatement:
+                            // foreach (var v in expr) x.Add(v).  Have to make sure we see expr.Count in the capacity list.
+                            spreadElements.Add(foreachStatement.Expression);
+                            continue;
+
+                        default:
+                            // Something we don't support (yet).
+                            return false;
+                    }
+                }
+
+                // Now, break up an expression like `1 + x.Length + y.Count` into the parts separated by the +'s
+                var currentArgumentExpression = argumentList.Arguments[0].Expression;
+                using var _2 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var expressionPieces);
+
+                while (true)
+                {
+                    if (currentArgumentExpression is BinaryExpressionSyntax binaryExpression)
+                    {
+                        if (binaryExpression.Kind() != SyntaxKind.AddExpression)
+                            return false;
+
+                        expressionPieces.Add(binaryExpression.Right);
+                        currentArgumentExpression = binaryExpression.Left;
+                    }
+                    else
+                    {
+                        expressionPieces.Add(currentArgumentExpression);
+                        break;
+                    }
+                }
+
+                // Determine the total constant value provided in the expression.  For each constant we see, remove that
+                // constant from the pieces list.  That way the pieces list only corresponds to the values to spread.
+                var totalConstantValue = 0;
+                for (var i = expressionPieces.Count - 1; i >= 0; i--)
+                {
+                    var piece = expressionPieces[i];
+                    var constant = this.SemanticModel.GetConstantValue(piece, cancellationToken);
+                    if (constant.Value is int value)
+                    {
+                        totalConstantValue += value;
+                        expressionPieces.RemoveAt(i);
+                    }
+                }
+
+                // If the constant didn't match the number of individual elements to add, we can't update this code.
+                if (totalConstantValue != individualElementCount)
+                    return false;
+
+                // After removing the constants, we should have an expression for each value we're going to spread.
+                if (expressionPieces.Count != spreadElements.Count)
+                    return false;
+
+                // Now make sure we have a match for each part of `x.Length + y.Length` to an element being spread
+                // into the collection.
+                foreach (var piece in expressionPieces)
+                {
+                    // we support x.Length, x.Count, and x.Count()
+                    var current = piece;
+                    if (piece is InvocationExpressionSyntax invocationExpression)
+                    {
+                        if (invocationExpression.ArgumentList.Arguments.Count != 0)
+                            return false;
+
+                        current = invocationExpression.Expression;
+                    }
+
+                    if (current is not MemberAccessExpressionSyntax(SyntaxKind.SimpleMemberAccessExpression) { Name.Identifier.ValueText: "Length" or "Count" } memberAccess)
+                        return false;
+
+                    current = memberAccess.Expression;
+
+                    // Now see if we have an item we're spreading matching 'x'.
+                    var matchIndex = spreadElements.FindIndex(SyntaxFacts.AreEquivalent, current);
+                    if (matchIndex < 0)
+                        return false;
+
+                    spreadElements.RemoveAt(matchIndex);
+                }
+
+                // If we had any spread elements remaining we can't proceed.
+                if (spreadElements.Count > 0)
+                    return false;
+
+                // We're all good.  The items we found matches up precisely to the capacity provided!
+                return true;
+            }
+
+            return false;
+        }
 
         bool CanSpreadFirstParameter(INamedTypeSymbol constructedType, IParameterSymbol firstParameter)
         {

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -68,7 +68,13 @@ internal sealed class CSharpUseCollectionInitializerDiagnosticAnalyzer :
             foreach (var match in preMatches)
             {
                 if (match.Node is ExpressionSyntax expression)
+                {
                     yield return match.UseSpread ? SpreadElement(expression) : ExpressionElement(expression);
+                }
+                else if (match.Node is ArgumentListSyntax argumentList)
+                {
+                    yield return WithElement(argumentList.WithoutTrivia());
+                }
             }
         }
 
@@ -77,7 +83,26 @@ internal sealed class CSharpUseCollectionInitializerDiagnosticAnalyzer :
             if (initializer != null)
             {
                 foreach (var expression in initializer.Expressions)
-                    yield return ExpressionElement(expression);
+                {
+                    if (expression is InitializerExpressionSyntax { Expressions: [var keyExpression, var valueExpression1] })
+                    {
+                        // { k, v } -> [k: v]
+                        yield return KeyValuePairElement(keyExpression, valueExpression1);
+                    }
+                    else if (expression is AssignmentExpressionSyntax
+                    {
+                        Left: ImplicitElementAccessSyntax { ArgumentList.Arguments: [var argument] },
+                        Right: var valueExpression2,
+                    })
+                    {
+                        // [k] = v -> [k: v]
+                        yield return KeyValuePairElement(argument.Expression, valueExpression2);
+                    }
+                    else
+                    {
+                        yield return ExpressionElement(expression);
+                    }
+                }
             }
         }
     }

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -202,11 +202,18 @@ internal static class CSharpCollectionExpressionRewriter
             //
             // For that sort of case.  Single element collections should stay closely associated with the original
             // expression.
+            return CollectionExpression([CreateElement(match)]).WithTriviaFrom(expressionToReplace);
+        }
+
+        CollectionElementSyntax CreateElement(CollectionMatch<TMatchNode> match)
+        {
+            if (match.Node is ArgumentListSyntax argumentList)
+                return WithElement(argumentList.WithoutTrivia());
+
             var expression = (ExpressionSyntax)(object)match.Node;
-            return CollectionExpression([
-                match.UseSpread
-                    ? SpreadElement(expression.WithoutTrivia())
-                    : ExpressionElement(expression.WithoutTrivia())]).WithTriviaFrom(expressionToReplace);
+            return match.UseSpread
+                ? SpreadElement(expression.WithoutTrivia())
+                : ExpressionElement(expression.WithoutTrivia());
         }
 
         CollectionExpressionSyntax CreateCollectionExpressionWithExistingElements()
@@ -220,7 +227,7 @@ internal static class CSharpCollectionExpressionRewriter
                 // braces (and initial elements) match whatever the initializer correct looks like.
 
                 var initialCollection = UseCollectionExpressionHelpers.ConvertInitializerToCollectionExpression(
-                    initializer, wasOnSingleLine: false);
+                    document.Text, initializer, wasOnSingleLine: false);
 
                 if (!makeMultiLineCollectionExpression &&
                     document.Text.AreOnSameLine(initializer.Expressions.First().GetFirstToken(), initializer.Expressions.Last().GetLastToken()))
@@ -259,7 +266,7 @@ internal static class CSharpCollectionExpressionRewriter
                 // end.
 
                 var initialCollection = UseCollectionExpressionHelpers.ConvertInitializerToCollectionExpression(
-                    initializer, wasOnSingleLine: false);
+                    document.Text, initializer, wasOnSingleLine: false);
 
                 if (document.Text.AreOnSameLine(initializer.OpenBraceToken.GetPreviousToken(), initializer.OpenBraceToken))
                 {
@@ -308,7 +315,7 @@ internal static class CSharpCollectionExpressionRewriter
                 // First, convert the existing initializer (and its expressions) into a corresponding collection
                 // expression.  This will fixup the braces properly for the collection expression.
                 var initialCollection = UseCollectionExpressionHelpers.ConvertInitializerToCollectionExpression(
-                    initializer, wasOnSingleLine: true);
+                    document.Text, initializer, wasOnSingleLine: true);
 
                 // now, add all the matches in after the existing elements.
                 var finalCollection = AddMatchesToExistingNonEmptyCollectionExpression(initialCollection, preferredIndentation: null);
@@ -461,33 +468,62 @@ internal static class CSharpCollectionExpressionRewriter
             {
                 // Create:
                 //
-                //      `x` for `collection.Add(x)`
-                //      `.. x` for `collection.AddRange(x)`
-                //      `x, y, z` for `collection.AddRange(x, y, z)`
-                var expressions = ConvertExpressions(expressionStatement.Expression, expr => IndentExpression(expressionStatement, expr, preferredIndentation));
+                //      `x: y` for `collection.Add(x, y)`               // when useKeyValue=true
+                //      `x: y` for `collection[x] = y`                  // when useKeyValue=true
+                //      `x` for `collection.Add(x)`                     // when useSpread=false
+                //      `.. x` for `collection.AddRange(x)`             // when useSpread=true
+                //      `x, y, z` for `collection.AddRange(x, y, z)`    // when useSpread=false
 
-                Contract.ThrowIfTrue(expressions.Length >= 2 && match.UseSpread);
-
-                if (match.UseSpread && expressions is [CollectionExpressionSyntax collectionExpression])
+                if (match.UseKeyValue)
                 {
-                    // If we're spreading a collection expression, just insert those inner collection expression
-                    // elements as is into the outer collection expression.
-                    foreach (var element in collectionExpression.Elements)
+                    if (expressionStatement.Expression is InvocationExpressionSyntax invocation)
                     {
-                        if (element is SpreadElementSyntax spreadElement)
-                        {
-                            yield return CreateCollectionElement(useSpread: true, spreadElement.Expression);
-                        }
-                        else if (element is ExpressionElementSyntax expressionElement)
-                        {
-                            yield return CreateCollectionElement(useSpread: false, expressionElement.Expression);
-                        }
+                        var arguments = invocation.ArgumentList.Arguments;
+                        yield return KeyValuePairElement(
+                            IndentExpression(expressionStatement, arguments[0].Expression, preferredIndentation),
+                            ColonToken.WithTriviaFrom(arguments.GetSeparator(0)),
+                            IndentExpression(expressionStatement, arguments[1].Expression, preferredIndentation));
+                    }
+                    else if (expressionStatement.Expression is AssignmentExpressionSyntax assignment)
+                    {
+                        var elementAccess = (ElementAccessExpressionSyntax)assignment.Left;
+                        yield return KeyValuePairElement(
+                            IndentExpression(expressionStatement, elementAccess.ArgumentList.Arguments[0].Expression, preferredIndentation),
+                            ColonToken.WithTrailingTrivia(assignment.OperatorToken.TrailingTrivia),
+                            IndentExpression(expressionStatement, assignment.Right, preferredIndentation));
+                    }
+                    else
+                    {
+                        throw ExceptionUtilities.Unreachable();
                     }
                 }
                 else
                 {
-                    foreach (var expression in expressions)
-                        yield return CreateCollectionElement(match.UseSpread, expression);
+                    var expressions = ConvertExpressions(expressionStatement.Expression, expr => IndentExpression(expressionStatement, expr, preferredIndentation));
+
+                    Contract.ThrowIfTrue(expressions.Length >= 2 && match.UseSpread);
+
+                    if (match.UseSpread && expressions is [CollectionExpressionSyntax collectionExpression])
+                    {
+                        // If we're spreading a collection expression, just insert those inner collection expression
+                        // elements as is into the outer collection expression.
+                        foreach (var element in collectionExpression.Elements)
+                        {
+                            if (element is SpreadElementSyntax spreadElement)
+                            {
+                                yield return CreateCollectionElement(useSpread: true, spreadElement.Expression);
+                            }
+                            else if (element is ExpressionElementSyntax expressionElement)
+                            {
+                                yield return CreateCollectionElement(useSpread: false, expressionElement.Expression);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foreach (var expression in expressions)
+                            yield return CreateCollectionElement(match.UseSpread, expression);
+                    }
                 }
             }
             else if (node is ForEachStatementSyntax foreachStatement)
@@ -526,6 +562,10 @@ internal static class CSharpCollectionExpressionRewriter
             else if (node is ExpressionSyntax expression)
             {
                 yield return CreateCollectionElement(match.UseSpread, IndentExpression(parentStatement: null, expression, preferredIndentation));
+            }
+            else if (node is ArgumentListSyntax argumentList)
+            {
+                yield return WithElement(argumentList.WithoutTrivia());
             }
             else
             {
@@ -743,7 +783,7 @@ internal static class CSharpCollectionExpressionRewriter
 
             bool CheckForMultiLine(ImmutableArray<CollectionMatch<TMatchNode>> matches)
             {
-                foreach (var (node, _) in matches)
+                foreach (var (node, _, _) in matches)
                 {
                     // if the statement we're replacing has any comments on it, then we need to be multiline to give them an
                     // appropriate place to go.

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
@@ -56,6 +56,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayCodeFixProvid
             editor.ReplaceNode(
                 initializer,
                 ConvertInitializerToCollectionExpression(
+                    text,
                     initializer,
                     IsOnSingleLine(text, initializer)));
         }

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderCodeFixProvider.cs
@@ -74,7 +74,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderCodeFixProv
         var subEditor = new SyntaxEditor(root, document.Project.Solution.Services);
 
         // Remove all the nodes mutating the builder.
-        foreach (var (statement, _) in analysisResult.Matches)
+        foreach (var (statement, _, _) in analysisResult.Matches)
             subEditor.RemoveNode(statement);
 
         // Remove the actual declaration of the builder.  Keep any comments on the builder declaration in case they're
@@ -97,7 +97,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderCodeFixProv
             => new(analysisResult.DiagnosticLocation,
                    root.GetCurrentNode(analysisResult.LocalDeclarationStatement)!,
                    root.GetCurrentNode(analysisResult.CreationExpression)!,
-                   analysisResult.Matches.SelectAsArray(m => new CollectionMatch<SyntaxNode>(root.GetCurrentNode(m.Node)!, m.UseSpread)),
+                   analysisResult.Matches.SelectAsArray(m => new CollectionMatch<SyntaxNode>(root.GetCurrentNode(m.Node)!, m.UseSpread, m.UseKeyValue)),
                    analysisResult.ChangesSemantics);
 
         // Creates a new document with all of the relevant nodes in analysisResult tracked so that we can find them
@@ -114,7 +114,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderCodeFixProv
 
             nodesToTrack.Add(analysisResult.LocalDeclarationStatement);
             nodesToTrack.Add(analysisResult.CreationExpression);
-            foreach (var (statement, _) in analysisResult.Matches)
+            foreach (var (statement, _, _) in analysisResult.Matches)
                 nodesToTrack.Add(statement);
 
             var newRoot = root.TrackNodes(nodesToTrack);

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
@@ -63,7 +63,7 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateCodeFixProvi
             semanticDocument.Root.ReplaceNode(invocationExpression, dummyObjectCreation), cancellationToken).ConfigureAwait(false);
         dummyObjectCreation = (ImplicitObjectCreationExpressionSyntax)newSemanticDocument.Root.GetAnnotatedNodes(dummyObjectAnnotation).Single();
         var expressions = dummyObjectCreation.ArgumentList.Arguments.Select(a => a.Expression);
-        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread));
+        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread, UseKeyValue: false));
 
         var collectionExpression = await CreateCollectionExpressionAsync(
             newSemanticDocument.Document,

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
@@ -25,8 +25,8 @@ using Microsoft.CodeAnalysis.UseCollectionInitializer;
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 
 using static CSharpCollectionExpressionRewriter;
-using static CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer;
 using static CSharpSyntaxTokens;
+using static CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer;
 using static SyntaxFactory;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.UseCollectionExpressionForFluent), Shared]
@@ -59,10 +59,10 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentCodeFixProvi
 
         // We want to replace `new[] { 1, 2, 3 }.Concat(x).Add(y).ToArray()` with the new collection expression.  To do
         // this, we go through the following steps.  First, we replace the whole expression with `new(x, y) { 1, 2, 3 }`
-        // (a dummy object creation expression). We then call into our helper which replaces expressions with
-        // collection expressions.  The reason for the dummy object creation expression is that it serves as an actual
-        // node the rewriting code can attach an initializer to, by which it can figure out appropriate wrapping and
-        // indentation for the collection expression elements.
+        // (a dummy object creation expression). We then call into our helper which replaces expressions with collection
+        // expressions.  The reason for the dummy object creation expression is that it serves as an actual node the
+        // rewriting code can attach an initializer to, by which it can figure out appropriate wrapping and indentation
+        // for the collection expression elements.
 
         var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
@@ -119,17 +119,17 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentCodeFixProvi
                     {
                         if (element is SpreadElementSyntax spreadElement)
                         {
-                            result.Add(new(spreadElement.Expression, UseSpread: true));
+                            result.Add(new(spreadElement.Expression, UseSpread: true, UseKeyValue: false));
                         }
                         else if (element is ExpressionElementSyntax expressionElement)
                         {
-                            result.Add(new(expressionElement.Expression, UseSpread: false));
+                            result.Add(new(expressionElement.Expression, UseSpread: false, UseKeyValue: false));
                         }
                     }
                 }
                 else
                 {
-                    result.Add(new(argument.Expression, match.UseSpread));
+                    result.Add(new(argument.Expression, match.UseSpread, UseKeyValue: false));
                 }
             }
 

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForNewCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForNewCodeFixProvider.cs
@@ -63,7 +63,7 @@ internal sealed partial class CSharpUseCollectionExpressionForNewCodeFixProvider
             semanticDocument.Root.ReplaceNode(objectCreationExpression, dummyObjectCreation), cancellationToken).ConfigureAwait(false);
         dummyObjectCreation = (ImplicitObjectCreationExpressionSyntax)newSemanticDocument.Root.GetAnnotatedNodes(dummyObjectAnnotation).Single();
         var expressions = dummyObjectCreation.ArgumentList.Arguments.Select(a => a.Expression);
-        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread));
+        var matches = expressions.SelectAsArray(e => new CollectionMatch<ExpressionSyntax>(e, useSpread, UseKeyValue: false));
 
         var collectionExpression = await CreateCollectionExpressionAsync(
             newSemanticDocument.Document,

--- a/src/Analyzers/CSharp/Tests/GenerateMethod/GenerateMethodTests.cs
+++ b/src/Analyzers/CSharp/Tests/GenerateMethod/GenerateMethodTests.cs
@@ -11165,6 +11165,261 @@ new TestParameters(new CSharpParseOptions(kind: SourceCodeKind.Regular)));
             """);
     }
 
+    [Fact]
+    public async Task GenerateInCollection1()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<string> s = [[|Goo|]()];
+                }
+            }
+            """,
+            """
+            using System;
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M()
+                {
+                    List<string> s = [Goo()];
+                }
+            
+                private string Goo()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task GenerateInCollection2()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    string[] s = [[|Goo|]()];
+                }
+            }
+            """,
+            """
+            using System;
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M()
+                {
+                    string[] s = [Goo()];
+                }
+            
+                private string Goo()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task GenerateInCollection3()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+             <Workspace>
+                <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferencesNetCoreApp="true">
+                    <Document>using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    ReadOnlySpan&lt;string&gt; s = [[|Goo|]()];
+                }
+            }</Document>
+                </Project>
+            </Workspace>
+            """,
+            """
+            using System;
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M()
+                {
+                    ReadOnlySpan<string> s = [Goo()];
+                }
+            
+                private string Goo()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task GenerateInCollection4()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    IList<string> s = [[|Goo|]()];
+                }
+            }
+            """,
+            """
+            using System;
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M()
+                {
+                    IList<string> s = [Goo()];
+                }
+            
+                private string Goo()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task GenerateInCollection5()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+             <Workspace>
+                <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferencesNet9="true">
+                    <Document>using System;
+            using System.Collections.Generic;
+            using System.Collections.Immutable;
+            
+            class C
+            {
+                void M()
+                {
+                    ImmutableArray&lt;string&gt; s = [[|Goo|]()];
+                }
+            }</Document>
+                </Project>
+            </Workspace>
+            """,
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Collections.Immutable;
+            
+            class C
+            {
+                void M()
+                {
+                    ImmutableArray<string> s = [Goo()];
+                }
+            
+                private string Goo()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task GenerateInDictionaryExpressionKey()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    Dictionary<string, int> s = [[|Goo|](): 0];
+                }
+            }
+            """,
+            """
+            using System;
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M()
+                {
+                    Dictionary<string, int> s = [Goo(): 0];
+                }
+            
+                private string Goo()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task GenerateInDictionaryExpressionValue()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    Dictionary<string, int> s = ["": [|Goo|]()];
+                }
+            }
+            """,
+            """
+            using System;
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M()
+                {
+                    Dictionary<string, int> s = ["": Goo()];
+                }
+            
+                private int Goo()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """);
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/60136")]
     public async Task GenerateIntoTopLevelProgramWithPartialType()
     {

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -5961,6 +5964,401 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestObjectCreationArgument1_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [|new|] List<int>(values);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [with(values)];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestObjectCreationArgument2_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [|new|] List<int>(values) { 1, 2, 3 };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [with(values), 1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestObjectCreationArgument3_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [|new|] List<int>(0) { 1, 2, 3 };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [with(0), 1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestObjectCreationArgument4_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [|new|] List<int>(capacity: 0) { 1, 2, 3 };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        List<int> list = [with(capacity: 0), 1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair1_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>() { { 1, "x" } };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [1: "x"];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair2_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>()
+                        {
+                            { 1, "x" },
+                            { 2, "y" },
+                        };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map =
+                        [
+                            1: "x",
+                            2: "y",
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair3_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>() { [1] = "x" };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [1: "x"];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair4_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>()
+                        {
+                            [1] = "x",
+                            [2] = "y",
+                        };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map =
+                        [
+                            1: "x",
+                            2: "y",
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair5_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>();
+                        [|map.Add(|]1, "x");
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [1: "x"];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair6_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [|new|] Dictionary<int, string>();
+                        map[1] = "x";
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<int, string> map = [1: "x"];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72699")]
+    public async Task TestKeyValuePair7_CSharp14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<string, string> map = [|new|] Dictionary<string, string>(StringComparer.Ordinal);
+                        map["x"] = "y";
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int[] values)
+                    {
+                        Dictionary<string, string> map = [with(StringComparer.Ordinal), "x": "y"];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }

--- a/src/Analyzers/Core/Analyzers/UseCollectionExpression/CollectionExpressionMatch.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionExpression/CollectionExpressionMatch.cs
@@ -16,4 +16,5 @@ namespace Microsoft.CodeAnalysis.UseCollectionExpression;
 /// what form it is.</param>
 internal readonly record struct CollectionMatch<TMatchNode>(
     TMatchNode Node,
-    bool UseSpread) where TMatchNode : SyntaxNode;
+    bool UseSpread,
+    bool UseKeyValue) where TMatchNode : SyntaxNode;

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
@@ -47,7 +47,7 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
         TVariableDeclaratorSyntax,
         TAnalyzer>, new()
 {
-    protected abstract bool IsComplexElementInitializer(SyntaxNode expression);
+    protected abstract bool IsComplexElementInitializer(SyntaxNode expression, out int initializerElementCount);
     protected abstract bool HasExistingInvalidInitializerForCollection();
     protected abstract bool AnalyzeMatchesAndCollectionConstructorForCollectionExpression(
         ArrayBuilder<CollectionMatch<SyntaxNode>> preMatches,
@@ -107,15 +107,20 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
             if (initializerExpressions is [var firstInit, ..])
             {
                 // if we have an object creation, and it *already* has an initializer in it (like `new T { { x, y } }`)
-                // this can't legally become a collection expression.
-                if (_analyzeForCollectionExpression && this.IsComplexElementInitializer(firstInit))
-                    return false;
+                // this can't legally become a collection expression.  Unless there are exactly two elements in the
+                // initializer, and we support k:v elements.
+                if (_analyzeForCollectionExpression && this.IsComplexElementInitializer(firstInit, out var initializerElementCount))
+                {
+                    if (initializerElementCount != 2 || !this.SyntaxFacts.SupportsKeyValuePairElement(_objectCreationExpression.SyntaxTree.Options))
+                        return false;
+                }
 
                 seenIndexAssignment = this.SyntaxFacts.IsElementAccessInitializer(firstInit);
                 seenInvocation = !seenIndexAssignment;
 
-                // An indexer can't be used with a collection expression.  So fail out immediately if we see that.
-                if (seenIndexAssignment && _analyzeForCollectionExpression)
+                // An indexer can't be used with a collection expression (except for dictionary expressions).  So fail
+                // out immediately if we see that.
+                if (_analyzeForCollectionExpression && seenIndexAssignment && !this.SyntaxFacts.SupportsKeyValuePairElement(_objectCreationExpression.SyntaxTree.Options))
                     return false;
             }
         }
@@ -168,21 +173,22 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
                     requiredArgumentName: null,
                     forCollectionExpression: false,
                     cancellationToken,
-                    out var instance) &&
+                    out var instance,
+                    out var useKeyValue) &&
                 this.State.ValuePatternMatches(instance))
             {
                 seenInvocation = true;
-                return new(expressionStatement, UseSpread: false);
+                return new(expressionStatement, UseSpread: false, useKeyValue);
             }
         }
 
         if (!seenInvocation)
         {
-            if (TryAnalyzeIndexAssignment(expressionStatement, cancellationToken, out var instance) &&
+            if (this.State.TryAnalyzeIndexAssignment(expressionStatement, cancellationToken, out var instance) &&
                 this.State.ValuePatternMatches(instance))
             {
                 seenIndexAssignment = true;
-                return new(expressionStatement, UseSpread: false);
+                return new(expressionStatement, UseSpread: false, UseKeyValue: true);
             }
         }
 
@@ -205,49 +211,5 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
             includeReducedExtensionMethods: true);
 
         return addMethods.Any(static m => m is IMethodSymbol methodSymbol && methodSymbol.Parameters.Any());
-    }
-
-    private bool TryAnalyzeIndexAssignment(
-        TExpressionStatementSyntax statement,
-        CancellationToken cancellationToken,
-        [NotNullWhen(true)] out TExpressionSyntax? instance)
-    {
-        instance = null;
-        if (!this.SyntaxFacts.SupportsIndexingInitializer(statement.SyntaxTree.Options))
-            return false;
-
-        if (!this.SyntaxFacts.IsSimpleAssignmentStatement(statement))
-            return false;
-
-        this.SyntaxFacts.GetPartsOfAssignmentStatement(statement, out var left, out var right);
-
-        if (!this.SyntaxFacts.IsElementAccessExpression(left))
-            return false;
-
-        // If we're initializing a variable, then we can't reference that variable on the right 
-        // side of the initialization.  Rewriting this into a collection initializer would lead
-        // to a definite-assignment error.
-        if (this.State.NodeContainsValuePatternOrReferencesInitializedSymbol(right, cancellationToken))
-            return false;
-
-        // Can't reference the variable being initialized in the arguments of the indexing expression.
-        this.SyntaxFacts.GetPartsOfElementAccessExpression(left, out var elementInstance, out var argumentList);
-        var elementAccessArguments = this.SyntaxFacts.GetArgumentsOfArgumentList(argumentList);
-        foreach (var argument in elementAccessArguments)
-        {
-            if (this.State.NodeContainsValuePatternOrReferencesInitializedSymbol(argument, cancellationToken))
-                return false;
-
-            // An index/range expression implicitly references the value being initialized.  So it cannot be used in the
-            // indexing expression.
-            var argExpression = this.SyntaxFacts.GetExpressionOfArgument(argument);
-            argExpression = this.SyntaxFacts.WalkDownParentheses(argExpression);
-
-            if (this.SyntaxFacts.IsIndexExpression(argExpression) || this.SyntaxFacts.IsRangeExpression(argExpression))
-                return false;
-        }
-
-        instance = elementInstance as TExpressionSyntax;
-        return instance != null;
     }
 }

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -132,7 +133,8 @@ internal readonly struct UpdateExpressionState<
         bool allowLinq,
         CancellationToken cancellationToken,
         [NotNullWhen(true)] out TExpressionSyntax? instance,
-        out bool useSpread)
+        out bool useSpread,
+        out bool useKeyValue)
     {
         // Look for a call to Add taking 1 arg
         if (this.TryAnalyzeAddInvocation(
@@ -140,7 +142,8 @@ internal readonly struct UpdateExpressionState<
                 requiredArgumentName: null,
                 forCollectionExpression: true,
                 cancellationToken,
-                out instance))
+                out instance,
+                out useKeyValue))
         {
             useSpread = false;
             return true;
@@ -176,8 +179,10 @@ internal readonly struct UpdateExpressionState<
         string? requiredArgumentName,
         bool forCollectionExpression,
         CancellationToken cancellationToken,
-        [NotNullWhen(true)] out TExpressionSyntax? instance)
+        [NotNullWhen(true)] out TExpressionSyntax? instance,
+        out bool useKeyValue)
     {
+        useKeyValue = false;
         if (!TryAnalyzeInvocation(
                 invocationExpression,
                 WellKnownMemberNames.CollectionInitializerAddMethodName,
@@ -189,10 +194,35 @@ internal readonly struct UpdateExpressionState<
             return false;
         }
 
-        // Collection expressions can only call the single argument Add method on a type. So if we don't have exactly
-        // one argument, fail out.
-        if (forCollectionExpression && arguments.Count != 1)
+        if (forCollectionExpression)
+        {
+            // A single-argument Add(x) can become a single expression element `x` in the collection expr.
+            if (arguments.Count == 1)
+                return true;
+
+            // A two-argument Add(x, y) can become a `x:y` element if the destination type has an indexer with
+            // complimentary type kinds as the Add method.
+            if (arguments.Count == 2 &&
+                this.SyntaxFacts.SupportsKeyValuePairElement(invocationExpression.SyntaxTree.Options) &&
+                this.SemanticModel.GetSymbolInfo(invocationExpression, cancellationToken).Symbol is IMethodSymbol
+                {
+                    Parameters: [var parameter1, var parameter2],
+                })
+            {
+                var instanceType = SemanticModel.GetTypeInfo(instance, cancellationToken).Type;
+                if (instanceType?
+                        .GetMembers(WellKnownMemberNames.Indexer)
+                        .Any(m => m is IPropertySymbol { Type: var propertyType, Parameters: [var propertyParameter] } &&
+                                  Equals(parameter1.Type, propertyParameter.Type) &&
+                                  Equals(parameter2.Type, propertyType)) is true)
+                {
+                    useKeyValue = true;
+                    return true;
+                }
+            }
+
             return false;
+        }
 
         return true;
     }
@@ -333,6 +363,54 @@ internal readonly struct UpdateExpressionState<
         return instance != null;
     }
 
+    public bool TryAnalyzeIndexAssignment(
+        TStatementSyntax statement,
+        CancellationToken cancellationToken,
+        [NotNullWhen(true)] out TExpressionSyntax? instance,
+        int supportedArgumentCount = -1)
+    {
+        instance = null;
+        if (!this.SyntaxFacts.SupportsIndexingInitializer(statement.SyntaxTree.Options))
+            return false;
+
+        if (!this.SyntaxFacts.IsSimpleAssignmentStatement(statement))
+            return false;
+
+        this.SyntaxFacts.GetPartsOfAssignmentStatement(statement, out var left, out var right);
+
+        if (!this.SyntaxFacts.IsElementAccessExpression(left))
+            return false;
+
+        // If we're initializing a variable, then we can't reference that variable on the right 
+        // side of the initialization.  Rewriting this into a collection initializer would lead
+        // to a definite-assignment error.
+        if (this.NodeContainsValuePatternOrReferencesInitializedSymbol(right, cancellationToken))
+            return false;
+
+        // Can't reference the variable being initialized in the arguments of the indexing expression.
+        this.SyntaxFacts.GetPartsOfElementAccessExpression(left, out var elementInstance, out var argumentList);
+        var elementAccessArguments = this.SyntaxFacts.GetArgumentsOfArgumentList(argumentList);
+        if (supportedArgumentCount >= 0 && elementAccessArguments.Count != supportedArgumentCount)
+            return false;
+
+        foreach (var argument in elementAccessArguments)
+        {
+            if (this.NodeContainsValuePatternOrReferencesInitializedSymbol(argument, cancellationToken))
+                return false;
+
+            // An index/range expression implicitly references the value being initialized.  So it cannot be used in the
+            // indexing expression.
+            var argExpression = this.SyntaxFacts.GetExpressionOfArgument(argument);
+            argExpression = this.SyntaxFacts.WalkDownParentheses(argExpression);
+
+            if (this.SyntaxFacts.IsIndexExpression(argExpression) || this.SyntaxFacts.IsRangeExpression(argExpression))
+                return false;
+        }
+
+        instance = elementInstance as TExpressionSyntax;
+        return instance != null;
+    }
+
     /// <summary>
     /// Analyze an statement to see if it it could be converted into elements for a new collection-expression.  This
     /// includes calls to <c>.Add</c> and <c>.AddRange</c>, as well as <c>foreach</c> statements that update the
@@ -361,10 +439,19 @@ internal readonly struct UpdateExpressionState<
             var expression = (TExpressionSyntax)@this.SyntaxFacts.GetExpressionOfExpressionStatement(expressionStatement);
 
             // Look for a call to Add or AddRange
-            if (@this.TryAnalyzeInvocationForCollectionExpression(expression, allowLinq: false, cancellationToken, out var instance, out var useSpread) &&
+            if (@this.TryAnalyzeInvocationForCollectionExpression(
+                    expression, allowLinq: false, cancellationToken, out var instance, out var useSpread, out var useKeyValue) &&
                 @this.ValuePatternMatches(instance))
             {
-                return new(expressionStatement, useSpread);
+                return new(expressionStatement, useSpread, useKeyValue);
+            }
+
+            // `x[y] = z` can be converted to `y:z` element if the destination type has an indexer with exactly 1 arg.
+            if (@this.SyntaxFacts.SupportsKeyValuePairElement(expression.SyntaxTree.Options) &&
+                @this.TryAnalyzeIndexAssignment(expressionStatement, cancellationToken, out instance, supportedArgumentCount: 1) &&
+                @this.ValuePatternMatches(instance))
+            {
+                return new(expressionStatement, UseSpread: false, UseKeyValue: true);
             }
 
             return null;
@@ -390,11 +477,12 @@ internal readonly struct UpdateExpressionState<
                     requiredArgumentName: identifier.Text,
                     forCollectionExpression: true,
                     cancellationToken,
-                    out var instance) &&
+                    out var instance,
+                    out var useKeyValue) &&
                 @this.ValuePatternMatches(instance))
             {
                 // `foreach` will become `..expr` when we make it into a collection expression.
-                return new(foreachStatement, UseSpread: true);
+                return new(foreachStatement, UseSpread: true, useKeyValue);
             }
 
             return null;
@@ -424,14 +512,15 @@ internal readonly struct UpdateExpressionState<
                     requiredArgumentName: null,
                     forCollectionExpression: true,
                     cancellationToken,
-                    out var instance) &&
+                    out var instance,
+                    out var useKeyValue) &&
                 @this.ValuePatternMatches(instance))
             {
                 if (whenFalse is null)
                 {
                     // add the form `.. x ? [y] : []` to the result
                     return @this.SyntaxFacts.SupportsCollectionExpressionNaturalType(ifStatement.SyntaxTree.Options)
-                        ? new(ifStatement, UseSpread: true)
+                        ? new(ifStatement, UseSpread: true, useKeyValue)
                         : null;
                 }
 
@@ -443,11 +532,12 @@ internal readonly struct UpdateExpressionState<
                         requiredArgumentName: null,
                         forCollectionExpression: true,
                         cancellationToken,
-                        out instance) &&
+                        out instance,
+                        out useKeyValue) &&
                     @this.ValuePatternMatches(instance))
                 {
                     // add the form `x ? y : z` to the result
-                    return new(ifStatement, UseSpread: false);
+                    return new(ifStatement, UseSpread: false, useKeyValue);
                 }
             }
 

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             Return VisualBasicObjectCreationHelpers.IsInitializerOfLocalDeclarationStatement(localDeclarationStatement, rootExpression, variableDeclarator)
         End Function
 
-        Protected Overrides Function IsComplexElementInitializer(expression As SyntaxNode) As Boolean
+        Protected Overrides Function IsComplexElementInitializer(expression As SyntaxNode, ByRef initializerElementCount As Integer) As Boolean
             ' Only called for collection expressions, which VB does not support
             Throw ExceptionUtilities.Unreachable()
         End Function

--- a/src/CodeStyle/CSharp/Tests/Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.csproj
+++ b/src/CodeStyle/CSharp/Tests/Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
     <PackageReference Include="Basic.Reference.Assemblies.Net60" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <!-- Directly reference the Workspaces project so we always test against the latest Roslyn bits -->

--- a/src/Compilers/CSharp/Portable/Binder/ParamsCollectionTypeApplicableIndexerInProgress.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ParamsCollectionTypeApplicableIndexerInProgress.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// This binder keeps track of the type for which we are trying to determine
+    /// whether the params collection type has an applicable indexer.
+    /// </summary>
+    internal sealed class ParamsCollectionTypeApplicableIndexerInProgress : Binder
+    {
+        internal readonly SyntaxNode Syntax;
+        internal readonly TypeSymbol CollectionType;
+
+        internal ParamsCollectionTypeApplicableIndexerInProgress(SyntaxNode syntax, TypeSymbol collectionType, Binder next) :
+            base(next)
+        {
+            Syntax = syntax;
+            CollectionType = collectionType;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -921,6 +921,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
+        {
+            if (node.CollectionCreation is { } collectionCreation)
+            {
+                if (node.CollectionBuilderSpanPlaceholder is { } spanPlaceholder)
+                {
+                    var elementType = ((NamedTypeSymbol)spanPlaceholder.Type!).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
+                    var safeContext = LocalRewriter.ShouldUseRuntimeHelpersCreateSpan(node, elementType.Type) ? SafeContext.ReturnOnly : _localScopeDepth;
+                    var placeholders = ArrayBuilder<(BoundValuePlaceholderBase, SafeContext)>.GetInstance();
+                    placeholders.Add((spanPlaceholder, safeContext));
+                    using var _ = new PlaceholderRegion(this, placeholders);
+                    Visit(collectionCreation);
+                }
+                else
+                {
+                    Visit(collectionCreation);
+                }
+            }
+            VisitList(node.Elements);
+            return null;
+        }
+
         public override BoundNode? VisitImplicitIndexerAccess(BoundImplicitIndexerAccess node)
         {
             // Verify we're only skipping placeholders for int values, where the escape scope is always CallingMethod.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
@@ -12,6 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ReadOnlySpan,
         CollectionBuilder,
         ImplementsIEnumerable,
+        ImplementsIEnumerableWithIndexer,
         ArrayInterface,
+        DictionaryInterface,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -136,6 +136,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new CollectionExpressionUncommonData(collectionExpressionTypeKind, elementType, constructor, constructorUsedInExpandedForm, elementConversions));
         }
 
+        internal static Conversion CreateKeyValuePairConversion(Conversion keyConversion, Conversion valueConversion)
+        {
+            return new Conversion(
+                ConversionKind.KeyValuePair,
+                new NestedUncommonData([keyConversion, valueConversion]));
+        }
+
         private Conversion(
             ConversionKind kind,
             UncommonData? uncommonData = null)
@@ -558,6 +565,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             constructor = null;
             isExpanded = false;
             return CollectionExpressionTypeKind.None;
+        }
+
+        internal bool TryGetKeyValueConversions(out Conversion keyConversion, out Conversion valueConversion)
+        {
+            if (Kind == ConversionKind.KeyValuePair)
+            {
+                Debug.Assert(_uncommonData is NestedUncommonData { _nestedConversionsOpt: [_, _] });
+                var nestedConversions = ((NestedUncommonData)_uncommonData)._nestedConversionsOpt;
+                keyConversion = nestedConversions[0];
+                valueConversion = nestedConversions[1];
+                return true;
+            }
+
+            keyConversion = NoConversion;
+            valueConversion = NoConversion;
+            return false;
         }
 
         // CONSIDER: public?

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         DefaultLiteral, // a conversion from a `default` literal to any type
         ObjectCreation, // a conversion from a `new()` expression to any type
         CollectionExpression, // a conversion from a collection expression to any type
+        KeyValuePair, // A pair of Key and Value conversions for converting from one KeyValuePair<,> type to another. The conversion is not part of the language, it is an implementation detail.
 
         InterpolatedStringHandler, // A conversion from an interpolated string literal to a type attributed with InterpolatedStringBuilderAttribute
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -1676,6 +1675,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 elementType = default;
                 return CollectionExpressionTypeKind.CollectionBuilder;
             }
+            else if (destination.IsInterfaceType())
+            {
+                if (destination.IsArrayInterface(out elementType))
+                {
+                    return CollectionExpressionTypeKind.ArrayInterface;
+                }
+                else if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureDictionaryExpressions) &&
+                    (isDictionaryType(compilation, destination, WellKnownType.System_Collections_Generic_IDictionary_KV, out elementType) ||
+                    isDictionaryType(compilation, destination, WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV, out elementType)))
+                {
+                    return CollectionExpressionTypeKind.DictionaryInterface;
+                }
+            }
             else if (implementsSpecialInterface(compilation, destination, SpecialType.System_Collections_IEnumerable))
             {
                 // ^ This implementation differs from Binder.CollectionInitializerTypeImplementsIEnumerable().
@@ -1687,23 +1699,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                 elementType = default;
                 return CollectionExpressionTypeKind.ImplementsIEnumerable;
             }
-            else if (destination.IsArrayInterface(out elementType))
-            {
-                return CollectionExpressionTypeKind.ArrayInterface;
-            }
 
             elementType = default;
             return CollectionExpressionTypeKind.None;
 
             static bool implementsSpecialInterface(CSharpCompilation compilation, TypeSymbol targetType, SpecialType specialInterface)
             {
+                Debug.Assert(!targetType.IsInterfaceType());
                 var allInterfaces = targetType.GetAllInterfacesOrEffectiveInterfaces();
                 var specialType = compilation.GetSpecialType(specialInterface);
                 return allInterfaces.Any(static (a, b) => ReferenceEquals(a.OriginalDefinition, b), specialType);
             }
+
+            static bool isDictionaryType(CSharpCompilation compilation, TypeSymbol targetType, WellKnownType dictionaryType, out TypeWithAnnotations elementType)
+            {
+                if (targetType is NamedTypeSymbol { Arity: 2 } namedType &&
+                    ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(dictionaryType)))
+                {
+                    elementType = TypeWithAnnotations.Create(compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_KeyValuePair_KV).
+                        Construct(namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics));
+                    return true;
+                }
+                elementType = default;
+                return false;
+            }
         }
 
-        internal static bool IsSpanOrListType(CSharpCompilation compilation, TypeSymbol targetType, WellKnownType spanType, [NotNullWhen(true)] out TypeWithAnnotations elementType)
+        internal static bool IsSpanOrListType(CSharpCompilation compilation, TypeSymbol targetType, WellKnownType spanType, out TypeWithAnnotations elementType)
         {
             if (targetType is NamedTypeSymbol { Arity: 1 } namedType
                 && ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(spanType)))
@@ -1713,6 +1735,55 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             elementType = default;
             return false;
+        }
+
+        internal static bool IsKeyValuePairType(CSharpCompilation compilation, TypeSymbol? targetType, WellKnownType keyValuePairType, out TypeWithAnnotations keyType, out TypeWithAnnotations valueType)
+        {
+            if (targetType is NamedTypeSymbol { Arity: 2 } namedType
+                && ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(keyValuePairType)))
+            {
+                var typeArguments = namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+                keyType = typeArguments[0];
+                valueType = typeArguments[1];
+                return true;
+            }
+            keyType = default;
+            valueType = default;
+            return false;
+        }
+
+        internal static bool IsKeyValuePairType(
+            CSharpCompilation compilation,
+            TypeSymbol? type,
+            [NotNullWhen(true)] out TypeSymbol? keyType,
+            [NotNullWhen(true)] out TypeSymbol? valueType)
+        {
+            if (IsKeyValuePairType(compilation, type, WellKnownType.System_Collections_Generic_KeyValuePair_KV, out var keyTypeWithAnnotations, out var valueTypeWithAnnotations))
+            {
+                keyType = keyTypeWithAnnotations.Type;
+                valueType = valueTypeWithAnnotations.Type;
+                return true;
+            }
+            keyType = null;
+            valueType = null;
+            return false;
+        }
+
+        internal static (TypeSymbol Key, TypeSymbol Value)? TryGetCollectionKeyValuePairTypes(
+            CSharpCompilation compilation,
+            CollectionExpressionTypeKind collectionTypeKind,
+            TypeSymbol elementType)
+        {
+            // https://github.com/dotnet/roslyn/issues/77871: Should apply to any collection of KeyValuePair<,>, not just dictionaries.
+            if (collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer or CollectionExpressionTypeKind.DictionaryInterface)
+            {
+                if (IsKeyValuePairType(compilation, elementType, out var keyType, out var valueType))
+                {
+                    return (keyType, valueType);
+                }
+                Debug.Assert(false);
+            }
+            return null;
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -683,13 +683,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
-                if (element is BoundCollectionExpressionSpreadElement spread)
+                switch (element)
                 {
-                    MakeSpreadElementTypeInferences(spread, targetElementType, ref useSiteInfo);
-                }
-                else
-                {
-                    MakeExplicitParameterTypeInferences(binder, (BoundExpression)element, targetElementType, kind, ref useSiteInfo);
+                    case BoundCollectionExpressionWithElement withElement:
+                        // Arguments do not affect type inference.
+                        break;
+                    case BoundCollectionExpressionSpreadElement spread:
+                        MakeSpreadElementTypeInferences(spread, targetElementType, ref useSiteInfo);
+                        break;
+                    case BoundKeyValuePairElement keyValuePairElement:
+                        // https://github.com/dotnet/roslyn/issues/77873: Handle input type inference for key:value elements.
+                        break;
+                    default:
+                        MakeExplicitParameterTypeInferences(binder, (BoundExpression)element, targetElementType, kind, ref useSiteInfo);
+                        break;
                 }
             }
         }
@@ -908,6 +915,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
+                // https://github.com/dotnet/roslyn/issues/77873: Handle output type inference for key:value elements.
                 if (element is BoundExpression expression)
                 {
                     MakeOutputTypeInferences(binder, expression, targetElementType, ref useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1351,12 +1351,21 @@ outerDefault:
 
                         if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable)
                         {
+                            if (binder.HasParamsCollectionTypeApplicableIndexerInProgress(syntax, type))
+                            {
+                                // We are in a cycle. Optimistically assume the type has an applicable indexer.
+                                break;
+                            }
+
+                            binder = new ParamsCollectionTypeApplicableIndexerInProgress(syntax, type, binder);
+
                             if (!binder.HasCollectionExpressionApplicableConstructor(syntax, type, constructor: out _, isExpanded: out _, BindingDiagnosticBag.Discarded))
                             {
                                 return false;
                             }
 
-                            if (!binder.HasCollectionExpressionApplicableAddMethod(syntax, type, addMethods: out _, BindingDiagnosticBag.Discarded))
+                            if (binder.GetCollectionExpressionApplicableIndexer(syntax, type, elementType.Type, BindingDiagnosticBag.Discarded) is null &&
+                                !binder.HasCollectionExpressionApplicableAddMethod(syntax, type, addMethods: out _, BindingDiagnosticBag.Discarded))
                             {
                                 return false;
                             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -19,7 +19,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // When this assertion fails, it means a new syntax is being used which corresponds to a BoundCall.
                 // The developer needs to determine how this new syntax should interact with interceptors (produce an error, permit intercepting the call, etc...)
-                Debug.Assert(this.WasCompilerGenerated || this.Syntax is InvocationExpressionSyntax or ConstructorInitializerSyntax or PrimaryConstructorBaseTypeSyntax { ArgumentList: { } },
+                Debug.Assert(this.WasCompilerGenerated ||
+                    this.Syntax is
+                        InvocationExpressionSyntax or
+                        ConstructorInitializerSyntax or
+                        PrimaryConstructorBaseTypeSyntax { ArgumentList: { } } or
+                        WithElementSyntax,
                     $"Unexpected syntax kind for BoundCall: {this.Syntax.Kind()}");
 
                 if (this.WasCompilerGenerated || this.Syntax is not InvocationExpressionSyntax syntax)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1917,14 +1917,10 @@
     <Field Name="CollectionTypeKind" Type="CollectionExpressionTypeKind"/>
     <!-- An expression placeholder value representing the initialized collection. -->
     <Field Name="Placeholder" Type="BoundObjectOrCollectionValuePlaceholder?" Null="allow" SkipInVisitor="true"/>
-    <!-- Constructor call to create the empty collection type. -->
+    <!-- Constructor or factory method call to create the collection instance. -->
     <Field Name="CollectionCreation" Type="BoundExpression?" Null="allow" SkipInVisitor="true"/>
-    <!-- Construct method for collection types with [CollectionBuilder]. -->
-    <Field Name="CollectionBuilderMethod" Type="MethodSymbol?" Null="allow"/>
-    <!-- Placeholder for collection builder method invocation. -->
-    <Field Name="CollectionBuilderInvocationPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
-    <!-- Conversion from collection builder method invocation to collection type. -->
-    <Field Name="CollectionBuilderInvocationConversion" Type="BoundExpression?" SkipInVisitor="true" Null="allow"/>
+    <!-- Placeholder for collection builder elements span. -->
+    <Field Name="CollectionBuilderSpanPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
     <!-- Indicates whether the collection expression was successfully target-typed (it is inside a conversion) -->
     <Field Name="WasTargetTyped" Type="bool" />
     <Field Name="UnconvertedCollectionExpression" Type="BoundUnconvertedCollectionExpression" Null="disallow" SkipInVisitor="true"/>
@@ -1947,6 +1943,38 @@
     <Field Name="ElementPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
     <!-- Statement executed for each collection element. -->
     <Field Name="IteratorBody" Type="BoundStatement?" SkipInVisitor="true" Null="allow"/>
+  </Node>
+
+  <!-- A key:value pair element within a collection expression. -->
+  <Node Name="BoundKeyValuePairElement" Base="BoundNode">
+    <!-- Key expression. -->
+    <Field Name="Key" Type="BoundExpression"/>
+    <!-- Value expression. -->
+    <Field Name="Value" Type="BoundExpression"/>
+    <!-- Placeholder for Key in assignment. -->
+    <Field Name="KeyPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
+    <!-- Placeholder for Value in assignment. -->
+    <Field Name="ValuePlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
+    <!-- Indexer assignment of key:value pair to containing dictionary. -->
+    <Field Name="IndexerAssignment" Type="BoundExpression?" SkipInVisitor="true" Null="allow"/>
+  </Node>
+
+  <!-- An expression element of KeyValuePair&lt;,&gt; type in a collection expression where the target type is a collection of KeyValuePair&lt;,&gt;. -->
+  <Node Name="BoundKeyValuePairExpressionElement" Base="BoundNode">
+    <!-- Expression. -->
+    <Field Name="Expression" Type="BoundExpression"/>
+    <!-- Placeholder for Expression in assignment. -->
+    <Field Name="ExpressionPlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
+    <!-- Indexer assignment of Key and Value properties of Expression to containing dictionary. -->
+    <Field Name="IndexerAssignment" Type="BoundExpression" SkipInVisitor="true"/>
+  </Node>
+
+  <!-- Unconverted collection expression arguments. -->
+  <Node Name="BoundCollectionExpressionWithElement" Base="BoundNode">
+    <Field Name="Arguments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+    <Field Name="ArgumentNamesOpt" Type="ImmutableArray&lt;(string Name, Location Location)?&gt;" Null="allow"/>
+    <Field Name="ArgumentRefKindsOpt" Type="ImmutableArray&lt;RefKind&gt;" Null="allow"/>
+    <Field Name="Binder" Type="Binder" Null="disallow"/>
   </Node>
 
   <!-- 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundWithElement.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundWithElement.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class BoundCollectionExpressionWithElement
+    {
+        internal void GetArguments(AnalyzedArguments analyzedArguments)
+        {
+            Debug.Assert(analyzedArguments.Arguments.IsEmpty);
+            analyzedArguments.Arguments.AddRange(Arguments);
+            if (!ArgumentNamesOpt.IsDefault)
+            {
+                analyzedArguments.Names.AddRange(ArgumentNamesOpt);
+            }
+            if (!ArgumentRefKindsOpt.IsDefault)
+            {
+                analyzedArguments.RefKinds.AddRange(ArgumentRefKindsOpt);
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6841,6 +6841,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureCollectionExpressions" xml:space="preserve">
     <value>collection expressions</value>
   </data>
+  <data name="IDS_FeatureCollectionExpressionArguments" xml:space="preserve">
+    <value>collection expression arguments</value>
+  </data>
+  <data name="IDS_FeatureDictionaryExpressions" xml:space="preserve">
+    <value>dictionary expressions</value>
+  </data>
   <data name="ERR_CollectionExpressionTargetTypeNotConstructible" xml:space="preserve">
     <value>Cannot initialize type '{0}' with a collection expression because the type is not constructible.</value>
   </data>
@@ -6873,6 +6879,18 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_CollectionExpressionEscape" xml:space="preserve">
     <value>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</value>
+  </data>
+  <data name="ERR_CollectionExpressionKeyValuePairNotSupported" xml:space="preserve">
+    <value>Collection expression type '{0}' does not support key-value pair elements.</value>
+  </data>
+  <data name="ERR_CollectionArgumentsMustBeFirst" xml:space="preserve">
+    <value>Collection argument element must be the first element.</value>
+  </data>
+  <data name="ERR_CollectionArgumentsNotSupportedForType" xml:space="preserve">
+    <value>Collection arguments are not supported for type '{0}'.</value>
+  </data>
+  <data name="ERR_CollectionArgumentsDynamicBinding" xml:space="preserve">
+    <value>Collection arguments cannot be dynamic; compile-time binding is required.</value>
   </data>
   <data name="INF_TooManyBoundLambdas" xml:space="preserve">
     <value>Compiling requires binding the lambda expression at least {0} times. Consider declaring the lambda expression with explicit parameter types, or if the containing method call is generic, consider using explicit type arguments.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2390,6 +2390,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_PPIgnoredNeedsFileBasedProgram = 9298,
         ERR_PPIgnoredFollowsIf = 9299,
 
+        ERR_CollectionExpressionKeyValuePairNotSupported = 9300,
+        ERR_CollectionArgumentsMustBeFirst = 9301,
+        ERR_CollectionArgumentsNotSupportedForType = 9302,
+        ERR_CollectionArgumentsDynamicBinding = 9303,
+
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)
         //  2) Add message to CSharpResources.resx

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2506,6 +2506,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_PPIgnoredFollowsToken
                 or ErrorCode.ERR_PPIgnoredNeedsFileBasedProgram
                 or ErrorCode.ERR_PPIgnoredFollowsIf
+                or ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported
+                or ErrorCode.ERR_CollectionArgumentsMustBeFirst
+                or ErrorCode.ERR_CollectionArgumentsNotSupportedForType
+                or ErrorCode.ERR_CollectionArgumentsDynamicBinding
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -301,6 +301,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeaturePartialEventsAndConstructors = MessageBase + 12852,
         IDS_FeatureExtensions = MessageBase + 12853,
         IDS_FeatureNullConditionalAssignment = MessageBase + 12854,
+        IDS_FeatureDictionaryExpressions = MessageBase + 12855,
+        IDS_FeatureCollectionExpressionArguments = MessageBase + 12856,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -488,6 +490,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeaturePartialEventsAndConstructors:
                 case MessageID.IDS_FeatureExtensions:
                 case MessageID.IDS_FeatureNullConditionalAssignment:
+                case MessageID.IDS_FeatureDictionaryExpressions: // semantic check
+                case MessageID.IDS_FeatureCollectionExpressionArguments:
                     return LanguageVersion.Preview;
 
                 // C# 13.0 features.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2099,7 +2099,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public override BoundNode VisitCollectionExpressionWithElement(BoundCollectionExpressionWithElement node)
+        {
+            // We only get here if the conversion of the collection expression to the
+            // target type failed. In this case, simply visit each argument.
+            VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, method: null, argsToParamsOpt: default, expanded: false);
+            return null;
+        }
+
         public override BoundNode VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node)
+        {
+            VisitRvalue(node.Expression);
+            return null;
+        }
+
+        public override BoundNode VisitKeyValuePairElement(BoundKeyValuePairElement node)
+        {
+            VisitRvalue(node.Key);
+            VisitRvalue(node.Value);
+            return null;
+        }
+
+        public override BoundNode VisitKeyValuePairExpressionElement(BoundKeyValuePairExpressionElement node)
         {
             VisitRvalue(node.Expression);
             return null;

--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -862,15 +862,25 @@ collection_expression
 
 collection_element
   : expression_element
+  | key_value_pair_element
   | spread_element
+  | with_element
   ;
 
 expression_element
   : expression
   ;
 
+key_value_pair_element
+  : expression ':' expression
+  ;
+
 spread_element
   : '..' expression
+  ;
+
+with_element
+  : 'with' argument_list
   ;
 
 conditional_access_expression

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -6682,6 +6682,167 @@ internal sealed partial class SpreadElementSyntax : CollectionElementSyntax
         => new SpreadElementSyntax(this.Kind, this.operatorToken, this.expression, GetDiagnostics(), annotations);
 }
 
+internal sealed partial class KeyValuePairElementSyntax : CollectionElementSyntax
+{
+    internal readonly ExpressionSyntax keyExpression;
+    internal readonly SyntaxToken colonToken;
+    internal readonly ExpressionSyntax valueExpression;
+
+    internal KeyValuePairElementSyntax(SyntaxKind kind, ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+      : base(kind, diagnostics, annotations)
+    {
+        this.SlotCount = 3;
+        this.AdjustFlagsAndWidth(keyExpression);
+        this.keyExpression = keyExpression;
+        this.AdjustFlagsAndWidth(colonToken);
+        this.colonToken = colonToken;
+        this.AdjustFlagsAndWidth(valueExpression);
+        this.valueExpression = valueExpression;
+    }
+
+    internal KeyValuePairElementSyntax(SyntaxKind kind, ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression, SyntaxFactoryContext context)
+      : base(kind)
+    {
+        this.SetFactoryContext(context);
+        this.SlotCount = 3;
+        this.AdjustFlagsAndWidth(keyExpression);
+        this.keyExpression = keyExpression;
+        this.AdjustFlagsAndWidth(colonToken);
+        this.colonToken = colonToken;
+        this.AdjustFlagsAndWidth(valueExpression);
+        this.valueExpression = valueExpression;
+    }
+
+    internal KeyValuePairElementSyntax(SyntaxKind kind, ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
+      : base(kind)
+    {
+        this.SlotCount = 3;
+        this.AdjustFlagsAndWidth(keyExpression);
+        this.keyExpression = keyExpression;
+        this.AdjustFlagsAndWidth(colonToken);
+        this.colonToken = colonToken;
+        this.AdjustFlagsAndWidth(valueExpression);
+        this.valueExpression = valueExpression;
+    }
+
+    public ExpressionSyntax KeyExpression => this.keyExpression;
+    public SyntaxToken ColonToken => this.colonToken;
+    public ExpressionSyntax ValueExpression => this.valueExpression;
+
+    internal override GreenNode? GetSlot(int index)
+        => index switch
+        {
+            0 => this.keyExpression,
+            1 => this.colonToken,
+            2 => this.valueExpression,
+            _ => null,
+        };
+
+    internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new CSharp.Syntax.KeyValuePairElementSyntax(this, parent, position);
+
+    public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitKeyValuePairElement(this);
+    public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitKeyValuePairElement(this);
+
+    public KeyValuePairElementSyntax Update(ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
+    {
+        if (keyExpression != this.KeyExpression || colonToken != this.ColonToken || valueExpression != this.ValueExpression)
+        {
+            var newNode = SyntaxFactory.KeyValuePairElement(keyExpression, colonToken, valueExpression);
+            var diags = GetDiagnostics();
+            if (diags?.Length > 0)
+                newNode = newNode.WithDiagnosticsGreen(diags);
+            var annotations = GetAnnotations();
+            if (annotations?.Length > 0)
+                newNode = newNode.WithAnnotationsGreen(annotations);
+            return newNode;
+        }
+
+        return this;
+    }
+
+    internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
+        => new KeyValuePairElementSyntax(this.Kind, this.keyExpression, this.colonToken, this.valueExpression, diagnostics, GetAnnotations());
+
+    internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
+        => new KeyValuePairElementSyntax(this.Kind, this.keyExpression, this.colonToken, this.valueExpression, GetDiagnostics(), annotations);
+}
+
+internal sealed partial class WithElementSyntax : CollectionElementSyntax
+{
+    internal readonly SyntaxToken withKeyword;
+    internal readonly ArgumentListSyntax argumentList;
+
+    internal WithElementSyntax(SyntaxKind kind, SyntaxToken withKeyword, ArgumentListSyntax argumentList, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+      : base(kind, diagnostics, annotations)
+    {
+        this.SlotCount = 2;
+        this.AdjustFlagsAndWidth(withKeyword);
+        this.withKeyword = withKeyword;
+        this.AdjustFlagsAndWidth(argumentList);
+        this.argumentList = argumentList;
+    }
+
+    internal WithElementSyntax(SyntaxKind kind, SyntaxToken withKeyword, ArgumentListSyntax argumentList, SyntaxFactoryContext context)
+      : base(kind)
+    {
+        this.SetFactoryContext(context);
+        this.SlotCount = 2;
+        this.AdjustFlagsAndWidth(withKeyword);
+        this.withKeyword = withKeyword;
+        this.AdjustFlagsAndWidth(argumentList);
+        this.argumentList = argumentList;
+    }
+
+    internal WithElementSyntax(SyntaxKind kind, SyntaxToken withKeyword, ArgumentListSyntax argumentList)
+      : base(kind)
+    {
+        this.SlotCount = 2;
+        this.AdjustFlagsAndWidth(withKeyword);
+        this.withKeyword = withKeyword;
+        this.AdjustFlagsAndWidth(argumentList);
+        this.argumentList = argumentList;
+    }
+
+    public SyntaxToken WithKeyword => this.withKeyword;
+    public ArgumentListSyntax ArgumentList => this.argumentList;
+
+    internal override GreenNode? GetSlot(int index)
+        => index switch
+        {
+            0 => this.withKeyword,
+            1 => this.argumentList,
+            _ => null,
+        };
+
+    internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new CSharp.Syntax.WithElementSyntax(this, parent, position);
+
+    public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitWithElement(this);
+    public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitWithElement(this);
+
+    public WithElementSyntax Update(SyntaxToken withKeyword, ArgumentListSyntax argumentList)
+    {
+        if (withKeyword != this.WithKeyword || argumentList != this.ArgumentList)
+        {
+            var newNode = SyntaxFactory.WithElement(withKeyword, argumentList);
+            var diags = GetDiagnostics();
+            if (diags?.Length > 0)
+                newNode = newNode.WithDiagnosticsGreen(diags);
+            var annotations = GetAnnotations();
+            if (annotations?.Length > 0)
+                newNode = newNode.WithAnnotationsGreen(annotations);
+            return newNode;
+        }
+
+        return this;
+    }
+
+    internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
+        => new WithElementSyntax(this.Kind, this.withKeyword, this.argumentList, diagnostics, GetAnnotations());
+
+    internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
+        => new WithElementSyntax(this.Kind, this.withKeyword, this.argumentList, GetDiagnostics(), annotations);
+}
+
 internal abstract partial class QueryClauseSyntax : CSharpSyntaxNode
 {
     internal QueryClauseSyntax(SyntaxKind kind, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
@@ -26884,6 +27045,8 @@ internal partial class CSharpSyntaxVisitor<TResult>
     public virtual TResult VisitCollectionExpression(CollectionExpressionSyntax node) => this.DefaultVisit(node);
     public virtual TResult VisitExpressionElement(ExpressionElementSyntax node) => this.DefaultVisit(node);
     public virtual TResult VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
+    public virtual TResult VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
+    public virtual TResult VisitWithElement(WithElementSyntax node) => this.DefaultVisit(node);
     public virtual TResult VisitQueryExpression(QueryExpressionSyntax node) => this.DefaultVisit(node);
     public virtual TResult VisitQueryBody(QueryBodySyntax node) => this.DefaultVisit(node);
     public virtual TResult VisitFromClause(FromClauseSyntax node) => this.DefaultVisit(node);
@@ -27134,6 +27297,8 @@ internal partial class CSharpSyntaxVisitor
     public virtual void VisitCollectionExpression(CollectionExpressionSyntax node) => this.DefaultVisit(node);
     public virtual void VisitExpressionElement(ExpressionElementSyntax node) => this.DefaultVisit(node);
     public virtual void VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
+    public virtual void VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
+    public virtual void VisitWithElement(WithElementSyntax node) => this.DefaultVisit(node);
     public virtual void VisitQueryExpression(QueryExpressionSyntax node) => this.DefaultVisit(node);
     public virtual void VisitQueryBody(QueryBodySyntax node) => this.DefaultVisit(node);
     public virtual void VisitFromClause(FromClauseSyntax node) => this.DefaultVisit(node);
@@ -27525,6 +27690,12 @@ internal partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<CSharpSyntaxNo
 
     public override CSharpSyntaxNode VisitSpreadElement(SpreadElementSyntax node)
         => node.Update((SyntaxToken)Visit(node.OperatorToken), (ExpressionSyntax)Visit(node.Expression));
+
+    public override CSharpSyntaxNode VisitKeyValuePairElement(KeyValuePairElementSyntax node)
+        => node.Update((ExpressionSyntax)Visit(node.KeyExpression), (SyntaxToken)Visit(node.ColonToken), (ExpressionSyntax)Visit(node.ValueExpression));
+
+    public override CSharpSyntaxNode VisitWithElement(WithElementSyntax node)
+        => node.Update((SyntaxToken)Visit(node.WithKeyword), (ArgumentListSyntax)Visit(node.ArgumentList));
 
     public override CSharpSyntaxNode VisitQueryExpression(QueryExpressionSyntax node)
         => node.Update((FromClauseSyntax)Visit(node.FromClause), (QueryBodySyntax)Visit(node.Body));
@@ -29654,6 +29825,49 @@ internal partial class ContextAwareSyntax
         if (cached != null) return (SpreadElementSyntax)cached;
 
         var result = new SpreadElementSyntax(SyntaxKind.SpreadElement, operatorToken, expression, this.context);
+        if (hash >= 0)
+        {
+            SyntaxNodeCache.AddNode(result, hash);
+        }
+
+        return result;
+    }
+
+    public KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
+    {
+#if DEBUG
+        if (keyExpression == null) throw new ArgumentNullException(nameof(keyExpression));
+        if (colonToken == null) throw new ArgumentNullException(nameof(colonToken));
+        if (colonToken.Kind != SyntaxKind.ColonToken) throw new ArgumentException(nameof(colonToken));
+        if (valueExpression == null) throw new ArgumentNullException(nameof(valueExpression));
+#endif
+
+        int hash;
+        var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.KeyValuePairElement, keyExpression, colonToken, valueExpression, this.context, out hash);
+        if (cached != null) return (KeyValuePairElementSyntax)cached;
+
+        var result = new KeyValuePairElementSyntax(SyntaxKind.KeyValuePairElement, keyExpression, colonToken, valueExpression, this.context);
+        if (hash >= 0)
+        {
+            SyntaxNodeCache.AddNode(result, hash);
+        }
+
+        return result;
+    }
+
+    public WithElementSyntax WithElement(SyntaxToken withKeyword, ArgumentListSyntax argumentList)
+    {
+#if DEBUG
+        if (withKeyword == null) throw new ArgumentNullException(nameof(withKeyword));
+        if (withKeyword.Kind != SyntaxKind.WithKeyword) throw new ArgumentException(nameof(withKeyword));
+        if (argumentList == null) throw new ArgumentNullException(nameof(argumentList));
+#endif
+
+        int hash;
+        var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.WithElement, withKeyword, argumentList, this.context, out hash);
+        if (cached != null) return (WithElementSyntax)cached;
+
+        var result = new WithElementSyntax(SyntaxKind.WithElement, withKeyword, argumentList, this.context);
         if (hash >= 0)
         {
             SyntaxNodeCache.AddNode(result, hash);
@@ -34976,6 +35190,49 @@ internal static partial class SyntaxFactory
         if (cached != null) return (SpreadElementSyntax)cached;
 
         var result = new SpreadElementSyntax(SyntaxKind.SpreadElement, operatorToken, expression);
+        if (hash >= 0)
+        {
+            SyntaxNodeCache.AddNode(result, hash);
+        }
+
+        return result;
+    }
+
+    public static KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
+    {
+#if DEBUG
+        if (keyExpression == null) throw new ArgumentNullException(nameof(keyExpression));
+        if (colonToken == null) throw new ArgumentNullException(nameof(colonToken));
+        if (colonToken.Kind != SyntaxKind.ColonToken) throw new ArgumentException(nameof(colonToken));
+        if (valueExpression == null) throw new ArgumentNullException(nameof(valueExpression));
+#endif
+
+        int hash;
+        var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.KeyValuePairElement, keyExpression, colonToken, valueExpression, out hash);
+        if (cached != null) return (KeyValuePairElementSyntax)cached;
+
+        var result = new KeyValuePairElementSyntax(SyntaxKind.KeyValuePairElement, keyExpression, colonToken, valueExpression);
+        if (hash >= 0)
+        {
+            SyntaxNodeCache.AddNode(result, hash);
+        }
+
+        return result;
+    }
+
+    public static WithElementSyntax WithElement(SyntaxToken withKeyword, ArgumentListSyntax argumentList)
+    {
+#if DEBUG
+        if (withKeyword == null) throw new ArgumentNullException(nameof(withKeyword));
+        if (withKeyword.Kind != SyntaxKind.WithKeyword) throw new ArgumentException(nameof(withKeyword));
+        if (argumentList == null) throw new ArgumentNullException(nameof(argumentList));
+#endif
+
+        int hash;
+        var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.WithElement, withKeyword, argumentList, out hash);
+        if (cached != null) return (WithElementSyntax)cached;
+
+        var result = new WithElementSyntax(SyntaxKind.WithElement, withKeyword, argumentList);
         if (hash >= 0)
         {
             SyntaxNodeCache.AddNode(result, hash);

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -228,6 +228,12 @@ public partial class CSharpSyntaxVisitor<TResult>
     /// <summary>Called when the visitor visits a SpreadElementSyntax node.</summary>
     public virtual TResult? VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
 
+    /// <summary>Called when the visitor visits a KeyValuePairElementSyntax node.</summary>
+    public virtual TResult? VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
+
+    /// <summary>Called when the visitor visits a WithElementSyntax node.</summary>
+    public virtual TResult? VisitWithElement(WithElementSyntax node) => this.DefaultVisit(node);
+
     /// <summary>Called when the visitor visits a QueryExpressionSyntax node.</summary>
     public virtual TResult? VisitQueryExpression(QueryExpressionSyntax node) => this.DefaultVisit(node);
 
@@ -969,6 +975,12 @@ public partial class CSharpSyntaxVisitor
     /// <summary>Called when the visitor visits a SpreadElementSyntax node.</summary>
     public virtual void VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
 
+    /// <summary>Called when the visitor visits a KeyValuePairElementSyntax node.</summary>
+    public virtual void VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
+
+    /// <summary>Called when the visitor visits a WithElementSyntax node.</summary>
+    public virtual void VisitWithElement(WithElementSyntax node) => this.DefaultVisit(node);
+
     /// <summary>Called when the visitor visits a QueryExpressionSyntax node.</summary>
     public virtual void VisitQueryExpression(QueryExpressionSyntax node) => this.DefaultVisit(node);
 
@@ -1709,6 +1721,12 @@ public partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<SyntaxNode?>
 
     public override SyntaxNode? VisitSpreadElement(SpreadElementSyntax node)
         => node.Update(VisitToken(node.OperatorToken), (ExpressionSyntax?)Visit(node.Expression) ?? throw new ArgumentNullException("expression"));
+
+    public override SyntaxNode? VisitKeyValuePairElement(KeyValuePairElementSyntax node)
+        => node.Update((ExpressionSyntax?)Visit(node.KeyExpression) ?? throw new ArgumentNullException("keyExpression"), VisitToken(node.ColonToken), (ExpressionSyntax?)Visit(node.ValueExpression) ?? throw new ArgumentNullException("valueExpression"));
+
+    public override SyntaxNode? VisitWithElement(WithElementSyntax node)
+        => node.Update(VisitToken(node.WithKeyword), (ArgumentListSyntax?)Visit(node.ArgumentList) ?? throw new ArgumentNullException("argumentList"));
 
     public override SyntaxNode? VisitQueryExpression(QueryExpressionSyntax node)
         => node.Update((FromClauseSyntax?)Visit(node.FromClause) ?? throw new ArgumentNullException("fromClause"), (QueryBodySyntax?)Visit(node.Body) ?? throw new ArgumentNullException("body"));
@@ -3426,6 +3444,33 @@ public static partial class SyntaxFactory
     /// <summary>Creates a new SpreadElementSyntax instance.</summary>
     public static SpreadElementSyntax SpreadElement(ExpressionSyntax expression)
         => SyntaxFactory.SpreadElement(SyntaxFactory.Token(SyntaxKind.DotDotToken), expression);
+
+    /// <summary>Creates a new KeyValuePairElementSyntax instance.</summary>
+    public static KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
+    {
+        if (keyExpression == null) throw new ArgumentNullException(nameof(keyExpression));
+        if (colonToken.Kind() != SyntaxKind.ColonToken) throw new ArgumentException(nameof(colonToken));
+        if (valueExpression == null) throw new ArgumentNullException(nameof(valueExpression));
+        return (KeyValuePairElementSyntax)Syntax.InternalSyntax.SyntaxFactory.KeyValuePairElement((Syntax.InternalSyntax.ExpressionSyntax)keyExpression.Green, (Syntax.InternalSyntax.SyntaxToken)colonToken.Node!, (Syntax.InternalSyntax.ExpressionSyntax)valueExpression.Green).CreateRed();
+    }
+
+    /// <summary>Creates a new KeyValuePairElementSyntax instance.</summary>
+    public static KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, ExpressionSyntax valueExpression)
+        => SyntaxFactory.KeyValuePairElement(keyExpression, SyntaxFactory.Token(SyntaxKind.ColonToken), valueExpression);
+
+    /// <summary>Creates a new WithElementSyntax instance.</summary>
+    public static WithElementSyntax WithElement(SyntaxToken withKeyword, ArgumentListSyntax argumentList)
+    {
+        if (withKeyword.Kind() != SyntaxKind.WithKeyword) throw new ArgumentException(nameof(withKeyword));
+        if (argumentList == null) throw new ArgumentNullException(nameof(argumentList));
+        return (WithElementSyntax)Syntax.InternalSyntax.SyntaxFactory.WithElement((Syntax.InternalSyntax.SyntaxToken)withKeyword.Node!, (Syntax.InternalSyntax.ArgumentListSyntax)argumentList.Green).CreateRed();
+    }
+
+#pragma warning disable RS0027
+    /// <summary>Creates a new WithElementSyntax instance.</summary>
+    public static WithElementSyntax WithElement(ArgumentListSyntax? argumentList = default)
+        => SyntaxFactory.WithElement(SyntaxFactory.Token(SyntaxKind.WithKeyword), argumentList ?? SyntaxFactory.ArgumentList());
+#pragma warning restore RS0027
 
     /// <summary>Creates a new QueryExpressionSyntax instance.</summary>
     public static QueryExpressionSyntax QueryExpression(FromClauseSyntax fromClause, QueryBodySyntax body)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -4273,6 +4273,108 @@ public sealed partial class SpreadElementSyntax : CollectionElementSyntax
     public SpreadElementSyntax WithExpression(ExpressionSyntax expression) => Update(this.OperatorToken, expression);
 }
 
+/// <remarks>
+/// <para>This node is associated with the following syntax kinds:</para>
+/// <list type="bullet">
+/// <item><description><see cref="SyntaxKind.KeyValuePairElement"/></description></item>
+/// </list>
+/// </remarks>
+public sealed partial class KeyValuePairElementSyntax : CollectionElementSyntax
+{
+    private ExpressionSyntax? keyExpression;
+    private ExpressionSyntax? valueExpression;
+
+    internal KeyValuePairElementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
+      : base(green, parent, position)
+    {
+    }
+
+    public ExpressionSyntax KeyExpression => GetRedAtZero(ref this.keyExpression)!;
+
+    public SyntaxToken ColonToken => new SyntaxToken(this, ((InternalSyntax.KeyValuePairElementSyntax)this.Green).colonToken, GetChildPosition(1), GetChildIndex(1));
+
+    public ExpressionSyntax ValueExpression => GetRed(ref this.valueExpression, 2)!;
+
+    internal override SyntaxNode? GetNodeSlot(int index)
+        => index switch
+        {
+            0 => GetRedAtZero(ref this.keyExpression)!,
+            2 => GetRed(ref this.valueExpression, 2)!,
+            _ => null,
+        };
+
+    internal override SyntaxNode? GetCachedSlot(int index)
+        => index switch
+        {
+            0 => this.keyExpression,
+            2 => this.valueExpression,
+            _ => null,
+        };
+
+    public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitKeyValuePairElement(this);
+    public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitKeyValuePairElement(this);
+
+    public KeyValuePairElementSyntax Update(ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
+    {
+        if (keyExpression != this.KeyExpression || colonToken != this.ColonToken || valueExpression != this.ValueExpression)
+        {
+            var newNode = SyntaxFactory.KeyValuePairElement(keyExpression, colonToken, valueExpression);
+            var annotations = GetAnnotations();
+            return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
+        }
+
+        return this;
+    }
+
+    public KeyValuePairElementSyntax WithKeyExpression(ExpressionSyntax keyExpression) => Update(keyExpression, this.ColonToken, this.ValueExpression);
+    public KeyValuePairElementSyntax WithColonToken(SyntaxToken colonToken) => Update(this.KeyExpression, colonToken, this.ValueExpression);
+    public KeyValuePairElementSyntax WithValueExpression(ExpressionSyntax valueExpression) => Update(this.KeyExpression, this.ColonToken, valueExpression);
+}
+
+/// <remarks>
+/// <para>This node is associated with the following syntax kinds:</para>
+/// <list type="bullet">
+/// <item><description><see cref="SyntaxKind.WithElement"/></description></item>
+/// </list>
+/// </remarks>
+public sealed partial class WithElementSyntax : CollectionElementSyntax
+{
+    private ArgumentListSyntax? argumentList;
+
+    internal WithElementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
+      : base(green, parent, position)
+    {
+    }
+
+    public SyntaxToken WithKeyword => new SyntaxToken(this, ((InternalSyntax.WithElementSyntax)this.Green).withKeyword, Position, 0);
+
+    public ArgumentListSyntax ArgumentList => GetRed(ref this.argumentList, 1)!;
+
+    internal override SyntaxNode? GetNodeSlot(int index) => index == 1 ? GetRed(ref this.argumentList, 1)! : null;
+
+    internal override SyntaxNode? GetCachedSlot(int index) => index == 1 ? this.argumentList : null;
+
+    public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitWithElement(this);
+    public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitWithElement(this);
+
+    public WithElementSyntax Update(SyntaxToken withKeyword, ArgumentListSyntax argumentList)
+    {
+        if (withKeyword != this.WithKeyword || argumentList != this.ArgumentList)
+        {
+            var newNode = SyntaxFactory.WithElement(withKeyword, argumentList);
+            var annotations = GetAnnotations();
+            return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
+        }
+
+        return this;
+    }
+
+    public WithElementSyntax WithWithKeyword(SyntaxToken withKeyword) => Update(withKeyword, this.ArgumentList);
+    public WithElementSyntax WithArgumentList(ArgumentListSyntax argumentList) => Update(this.WithKeyword, argumentList);
+
+    public WithElementSyntax AddArgumentListArguments(params ArgumentSyntax[] items) => WithArgumentList(this.ArgumentList.WithArguments(this.ArgumentList.Arguments.AddRange(items)));
+}
+
 public abstract partial class QueryClauseSyntax : CSharpSyntaxNode
 {
     internal QueryClauseSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -43,30 +43,39 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (collectionTypeKind)
                 {
                     case CollectionExpressionTypeKind.ImplementsIEnumerable:
-                        if (ConversionsBase.IsSpanOrListType(_compilation, node.Type, WellKnownType.System_Collections_Generic_List_T, out var listElementType))
+                        if (ConversionsBase.IsSpanOrListType(_compilation, node.Type, WellKnownType.System_Collections_Generic_List_T, out var listElementType) &&
+                            usesParameterlessListConstructor(_compilation, node))
                         {
                             if (TryRewriteSingleElementSpreadToList(node, listElementType, out var result))
                             {
                                 return result;
                             }
 
-                            if (useListOptimization(_compilation, node))
+                            // If the collection type is List<T>, and the list is created with the parameterless constructor,
+                            // and items are added using the expected List<T>.Add(T) method,
+                            // then construction can be optimized to use CollectionsMarshal methods.
+                            if (usesListAddMethodForAllElements(_compilation, node))
                             {
                                 return CreateAndPopulateList(node, listElementType, node.Elements.SelectAsArray(static (element, node) => unwrapListElement(node, element), node));
                             }
                         }
                         return VisitCollectionInitializerCollectionExpression(node, node.Type);
+                    case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
+                        return VisitImplementsIEnumerableWithIndexerCollectionExpression(node, (NamedTypeSymbol)node.Type);
                     case CollectionExpressionTypeKind.Array:
                     case CollectionExpressionTypeKind.Span:
                     case CollectionExpressionTypeKind.ReadOnlySpan:
                         Debug.Assert(elementType is { });
                         return VisitArrayOrSpanCollectionExpression(node, collectionTypeKind, node.Type, TypeWithAnnotations.Create(elementType));
                     case CollectionExpressionTypeKind.CollectionBuilder:
+                        Debug.Assert(Binder.GetCollectionBuilderMethod(node) is { Parameters: [var parameter] });
+
                         // A few special cases when a collection type is an ImmutableArray<T>
                         if (ConversionsBase.IsSpanOrListType(_compilation, node.Type, WellKnownType.System_Collections_Immutable_ImmutableArray_T, out var arrayElementType))
                         {
                             // For `[]` try to use `ImmutableArray<T>.Empty` singleton if available
                             if (node.Elements.IsEmpty &&
+                                usesSingleParameterBuilderMethod(_compilation, node, arrayElementType) &&
                                 _compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Immutable_ImmutableArray_T__Empty) is FieldSymbol immutableArrayOfTEmpty)
                             {
                                 var immutableArrayOfTargetCollectionTypeEmpty = immutableArrayOfTEmpty.AsMember((NamedTypeSymbol)node.Type);
@@ -85,6 +94,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return VisitCollectionBuilderCollectionExpression(node);
                     case CollectionExpressionTypeKind.ArrayInterface:
                         return VisitListInterfaceCollectionExpression(node);
+                    case CollectionExpressionTypeKind.DictionaryInterface:
+                        return VisitDictionaryInterfaceCollectionExpression(node);
                     default:
                         throw ExceptionUtilities.UnexpectedValue(collectionTypeKind);
                 }
@@ -94,24 +105,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _factory.Syntax = previousSyntax;
             }
 
-            // If the collection type is List<T> and items are added using the expected List<T>.Add(T) method,
-            // then construction can be optimized to use CollectionsMarshal methods.
-            static bool useListOptimization(CSharpCompilation compilation, BoundCollectionExpression node)
+            static bool usesParameterlessListConstructor(CSharpCompilation compilation, BoundCollectionExpression node)
             {
-                var elements = node.Elements;
-                if (elements.Length == 0)
-                {
-                    return true;
-                }
-                var addMethod = (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__Add);
-                if (addMethod is null)
-                {
-                    return false;
-                }
-                return elements.All(canOptimizeListElement, addMethod);
+                var ctor = (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__ctor);
+                return ctor is { } &&
+                    node.CollectionCreation is BoundObjectCreationExpression { Constructor: var objectCreate } &&
+                    object.ReferenceEquals(ctor, objectCreate.OriginalDefinition);
             }
 
-            static bool canOptimizeListElement(BoundNode element, MethodSymbol addMethod)
+            static bool usesListAddMethodForAllElements(CSharpCompilation compilation, BoundCollectionExpression node)
+            {
+                var addMethod = (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__Add);
+                return addMethod is { } &&
+                    node.Elements.All(usesListAddMethod, addMethod);
+            }
+
+            static bool usesListAddMethod(BoundNode element, MethodSymbol addMethod)
             {
                 BoundExpression expr;
                 if (element is BoundCollectionExpressionSpreadElement spreadElement)
@@ -128,6 +137,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return addMethod.Equals(collectionInitializer.AddMethod.OriginalDefinition);
                 }
                 return false;
+            }
+
+            static bool usesSingleParameterBuilderMethod(CSharpCompilation compilation, BoundCollectionExpression node, TypeWithAnnotations elementType)
+            {
+                var method = Binder.GetCollectionBuilderMethod(node);
+                Debug.Assert(method is { Parameters: [var parameter] } &&
+                    parameter.Type.Equals(compilation.GetWellKnownType(WellKnownType.System_ReadOnlySpan_T).Construct([elementType]), TypeCompareKind.AllIgnoreOptions));
+                return method is { Parameters.Length: 1 };
             }
 
             static BoundNode unwrapListElement(BoundCollectionExpression node, BoundNode element)
@@ -218,13 +235,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             spreadExpression = null;
 
-            if (node is
-                {
-                    CollectionBuilderMethod: { } builder,
-                    Elements: [BoundCollectionExpressionSpreadElement { Expression: { Type: NamedTypeSymbol spreadType } expr }],
-                } &&
-                ConversionsBase.HasIdentityConversion(builder.Parameters[0].Type, spreadType) &&
-                (!builder.ReturnType.IsRefLikeType || builder.Parameters[0].EffectiveScope == ScopedKind.ScopedValue))
+            if (node.Elements is [BoundCollectionExpressionSpreadElement { Expression: { Type: NamedTypeSymbol spreadType } expr }] &&
+                Binder.GetCollectionBuilderMethod(node) is { Parameters: [var parameter] } builder &&
+                ConversionsBase.HasIdentityConversion(parameter.Type, spreadType) &&
+                (!builder.ReturnType.IsRefLikeType || parameter.EffectiveScope == ScopedKind.ScopedValue))
             {
                 spreadExpression = expr;
             }
@@ -247,7 +261,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(!_inExpressionLambda);
             Debug.Assert(_additionalLocals is { });
-            Debug.Assert(node.CollectionCreation is null); // shouldn't have generated a constructor call
             Debug.Assert(node.Placeholder is null);
 
             var syntax = node.Syntax;
@@ -465,22 +478,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        private BoundExpression VisitDictionaryInterfaceCollectionExpression(BoundCollectionExpression node)
+        {
+            Debug.Assert(!_inExpressionLambda);
+            Debug.Assert(_factory.ModuleBuilderOpt is { });
+            Debug.Assert(_diagnostics.DiagnosticBag is { });
+            Debug.Assert(node.Type is NamedTypeSymbol);
+            Debug.Assert(node.CollectionCreation is null);
+            Debug.Assert(node.Placeholder is { });
+
+            var interfaceType = (NamedTypeSymbol)node.Type;
+            var typeArguments = interfaceType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+            var collectionType = _factory.WellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV).Construct(typeArguments);
+
+            // https://github.com/dotnet/roslyn/issues/77878: Create a custom interface implementation for IReadOnlyDictionary<K, V> to enforce immutability.
+            // Dictionary<K, V> dictionary = new();
+            var constructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor)).AsMember(collectionType);
+            var rewrittenReceiver = _factory.New(constructor, ImmutableArray<BoundExpression>.Empty);
+
+            var collection = PopulateDictionary(node, collectionType, rewrittenReceiver);
+            return _factory.Convert(node.Type, collection);
+        }
+
         private BoundExpression VisitCollectionBuilderCollectionExpression(BoundCollectionExpression node)
         {
             Debug.Assert(!_inExpressionLambda);
             Debug.Assert(node.Type is { });
-            Debug.Assert(node.CollectionCreation is null);
+            Debug.Assert(node.CollectionCreation is { });
             Debug.Assert(node.Placeholder is null);
-            Debug.Assert(node.CollectionBuilderMethod is { });
-            Debug.Assert(node.CollectionBuilderInvocationPlaceholder is { });
-            Debug.Assert(node.CollectionBuilderInvocationConversion is { });
+            Debug.Assert(node.CollectionBuilderSpanPlaceholder is { Type: NamedTypeSymbol { } });
 
-            var constructMethod = node.CollectionBuilderMethod;
-
-            var spanType = (NamedTypeSymbol)constructMethod.Parameters[0].Type;
+            var spanPlaceholder = node.CollectionBuilderSpanPlaceholder;
+            var spanType = (NamedTypeSymbol)spanPlaceholder.Type;
             Debug.Assert(spanType.OriginalDefinition.Equals(_compilation.GetWellKnownType(WellKnownType.System_ReadOnlySpan_T), TypeCompareKind.AllIgnoreOptions));
-
-            var elementType = spanType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
 
             // If collection expression is of form `[.. anotherReadOnlySpan]`
             // with `anotherReadOnlySpan` being a ReadOnlySpan of the same type as target collection type
@@ -488,28 +518,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we can directly use `anotherReadOnlySpan` as collection builder argument and skip the copying assignment.
             BoundExpression span = CanOptimizeSingleSpreadAsCollectionBuilderArgument(node, out var spreadExpression)
                 ? VisitExpression(spreadExpression)
-                : VisitArrayOrSpanCollectionExpression(node, CollectionExpressionTypeKind.ReadOnlySpan, spanType, elementType);
+                : VisitArrayOrSpanCollectionExpression(node, CollectionExpressionTypeKind.ReadOnlySpan, spanType, spanType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0]);
 
-            var invocation = new BoundCall(
-                node.Syntax,
-                receiverOpt: null,
-                initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
-                method: constructMethod,
-                arguments: ImmutableArray.Create(span),
-                argumentNamesOpt: default,
-                argumentRefKindsOpt: default,
-                isDelegateCall: false,
-                expanded: false,
-                invokedAsExtensionMethod: false,
-                argsToParamsOpt: default,
-                defaultArguments: default,
-                resultKind: LookupResultKind.Viable,
-                type: constructMethod.ReturnType);
-
-            var invocationPlaceholder = node.CollectionBuilderInvocationPlaceholder;
-            AddPlaceholderReplacement(invocationPlaceholder, invocation);
-            var result = VisitExpression(node.CollectionBuilderInvocationConversion);
-            RemovePlaceholderReplacement(invocationPlaceholder);
+            AddPlaceholderReplacement(spanPlaceholder, span);
+            var result = VisitExpression(node.CollectionCreation);
+            RemovePlaceholderReplacement(spanPlaceholder);
             return result;
         }
 
@@ -1198,6 +1211,97 @@ namespace Microsoft.CodeAnalysis.CSharp
                 locals,
                 sideEffects.ToImmutableAndFree(),
                 listTemp,
+                collectionType);
+        }
+
+        private BoundExpression VisitImplementsIEnumerableWithIndexerCollectionExpression(BoundCollectionExpression node, NamedTypeSymbol collectionType)
+        {
+            Debug.Assert(!_inExpressionLambda);
+            Debug.Assert(node.CollectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer);
+
+            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
+            Debug.Assert(rewrittenReceiver is { });
+            return PopulateDictionary(node, collectionType, rewrittenReceiver);
+        }
+
+        /// <summary>
+        /// Populate a dictionary from a collection expression.
+        /// The collection may or may not have a known length.
+        /// </summary>
+        private BoundExpression PopulateDictionary(BoundCollectionExpression node, NamedTypeSymbol collectionType, BoundExpression rewrittenReceiver)
+        {
+            var elements = node.Elements;
+            var localsBuilder = ArrayBuilder<BoundLocal>.GetInstance();
+            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance(elements.Length + 1);
+
+            // Create a temp for the dictionary.
+            BoundAssignmentOperator assignmentToTemp;
+            BoundLocal dictionaryTemp = _factory.StoreToTemp(rewrittenReceiver, out assignmentToTemp);
+            localsBuilder.Add(dictionaryTemp);
+            sideEffects.Add(assignmentToTemp);
+
+            var placeholder = node.Placeholder;
+            Debug.Assert(placeholder is { });
+
+            AddPlaceholderReplacement(placeholder, dictionaryTemp);
+
+            foreach (var element in elements)
+            {
+                switch (element)
+                {
+                    case BoundKeyValuePairElement keyValuePairElement:
+                        {
+                            // dictionary[key] = value;
+                            Debug.Assert(keyValuePairElement is { Key: { }, Value: { }, KeyPlaceholder: { }, ValuePlaceholder: { }, IndexerAssignment: { } });
+                            AddPlaceholderReplacement(keyValuePairElement.KeyPlaceholder, VisitExpression(keyValuePairElement.Key));
+                            AddPlaceholderReplacement(keyValuePairElement.ValuePlaceholder, VisitExpression(keyValuePairElement.Value));
+                            sideEffects.Add(VisitExpression(keyValuePairElement.IndexerAssignment));
+                            RemovePlaceholderReplacement(keyValuePairElement.ValuePlaceholder);
+                            RemovePlaceholderReplacement(keyValuePairElement.KeyPlaceholder);
+                        }
+                        break;
+                    case BoundKeyValuePairExpressionElement keyValuePairExpressionElement:
+                        {
+                            // dictionary[element.Key] = element.Value;
+                            var rewrittenExpression = VisitExpression(keyValuePairExpressionElement.Expression);
+                            BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+                            localsBuilder.Add(exprTemp);
+                            sideEffects.Add(assignmentToTemp);
+                            AddPlaceholderReplacement(keyValuePairExpressionElement.ExpressionPlaceholder, exprTemp);
+                            sideEffects.Add(VisitExpression(keyValuePairExpressionElement.IndexerAssignment));
+                            RemovePlaceholderReplacement(keyValuePairExpressionElement.ExpressionPlaceholder);
+                        }
+                        break;
+                    case BoundCollectionExpressionSpreadElement spreadElement:
+                        {
+                            var rewrittenExpression = VisitExpression(spreadElement.Expression);
+                            var rewrittenElement = MakeCollectionExpressionSpreadElement(
+                                spreadElement,
+                                rewrittenExpression,
+                                iteratorBody =>
+                                {
+                                    // dictionary[item.Key] = item.Value;
+                                    var expr = VisitExpression(((BoundExpressionStatement)iteratorBody).Expression);
+                                    return new BoundExpressionStatement(expr.Syntax, expr);
+                                });
+                            sideEffects.Add(rewrittenElement);
+                        }
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(element);
+                }
+            }
+
+            RemovePlaceholderReplacement(placeholder);
+
+            var locals = localsBuilder.SelectAsArray(l => l.LocalSymbol);
+            localsBuilder.Free();
+
+            return new BoundSequence(
+                node.Syntax,
+                locals,
+                sideEffects.ToImmutableAndFree(),
+                dictionaryTemp,
                 collectionType);
         }
 

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,33 @@
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.ColonToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.KeyExpression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.SyntaxToken colonToken, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.ValueExpression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithColonToken(Microsoft.CodeAnalysis.SyntaxToken colonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithKeyExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithValueExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.AddArgumentListArguments(params Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax![]! items) -> Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.ArgumentList.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken withKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax! argumentList) -> Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.WithArgumentList(Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax! argumentList) -> Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.WithKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.WithWithKeyword(Microsoft.CodeAnalysis.SyntaxToken withKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax!
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.KeyValuePairElement = 9081 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.WithElement = 9082 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> Microsoft.CodeAnalysis.SyntaxNode?
+override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitWithElement(Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax! node) -> Microsoft.CodeAnalysis.SyntaxNode?
+override Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor! visitor) -> void
+override Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>! visitor) -> TResult?
+override Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor! visitor) -> void
+override Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>! visitor) -> TResult?
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.SyntaxToken colonToken, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WithElement(Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax? argumentList = null) -> Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax!
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WithElement(Microsoft.CodeAnalysis.SyntaxToken withKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax! argumentList) -> Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax!
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> void
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitWithElement(Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax! node) -> void
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> TResult?
 abstract Microsoft.CodeAnalysis.CSharp.InterceptableLocation.Equals(Microsoft.CodeAnalysis.CSharp.InterceptableLocation? other) -> bool
 Microsoft.CodeAnalysis.CSharp.Syntax.ExtensionDeclarationSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ExtensionDeclarationSyntax.AddAttributeLists(params Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax![]! items) -> Microsoft.CodeAnalysis.CSharp.Syntax.ExtensionDeclarationSyntax!
@@ -58,3 +88,4 @@ static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.IgnoredDirectiveTrivia(bool i
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.IgnoredDirectiveTrivia(Microsoft.CodeAnalysis.SyntaxToken hashToken, Microsoft.CodeAnalysis.SyntaxToken colonToken, Microsoft.CodeAnalysis.SyntaxToken endOfDirectiveToken, bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.IgnoredDirectiveTriviaSyntax!
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitIgnoredDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.IgnoredDirectiveTriviaSyntax! node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitIgnoredDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.IgnoredDirectiveTriviaSyntax! node) -> TResult?
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitWithElement(Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax! node) -> TResult?

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -273,6 +273,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     targetMethodKind = MethodKind.PropertyGet;
                     break;
 
+                case MemberFlags.PropertySet:
+                    targetSymbolKind = SymbolKind.Method;
+                    targetMethodKind = MethodKind.PropertySet;
+                    break;
+
                 case MemberFlags.Field:
                     targetSymbolKind = SymbolKind.Field;
                     break;

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -1839,6 +1839,21 @@
     </Field>
     <Field Name="Expression" Type="ExpressionSyntax" />
   </Node>
+  <Node Name="KeyValuePairElementSyntax" Base="CollectionElementSyntax">
+    <Kind Name="KeyValuePairElement"/>
+    <Field Name="KeyExpression" Type="ExpressionSyntax" />
+    <Field Name="ColonToken" Type="SyntaxToken">
+      <Kind Name="ColonToken"/>
+    </Field>
+    <Field Name="ValueExpression" Type="ExpressionSyntax" />
+  </Node>
+  <Node Name="WithElementSyntax" Base="CollectionElementSyntax">
+    <Kind Name="WithElement"/>
+    <Field Name="WithKeyword" Type="SyntaxToken">
+      <Kind Name="WithKeyword"/>
+    </Field>
+    <Field Name="ArgumentList" Type="ArgumentListSyntax" />
+  </Node>
   <AbstractNode Name="QueryClauseSyntax" Base="CSharpSyntaxNode">
   </AbstractNode>
   <AbstractNode Name="SelectOrGroupClauseSyntax" Base="CSharpSyntaxNode">

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -931,5 +931,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ExtensionDeclaration = 9079,
 
         IgnoredDirectiveTrivia = 9080,
+        KeyValuePairElement = 9081,
+        WithElement = 9082,
     }
 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -452,6 +452,21 @@
         <target state="translated">{0} neimplementuje člen rozhraní {1}. {2} nemůže implementovat {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">Název metody CollectionBuilderAttribute je neplatný.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Tuto verzi {0} nelze použít s výrazy kolekce.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">zaškrtnuté uživatelem definované operátory</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">výrazy kolekce</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">kovariantní návratové hodnoty</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -452,6 +452,21 @@
         <target state="translated">Der Schnittstellenmember "{1}" wird von "{0}" nicht implementiert. "{1}" kann von "{2}" nicht implementiert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">Der Name der CollectionBuilderAttribute-Methode ist ungültig.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Diese Version von „{0}“ kann nicht mit Auflistungsausdrücken verwendet werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">Überprüfte benutzerdefinierte Operatoren</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">Sammlungsausdrücke</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">Covariante Rückgaben</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -452,6 +452,21 @@
         <target state="translated">"{0}" no implementa el miembro de interfaz "{1}". "{2}" no puede implementar "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">El nombre del método CollectionBuilderAttribute no es válido.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Esta versión de '{0}' no se puede usar con expresiones de colección.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">operadores definidos por el usuario comprobados</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">expresiones de colección</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">valores devueltos de covariante</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -452,6 +452,21 @@
         <target state="translated">'{0}' n'implémente pas le membre d'interface '{1}'. '{2}' ne peut pas implémenter '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">Le nom de la méthode CollectionBuilderAttribute n’est pas valide.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Cette version de « {0} » ne peut pas être utilisée avec des expressions de collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">opérateurs définis par l’utilisateur vérifiés</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">expressions de collection</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">retours covariants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -452,6 +452,21 @@
         <target state="translated">'{0}' non implementa il membro di interfaccia '{1}'. '{2}' non può implementare '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">Il nome del metodo CollectionBuilderAttribute non è valido.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Questa versione di '{0}' non può essere utilizzata con espressioni di raccolta.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">operatori definiti dall'utente controllati</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">espressioni di raccolta</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">tipi restituiti covarianti</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -452,6 +452,21 @@
         <target state="translated">'{0}' は、インターフェイス メンバー '{1}' を実装していません。'{2}' は '{1}' を実装できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">CollectionBuilderAttribute メソッド名が無効です。</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">このバージョンの '{0}' は、コレクション式では使用できません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">チェックされたユーザー定義演算子</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">コレクション式</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">covariant の戻り値</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -452,6 +452,21 @@
         <target state="translated">'{0}'은(는) 인터페이스 멤버 '{1}'을(를) 구현하지 않습니다. '{2}'은(는) '{1}'을(를) 구현할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">CollectionBuilderAttribute 메서드 이름이 잘못되었습니다.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">이 버전의 '{0}'은(는) 컬렉션 식과 함께 사용할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">확인된 사용자 정의 연산자</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">컬렉션 식</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">공변(covariant) 반환</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -452,6 +452,21 @@
         <target state="translated">Element „{0}” nie implementuje składowej interfejsu „{1}”. Element „{2}” nie może implementować elementu „{1}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">Nazwa metody CollectionBuilderAttribute jest nieprawidłowa.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Tej wersji elementu „{0}” nie można używać z wyrażeniami kolekcji.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">zaznaczone operatory zdefiniowane przez użytkownika</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">wyrażenia kolekcji</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">zwroty kowariantne</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -452,6 +452,21 @@
         <target state="translated">'{0}' não implementa o membro de interface '{1}'. '{2}' não pode implementar '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">O nome do método CollectionBuilderAttribute é inválido.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Esta versão de '{0}' não pode ser usada com expressões de coleção.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">operadores verificados, definidos pelo usuário</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">expressões de coleção</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">retornos de covariante</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -452,6 +452,21 @@
         <target state="translated">"{0}" не реализует элемент интерфейса "{1}". "{2}" не может реализовывать "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">Недопустимое имя метода CollectionBuilderAttribute.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Невозможно использовать эту версию "{0}" с выражениями коллекций.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">проверенные операторы, определяемые пользователем</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">выражения коллекции</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">ковариантные возвращаемые значения</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -452,6 +452,21 @@
         <target state="translated">'{0}, '{1}' arabirim üyesini uygulamıyor. '{2}', '{1}' üyesini uygulayamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">CollectionBuilderAttribute yöntemi adı geçersiz.</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">Bu '{0}' sürümü koleksiyon ifadeleri ile kullanılamaz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">kullanıcı tanımlı işleçler işaretlendi</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">koleksiyon ifadeleri</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">birlikte değişken dönüşler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -452,6 +452,21 @@
         <target state="translated">“{0}”不实现接口成员“{1}”。“{2}”无法实现“{1}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">CollectionBuilderAttribute 方法名称无效。</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">“{0}”的此版本无法与集合表达式一起使用。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">选中的用户定义运算符</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">集合表达式</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">协变返回</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -452,6 +452,21 @@
         <target state="translated">'{0}' 未實作介面成員 '{1}'。'{2}' 無法實作 '{1}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
+        <source>Collection argument element must be the first element.</source>
+        <target state="new">Collection argument element must be the first element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
+        <source>Collection arguments are not supported for type '{0}'.</source>
+        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">
         <source>The CollectionBuilderAttribute method name is invalid.</source>
         <target state="translated">CollectionBuilderAttribute 方法名稱無效。</target>
@@ -480,6 +495,11 @@
       <trans-unit id="ERR_CollectionExpressionImmutableArray">
         <source>This version of '{0}' cannot be used with collection expressions.</source>
         <target state="translated">此版本的 '{0}' 無法與集合運算式一起使用。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
@@ -2527,6 +2547,11 @@
         <target state="translated">已檢查使用者定義的運算子</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCollectionExpressionArguments">
+        <source>collection expression arguments</source>
+        <target state="new">collection expression arguments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCollectionExpressions">
         <source>collection expressions</source>
         <target state="translated">集合運算式</target>
@@ -2535,6 +2560,11 @@
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">Covariant 傳回</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">

--- a/src/Compilers/CSharp/Test/Emit3/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
@@ -33,9 +33,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // https://github.com/dotnet/roslyn/issues/44682 Add to all in one
             missingSyntaxKinds.Add(SyntaxKind.WithExpression);
             missingSyntaxKinds.Add(SyntaxKind.RecordDeclaration);
-            missingSyntaxKinds.Add(SyntaxKind.CollectionExpression);
-            missingSyntaxKinds.Add(SyntaxKind.ExpressionElement);
-            missingSyntaxKinds.Add(SyntaxKind.SpreadElement);
             // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Add to all-in-one
             missingSyntaxKinds.Add(SyntaxKind.ExtensionDeclaration);
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionArgumentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionArgumentTests.cs
@@ -1,0 +1,4136 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class CollectionExpressionArgumentTests : CSharpTestBase
+    {
+        private static string IncludeExpectedOutput(string expectedOutput) => ExecutionConditionUtil.IsMonoOrCoreClr ? expectedOutput : null;
+
+        private const string s_collectionExtensions = CollectionExpressionTests.s_collectionExtensions;
+
+        public static readonly TheoryData<LanguageVersion> LanguageVersions = new([LanguageVersion.CSharp13, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersion_01(LanguageVersion languageVersion)
+        {
+            string source = """
+                int[] a = [with()];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,12): error CS0103: The name 'with' does not exist in the current context
+                    // int[] a = [with()];
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(1, 12));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersion_02(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                List<int> l = [1, with(), 3, with(capacity: 4)];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (2,19): error CS0103: The name 'with' does not exist in the current context
+                    // List<int> l = [1, with(), 3, with(capacity: 4)];
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 19),
+                    // (2,30): error CS0103: The name 'with' does not exist in the current context
+                    // List<int> l = [1, with(), 3, with(capacity: 4)];
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 30));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (2,19): error CS9301: Collection argument element must be the first element.
+                    // List<int> l = [1, with(), 3, with(capacity: 4)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 19),
+                    // (2,30): error CS9301: Collection argument element must be the first element.
+                    // List<int> l = [1, with(), 3, with(capacity: 4)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 30));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersion_03(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                List<int> l = [with(x: 1), with(y: 2)];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (2,16): error CS0103: The name 'with' does not exist in the current context
+                    // List<int> l = [with(x: 1), with(y: 2)];
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 16),
+                    // (2,28): error CS0103: The name 'with' does not exist in the current context
+                    // List<int> l = [with(x: 1), with(y: 2)];
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 28));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (2,21): error CS1739: The best overload for 'List' does not have a parameter named 'x'
+                    // List<int> l = [with(x: 1), with(y: 2)];
+                    Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("List", "x").WithLocation(2, 21),
+                    // (2,28): error CS9301: Collection argument element must be the first element.
+                    // List<int> l = [with(x: 1), with(y: 2)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 28),
+                    // (2,33): error CS1739: The best overload for 'List' does not have a parameter named 'y'
+                    // List<int> l = [with(x: 1), with(y: 2)];
+                    Diagnostic(ErrorCode.ERR_BadNamedArgument, "y").WithArguments("List", "y").WithLocation(2, 33));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersion_04(LanguageVersion languageVersion)
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => default;
+                }
+                """;
+            string sourceB = """
+                MyCollection<int> c = [
+                    with(),
+                    with(arg: 0),
+                    with(unknown: 1)];
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                targetFramework: TargetFramework.Net80);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (2,5): error CS0103: The name 'with' does not exist in the current context
+                    //     with(),
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 5),
+                    // (3,5): error CS0103: The name 'with' does not exist in the current context
+                    //     with(arg: 0),
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(3, 5),
+                    // (4,5): error CS0103: The name 'with' does not exist in the current context
+                    //     with(unknown: 1)];
+                    Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(4, 5));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,23): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                    // MyCollection<int> c = [
+                    Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, @"[
+    with(),
+    with(arg: 0),
+    with(unknown: 1)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(1, 23),
+                    // (3,5): error CS9301: Collection argument element must be the first element.
+                    //     with(arg: 0),
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(3, 5),
+                    // (4,5): error CS9301: Collection argument element must be the first element.
+                    //     with(unknown: 1)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(4, 5));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersion_05(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                List<string> list;
+                list = [with(capacity: 1), "one"];
+                list.Report();
+                list = [@with(capacity: 2), "two"];
+                list.Report();
+                string with(int capacity) => $"with({capacity})";
+                """;
+            var verifier = CompileAndVerify([source, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: (languageVersion == LanguageVersion.CSharp13 ? "[with(1), one], [with(2), two], " : "[one], [with(2), two], "));
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void EmptyArguments_Array()
+        {
+            string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                        EmptyArgs<int>().Report();
+                    }
+                    static T[] NoArgs<T>() => [];
+                    static T[] EmptyArgs<T>() => [with()];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                expectedOutput: "[], [], ");
+            verifier.VerifyDiagnostics();
+            string expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  call       "T[] System.Array.Empty<T>()"
+                  IL_0005:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<T>", expectedIL);
+        }
+
+        [Fact]
+        public void Arguments_Array()
+        {
+            string source = """
+                class Program
+                {
+                    static void F<T>(T t)
+                    {
+                        T[] a;
+                        a = [with(default), t];
+                        a = [t, with(default)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,14): error CS9302: Collection arguments are not supported for type 'T[]'.
+                //         a = [with(default), t];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("T[]").WithLocation(6, 14),
+                // (7,17): error CS9301: Collection argument element must be the first element.
+                //         a = [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(7, 17),
+                // (7,17): error CS9302: Collection arguments are not supported for type 'T[]'.
+                //         a = [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("T[]").WithLocation(7, 17));
+
+            // Collection arguments do not affect convertibility.
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var collections = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().ToArray();
+            Assert.Equal(2, collections.Length);
+            VerifyTypes(model, collections[0], expectedType: null, expectedConvertedType: "T[]", ConversionKind.CollectionExpression);
+            VerifyTypes(model, collections[1], expectedType: null, expectedConvertedType: "T[]", ConversionKind.CollectionExpression);
+        }
+
+        private static void VerifyTypes(SemanticModel model, ExpressionSyntax expr, string expectedType, string expectedConvertedType, ConversionKind expectedConversionKind)
+        {
+            var typeInfo = model.GetTypeInfo(expr);
+            var conversion = model.GetConversion(expr);
+            Assert.Equal(expectedType, typeInfo.Type?.ToTestDisplayString());
+            Assert.Equal(expectedConvertedType, typeInfo.ConvertedType?.ToTestDisplayString());
+            Assert.Equal(expectedConversionKind, conversion.Kind);
+        }
+
+        [Theory]
+        [InlineData("ReadOnlySpan")]
+        [InlineData("Span")]
+        public void EmptyArguments_Span(string spanType)
+        {
+            string source = $$"""
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                        EmptyArgs<int>().Report();
+                    }
+                    static T[] NoArgs<T>()
+                    {
+                        {{spanType}}<T> x = [];
+                        return x.ToArray();
+                    }
+                    static T[] EmptyArgs<T>()
+                    {
+                        {{spanType}}<T> x = [with()];
+                        return x.ToArray();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL = $$"""
+                {
+                  // Code size       16 (0x10)
+                  .maxstack  1
+                  .locals init (System.{{spanType}}<T> V_0) //x
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "System.{{spanType}}<T>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  call       "T[] System.{{spanType}}<T>.ToArray()"
+                  IL_000f:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<T>", expectedIL);
+        }
+
+        [Theory]
+        [InlineData("ReadOnlySpan")]
+        [InlineData("Span")]
+        public void Arguments_Span(string spanType)
+        {
+            string source = $$"""
+                using System;
+                class Program
+                {
+                    static void F<T>(T t)
+                    {
+                        {{spanType}}<T> x =
+                            [with(default), t];
+                        {{spanType}}<T> y =
+                            [t, with(default)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (7,14): error CS9302: Collection arguments are not supported for type 'ReadOnlySpan<T>'.
+                //             [with(default), t];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.{spanType}<T>").WithLocation(7, 14),
+                // (9,17): error CS9301: Collection argument element must be the first element.
+                //             [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(9, 17),
+                // (9,17): error CS9302: Collection arguments are not supported for type 'ReadOnlySpan<T>'.
+                //             [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.{spanType}<T>").WithLocation(9, 17));
+        }
+
+        [Fact]
+        public void EmptyArguments_List_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                        EmptyArgs<int>().Report();
+                    }
+                    static List<T> NoArgs<T>() => [];
+                    static List<T> EmptyArgs<T>() => [with()];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+                  IL_0005:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<T>", expectedIL);
+        }
+
+        [Fact]
+        public void EmptyArguments_List_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>(1, 2).Report();
+                        EmptyArgs<int>(3, 4).Report();
+                    }
+                    static List<T> NoArgs<T>(T x, T y) => [x, y];
+                    static List<T> EmptyArgs<T>(T x, T y) => [with(), x, y];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[1, 2], [3, 4], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL = """
+                {
+                  // Code size       57 (0x39)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                System.Span<T> V_1,
+                                int V_2)
+                  IL_0000:  ldc.i4.2
+                  IL_0001:  stloc.0
+                  IL_0002:  ldloc.0
+                  IL_0003:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0008:  dup
+                  IL_0009:  ldloc.0
+                  IL_000a:  call       "void System.Runtime.InteropServices.CollectionsMarshal.SetCount<T>(System.Collections.Generic.List<T>, int)"
+                  IL_000f:  dup
+                  IL_0010:  call       "System.Span<T> System.Runtime.InteropServices.CollectionsMarshal.AsSpan<T>(System.Collections.Generic.List<T>)"
+                  IL_0015:  stloc.1
+                  IL_0016:  ldc.i4.0
+                  IL_0017:  stloc.2
+                  IL_0018:  ldloca.s   V_1
+                  IL_001a:  ldloc.2
+                  IL_001b:  call       "ref T System.Span<T>.this[int].get"
+                  IL_0020:  ldarg.0
+                  IL_0021:  stobj      "T"
+                  IL_0026:  ldloc.2
+                  IL_0027:  ldc.i4.1
+                  IL_0028:  add
+                  IL_0029:  stloc.2
+                  IL_002a:  ldloca.s   V_1
+                  IL_002c:  ldloc.2
+                  IL_002d:  call       "ref T System.Span<T>.this[int].get"
+                  IL_0032:  ldarg.1
+                  IL_0033:  stobj      "T"
+                  IL_0038:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<T>", expectedIL);
+        }
+
+        [Fact]
+        public void Arguments_List()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var l = F(1);
+                        l.Report();
+                        Console.WriteLine(l.Capacity);
+                    }
+                    static List<T> F<T>(T t) => [with(capacity: 2), t];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                expectedOutput: "[1], 2");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<T>(T)", """
+                {
+                  // Code size       14 (0xe)
+                  .maxstack  3
+                  IL_0000:  ldc.i4.2
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.0
+                  IL_0008:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                  IL_000d:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [InlineData("IEnumerable")]
+        [InlineData("IReadOnlyCollection")]
+        [InlineData("IReadOnlyList")]
+        [InlineData("ICollection")]
+        [InlineData("IList")]
+        public void EmptyArguments_ArrayInterface(string interfaceType)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                        EmptyArgs<int>().Report();
+                    }
+                    static {{interfaceType}}<T> NoArgs<T>() => [];
+                    static {{interfaceType}}<T> EmptyArgs<T>() => [with()];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL;
+            if (interfaceType is "IEnumerable" or "IReadOnlyCollection" or "IReadOnlyList")
+            {
+                expectedIL = """
+                    {
+                      // Code size        6 (0x6)
+                      .maxstack  1
+                      IL_0000:  call       "T[] System.Array.Empty<T>()"
+                      IL_0005:  ret
+                    }
+                    """;
+            }
+            else
+            {
+                expectedIL = """
+                    {
+                      // Code size        6 (0x6)
+                      .maxstack  1
+                      IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+                      IL_0005:  ret
+                    }
+                    """;
+            }
+            verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<T>", expectedIL);
+        }
+
+        [Theory]
+        [InlineData("IEnumerable")]
+        [InlineData("IReadOnlyCollection")]
+        [InlineData("IReadOnlyList")]
+        [InlineData("ICollection")]
+        [InlineData("IList")]
+        public void Arguments_ArrayInterface(string interfaceType)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void F<T>(T t)
+                    {
+                        {{interfaceType}}<T> i;
+                        i = [with(default), t];
+                        i = [t, with(default)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (7,14): error CS9302: Collection arguments are not supported for type 'IEnumerable<T>'.
+                //         i = [with(default), t];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.Collections.Generic.{interfaceType}<T>").WithLocation(7, 14),
+                // (8,17): error CS9301: Collection argument element must be the first element.
+                //         i = [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(8, 17),
+                // (8,17): error CS9302: Collection arguments are not supported for type 'IEnumerable<T>'.
+                //         i = [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.Collections.Generic.{interfaceType}<T>").WithLocation(8, 17));
+
+            // Collection arguments do not affect convertibility.
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var collections = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().ToArray();
+            Assert.Equal(2, collections.Length);
+            VerifyTypes(model, collections[0], expectedType: null, expectedConvertedType: $"System.Collections.Generic.{interfaceType}<T>", ConversionKind.CollectionExpression);
+            VerifyTypes(model, collections[1], expectedType: null, expectedConvertedType: $"System.Collections.Generic.{interfaceType}<T>", ConversionKind.CollectionExpression);
+        }
+
+        [Theory]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void EmptyArguments_DictionaryInterface(string interfaceType)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<string, int>().Report();
+                        EmptyArgs<string, int>().Report();
+                    }
+                    static {{interfaceType}}<K, V> NoArgs<K, V>() => [];
+                    static {{interfaceType}}<K, V> EmptyArgs<K, V>() => [with()];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoArgs<K, V>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<K, V>", expectedIL);
+        }
+
+        [Theory]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void Arguments_DictionaryInterface(string interfaceType)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void F<K, V>(K k, V v)
+                    {
+                        {{interfaceType}}<K, V> i;
+                        i = [with(default), k:v];
+                        i = [k:v, with(default)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (7,14): error CS9302: Collection arguments are not supported for type 'IDictionary<K, V>'.
+                //         i = [with(default), k:v];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.Collections.Generic.{interfaceType}<K, V>").WithLocation(7, 14),
+                // (8,19): error CS9301: Collection argument element must be the first element.
+                //         i = [k:v, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(8, 19),
+                // (8,19): error CS9302: Collection arguments are not supported for type 'IDictionary<K, V>'.
+                //         i = [k:v, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.Collections.Generic.{interfaceType}<K, V>").WithLocation(8, 19));
+        }
+
+        [Fact]
+        public void CollectionInitializer_MultipleConstructors()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection() { }
+                    public MyCollection(T arg) { Arg = arg; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Console.WriteLine((EmptyArgs<int>().Arg, NonEmptyArgs(2).Arg));
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB],
+                expectedOutput: "(0, 2)");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.EmptyArgs<T>()", """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "MyCollection<T>..ctor()"
+                  IL_0005:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.NonEmptyArgs<T>(T)", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "MyCollection<T>..ctor(T)"
+                  IL_0006:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void CollectionInitializer_NoParameterlessConstructor()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection(T arg) { Arg = arg; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class Program
+                {
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (13,46): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                //     static MyCollection<T> EmptyArgs<T>() => [with()];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with()]").WithLocation(13, 46),
+                // (14,52): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                //     static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with(t)]").WithLocation(14, 52));
+        }
+
+        [Fact]
+        public void CollectionInitializer_OptionalParameter()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection(T arg = default) { Arg = arg; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Console.WriteLine((EmptyArgs<int>().Arg, NonEmptyArgs(2).Arg));
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB],
+                expectedOutput: "(0, 2)");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.EmptyArgs<T>()", """
+                {
+                  // Code size       15 (0xf)
+                  .maxstack  1
+                  .locals init (T V_0)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "T"
+                  IL_0008:  ldloc.0
+                  IL_0009:  newobj     "MyCollection<T>..ctor(T)"
+                  IL_000e:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.NonEmptyArgs<T>(T)", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "MyCollection<T>..ctor(T)"
+                  IL_0006:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void CollectionInitializer_ParamsParameter()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T[] Args;
+                    public MyCollection(params T[] args) { Args = args; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        EmptyArgs<int>().Args.Report();
+                        OneArg(1).Args.Report();
+                        TwoArgs(2, 3).Args.Report();
+                        MultipleArgs([4, 5]).Args.Report();
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> OneArg<T>(T t) => [with(t)];
+                    static MyCollection<T> TwoArgs<T>(T x, T y) => [with(x, y)];
+                    static MyCollection<T> MultipleArgs<T>(T[] args) => [with(args)];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB, s_collectionExtensions],
+                expectedOutput: "[], [1], [2, 3], [4, 5], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.EmptyArgs<T>()", """
+                {
+                  // Code size       11 (0xb)
+                  .maxstack  1
+                  IL_0000:  call       "T[] System.Array.Empty<T>()"
+                  IL_0005:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_000a:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.OneArg<T>(T)", """
+                {
+                  // Code size       20 (0x14)
+                  .maxstack  4
+                  IL_0000:  ldc.i4.1
+                  IL_0001:  newarr     "T"
+                  IL_0006:  dup
+                  IL_0007:  ldc.i4.0
+                  IL_0008:  ldarg.0
+                  IL_0009:  stelem     "T"
+                  IL_000e:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_0013:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.TwoArgs<T>(T, T)", """
+                {
+                  // Code size       28 (0x1c)
+                  .maxstack  4
+                  IL_0000:  ldc.i4.2
+                  IL_0001:  newarr     "T"
+                  IL_0006:  dup
+                  IL_0007:  ldc.i4.0
+                  IL_0008:  ldarg.0
+                  IL_0009:  stelem     "T"
+                  IL_000e:  dup
+                  IL_000f:  ldc.i4.1
+                  IL_0010:  ldarg.1
+                  IL_0011:  stelem     "T"
+                  IL_0016:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_001b:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.MultipleArgs<T>(T[])", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_0006:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void CollectionInitializer_ObsoleteConstructor_01()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection() { }
+                    [Obsolete]
+                    public MyCollection(T arg) { }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with()];
+                        c = [with(default)];
+                    }
+                    static void F<T>(params MyCollection<T> c) { }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (7,13): warning CS0612: 'MyCollection<int>.MyCollection(int)' is obsolete
+                //         c = [with(default)];
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[with(default)]").WithArguments("MyCollection<int>.MyCollection(int)").WithLocation(7, 13));
+        }
+
+        [Fact]
+        public void CollectionInitializer_ObsoleteConstructor_02()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    [Obsolete]
+                    public MyCollection(T arg = default) { }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with()];
+                        c = [with(default)];
+                    }
+                    static void F<T>(params MyCollection<T> c) { }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): warning CS0612: 'MyCollection<int>.MyCollection(int)' is obsolete
+                //         c = [with()];
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[with()]").WithArguments("MyCollection<int>.MyCollection(int)").WithLocation(6, 13),
+                // (7,13): warning CS0612: 'MyCollection<int>.MyCollection(int)' is obsolete
+                //         c = [with(default)];
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[with(default)]").WithArguments("MyCollection<int>.MyCollection(int)").WithLocation(7, 13),
+                // (9,22): warning CS0612: 'MyCollection<T>.MyCollection(T)' is obsolete
+                //     static void F<T>(params MyCollection<T> c) { }
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "params MyCollection<T> c").WithArguments("MyCollection<T>.MyCollection(T)").WithLocation(9, 22));
+        }
+
+        [Fact]
+        public void CollectionBuilder_MultipleBuilderMethods()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    private readonly List<T> _items;
+                    public MyCollection(T arg, ReadOnlySpan<T> items) { Arg = arg; _items = new(items.ToArray()); }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => new(default, items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => new(arg, items);
+                }
+                """;
+            string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = EmptyArgs(1);
+                        Console.Write("{0}, ", c.Arg);
+                        c.Report();
+                        c = NonEmptyArgs<int>(2);
+                        Console.Write("{0}, ", c.Arg);
+                        c.Report();
+                    }
+                    static MyCollection<T> EmptyArgs<T>(T t) => [with(), t];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t), t];
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (15,53): error CS9302: Collection arguments are not supported for type 'MyCollection<T>'.
+                //     static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t), t];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<T>").WithLocation(15, 53));
+        }
+
+        [Fact]
+        public void CollectionBuilder_NoParameterlessBuilderMethod()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => default;
+                }
+                """;
+            string sourceB = """
+                using System;
+                class Program
+                {
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (4,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> EmptyArgs<T>() => [with()];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(4, 46),
+                // (5,52): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(t)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(5, 52),
+                // (6,38): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 38));
+        }
+
+        [Fact]
+        public void CollectionBuilder_OptionalParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection(T arg, ReadOnlySpan<T> items) { Arg = arg; }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => new(arg, items);
+                }
+                """;
+            string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Console.WriteLine(EmptyArgs<int>().Arg);
+                        Console.WriteLine(NonEmptyArgs(2).Arg);
+                        Console.WriteLine(Params(3, 4).Arg);
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (8,27): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         Console.WriteLine(Params(3, 4).Arg);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "Params(3, 4)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 27),
+                // (10,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> EmptyArgs<T>() => [with()];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 46),
+                // (11,52): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(t)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 52),
+                // (12,38): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 38));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ParamsParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T[] Args;
+                    public MyCollection(ReadOnlySpan<T> items, T[] args) { Args = args; }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(items, args);
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        EmptyArgs<int>().Args.Report();
+                        OneArg(1).Args.Report();
+                        TwoArgs(2, 3).Args.Report();
+                        MultipleArgs([4, 5]).Args.Report();
+                        Params(6).Args.Report();
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> OneArg<T>(T t) => [with(t)];
+                    static MyCollection<T> TwoArgs<T>(T x, T y) => [with(x, y)];
+                    static MyCollection<T> MultipleArgs<T>(T[] args) => [with(args)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (9,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         Params(6).Args.Report();
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "Params(6)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 9),
+                // (11,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> EmptyArgs<T>() => [with()];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 46),
+                // (12,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> OneArg<T>(T t) => [with(t)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(t)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 46),
+                // (13,52): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> TwoArgs<T>(T x, T y) => [with(x, y)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(x, y)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(13, 52),
+                // (14,57): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> MultipleArgs<T>(T[] args) => [with(args)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(14, 57),
+                // (15,38): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(15, 38));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ImplicitParameter_Optional()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items) { _list = new(items.ToArray()); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items = default) => new(items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [1, 2, 3];
+                        c.Report();
+                        c = [with(), 4];
+                        c.Report();
+                        F(5, 6);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [1, 2, 3], [4], [5, 6], "));
+            verifier.VerifyDiagnostics();
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with(1)];
+                        c = [with(2), 3];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,14): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                //         c = [with(1)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 14),
+                // (7,14): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                //         c = [with(2), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 14));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ImplicitParameter_Params_01()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items) { _list = new(items.ToArray()); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(params ReadOnlySpan<T> items) => new(items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [1, 2, 3];
+                        c.Report();
+                        c = [with(), 4];
+                        c.Report();
+                        F(5, 6);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [1, 2, 3], [4], [5, 6], "));
+            verifier.VerifyDiagnostics();
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with(1)];
+                        c = [with(2), 3];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,14): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                //         c = [with(1)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 14),
+                // (7,14): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                //         c = [with(2), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 14));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ImplicitParameter_Params_02()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items) { _list = new(items.ToArray()); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(params ReadOnlySpan<T> items) => new(items);
+                }
+                """;
+            string sourceB = """
+                using System;
+                class MyItem
+                {
+                    public static implicit operator MyItem(ReadOnlySpan<MyItem> items) => new();
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyItem x = new();
+                        MyItem y = new();
+                        MyCollection<MyItem> c;
+                        c = [];
+                        c = [x, y];
+                        c = [with(x)];
+                        c = [with(x), y];
+                        c = [with(), x, y];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+            // https://github.com/dotnet/roslyn/issues/77866: [with(x)] and [with(x), y] should
+            // result in errors since x should not be included in the params argument. Should
+            // be fixed when the last parameter of the builder method is the items parameter.
+            comp.VerifyEmitDiagnostics(
+                // (15,14): error CS9302: Collection arguments are not supported for type 'MyCollection<MyItem>'.
+                //         c = [with(x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<MyItem>").WithLocation(15, 14),
+                // (16,14): error CS9302: Collection arguments are not supported for type 'MyCollection<MyItem>'.
+                //         c = [with(x), y];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<MyItem>").WithLocation(16, 14));
+        }
+
+        // C#7.3 feature ImprovedOverloadCandidates drops candidates with constraint violations
+        // (see OverloadResolution.RemoveConstraintViolations()) which allows constructing
+        // MyCollection<T> and MyCollection<U> with different factory methods.
+        [Fact]
+        public void CollectionBuilder_MultipleBuilderMethods_GenericConstraints_ClassAndStruct()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(ReadOnlySpan<T> items)
+                    {
+                        _items = new(items.ToArray());
+                    }
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) where T : class => new(items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) where T : struct => new(arg, items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB1], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (3,58): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(3, 58));
+
+            string sourceB2 = """
+                class Program
+                {
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                    static MyCollection<T> NoConstraintsParams<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (3,58): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "NoConstraintsParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(3, 58));
+
+            string sourceB3 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceA, sourceB3, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (8,78): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(8, 78));
+
+            string sourceB4 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+                    static MyCollection<T> StructConstraintParams<T>(params MyCollection<T> c) where T : struct => c;
+                    static MyCollection<T> ClassConstraintParams<T>(params MyCollection<T> c) where T : class => c;
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceA, sourceB4, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (8,78): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "StructConstraintParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(8, 78));
+        }
+
+        [Fact]
+        public void CollectionBuilder_MultipleBuilderMethods_GenericConstraints_NoneAndClass()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(ReadOnlySpan<T> items)
+                    {
+                        _items = new(items.ToArray());
+                    }
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => new(items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) where T : class => new(arg, items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[1, 2], [3, 4], [5, 6], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL = """
+                {
+                  // Code size       50 (0x32)
+                  .maxstack  2
+                  .locals init (<>y__InlineArray2<T> V_0)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray2<T>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_0010:  ldarg.0
+                  IL_0011:  stobj      "T"
+                  IL_0016:  ldloca.s   V_0
+                  IL_0018:  ldc.i4.1
+                  IL_0019:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_001e:  ldarg.1
+                  IL_001f:  stobj      "T"
+                  IL_0024:  ldloca.s   V_0
+                  IL_0026:  ldc.i4.2
+                  IL_0027:  call       "System.ReadOnlySpan<T> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray2<T>, T>(in <>y__InlineArray2<T>, int)"
+                  IL_002c:  call       "MyCollection<T> MyBuilder.Create<T>(System.ReadOnlySpan<T>)"
+                  IL_0031:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoConstraints<T>", expectedIL);
+            verifier.VerifyIL("Program.StructConstraint<T>", expectedIL);
+            verifier.VerifyIL("Program.ClassConstraint<T>", expectedIL);
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+                    static MyCollection<T> NoConstraintsParams<T>(params MyCollection<T> c) => c;
+                    static MyCollection<T> StructConstraintParams<T>(params MyCollection<T> c) where T : struct => c;
+                    static MyCollection<T> ClassConstraintParams<T>(params MyCollection<T> c) where T : class => c;
+                }
+                """;
+            verifier = CompileAndVerify(
+                [sourceA, sourceB2, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[1, 2], [3, 4], [5, 6], "));
+            verifier.VerifyDiagnostics();
+            expectedIL = """
+                {
+                  // Code size       55 (0x37)
+                  .maxstack  2
+                  .locals init (<>y__InlineArray2<T> V_0)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray2<T>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_0010:  ldarg.0
+                  IL_0011:  stobj      "T"
+                  IL_0016:  ldloca.s   V_0
+                  IL_0018:  ldc.i4.1
+                  IL_0019:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_001e:  ldarg.1
+                  IL_001f:  stobj      "T"
+                  IL_0024:  ldloca.s   V_0
+                  IL_0026:  ldc.i4.2
+                  IL_0027:  call       "System.ReadOnlySpan<T> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray2<T>, T>(in <>y__InlineArray2<T>, int)"
+                  IL_002c:  call       "MyCollection<T> MyBuilder.Create<T>(System.ReadOnlySpan<T>)"
+                  IL_0031:  call       "MyCollection<T> Program.NoConstraintsParams<T>(params MyCollection<T>)"
+                  IL_0036:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoConstraints<T>", expectedIL);
+            verifier.VerifyIL("Program.StructConstraint<T>", expectedIL.Replace("NoConstraintsParams", "StructConstraintParams"));
+            verifier.VerifyIL("Program.ClassConstraint<T>", expectedIL.Replace("NoConstraintsParams", "ClassConstraintParams"));
+        }
+
+        [Fact]
+        public void CollectionBuilder_MultipleBuilderMethods_GenericConstraints_StructAndNone()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(ReadOnlySpan<T> items)
+                    {
+                        _items = new(items.ToArray());
+                    }
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) where T : struct => new(items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => new(arg, items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (9,58): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(9, 58),
+                // (11,76): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(11, 76));
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+                    static MyCollection<T> NoConstraintsParams<T>(params MyCollection<T> c) => c;
+                    static MyCollection<T> StructConstraintParams<T>(params MyCollection<T> c) where T : struct => c;
+                    static MyCollection<T> ClassConstraintParams<T>(params MyCollection<T> c) where T : class => c;
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceA, sourceB2, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (9,58): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "NoConstraintsParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(9, 58),
+                // (11,76): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+                //     static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "ClassConstraintParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(11, 76));
+        }
+
+        [Fact]
+        public void CollectionBuilder_NamedParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T x, T y)
+                    {
+                        _list = new();
+                        _list.Add(x);
+                        _list.Add(y);
+                        _list.AddRange(items.ToArray());
+                    }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T x = default, T y = default) => new(items, x, y);
+                }
+                """;
+            string sourceB = """
+                MyCollection<int> c;
+                c = [with(x: 1), 2, 3];
+                c.Report();
+                c = [with(y: 4), 5];
+                c.Report();
+                c = [with(y: 6, x: 7), 8];
+                c.Report();
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (2,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(x: 1), 2, 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(2, 6),
+                // (4,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(y: 4), 5];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(4, 6),
+                // (6,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(y: 6, x: 7), 8];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6));
+        }
+
+        [Fact]
+        public void CollectionBuilder_RefParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, ref T x) => new(items, x);
+                }
+                """;
+
+            string sourceB1 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                c = [with(ref x)];
+                c.Report();
+                x = 2;
+                c = [with(ref r)];
+                c.Report();
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(ref x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+                // (8,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(ref r)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6));
+
+            string sourceB2 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref readonly int ro = ref x;
+                c = [with(0)];
+                c = [with(x)];
+                c = [with(in x)];
+                c = [with(ref ro)];
+                c = [with(out x)];
+                """;
+            comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(0)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+                // (6,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+                // (7,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6),
+                // (8,15): error CS1510: A ref or out value must be an assignable variable
+                // c = [with(ref ro)];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "ro").WithLocation(8, 15),
+                // (9,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(out x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(9, 6));
+        }
+
+        [Fact]
+        public void CollectionBuilder_RefReadonlyParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, ref readonly T x) => new(items, x);
+                }
+                """;
+
+            string sourceB1 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                ref readonly int ro = ref x;
+                c = [with(0)];
+                c.Report();
+                c = [with(x)];
+                c.Report();
+                x = 2;
+                c = [with(ref x)];
+                c.Report();
+                x = 3;
+                c = [with(ref r)];
+                c.Report();
+                x = 4;
+                c = [with(in ro)];
+                c.Report();
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(0)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+                // (8,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6),
+                // (11,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(ref x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(11, 6),
+                // (14,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(ref r)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(14, 6),
+                // (17,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in ro)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(17, 6));
+
+            string sourceB2 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref readonly int ro = ref x;
+                c = [with(in x)];
+                c = [with(ref ro)];
+                c = [with(out x)];
+                """;
+            comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+                // (6,15): error CS1510: A ref or out value must be an assignable variable
+                // c = [with(ref ro)];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "ro").WithLocation(6, 15),
+                // (7,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(out x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6));
+        }
+
+        [Fact]
+        public void CollectionBuilder_InParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, in T x) => new(items, x);
+                }
+                """;
+
+            string sourceB1 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                ref readonly int ro = ref x;
+                c = [with(0)];
+                c.Report();
+                c = [with(x)];
+                c.Report();
+                x = 2;
+                c = [with(ref x)];
+                c.Report();
+                x = 3;
+                c = [with(in x)];
+                c.Report();
+                x = 4;
+                c = [with(in r)];
+                c.Report();
+                x = 5;
+                c = [with(in ro)];
+                c.Report();
+                """;
+            var comp = CreateCompilation([sourceA, sourceB1, s_collectionExtensions], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(0)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+                // (8,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6),
+                // (11,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(ref x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(11, 6),
+                // (14,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(14, 6),
+                // (17,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in r)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(17, 6),
+                // (20,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in ro)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(20, 6));
+
+            string sourceB2 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref readonly int ro = ref x;
+                c = [with(ref ro)];
+                """;
+            comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,15): error CS1510: A ref or out value must be an assignable variable
+                // c = [with(ref ro)];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "ro").WithLocation(5, 15));
+        }
+
+        [Fact]
+        public void CollectionBuilder_OutParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, out T x) { x = default; return new(items, x); }
+                }
+                """;
+
+            string sourceB1 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                c = [with(out x)];
+                c.Report();
+                x = 2;
+                c = [with(out r), 3];
+                c.Report();
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(out x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+                // (8,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(out r), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6));
+
+            string sourceB2 = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                c = [with(1)];
+                c = [with(x)];
+                c = [with(ref x)];
+                c = [with(in x)];
+                """;
+            comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (4,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(1)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(4, 6),
+                // (5,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+                // (6,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(ref x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+                // (7,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6));
+        }
+
+        [Fact]
+        public void CollectionBuilder_RefParameter_Overloads()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T x, T y)
+                    {
+                        _list = new();
+                        _list.Add(x);
+                        _list.Add(y);
+                        _list.AddRange(items.ToArray());
+                    }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, in T x) => new(items, x, default);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T x, ref T y) => new(items, x, y);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, out T x, T y) { x = default; return new(items, x, y); }
+                }
+                """;
+            string sourceB = """
+                #pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                int y = 2;
+                c = [with(in x)];
+                c.Report();
+                c = [with(1), 3];
+                c.Report();
+                c = [with(x, ref y)];
+                c.Report();
+                c = [with(out x, y), 3];
+                c.Report();
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(in x)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+                // (7,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(1), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6),
+                // (9,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(x, ref y)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(9, 6),
+                // (11,6): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                // c = [with(out x, y), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(11, 6));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ReferenceImplicitParameter()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => new(items, arg);
+                }
+                """;
+            string sourceB = """
+                MyCollection<int> c;
+                c = [with(items: default)];
+                c = [with(items: default, 1)];
+                c = [with(items: default, arg: 2)];
+                c = [with(3, items: default)];
+                c = [with(arg: 4, items: default)];
+                c = [with(default, 5)];
+                c = [with(default, arg: 6)];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (2,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // c = [with(items: default)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(items: default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(2, 5),
+                // (2,18): error CS8716: There is no target type for the default literal.
+                // c = [with(items: default)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(2, 18),
+                // (3,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // c = [with(items: default, 1)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(items: default, 1)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(3, 5),
+                // (3,18): error CS8716: There is no target type for the default literal.
+                // c = [with(items: default, 1)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(3, 18),
+                // (4,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // c = [with(items: default, arg: 2)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(items: default, arg: 2)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(4, 5),
+                // (4,18): error CS8716: There is no target type for the default literal.
+                // c = [with(items: default, arg: 2)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(4, 18),
+                // (5,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // c = [with(3, items: default)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(3, items: default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(5, 5),
+                // (5,21): error CS8716: There is no target type for the default literal.
+                // c = [with(3, items: default)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(5, 21),
+                // (6,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // c = [with(arg: 4, items: default)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(arg: 4, items: default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 5),
+                // (6,26): error CS8716: There is no target type for the default literal.
+                // c = [with(arg: 4, items: default)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(6, 26),
+                // (7,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // c = [with(default, 5)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default, 5)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 5),
+                // (7,11): error CS8716: There is no target type for the default literal.
+                // c = [with(default, 5)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(7, 11),
+                // (8,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // c = [with(default, arg: 6)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default, arg: 6)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 5),
+                // (8,11): error CS8716: There is no target type for the default literal.
+                // c = [with(default, arg: 6)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(8, 11));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ReadOnlySpanConstraint()
+        {
+            string sourceA = """
+                namespace System
+                {
+                    public ref struct ReadOnlySpan<T>
+                        where T : struct
+                    {
+                    }
+                }
+                """;
+            string sourceB = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, int arg) where T : struct => default;
+                }
+                """;
+            string sourceC = """
+                class Program
+                {
+                    static MyCollection<T> NoArgs<T>() => [];
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> WithArg<T>(int arg) => [with(arg)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB, sourceC, CollectionBuilderAttributeDefinition]);
+            comp.VerifyEmitDiagnostics(
+                // (3,43): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+                //     static MyCollection<T> NoArgs<T>() => [];
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[]").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(3, 43),
+                // (4,46): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+                //     static MyCollection<T> EmptyArgs<T>() => [with()];
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[with()]").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(4, 46),
+                // (5,51): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+                //     static MyCollection<T> WithArg<T>(int arg) => [with(arg)];
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[with(arg)]").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(5, 51),
+                // (5,52): error CS9302: Collection arguments are not supported for type 'MyCollection<T>'.
+                //     static MyCollection<T> WithArg<T>(int arg) => [with(arg)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<T>").WithLocation(5, 52),
+                // (13,61): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+                //     public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "items").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(13, 61));
+        }
+
+        [Fact]
+        public void CollectionBuilder_SpreadElement_BoxingConversion()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                interface IMyCollection<T> : IEnumerable<T>
+                {
+                }
+                class MyCollectionBuilder
+                {
+                    public struct MyCollection<T> : IMyCollection<T>
+                    {
+                        private readonly List<T> _list;
+                        public MyCollection(ReadOnlySpan<T> items, T arg)
+                        {
+                            _list = new(items.ToArray());
+                            _list.Add(arg);
+                        }
+                        public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+                        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    }
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => new(items, arg);
+                }
+                """;
+            string sourceB = """
+                #nullable enable
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        IMyCollection<string?> x = F<string>([], default!);
+                        x.Report();
+                        IMyCollection<int> y = F<int>([1, 2], 3);
+                        y.Report();
+                    }
+                    static IMyCollection<T?> F<T>(ReadOnlySpan<T> items, T arg) => [with(arg), ..items];
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (12,69): error CS9302: Collection arguments are not supported for type 'IMyCollection<T?>'.
+                //     static IMyCollection<T?> F<T>(ReadOnlySpan<T> items, T arg) => [with(arg), ..items];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("IMyCollection<T?>").WithLocation(12, 69));
+        }
+
+        [Fact]
+        public void CollectionBuilder_UseSiteError_Method()
+        {
+            // [CollectionBuilder(typeof(MyCollectionBuilder), "Create")]
+            // public sealed class MyCollection<T>
+            // {
+            //     public IEnumerator<T> GetEnumerator() { }
+            // }
+            // public static class MyCollectionBuilder
+            // {
+            //     [CompilerFeatureRequired("MyFeature")]
+            //     public static MyCollection<T> MyCollectionBuilder.Create<T>(ReadOnlySpan<T>, object arg = null) { }
+            // }
+            string sourceA = """
+                .assembly extern System.Runtime { .ver 8:0:0:0 .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A) }
+                .class public sealed MyCollection`1<T>
+                {
+                  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CollectionBuilderAttribute::.ctor(class [System.Runtime]System.Type, string) = { type(MyCollectionBuilder) string('Create') }
+                  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+                  .method public instance class [System.Runtime]System.Collections.Generic.IEnumerator`1<!T> GetEnumerator() { ldnull ret }
+                }
+                .class public abstract sealed MyCollectionBuilder
+                {
+                  .method public static class MyCollection`1<!!T> Create<T>(valuetype [System.Runtime]System.ReadOnlySpan`1<!!T> items, [opt] object arg)
+                  {
+                    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute::.ctor(string) = { string('MyFeature') }
+                    .param [2] = nullref
+                    ldnull ret
+                  }
+                }
+                """;
+            var refA = CompileIL(sourceA);
+
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+                // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with()];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+                // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+                // (8,19): error CS8716: There is no target type for the default literal.
+                //         c = [with(default)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(8, 19),
+                // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = F(1, 2);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(1, 2)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13),
+                // (11,33): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 33));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ObsoleteBuilderMethod_01()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    [Obsolete]
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => default;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (8,14): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                //         c = [with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 14));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ObsoleteBuilderMethod_02()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    [Obsolete]
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => default;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+                // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with()];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+                // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+                // (8,19): error CS8716: There is no target type for the default literal.
+                //         c = [with(default)];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(8, 19),
+                // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = F(1, 2);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(1, 2)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13),
+                // (11,33): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 33));
+        }
+
+        [Fact]
+        public void CollectionBuilder_UnmanagedCallersOnly()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection : IEnumerable<int>
+                {
+                    IEnumerator<int> IEnumerable<int>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    [UnmanagedCallersOnly]
+                    public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection c;
+                        c = [];
+                        c = [with()];
+                        c = [with(0)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection F(params MyCollection c) => c;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "int", "MyCollection").WithLocation(6, 13),
+                // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+                //         c = [with()];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "int", "MyCollection").WithLocation(7, 13),
+                // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+                //         c = [with(0)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(0)]").WithArguments("Create", "int", "MyCollection").WithLocation(8, 13),
+                // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+                //         c = F(1, 2);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(1, 2)").WithArguments("Create", "int", "MyCollection").WithLocation(9, 13),
+                // (11,27): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+                //     static MyCollection F(params MyCollection c) => c;
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection c").WithArguments("Create", "int", "MyCollection").WithLocation(11, 27),
+                // (15,19): error CS8894: Cannot use 'MyCollection' as a return type on a method attributed with 'UnmanagedCallersOnly'.
+                //     public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+                Diagnostic(ErrorCode.ERR_CannotUseManagedTypeInUnmanagedCallersOnly, "MyCollection").WithArguments("MyCollection", "return").WithLocation(15, 19),
+                // (15,39): error CS8894: Cannot use 'ReadOnlySpan<int>' as a parameter type on a method attributed with 'UnmanagedCallersOnly'.
+                //     public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+                Diagnostic(ErrorCode.ERR_CannotUseManagedTypeInUnmanagedCallersOnly, "ReadOnlySpan<int> items").WithArguments("System.ReadOnlySpan<int>", "parameter").WithLocation(15, 39),
+                // (15,64): error CS8894: Cannot use 'object[]' as a parameter type on a method attributed with 'UnmanagedCallersOnly'.
+                //     public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+                Diagnostic(ErrorCode.ERR_CannotUseManagedTypeInUnmanagedCallersOnly, "params object[] args").WithArguments("object[]", "parameter").WithLocation(15, 64));
+        }
+
+        [Fact]
+        public void CollectionBuilder_GenericConstraints_01()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => new(default, items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) where T : struct => new(arg, items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> x;
+                        x = [with(), 1];
+                        x.Report();
+                        MyCollection<int> y;
+                        y = [with(2), 3];
+                        y.Report();
+                        x = F((object)1);
+                        x.Report();
+                        y = F(3);
+                        y.Report();
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (9,14): error CS9302: Collection arguments are not supported for type 'MyCollection<int>'.
+                //         y = [with(2), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(9, 14));
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> x;
+                        x = [with(default)];
+                        x = [with(2), 3];
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceA, sourceB2],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,14): error CS9302: Collection arguments are not supported for type 'MyCollection<object>'.
+                //         x = [with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<object>").WithLocation(6, 14),
+                // (7,14): error CS9302: Collection arguments are not supported for type 'MyCollection<object>'.
+                //         x = [with(2), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<object>").WithLocation(7, 14));
+        }
+
+        [Fact]
+        public void CollectionBuilder_GenericConstraints_02()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) where T : struct => new(arg, items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [with(), 1];
+                        c.Report();
+                        c = [with(2)];
+                        c.Report();
+                        F<int>();
+                        F(3);
+                        F(4, 5);
+                    }
+                    static void F<T>(params MyCollection<T> c) where T : struct
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+                // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(), 1];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+                // (10,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(2)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 13),
+                // (12,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F<int>();
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<int>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 9),
+                // (13,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F(3);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(3)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(13, 9),
+                // (14,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F(4, 5);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(4, 5)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(14, 9),
+                // (16,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static void F<T>(params MyCollection<T> c) where T : struct
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(16, 22));
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> c;
+                        c = [];
+                        c = [with(), 1];
+                        c = [with(2)];
+                        F<object>();
+                        F((object)3);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceA, sourceB2],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+                // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(), 1];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+                // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(2)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+                // (9,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F<object>();
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<object>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 9),
+                // (10,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F((object)3);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F((object)3)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 9),
+                // (12,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static void F<T>(params MyCollection<T> c)
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 22));
+        }
+
+        [Fact]
+        public void CollectionBuilder_GenericConstraints_03()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T[] args, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.AddRange(args);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) where T : struct => new(args, items);
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [with(), 1];
+                        c.Report();
+                        c = [with(2, 3)];
+                        c.Report();
+                        F<int>();
+                        F(4, 5);
+                    }
+                    static void F<T>(params MyCollection<T> c) where T : struct
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB1, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+                // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(), 1];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+                // (10,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(2, 3)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2, 3)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 13),
+                // (12,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F<int>();
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<int>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 9),
+                // (13,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F(4, 5);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(4, 5)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(13, 9),
+                // (15,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static void F<T>(params MyCollection<T> c) where T : struct
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(15, 22));
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> c;
+                        c = [];
+                        c = [with(), 1];
+                        c = [with(2, 3)];
+                        F<object>();
+                        F((object)4, 5);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceA, sourceB2],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+                // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(), 1];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+                // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(2, 3)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2, 3)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+                // (9,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F<object>();
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<object>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 9),
+                // (10,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         F((object)4, 5);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F((object)4, 5)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 9),
+                // (12,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static void F<T>(params MyCollection<T> c)
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 22));
+        }
+
+        [Fact]
+        public void List_NoElements()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Report(ListNoArguments<int>());
+                        Report(ListEmptyArguments<int>());
+                        Report(ListWithCapacity<int>(16));
+                    }
+                    static void Report<T>(List<T> list)
+                    {
+                        Console.WriteLine("Count:{0}, Capacity:{1}", list.Count, list.Capacity);
+                    }
+                    static List<T> ListNoArguments<T>() => [];
+                    static List<T> ListEmptyArguments<T>() => [with()];
+                    static List<T> ListWithCapacity<T>(int capacity) => [with(capacity: capacity)];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                source,
+                expectedOutput: """
+                    Count:0, Capacity:0
+                    Count:0, Capacity:0
+                    Count:0, Capacity:16
+                    """);
+            verifier.VerifyDiagnostics();
+            string expectedILNoArguments = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+                  IL_0005:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.ListNoArguments<T>", expectedILNoArguments);
+            verifier.VerifyIL("Program.ListEmptyArguments<T>", expectedILNoArguments);
+            verifier.VerifyIL("Program.ListWithCapacity<T>", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void List_SingleSpread()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Report(ListNoArguments([1, 2]));
+                        Report(ListEmptyArguments([3, 4]));
+                        Report(ListWithCapacity([5, 6], 16));
+                    }
+                    static void Report<T>(List<T> list)
+                    {
+                        list.Report();
+                        Console.WriteLine("Capacity:{0}", list.Capacity);
+                    }
+                    static List<T> ListNoArguments<T>(IEnumerable<T> e) => [..e];
+                    static List<T> ListEmptyArguments<T>(IEnumerable<T> e) => [with(), ..e];
+                    static List<T> ListWithCapacity<T>(IEnumerable<T> e, int capacity) => [with(capacity: capacity), ..e];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                expectedOutput: """
+                    [1, 2], Capacity:2
+                    [3, 4], Capacity:2
+                    [5, 6], Capacity:16
+                    """);
+            verifier.VerifyDiagnostics();
+            string expectedILNoArguments = """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "System.Collections.Generic.List<T> System.Linq.Enumerable.ToList<T>(System.Collections.Generic.IEnumerable<T>)"
+                  IL_0006:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.ListNoArguments<T>", expectedILNoArguments);
+            verifier.VerifyIL("Program.ListEmptyArguments<T>", expectedILNoArguments);
+            verifier.VerifyIL("Program.ListWithCapacity<T>", """
+                {
+                  // Code size       52 (0x34)
+                  .maxstack  2
+                  .locals init (System.Collections.Generic.List<T> V_0,
+                                System.Collections.Generic.IEnumerator<T> V_1,
+                                T V_2)
+                  IL_0000:  ldarg.1
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  stloc.0
+                  IL_0007:  ldarg.0
+                  IL_0008:  callvirt   "System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator()"
+                  IL_000d:  stloc.1
+                  .try
+                  {
+                    IL_000e:  br.s       IL_001e
+                    IL_0010:  ldloc.1
+                    IL_0011:  callvirt   "T System.Collections.Generic.IEnumerator<T>.Current.get"
+                    IL_0016:  stloc.2
+                    IL_0017:  ldloc.0
+                    IL_0018:  ldloc.2
+                    IL_0019:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                    IL_001e:  ldloc.1
+                    IL_001f:  callvirt   "bool System.Collections.IEnumerator.MoveNext()"
+                    IL_0024:  brtrue.s   IL_0010
+                    IL_0026:  leave.s    IL_0032
+                  }
+                  finally
+                  {
+                    IL_0028:  ldloc.1
+                    IL_0029:  brfalse.s  IL_0031
+                    IL_002b:  ldloc.1
+                    IL_002c:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_0031:  endfinally
+                  }
+                  IL_0032:  ldloc.0
+                  IL_0033:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void CollectionBuilder_SingleSpread()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T[] args, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.AddRange(items.ToArray());
+                        _items.AddRange(args);
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(args, items);
+                }
+                """;
+            string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArguments([1, 2]).Report();
+                        EmptyArguments([3, 4]).Report();
+                        WithArguments([5, 6], 7).Report();
+                    }
+                    static MyCollection<T> NoArguments<T>(ReadOnlySpan<T> s) => [..s];
+                    static MyCollection<T> EmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+                    static MyCollection<T> WithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (10,65): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> NoArguments<T>(ReadOnlySpan<T> s) => [..s];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[..s]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 65),
+                // (11,68): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> EmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), ..s]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 68),
+                // (12,84): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //     static MyCollection<T> WithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args), ..s]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 84));
+        }
+
+        [Fact]
+        public void ImmutableArray_NoElements()
+        {
+            string sourceA = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                namespace System.Collections.Immutable
+                {
+                    [CollectionBuilder(typeof(MyBuilder), "Create")]
+                    public struct ImmutableArray<T> : IEnumerable<T>
+                    {
+                        public static readonly ImmutableArray<T> Empty = new(default, new T[0]);
+                        private readonly List<T> _items;
+                        internal ImmutableArray(ReadOnlySpan<T> items, T[] args)
+                        {
+                            _items = new();
+                            _items.AddRange(items.ToArray());
+                            _items.AddRange(args);
+                        }
+                        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    }
+                    public static class MyBuilder
+                    {
+                        public static ImmutableArray<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(items, args);
+                    }
+                }
+                """;
+            string sourceB = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System.Collections.Immutable;
+                class Program
+                {
+                    static void Main()
+                    {
+                        ImmutableArrayNoArguments<int>().Report();
+                        ImmutableArrayEmptyArguments<int>().Report();
+                        ImmutableArrayWithArguments(5, 6).Report();
+                    }
+                    static ImmutableArray<T> ImmutableArrayNoArguments<T>() => [];
+                    static ImmutableArray<T> ImmutableArrayEmptyArguments<T>() => [with()];
+                    static ImmutableArray<T> ImmutableArrayWithArguments<T>(params T[] args) => [with(args)];
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (11,64): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+                //     static ImmutableArray<T> ImmutableArrayNoArguments<T>() => [];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(11, 64),
+                // (12,67): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+                //     static ImmutableArray<T> ImmutableArrayEmptyArguments<T>() => [with()];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(12, 67),
+                // (13,81): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+                //     static ImmutableArray<T> ImmutableArrayWithArguments<T>(params T[] args) => [with(args)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args)]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(13, 81));
+        }
+
+        [Fact]
+        public void ImmutableArray_SingleSpread()
+        {
+            string sourceA = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                namespace System.Collections.Immutable
+                {
+                    [CollectionBuilder(typeof(MyBuilder), "Create")]
+                    public struct ImmutableArray<T> : IEnumerable<T>
+                    {
+                        private readonly List<T> _items;
+                        internal ImmutableArray(ReadOnlySpan<T> items, T[] args)
+                        {
+                            _items = new();
+                            _items.AddRange(items.ToArray());
+                            _items.AddRange(args);
+                        }
+                        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    }
+                    public static class MyBuilder
+                    {
+                        public static ImmutableArray<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(items, args);
+                    }
+                }
+                """;
+            string sourceB = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System;
+                using System.Collections.Immutable;
+                class Program
+                {
+                    static void Main()
+                    {
+                        ImmutableArrayNoArguments([1, 2]).Report();
+                        ImmutableArrayEmptyArguments([3, 4]).Report();
+                        ImmutableArrayWithArguments([5, 6], 7).Report();
+                    }
+                    static ImmutableArray<T> ImmutableArrayNoArguments<T>(ReadOnlySpan<T> s) => [..s];
+                    static ImmutableArray<T> ImmutableArrayEmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+                    static ImmutableArray<T> ImmutableArrayWithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (12,81): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+                //     static ImmutableArray<T> ImmutableArrayNoArguments<T>(ReadOnlySpan<T> s) => [..s];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[..s]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(12, 81),
+                // (13,84): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+                //     static ImmutableArray<T> ImmutableArrayEmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), ..s]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(13, 84),
+                // (14,100): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+                //     static ImmutableArray<T> ImmutableArrayWithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args), ..s]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(14, 100));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RefSafety_ConstructorArguments(bool scopedInParameter, bool scopedOutArgument)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                ref struct R<T>
+                {
+                    public R(ref T t) { }
+                }
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection() { }
+                    public MyCollection({{(scopedInParameter ? "scoped" : "")}} R<T> a, out R<T> b) { b = default; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                """;
+            string sourceB = $$"""
+                class Program
+                {
+                    static void F<T>(T x, T y)
+                    {
+                        MyCollection<T> c;
+                        T t = default;
+                        R<T> a = new(ref t);
+                        {{(scopedOutArgument ? "scoped" : "")}} R<T> b;
+                        c = new(a, out b);
+                        c = [with(a, out b), x, y];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            if (scopedInParameter || scopedOutArgument)
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS8350: This combination of arguments to 'MyCollection<T>.MyCollection(R<T>, out R<T>)' is disallowed because it may expose variables referenced by parameter 'a' outside of their declaration scope
+                    //         c = new(a, out b);
+                    Diagnostic(ErrorCode.ERR_CallArgMixing, "new(a, out b)").WithArguments("MyCollection<T>.MyCollection(R<T>, out R<T>)", "a").WithLocation(9, 13),
+                    // (9,17): error CS8352: Cannot use variable 'a' in this context because it may expose referenced variables outside of their declaration scope
+                    //         c = new(a, out b);
+                    Diagnostic(ErrorCode.ERR_EscapeVariable, "a").WithArguments("a").WithLocation(9, 17),
+                    // (10,13): error CS8350: This combination of arguments to 'MyCollection<T>.MyCollection(R<T>, out R<T>)' is disallowed because it may expose variables referenced by parameter 'a' outside of their declaration scope
+                    //         c = [with(a, out b), x, y];
+                    Diagnostic(ErrorCode.ERR_CallArgMixing, "[with(a, out b), x, y]").WithArguments("MyCollection<T>.MyCollection(R<T>, out R<T>)", "a").WithLocation(10, 13),
+                    // (10,19): error CS8352: Cannot use variable 'a' in this context because it may expose referenced variables outside of their declaration scope
+                    //         c = [with(a, out b), x, y];
+                    Diagnostic(ErrorCode.ERR_EscapeVariable, "a").WithArguments("a").WithLocation(10, 19));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RefSafety_CollectionBuilderArguments(bool scopedInParameter, bool scopedOutArgument)
+        {
+            string sourceA = $$"""
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>({{(scopedInParameter ? "scoped" : "")}} ReadOnlySpan<T> items, out ReadOnlySpan<T> other)
+                    {
+                        other = default;
+                        return default;
+                    }
+                }
+                """;
+            string sourceB = $$"""
+                using System;
+                class Program
+                {
+                    static void F<T>(T x, T y)
+                    {
+                        MyCollection<T> c;
+                        {{(scopedOutArgument ? "scoped" : "")}} ReadOnlySpan<T> s;
+                        c = MyBuilder.Create([x, y], out s);
+                        c = [with(out s), x, y];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+            if (scopedInParameter || scopedOutArgument)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                    //         c = [with(out s), x, y];
+                    Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(out s), x, y]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (8,13): error CS8350: This combination of arguments to 'MyBuilder.Create<T>(ReadOnlySpan<T>, out ReadOnlySpan<T>)' is disallowed because it may expose variables referenced by parameter 'items' outside of their declaration scope
+                    //         c = MyBuilder.Create([x, y], out s);
+                    Diagnostic(ErrorCode.ERR_CallArgMixing, "MyBuilder.Create([x, y], out s)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>, out System.ReadOnlySpan<T>)", "items").WithLocation(8, 13),
+                    // (8,30): error CS9203: A collection expression of type 'ReadOnlySpan<T>' cannot be used in this context because it may be exposed outside of the current scope.
+                    //         c = MyBuilder.Create([x, y], out s);
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[x, y]").WithArguments("System.ReadOnlySpan<T>").WithLocation(8, 30),
+                    // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                    //         c = [with(out s), x, y];
+                    Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(out s), x, y]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13));
+            }
+        }
+
+        [Fact]
+        public void Empty_TypeParameter()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                interface IAdd<T> : IEnumerable<T>
+                {
+                    void Add(T t);
+                }
+                struct MyCollection<T> : IAdd<T>
+                {
+                    private List<T> _list;
+                    void IAdd<T>.Add(T t) { GetList().Add(t); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetList().GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetList().GetEnumerator();
+                    private List<T> GetList() => _list ??= new();
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int, MyCollection<int>>().Report();
+                        EmptyArgs<int, MyCollection<int>>().Report();
+                    }
+                    static U NoArgs<T, U>()
+                        where U : IAdd<T>, new()
+                    {
+                        return [];
+                    }
+                    static U EmptyArgs<T, U>()
+                        where U : IAdd<T>, new()
+                    {
+                        return [with()];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB1, s_collectionExtensions],
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  call       "U System.Activator.CreateInstance<U>()"
+                  IL_0005:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoArgs<T, U>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<T, U>", expectedIL);
+
+            string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int, MyCollection<int>>().Report();
+                        EmptyArgs<int, MyCollection<int>>().Report();
+                    }
+                    static U NoArgs<T, U>()
+                        where U : struct, IAdd<T>
+                    {
+                        return [];
+                    }
+                    static U EmptyArgs<T, U>()
+                        where U : struct, IAdd<T>
+                    {
+                        return [with()];
+                    }
+                }
+                """;
+            verifier = CompileAndVerify(
+                [sourceA, sourceB2, s_collectionExtensions],
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[], [], "));
+            verifier.VerifyDiagnostics();
+            expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  call       "U System.Activator.CreateInstance<U>()"
+                  IL_0005:  ret
+                }
+                """;
+            verifier.VerifyIL("Program.NoArgs<T, U>", expectedIL);
+            verifier.VerifyIL("Program.EmptyArgs<T, U>", expectedIL);
+        }
+
+        [Fact]
+        public void Arguments_TypeParameter()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                interface IAdd<T> : IEnumerable<T>
+                {
+                    void Add(T t);
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void NonEmptyArgsNew<T, U>(T t)
+                        where U : IAdd<T>, new()
+                    {
+                        U x;
+                        x = [with(t), t];
+                        x = [t, with(t)];
+                    }
+                    static void NonEmptyArgsStruct<T, U>(T t)
+                        where U : struct, IAdd<T>
+                    {
+                        U y;
+                        y = [with(t), t];
+                        y = [t, with(t)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (7,13): error CS0417: 'U': cannot provide arguments when creating an instance of a variable type
+                //         x = [with(t), t];
+                Diagnostic(ErrorCode.ERR_NewTyvarWithArgs, "[with(t), t]").WithArguments("U").WithLocation(7, 13),
+                // (8,13): error CS0417: 'U': cannot provide arguments when creating an instance of a variable type
+                //         x = [t, with(t)];
+                Diagnostic(ErrorCode.ERR_NewTyvarWithArgs, "[t, with(t)]").WithArguments("U").WithLocation(8, 13),
+                // (8,17): error CS9301: Collection argument element must be the first element.
+                //         x = [t, with(t)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(8, 17),
+                // (14,13): error CS0417: 'U': cannot provide arguments when creating an instance of a variable type
+                //         y = [with(t), t];
+                Diagnostic(ErrorCode.ERR_NewTyvarWithArgs, "[with(t), t]").WithArguments("U").WithLocation(14, 13),
+                // (15,13): error CS0417: 'U': cannot provide arguments when creating an instance of a variable type
+                //         y = [t, with(t)];
+                Diagnostic(ErrorCode.ERR_NewTyvarWithArgs, "[t, with(t)]").WithArguments("U").WithLocation(15, 13),
+                // (15,17): error CS9301: Collection argument element must be the first element.
+                //         y = [t, with(t)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(15, 17));
+        }
+
+        [Fact]
+        public void UnrecognizedType()
+        {
+            string source = """
+                class Program
+                {
+                    static A EmptyArgs() => [with()];
+                    static B NonEmptyArgs() => [with(default)];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (3,12): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                //     static A EmptyArgs() => [with()];
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(3, 12),
+                // (4,12): error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)
+                //     static B NonEmptyArgs() => [with(default)];
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "B").WithArguments("B").WithLocation(4, 12));
+        }
+
+        [Fact]
+        public void EvaluationOrder_CollectionInitializer()
+        {
+            string sourceA = """
+                using System;
+                class A
+                {
+                    private int _i;
+                    private A(int i) { _i = i; }
+                    public static implicit operator A(int i)
+                    {
+                        Console.WriteLine("{0} -> A", i);
+                        return new(i);
+                    }
+                    public override string ToString() => _i.ToString();
+                }
+                """;
+            string sourceB = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection(A x = null, A y = null) { Console.WriteLine("MyCollection({0}, {1})", x, y); }
+                    public void Add(T t) { Console.WriteLine("Add({0})", t); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceC = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<A> c;
+                        c = [with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB, sourceC],
+                expectedOutput: """
+                    1
+                    1 -> A
+                    2
+                    2 -> A
+                    MyCollection(2, 1)
+                    3
+                    3 -> A
+                    Add(3)
+                    4
+                    4 -> A
+                    Add(4)
+                    """);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Main()", """
+                {
+                  // Code size       65 (0x41)
+                  .maxstack  3
+                  .locals init (A V_0)
+                  IL_0000:  ldc.i4.1
+                  IL_0001:  call       "int Program.Identity<int>(int)"
+                  IL_0006:  call       "A A.op_Implicit(int)"
+                  IL_000b:  stloc.0
+                  IL_000c:  ldc.i4.2
+                  IL_000d:  call       "int Program.Identity<int>(int)"
+                  IL_0012:  call       "A A.op_Implicit(int)"
+                  IL_0017:  ldloc.0
+                  IL_0018:  newobj     "MyCollection<A>..ctor(A, A)"
+                  IL_001d:  dup
+                  IL_001e:  ldc.i4.3
+                  IL_001f:  call       "int Program.Identity<int>(int)"
+                  IL_0024:  call       "A A.op_Implicit(int)"
+                  IL_0029:  callvirt   "void MyCollection<A>.Add(A)"
+                  IL_002e:  dup
+                  IL_002f:  ldc.i4.4
+                  IL_0030:  call       "int Program.Identity<int>(int)"
+                  IL_0035:  call       "A A.op_Implicit(int)"
+                  IL_003a:  callvirt   "void MyCollection<A>.Add(A)"
+                  IL_003f:  pop
+                  IL_0040:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void EvaluationOrder_CollectionBuilder()
+        {
+            string sourceA = """
+                using System;
+                class A
+                {
+                    private int _i;
+                    private A(int i) { _i = i; }
+                    public static implicit operator A(int i)
+                    {
+                        Console.WriteLine("{0} -> A", i);
+                        return new(i);
+                    }
+                    public override string ToString() => _i.ToString();
+                }
+                """;
+            string sourceB = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection(ReadOnlySpan<T> items, A x, A y) { Console.WriteLine("MyCollection({0}, {1})", x, y); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, A x = null, A y = null) => new(items, x, y);
+                }
+                """;
+            string sourceC = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<A> c;
+                        c = [with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            // https://github.com/dotnet/roslyn/issues/77866: 1, ..., 2, ..., should be evaluated before 3, ..., 4, ... .
+            // Should be fixed when the last parameter of the builder method is the items parameter.
+            var comp = CreateCompilation(
+                [sourceA, sourceB, sourceC],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13));
+        }
+
+        [Fact]
+        public void Arglist()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection : IEnumerable
+                {
+                    public readonly List<int> Args;
+                    public MyCollection() { Args = new(); }
+                    public MyCollection(__arglist) { Args = GetArgs(0, new ArgIterator(__arglist)); }
+                    public MyCollection(int x, __arglist) { Args = GetArgs(x, new ArgIterator(__arglist)); }
+                    private static List<int> GetArgs(int x, ArgIterator iterator)
+                    {
+                        var args = new List<int>();
+                        args.Add(x);
+                        while (iterator.GetRemainingCount() > 0)
+                            args.Add(__refvalue(iterator.GetNextArg(), int));
+                        return args;
+                    }
+                    public void Add(object o) { }
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        F1().Args.Report();
+                        F2().Args.Report();
+                        F3(1, 2).Args.Report();
+                        F4(3, 4).Args.Report();
+                    }
+                    static MyCollection F1() => [with()];
+                    static MyCollection F2() => [with(__arglist())];
+                    static MyCollection F3(int x, int y) => [with(__arglist(x, y))];
+                    static MyCollection F4(int x, int y) => [with(x, __arglist(y))];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB, s_collectionExtensions],
+                targetFramework: TargetFramework.NetFramework,
+                verify: Verification.FailsILVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? null : "[], [0], [0, 1, 2], [3, 4], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.F1", """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "MyCollection..ctor()"
+                  IL_0005:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.F2", """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "MyCollection..ctor(__arglist)"
+                  IL_0005:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.F3", """
+                {
+                  // Code size        8 (0x8)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldarg.1
+                  IL_0002:  newobj     "MyCollection..ctor(__arglist) with __arglist( int, int)"
+                  IL_0007:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.F4", """
+                {
+                  // Code size        8 (0x8)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldarg.1
+                  IL_0002:  newobj     "MyCollection..ctor(int, __arglist) with __arglist( int)"
+                  IL_0007:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void Arglist_NoParameterlessConstructor()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                class MyCollection : IEnumerable
+                {
+                    public MyCollection(__arglist) { }
+                    public void Add(object o) { }
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection c;
+                        c = [];
+                        c = [with()];
+                        c = [with(__arglist())];
+                        c = [with(__arglist(0))];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (7,13): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                //         c = [];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[]").WithLocation(7, 13),
+                // (8,13): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                //         c = [with()];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with()]").WithLocation(8, 13),
+                // (9,13): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                //         c = [with(__arglist())];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with(__arglist())]").WithLocation(9, 13),
+                // (10,13): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                //         c = [with(__arglist(0))];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with(__arglist(0))]").WithLocation(10, 13));
+        }
+
+        [Fact]
+        public void DynamicArguments_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        List<object> l;
+                        l = [with(), (dynamic)2];
+                        l = [with(capacity: 1)];
+                        l = [with(capacity: (dynamic)1)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (9,29): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         l = [with(capacity: (dynamic)1)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)1").WithLocation(9, 29));
+        }
+
+        [Fact]
+        public void DynamicArguments_02()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection(object x = null, object y = null) { }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with(), (dynamic)3];
+                        c = [with(1)];
+                        c = [with(y: "2")];
+                        c = [with(1, "2"), (dynamic)3];
+                        c = [with((dynamic)1)];
+                        c = [with(y: (dynamic)"2")];
+                        c = [3, with(1, (dynamic)"2")];
+                        c = [with((dynamic)1, (dynamic)"2"), 3];
+                        c = [with(x => { })];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (10,19): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [with((dynamic)1)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)1").WithLocation(10, 19),
+                // (11,22): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [with(y: (dynamic)"2")];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, @"(dynamic)""2""").WithLocation(11, 22),
+                // (12,17): error CS9301: Collection argument element must be the first element.
+                //         c = [3, with(1, (dynamic)"2")];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(12, 17),
+                // (12,25): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [3, with(1, (dynamic)"2")];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, @"(dynamic)""2""").WithLocation(12, 25),
+                // (13,19): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [with((dynamic)1, (dynamic)"2"), 3];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)1").WithLocation(13, 19),
+                // (14,21): error CS8917: The delegate type could not be inferred.
+                //         c = [with(x => { })];
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "=>").WithLocation(14, 21));
+        }
+
+        [Theory]
+        [InlineData("ref")]
+        [InlineData("in ")]
+        [InlineData("out")]
+        public void DynamicArguments_03(string refKind)
+        {
+            string source = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection() { }
+                    public MyCollection({{refKind}} object obj) { throw null; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        object o = null;
+                        dynamic d = o;
+                        MyCollection<object> c;
+                        c = [with({{refKind}} o)];
+                        c = [with({{refKind}} d)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (19,23): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [with(in  d)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(19, 23));
+        }
+
+        [Fact]
+        public void DynamicArguments_04()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection : IEnumerable
+                {
+                    public MyCollection(dynamic d = null) { }
+                    public void Add(object o) { }
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        object o = null;
+                        dynamic d = o;
+                        MyCollection c;
+                        c = [with()];
+                        c = [with(null)];
+                        c = [with(default)];
+                        c = [with(0)];
+                        c = [with((dynamic)null)];
+                        c = [with((dynamic)0)];
+                        c = [with(o)];
+                        c = [with(d)];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (12,19): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [with((dynamic)null)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)null").WithLocation(12, 19),
+                // (13,19): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [with((dynamic)0)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)0").WithLocation(13, 19),
+                // (15,19): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         c = [with(d)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(15, 19));
+        }
+
+        [Fact]
+        public void DynamicArguments_05()
+        {
+            string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        A a;
+                        a = [with(null), (dynamic)null];
+                        a = [with((dynamic)null), null];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (5,9): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                //         A a;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(5, 9),
+                // (7,19): error CS9303: Collection arguments cannot be dynamic; compile-time binding is required.
+                //         a = [with((dynamic)null), null];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)null").WithLocation(7, 19));
+        }
+
+        [Fact]
+        public void TypeInference_List()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([with()]);
+                        Identity([with(capacity: 1), default]);
+                        Identity([with(capacity: 1), 3]);
+                        Identity([with(collection: [default, 2]), default]);
+                        Identity([with(collection: [default]), default, 3]);
+                    }
+                    static List<T> Identity<T>(List<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,9): error CS0411: The type arguments for method 'Program.Identity<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([with()]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(System.Collections.Generic.List<T>)").WithLocation(6, 9),
+                // (7,9): error CS0411: The type arguments for method 'Program.Identity<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([with(capacity: 1), default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(System.Collections.Generic.List<T>)").WithLocation(7, 9),
+                // (9,9): error CS0411: The type arguments for method 'Program.Identity<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([with(collection: [default, 2]), default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(System.Collections.Generic.List<T>)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TypeInference_CollectionInitializer()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(params T[] args) { _items = new(args); }
+                    public void Add(T t) { _items.Add(t); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([with()]);
+                        Identity([with(default, 2), default]);
+                        Identity([with(default), default, 3]);
+                    }
+                    static MyCollection<T> Identity<T>(MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (5,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([with()]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(5, 9),
+                // (6,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([with(default, 2), default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(6, 9));
+        }
+
+        [Fact]
+        public void TypeInference_CollectionBuilder()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T[] args, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.AddRange(items.ToArray());
+                        _items.AddRange(args);
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(args, items);
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([with()]);
+                        Identity([with(default, 2), default]);
+                        Identity([with(default), default, 3]);
+                    }
+                    static MyCollection<T> Identity<T>(MyCollection<T> c) => c;
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB],
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (5,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([with()]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(5, 9),
+                // (6,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([with(default, 2), default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(6, 9),
+                // (7,18): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         Identity([with(default), default, 3]);
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default), default, 3]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 18),
+                // (7,24): error CS8716: There is no target type for the default literal.
+                //         Identity([with(default), default, 3]);
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(7, 24),
+                // (7,34): error CS8716: There is no target type for the default literal.
+                //         Identity([with(default), default, 3]);
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(7, 34));
+        }
+
+        [Fact]
+        public void ParamsCycle_ParamsConstructorOnly()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    public MyCollection(params MyCollection<T> other) { _list = new(other); }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+            string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(null)];
+                c = [with(1)];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (2,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+                // c = [];
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(2, 5),
+                // (3,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+                // c = [with()];
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with()]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(3, 5),
+                // (5,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+                // c = [with(1)];
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with(1)]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(5, 5));
+        }
+
+        [Fact]
+        public void ParamsCycle_MultipleConstructors()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    public MyCollection() { _list = new(); }
+                    public MyCollection(params MyCollection<T> other) { _list = new(other); }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+            string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(null)];
+                c = [with(1)];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (5,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection()'.
+                // c = [with(1)];
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with(1)]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection()").WithLocation(5, 5));
+        }
+
+        [Fact]
+        public void ParamsCycle_PrivateParameterlessConstructor()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    private MyCollection() { }
+                    public MyCollection(params MyCollection<T> other) { _list = new(other); }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+            string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(null)];
+                c = [with(1)];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (2,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+                // c = [];
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(2, 5),
+                // (3,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+                // c = [with()];
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with()]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(3, 5),
+                // (5,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+                // c = [with(1)];
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with(1)]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(5, 5),
+                // (9,25): error CS9224: Method 'MyCollection<T>.MyCollection()' cannot be less visible than the member with params collection 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+                //     public MyCollection(params MyCollection<T> other) { _list = new(other); }
+                Diagnostic(ErrorCode.ERR_ParamsMemberCannotBeLessVisibleThanDeclaringMember, "params MyCollection<T> other").WithArguments("MyCollection<T>.MyCollection()", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(9, 25));
+        }
+
+        [Fact]
+        public void ParamsCycle_NoParameterlessConstructor()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    public MyCollection(T x, params MyCollection<T> y)
+                    {
+                        _list = new();
+                        _list.Add(x);
+                        _list.AddRange(y);
+                    }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+            string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(1)];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (2,5): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                // c = [];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[]").WithLocation(2, 5),
+                // (3,5): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                // c = [with()];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with()]").WithLocation(3, 5),
+                // (4,5): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+                // c = [with(1)];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with(1)]").WithLocation(4, 5),
+                // (8,30): error CS9228: Non-array params collection type must have an applicable constructor that can be called with no arguments.
+                //     public MyCollection(T x, params MyCollection<T> y)
+                Diagnostic(ErrorCode.ERR_ParamsCollectionMissingConstructor, "params MyCollection<T> y").WithLocation(8, 30));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
@@ -1,0 +1,4332 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class DictionaryExpressionTests : CSharpTestBase
+    {
+        private static string IncludeExpectedOutput(string expectedOutput) => ExecutionConditionUtil.IsMonoOrCoreClr ? expectedOutput : null;
+
+        private const string s_collectionExtensions = CollectionExpressionTests.s_collectionExtensions;
+        private const string s_dictionaryExtensions = """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Text;
+            static class DictionaryExtensions
+            {
+                private static void Append(StringBuilder builder, object value)
+                {
+                    builder.Append(value is null ? "null" : value.ToString());
+                }
+                internal static void Report<K, V>(this IEnumerable<KeyValuePair<K, V>> e)
+                {
+                    e = e.OrderBy(kvp => kvp.Key);
+                    var builder = new StringBuilder();
+                    builder.Append("[");
+                    bool isFirst = true;
+                    foreach (var kvp in e)
+                    {
+                        if (!isFirst) builder.Append(", ");
+                        isFirst = false;
+                        Append(builder, kvp.Key);
+                        builder.Append(":");
+                        Append(builder, kvp.Value);
+                    }
+                    builder.Append("], ");
+                    Console.Write(builder.ToString());
+                }
+            }
+            """;
+
+        public static readonly TheoryData<LanguageVersion> LanguageVersions = new([LanguageVersion.CSharp13, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_01(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d = [1:"one"];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (2,30): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // IDictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, @"[1:""one""]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(2, 30),
+                    // (2,32): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // IDictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(2, 32));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_02(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d;
+                d = [];
+                var x = new KeyValuePair<int, string>(2, "two");
+                var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                d = [x];
+                d = [..y];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (3,5): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // d = [];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(3, 5),
+                    // (6,5): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // d = [x];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[x]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(6, 5),
+                    // (7,5): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // d = [..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[..y]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(7, 5));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_03(LanguageVersion languageVersion)
+        {
+            string source = """
+                var x = [1:"one"];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,9): error CS9176: There is no target type for the collection expression.
+                    // var x = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, @"[1:""one""]").WithLocation(1, 9),
+                    // (1,11): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // var x = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(1, 11));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,9): error CS9176: There is no target type for the collection expression.
+                    // var x = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, @"[1:""one""]").WithLocation(1, 9));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_04(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Dictionary<int, string> d = [];
+                        d.Report();
+                    }
+                }
+                """;
+            // C#12 collection expressions support target types that implement IEnumerable,
+            // with no Add requirement if the collection is empty.
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: "[], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size       11 (0xb)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                  IL_0005:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_000a:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void LanguageVersionDiagnostics_05(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            bool includeExtensionAdd)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Dictionary<int, string> d = [1:"one"];
+                        d.Report();
+                    }
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                static class Extensions
+                {
+                    internal static void Add<K, V>(this Dictionary<K, V> d, KeyValuePair<K, V> kvp)
+                    {
+                        d.Add(kvp.Key, kvp.Value);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                includeExtensionAdd ? [sourceA, sourceB, s_dictionaryExtensions] : [sourceA, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13 && !includeExtensionAdd)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,37): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, @"[1:""one""]").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(6, 37),
+                    // (6,38): error CS9300: Collection expression type 'Dictionary<int, string>' does not support key-value pair elements.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"1:""one""").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(6, 38),
+                    // (6,39): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(6, 39));
+            }
+            else if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,38): error CS9300: Collection expression type 'Dictionary<int, string>' does not support key-value pair elements.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"1:""one""").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(6, 38),
+                    // (6,39): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(6, 39));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[1:one], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size       23 (0x17)
+                      .maxstack  4
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                      IL_0005:  dup
+                      IL_0006:  ldc.i4.1
+                      IL_0007:  ldstr      "one"
+                      IL_000c:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                      IL_0011:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0016:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void BreakingChange_DictionaryAdd_01(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            bool includeExtensionAdd)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Dictionary<int, string> d;
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        d = [x];
+                        d.Report();
+                        d = [..y];
+                        d.Report();
+                    }
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                static class Extensions
+                {
+                    internal static void Add<K, V>(this Dictionary<K, V> d, KeyValuePair<K, V> kvp)
+                    {
+                        d.Add(kvp.Key, kvp.Value);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                includeExtensionAdd ? [sourceA, sourceB, s_dictionaryExtensions] : [sourceA, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13 && !includeExtensionAdd)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
+                    //         d = [x];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[x]").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(9, 13),
+                    // (11,13): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
+                    //         d = [..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[..y]").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(11, 13));
+                return;
+            }
+            var verifier = CompileAndVerify(comp, expectedOutput: "[2:two], [3:three], ");
+            verifier.VerifyDiagnostics();
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                        // Code size       99 (0x63)
+                        .maxstack  5
+                        .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    System.Collections.Generic.Dictionary<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_4)
+                        IL_0000:  ldloca.s   V_0
+                        IL_0002:  ldc.i4.2
+                        IL_0003:  ldstr      "two"
+                        IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                        IL_000d:  ldc.i4.1
+                        IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                        IL_0013:  dup
+                        IL_0014:  ldc.i4.0
+                        IL_0015:  ldc.i4.3
+                        IL_0016:  ldstr      "three"
+                        IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                        IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                        IL_0025:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                        IL_002a:  dup
+                        IL_002b:  ldloc.0
+                        IL_002c:  call       "void Extensions.Add<int, string>(System.Collections.Generic.Dictionary<int, string>, System.Collections.Generic.KeyValuePair<int, string>)"
+                        IL_0031:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                        IL_0036:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                        IL_003b:  stloc.1
+                        IL_003c:  stloc.2
+                        IL_003d:  ldc.i4.0
+                        IL_003e:  stloc.3
+                        IL_003f:  br.s       IL_0056
+                        IL_0041:  ldloc.2
+                        IL_0042:  ldloc.3
+                        IL_0043:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                        IL_0048:  stloc.s    V_4
+                        IL_004a:  ldloc.1
+                        IL_004b:  ldloc.s    V_4
+                        IL_004d:  call       "void Extensions.Add<int, string>(System.Collections.Generic.Dictionary<int, string>, System.Collections.Generic.KeyValuePair<int, string>)"
+                        IL_0052:  ldloc.3
+                        IL_0053:  ldc.i4.1
+                        IL_0054:  add
+                        IL_0055:  stloc.3
+                        IL_0056:  ldloc.3
+                        IL_0057:  ldloc.2
+                        IL_0058:  ldlen
+                        IL_0059:  conv.i4
+                        IL_005a:  blt.s      IL_0041
+                        IL_005c:  ldloc.1
+                        IL_005d:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                        IL_0062:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                // Using indexer rather than extension method Add() is a breaking change from C#13.
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      130 (0x82)
+                      .maxstack  5
+                      .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    System.Collections.Generic.KeyValuePair<int, string> V_1,
+                                    System.Collections.Generic.Dictionary<int, string> V_2,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_3,
+                                    int V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.2
+                      IL_0003:  ldstr      "two"
+                      IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_000d:  ldc.i4.1
+                      IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0013:  dup
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  ldc.i4.3
+                      IL_0016:  ldstr      "three"
+                      IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0025:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                      IL_002a:  ldloc.0
+                      IL_002b:  stloc.1
+                      IL_002c:  dup
+                      IL_002d:  ldloca.s   V_1
+                      IL_002f:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0034:  ldloca.s   V_1
+                      IL_0036:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_003b:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                      IL_0040:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0045:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                      IL_004a:  stloc.2
+                      IL_004b:  stloc.3
+                      IL_004c:  ldc.i4.0
+                      IL_004d:  stloc.s    V_4
+                      IL_004f:  br.s       IL_0074
+                      IL_0051:  ldloc.3
+                      IL_0052:  ldloc.s    V_4
+                      IL_0054:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0059:  stloc.1
+                      IL_005a:  ldloc.2
+                      IL_005b:  ldloca.s   V_1
+                      IL_005d:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0062:  ldloca.s   V_1
+                      IL_0064:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0069:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                      IL_006e:  ldloc.s    V_4
+                      IL_0070:  ldc.i4.1
+                      IL_0071:  add
+                      IL_0072:  stloc.s    V_4
+                      IL_0074:  ldloc.s    V_4
+                      IL_0076:  ldloc.3
+                      IL_0077:  ldlen
+                      IL_0078:  conv.i4
+                      IL_0079:  blt.s      IL_0051
+                      IL_007b:  ldloc.2
+                      IL_007c:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0081:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void BreakingChange_DictionaryAdd_02(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            bool includeAdd)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                struct MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d;
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => GetDictionary().GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return GetDictionary()[key]; }
+                        set { GetDictionary()[key] = value; }
+                    }
+                    {{(includeAdd ? "public void Add(KeyValuePair<K, V> kvp) { ((ICollection<KeyValuePair<K, V>>)GetDictionary()).Add(kvp); }" : "")}}
+                    private Dictionary<K, V> GetDictionary() => _d ??= new();
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d;
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        d = [x];
+                        d.Report();
+                        d = [..y];
+                        d.Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13 && !includeAdd)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                    //         d = [x];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[x]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(9, 13),
+                    // (11,13): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                    //         d = [..y];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..y]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(11, 13));
+                return;
+            }
+            var verifier = CompileAndVerify(comp, expectedOutput: "[2:two], [3:three], ");
+            verifier.VerifyDiagnostics();
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      117 (0x75)
+                      .maxstack  5
+                      .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    MyDictionary<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.2
+                      IL_0003:  ldstr      "two"
+                      IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_000d:  ldc.i4.1
+                      IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0013:  dup
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  ldc.i4.3
+                      IL_0016:  ldstr      "three"
+                      IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0025:  ldloca.s   V_1
+                      IL_0027:  initobj    "MyDictionary<int, string>"
+                      IL_002d:  ldloca.s   V_1
+                      IL_002f:  ldloc.0
+                      IL_0030:  call       "void MyDictionary<int, string>.Add(System.Collections.Generic.KeyValuePair<int, string>)"
+                      IL_0035:  ldloc.1
+                      IL_0036:  box        "MyDictionary<int, string>"
+                      IL_003b:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0040:  ldloca.s   V_1
+                      IL_0042:  initobj    "MyDictionary<int, string>"
+                      IL_0048:  stloc.2
+                      IL_0049:  ldc.i4.0
+                      IL_004a:  stloc.3
+                      IL_004b:  br.s       IL_0063
+                      IL_004d:  ldloc.2
+                      IL_004e:  ldloc.3
+                      IL_004f:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0054:  stloc.s    V_4
+                      IL_0056:  ldloca.s   V_1
+                      IL_0058:  ldloc.s    V_4
+                      IL_005a:  call       "void MyDictionary<int, string>.Add(System.Collections.Generic.KeyValuePair<int, string>)"
+                      IL_005f:  ldloc.3
+                      IL_0060:  ldc.i4.1
+                      IL_0061:  add
+                      IL_0062:  stloc.3
+                      IL_0063:  ldloc.3
+                      IL_0064:  ldloc.2
+                      IL_0065:  ldlen
+                      IL_0066:  conv.i4
+                      IL_0067:  blt.s      IL_004d
+                      IL_0069:  ldloc.1
+                      IL_006a:  box        "MyDictionary<int, string>"
+                      IL_006f:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0074:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                // Using indexer rather than instance method Add() is a breaking change from C#13.
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      148 (0x94)
+                      .maxstack  5
+                      .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    MyDictionary<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_2,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_3,
+                                    int V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.2
+                      IL_0003:  ldstr      "two"
+                      IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_000d:  ldc.i4.1
+                      IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0013:  dup
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  ldc.i4.3
+                      IL_0016:  ldstr      "three"
+                      IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0025:  ldloca.s   V_1
+                      IL_0027:  initobj    "MyDictionary<int, string>"
+                      IL_002d:  ldloc.0
+                      IL_002e:  stloc.2
+                      IL_002f:  ldloca.s   V_1
+                      IL_0031:  ldloca.s   V_2
+                      IL_0033:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0038:  ldloca.s   V_2
+                      IL_003a:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_003f:  call       "void MyDictionary<int, string>.this[int].set"
+                      IL_0044:  ldloc.1
+                      IL_0045:  box        "MyDictionary<int, string>"
+                      IL_004a:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_004f:  ldloca.s   V_1
+                      IL_0051:  initobj    "MyDictionary<int, string>"
+                      IL_0057:  stloc.3
+                      IL_0058:  ldc.i4.0
+                      IL_0059:  stloc.s    V_4
+                      IL_005b:  br.s       IL_0081
+                      IL_005d:  ldloc.3
+                      IL_005e:  ldloc.s    V_4
+                      IL_0060:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0065:  stloc.2
+                      IL_0066:  ldloca.s   V_1
+                      IL_0068:  ldloca.s   V_2
+                      IL_006a:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_006f:  ldloca.s   V_2
+                      IL_0071:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0076:  call       "void MyDictionary<int, string>.this[int].set"
+                      IL_007b:  ldloc.s    V_4
+                      IL_007d:  ldc.i4.1
+                      IL_007e:  add
+                      IL_007f:  stloc.s    V_4
+                      IL_0081:  ldloc.s    V_4
+                      IL_0083:  ldloc.3
+                      IL_0084:  ldlen
+                      IL_0085:  conv.i4
+                      IL_0086:  blt.s      IL_005d
+                      IL_0088:  ldloc.1
+                      IL_0089:  box        "MyDictionary<int, string>"
+                      IL_008e:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0093:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void Dictionary_01(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F<int, string>().Report();
+                    }
+                    static {{typeName}}<K, V> F<K, V>()
+                    {
+                        return [];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<K, V>", """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void Dictionary_02(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        F(1, "one", x, y).Report();
+                    }
+                    static {{typeName}}<K, V> F<K, V>(K k, V v, KeyValuePair<K, V> e, IEnumerable<KeyValuePair<K, V>> s)
+                    {
+                        return /*<bind>*/[k:v, e, ..s]/*</bind>*/;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[1:one, 2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<K, V>", """
+                {
+                  // Code size       94 (0x5e)
+                  .maxstack  3
+                  .locals init (System.Collections.Generic.Dictionary<K, V> V_0,
+                                System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> V_2,
+                                System.Collections.Generic.KeyValuePair<K, V> V_3)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  stloc.0
+                  IL_0006:  ldloc.0
+                  IL_0007:  ldarg.0
+                  IL_0008:  ldarg.1
+                  IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000e:  ldarg.2
+                  IL_000f:  stloc.1
+                  IL_0010:  ldloc.0
+                  IL_0011:  ldloca.s   V_1
+                  IL_0013:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_0018:  ldloca.s   V_1
+                  IL_001a:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_001f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0024:  ldarg.3
+                  IL_0025:  callvirt   "System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                  IL_002a:  stloc.2
+                  .try
+                  {
+                    IL_002b:  br.s       IL_0048
+                    IL_002d:  ldloc.2
+                    IL_002e:  callvirt   "System.Collections.Generic.KeyValuePair<K, V> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>>.Current.get"
+                    IL_0033:  stloc.3
+                    IL_0034:  ldloc.0
+                    IL_0035:  ldloca.s   V_3
+                    IL_0037:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                    IL_003c:  ldloca.s   V_3
+                    IL_003e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                    IL_0043:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                    IL_0048:  ldloc.2
+                    IL_0049:  callvirt   "bool System.Collections.IEnumerator.MoveNext()"
+                    IL_004e:  brtrue.s   IL_002d
+                    IL_0050:  leave.s    IL_005c
+                  }
+                  finally
+                  {
+                    IL_0052:  ldloc.2
+                    IL_0053:  brfalse.s  IL_005b
+                    IL_0055:  ldloc.2
+                    IL_0056:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_005b:  endfinally
+                  }
+                  IL_005c:  ldloc.0
+                  IL_005d:  ret
+                }
+                """);
+            var comp = (CSharpCompilation)verifier.Compilation;
+            string constructMethod = typeName == "Dictionary" ? "System.Collections.Generic.Dictionary<K, V>..ctor()" : "null";
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                $$"""
+                ICollectionExpressionOperation (3 elements, ConstructMethod: {{constructMethod}}) (OperationKind.CollectionExpression, Type: System.Collections.Generic.{{typeName}}<K, V>) (Syntax: '[k:v, e, ..s]')
+                  Elements(3):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'e')
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<K, V>) (OperationKind.Spread, Type: null) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void Dictionary_Params(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            [CombinatorialValues("Dictionary", "IDictionary", "IReadOnlyDictionary")] string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params<int, string>();
+                        Three<int, string>(new(1, "one"), new(2, "two"), new(1, "three"));
+                    }
+                    static void Empty<K, V>() { Params<K, V>(); }
+                    static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                    static void Params<K, V>(params {{typeName}}<K, V> args) { args.Report(); }
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                if (typeName == "Dictionary")
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (6,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params Dictionary<K, V>)'
+                        //         Params<int, string>();
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<int, string>").WithArguments("args", "Program.Params<K, V>(params System.Collections.Generic.Dictionary<K, V>)").WithLocation(6, 9),
+                        // (9,33): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params Dictionary<K, V>)'
+                        //     static void Empty<K, V>() { Params<K, V>(); }
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<K, V>").WithArguments("args", "Program.Params<K, V>(params System.Collections.Generic.Dictionary<K, V>)").WithLocation(9, 33),
+                        // (10,97): error CS1501: No overload for method 'Params' takes 3 arguments
+                        //     static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "Params").WithArguments("Params", "3").WithLocation(10, 97),
+                        // (11,30): error CS9215: Collection expression type 'Dictionary<K, V>' must have an instance or extension method 'Add' that can be called with a single argument.
+                        //     static void Params<K, V>(params Dictionary<K, V> args) { args.Report(); }
+                        Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "params Dictionary<K, V> args").WithArguments("System.Collections.Generic.Dictionary<K, V>").WithLocation(11, 30));
+                }
+                else
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (6,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params IDictionary<K, V>)'
+                        //         Params<int, string>();
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<int, string>").WithArguments("args", $"Program.Params<K, V>(params System.Collections.Generic.{typeName}<K, V>)").WithLocation(6, 9),
+                        // (9,33): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params IDictionary<K, V>)'
+                        //     static void Empty<K, V>() { Params<K, V>(); }
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<K, V>").WithArguments("args", $"Program.Params<K, V>(params System.Collections.Generic.{typeName}<K, V>)").WithLocation(9, 33),
+                        // (10,97): error CS1501: No overload for method 'Params' takes 3 arguments
+                        //     static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "Params").WithArguments("Params", "3").WithLocation(10, 97),
+                        // (11,30): error CS0225: The params parameter must have a valid collection type
+                        //     static void Params<K, V>(params IDictionary<K, V> args) { args.Report(); }
+                        Diagnostic(ErrorCode.ERR_ParamsMustBeCollection, "params").WithLocation(11, 30));
+                }
+            }
+            else
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    expectedOutput: "[], [1:three, 2:two], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Empty<K, V>", $$"""
+                    {
+                      // Code size       11 (0xb)
+                      .maxstack  1
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                      IL_0005:  call       "void Program.Params<K, V>(params System.Collections.Generic.{{typeName}}<K, V>)"
+                      IL_000a:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.Three<K, V>", $$"""
+                    {
+                      // Code size       77 (0x4d)
+                      .maxstack  4
+                      .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_2)
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                      IL_0005:  ldarg.0
+                      IL_0006:  stloc.0
+                      IL_0007:  dup
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_000f:  ldloca.s   V_0
+                      IL_0011:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0016:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_001b:  ldarg.1
+                      IL_001c:  stloc.1
+                      IL_001d:  dup
+                      IL_001e:  ldloca.s   V_1
+                      IL_0020:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0025:  ldloca.s   V_1
+                      IL_0027:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_002c:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_0031:  ldarg.2
+                      IL_0032:  stloc.2
+                      IL_0033:  dup
+                      IL_0034:  ldloca.s   V_2
+                      IL_0036:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_003b:  ldloca.s   V_2
+                      IL_003d:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0042:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_0047:  call       "void Program.Params<K, V>(params System.Collections.Generic.{{typeName}}<K, V>)"
+                      IL_004c:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void CustomDictionary_Params(LanguageVersion languageVersion)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return _d[key]; }
+                        set { _d[key] = value; }
+                    }
+                }
+                """;
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params<int, string>();
+                        Three<int, string>(new(1, "one"), new(2, "two"), new(1, "three"));
+                    }
+                    static void Empty<K, V>() { Params<K, V>(); }
+                    static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                    static void Params<K, V>(params MyDictionary<K, V> args) { args.Report(); }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params MyDictionary<K, V>)'
+                    //         Params<int, string>();
+                    Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<int, string>").WithArguments("args", "Program.Params<K, V>(params MyDictionary<K, V>)").WithLocation(6, 9),
+                    // (9,33): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params MyDictionary<K, V>)'
+                    //     static void Empty<K, V>() { Params<K, V>(); }
+                    Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<K, V>").WithArguments("args", "Program.Params<K, V>(params MyDictionary<K, V>)").WithLocation(9, 33),
+                    // (10,97): error CS1501: No overload for method 'Params' takes 3 arguments
+                    //     static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "Params").WithArguments("Params", "3").WithLocation(10, 97),
+                    // (11,30): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                    //     static void Params<K, V>(params MyDictionary<K, V> args) { args.Report(); }
+                    Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(11, 30));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    expectedOutput: "[], [1:three, 2:two], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Empty<K, V>", $$"""
+                    {
+                      // Code size       11 (0xb)
+                      .maxstack  1
+                      IL_0000:  newobj     "MyDictionary<K, V>..ctor()"
+                      IL_0005:  call       "void Program.Params<K, V>(params MyDictionary<K, V>)"
+                      IL_000a:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.Three<K, V>", $$"""
+                    {
+                      // Code size       77 (0x4d)
+                      .maxstack  4
+                      .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_2)
+                      IL_0000:  newobj     "MyDictionary<K, V>..ctor()"
+                      IL_0005:  ldarg.0
+                      IL_0006:  stloc.0
+                      IL_0007:  dup
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_000f:  ldloca.s   V_0
+                      IL_0011:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0016:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_001b:  ldarg.1
+                      IL_001c:  stloc.1
+                      IL_001d:  dup
+                      IL_001e:  ldloca.s   V_1
+                      IL_0020:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0025:  ldloca.s   V_1
+                      IL_0027:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_002c:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0031:  ldarg.2
+                      IL_0032:  stloc.2
+                      IL_0033:  dup
+                      IL_0034:  ldloca.s   V_2
+                      IL_0036:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_003b:  ldloca.s   V_2
+                      IL_003d:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0042:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0047:  call       "void Program.Params<K, V>(params MyDictionary<K, V>)"
+                      IL_004c:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void Dictionary_DuplicateKeys(string typeName)
+        {
+            string source = $$"""
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(101, "one");
+                        var y = new KeyValuePair<int, string>(202, "two");
+                        var z = new KeyValuePair<int, string>(101, "three");
+                        Report(F1(x, y, z));
+                        Report(F1(y, z, x));
+                        Report(F1(z, x, y));
+                        Report(F2(x, y, z));
+                        Report(F2(y, z, x));
+                        Report(F2(z, x, y));
+                        Report(F3(x, y, z));
+                        Report(F3(y, z, x));
+                        Report(F3(z, x, y));
+                    }
+                    static void Report<K, V>({{typeName}}<K, V> d)
+                    {
+                        d.Report();
+                        Console.WriteLine();
+                    }
+                    static {{typeName}}<K, V> F1<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z)
+                    {
+                        return [x.Key:x.Value, y, .. new[] { z }];
+                    }
+                    static {{typeName}}<K, V> F2<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z)
+                    {
+                        return [x, .. new[] { y }, z.Key:z.Value];
+                    }
+                    static {{typeName}}<K, V> F3<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z)
+                    {
+                        return [.. new[] { x }, y.Key:y.Value, z];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    [101:three, 202:two], 
+                    [101:one, 202:two], 
+                    [101:one, 202:two], 
+                    [101:three, 202:two], 
+                    [101:one, 202:two], 
+                    [101:one, 202:two], 
+                    [101:three, 202:two], 
+                    [101:one, 202:two], 
+                    [101:one, 202:two], 
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void DictionaryNotImplementingIDictionary(string typeName)
+        {
+            string sourceA = """
+                namespace System
+                {
+                    public class Object { }
+                    public abstract class ValueType { }
+                    public class String { }
+                    public class Type { }
+                    public struct Void { }
+                    public struct Boolean { }
+                    public struct Int32 { }
+                    public struct Enum { }
+                    public class Attribute { }
+                    public class AttributeUsageAttribute : Attribute
+                    {
+                        public AttributeUsageAttribute(AttributeTargets t) { }
+                        public bool AllowMultiple { get; set; }
+                        public bool Inherited { get; set; }
+                    }
+                    public enum AttributeTargets { }
+                    public interface IDisposable
+                    {
+                        void Dispose();
+                    }
+                }
+                namespace System.Collections
+                {
+                    public interface IEnumerator
+                    {
+                        bool MoveNext();
+                        object Current { get; }
+                    }
+                    public interface IEnumerable
+                    {
+                        IEnumerator GetEnumerator();
+                    }
+                }
+                namespace System.Collections.Generic
+                {
+                    public interface IEnumerator<T> : IEnumerator
+                    {
+                        new T Current { get; }
+                    }
+                    public interface IEnumerable<T> : IEnumerable
+                    {
+                        new IEnumerator<T> GetEnumerator();
+                    }
+                    public interface IDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+                    {
+                    }
+                    public interface IReadOnlyDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+                    {
+                    }
+                    public struct KeyValuePair<TKey, TValue>
+                    {
+                        public TKey Key { get; }
+                        public TValue Value { get; }
+                    }
+                    public sealed class Dictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+                    {
+                        public Dictionary() { }
+                        public TValue this[TKey key] { get { return default; } set { } }
+                        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => null;
+                        IEnumerator IEnumerable.GetEnumerator() => null;
+                    }
+                }
+                namespace System.Reflection
+                {
+                    public class DefaultMemberAttribute : Attribute
+                    {
+                        public DefaultMemberAttribute(string name) { }
+                    }
+                }
+                """;
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var d = F(1, "one", new KeyValuePair<int, string>(), null);
+                    }
+                    static {{typeName}}<K, V> F<K, V>(K k, V v, KeyValuePair<K, V> x, IEnumerable<KeyValuePair<K, V>> y)
+                    {
+                        return [k:v, x, ..y];
+                    }
+                }
+                """;
+            var comp = CreateEmptyCompilation(new[] { sourceA, sourceB });
+            var emitOptions = Microsoft.CodeAnalysis.Emit.EmitOptions.Default.WithRuntimeMetadataVersion("0.0.0.0");
+            if (typeName == "Dictionary")
+            {
+                comp.VerifyEmitDiagnostics(emitOptions);
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(emitOptions,
+                    // 1.cs(10,16): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.Dictionary<K, V>' to 'System.Collections.Generic.IDictionary<K, V>'
+                    //         return [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "[k:v, x, ..y]").WithArguments("System.Collections.Generic.Dictionary<K, V>", $"System.Collections.Generic.{typeName}<K, V>").WithLocation(10, 16));
+            }
+        }
+
+        [Theory]
+        [InlineData("IDictionary<int, string>")]
+        [InlineData("IReadOnlyDictionary<int, string>")]
+        public void DictionaryInterface_MissingMember(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                {{typeName}} d;
+                d = [];
+                d = [1:"one"];
+                d = [new KeyValuePair<int, string>(2, "two")];
+                d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_List_T);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source);
+            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_Dictionary_KV);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0518: Predefined type 'System.Collections.Generic.Dictionary`2' is not defined or imported
+                // d = [];
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "[]").WithArguments("System.Collections.Generic.Dictionary`2").WithLocation(3, 5),
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(3, 5),
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(3, 5),
+                // (4,5): error CS0518: Predefined type 'System.Collections.Generic.Dictionary`2' is not defined or imported
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"[1:""one""]").WithArguments("System.Collections.Generic.Dictionary`2").WithLocation(4, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(4, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(4, 5),
+                // (5,5): error CS0518: Predefined type 'System.Collections.Generic.Dictionary`2' is not defined or imported
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.Dictionary`2").WithLocation(5, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(5, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(5, 5),
+                // (6,5): error CS0518: Predefined type 'System.Collections.Generic.Dictionary`2' is not defined or imported
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.Dictionary`2").WithLocation(6, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 5));
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(3, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(4, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(5, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 5));
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(3, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(4, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(5, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 5));
+        }
+
+        [Theory]
+        [InlineData("IDictionary<int, string>")]
+        [InlineData("IReadOnlyDictionary<int, string>")]
+        public void KeyValuePair_MissingMember_DictionaryInterface(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                {{typeName}} d;
+                d = [];
+                d = [1:"one"];
+                d = [new KeyValuePair<int, string>(2, "two")];
+                d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source);
+            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_KeyValuePair_KV);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(3, 5),
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(3, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(4, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(4, 5));
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(3, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(4, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 5));
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(3, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(4, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 5));
+        }
+
+        [Fact]
+        public void KeyValuePair_MissingMember_CustomDictionary()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K k] { get => default; set { } }
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB = """
+                using System.Collections.Generic;
+                MyDictionary<int, string> d;
+                d = [];
+                d = [1:"one"];
+                d = [new KeyValuePair<int, string>(2, "two")];
+                d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                """;
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_KeyValuePair_KV);
+            comp.VerifyEmitDiagnostics(
+                // (4,5): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[1:""one""]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(4, 5),
+                // (4,6): error CS9300: Collection expression type 'MyDictionary<int, string>' does not support key-value pair elements.
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"1:""one""").WithArguments("MyDictionary<int, string>").WithLocation(4, 6),
+                // (5,5): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(5, 5),
+                // (6,5): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(6, 5));
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(3, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(4, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 5));
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            comp.VerifyEmitDiagnostics(
+                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(3, 5),
+                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(4, 5),
+                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 5),
+                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 5));
+        }
+
+        [Fact]
+        public void RefSafety_Indexer()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Diagnostics.CodeAnalysis;
+                ref struct MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private ref readonly K _key;
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[[UnscopedRef] in K key]  { get { return default; } set { _key = ref key; } }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static MyDictionary<K, V> FromPair1<K, V>(K k, V v)
+                    {
+                        MyDictionary<K, V> d = new();
+                        d[k] = v;
+                        return d;
+                    }
+                    static MyDictionary<K, V> FromPair2<K, V>(K k, V v)
+                    {
+                        MyDictionary<K, V> d;
+                        d = [k:v];
+                        return d;
+                    }
+                    static MyDictionary<K, V> FromPair3<K, V>(K k, V v)
+                    {
+                        MyDictionary<K, V> d = [k:v];
+                        return d;
+                    }
+                    static MyDictionary<K, V> FromPair4<K, V>(ref K k, ref V v)
+                    {
+                        return [k:v];
+                    }
+                    static MyDictionary<K, V> FromPair5<K, V>(V v)
+                    {
+                        MyDictionary<K, V> d = [MakeKey<K>():v];
+                        return d;
+                    }
+                    static K MakeKey<K>() => default;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net90);
+            comp.VerifyEmitDiagnostics(
+                // (6,9): error CS8350: This combination of arguments to 'MyDictionary<K, V>.this[in K]' is disallowed because it may expose variables referenced by parameter 'key' outside of their declaration scope
+                //         d[k] = v;
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "d[k]").WithArguments("MyDictionary<K, V>.this[in K]", "key").WithLocation(6, 9),
+                // (6,11): error CS8166: Cannot return a parameter by reference 'k' because it is not a ref parameter
+                //         d[k] = v;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "k").WithArguments("k").WithLocation(6, 11),
+                // (12,13): error CS9203: A collection expression of type 'MyDictionary<K, V>' cannot be used in this context because it may be exposed outside of the current scope.
+                //         d = [k:v];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[k:v]").WithArguments("MyDictionary<K, V>").WithLocation(12, 13),
+                // (18,16): error CS8352: Cannot use variable 'd' in this context because it may expose referenced variables outside of their declaration scope
+                //         return d;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "d").WithArguments("d").WithLocation(18, 16),
+                // (22,16): error CS9203: A collection expression of type 'MyDictionary<K, V>' cannot be used in this context because it may be exposed outside of the current scope.
+                //         return [k:v];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[k:v]").WithArguments("MyDictionary<K, V>").WithLocation(22, 16),
+                // (27,16): error CS8352: Cannot use variable 'd' in this context because it may expose referenced variables outside of their declaration scope
+                //         return d;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "d").WithArguments("d").WithLocation(27, 16));
+        }
+
+        [Fact]
+        public void Async()
+        {
+            string source = """
+                using System.Collections.Generic;
+                using System.Threading.Tasks;
+                class Program
+                {
+                    static async Task Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        (await Create(1, "one", x, y)).Report();
+                    }
+                    static async Task<IDictionary<object, object>> Create<K, V>(K k, V v, KeyValuePair<K, V> e, IEnumerable<KeyValuePair<K, V>> s)
+                    {
+                        return [await F(k):v, k:await F(v), await F(e), .. await F(s)];
+                    }
+                    static async Task<T> F<T>(T t)
+                    {
+                        await Task.Yield();
+                        return t;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[1:one, 2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F(1, "one").Report();
+                    }
+                    static IDictionary<long, object> F(int x, string y)
+                    {
+                        return /*<bind>*/[x:y]/*</bind>*/;
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[1:one], ");
+            verifier.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var kvpElement = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(kvpElement.KeyExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int64, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(kvpElement.ValueExpression);
+            Assert.Equal(SpecialType.System_String, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Object, typeInfo.ConvertedType.SpecialType);
+
+            // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Int64, System.Object>) (Syntax: '[x:y]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'x:y')
+                """);
+        }
+
+        [Fact]
+        public void KeyValuePairExpressionConversions_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>();
+                        IDictionary<object, object> d = /*<bind>*/[x]/*</bind>*/;
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify([source, s_dictionaryExtensions], expectedOutput: "[0:null], ");
+            verifier.VerifyDiagnostics();
+
+            var comp = (CSharpCompilation)verifier.Compilation;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var element = tree.GetRoot().DescendantNodes().OfType<ExpressionElementSyntax>().Single();
+            // https://github.com/dotnet/roslyn/issues/77872: Implement GetTypeInfo() support.
+            var typeInfo = model.GetTypeInfo(element.Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[x]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'x')
+                """);
+        }
+
+        [Fact]
+        public void KeyValuePairExpressionConversions_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var y = new KeyValuePair<int, string>[0];
+                        IDictionary<object, object> d = /*<bind>*/[..y]/*</bind>*/;
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify([source, s_dictionaryExtensions], expectedOutput: "[], ");
+            verifier.VerifyDiagnostics();
+
+            var comp = (CSharpCompilation)verifier.Compilation;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var element = tree.GetRoot().DescendantNodes().OfType<SpreadElementSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(element.Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[..y]')
+                  Elements(1):
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null) (Syntax: '..y')
+                        Operand:
+                          ILocalReferenceOperation: y (OperationKind.LocalReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) (Syntax: 'y')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """);
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        var d = F(x, y);
+                        d.Report();
+                    }
+                    static IDictionary<long, object> F(KeyValuePair<int, string> x, IEnumerable<KeyValuePair<int, string>> y)
+                    {
+                        return [x, ..y];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_03()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static IDictionary<int, string> F1(KeyValuePair<int?, string> x1, IEnumerable<KeyValuePair<int?, string>> y1)
+                    {
+                        return [x1, ..y1];
+                    }
+                    static IDictionary<int, string> F2(KeyValuePair<int, object> x2, IEnumerable<KeyValuePair<int, object>> y2)
+                    {
+                        return [x2, ..y2];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,17): error CS0029: Cannot implicitly convert type 'int?' to 'int'
+                //         return [x1, ..y1];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x1").WithArguments("int?", "int").WithLocation(6, 17),
+                // (6,23): error CS0029: Cannot implicitly convert type 'int?' to 'int'
+                //         return [x1, ..y1];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "y1").WithArguments("int?", "int").WithLocation(6, 23),
+                // (10,17): error CS0029: Cannot implicitly convert type 'object' to 'string'
+                //         return [x2, ..y2];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x2").WithArguments("object", "string").WithLocation(10, 17),
+                // (10,23): error CS0029: Cannot implicitly convert type 'object' to 'string'
+                //         return [x2, ..y2];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "y2").WithArguments("object", "string").WithLocation(10, 23));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_04()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, int> d;
+                d = [null:default];
+                d = [default:null];
+                d = [default, null];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (3,6): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
+                // d = [null:default];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(3, 6),
+                // (4,14): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
+                // d = [default:null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(4, 14),
+                // (5,15): error CS0037: Cannot convert null to 'KeyValuePair<int, int>' because it is a non-nullable value type
+                // d = [default, null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("System.Collections.Generic.KeyValuePair<int, int>").WithLocation(5, 15));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_05()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static IDictionary<K, V> F1<K, V>(K k) => [k];
+                    static IDictionary<K, V> F2<K, V>(IEnumerable<K> e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (4,48): error CS0029: Cannot implicitly convert type 'K' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static IDictionary<K, V> F1<K, V>(K k) => [k];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "k").WithArguments("K", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(4, 48),
+                // (5,63): error CS0029: Cannot implicitly convert type 'K' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static IDictionary<K, V> F2<K, V>(IEnumerable<K> e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("K", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(5, 63));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_06()
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                public class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public override string ToString() => $"{Key}:{Value}";
+                    public static implicit operator MyKeyValuePair<K, V>(KeyValuePair<K, V> kvp) => new(kvp.Key, kvp.Value);
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB1 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F(1, "one");
+                    }
+                    static IEnumerable<MyKeyValuePair<K, V>> F<K, V>(K k, V v)
+                    {
+                        return [k:v];
+                    }
+                }
+                """;
+            comp = CreateCompilation(sourceB1, references: [refA]);
+            comp.VerifyEmitDiagnostics(
+                // (10,17): error CS9300: Collection expression type 'IEnumerable<MyKeyValuePair<K, V>>' does not support key-value pair elements.
+                //         return [k:v];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("System.Collections.Generic.IEnumerable<MyKeyValuePair<K, V>>").WithLocation(10, 17));
+
+            string sourceB2 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var e = F(new KeyValuePair<int, string>(2, "two"), new KeyValuePair<int, string>[] { new(3, "three") });
+                        e.Report();
+                    }
+                    static IEnumerable<MyKeyValuePair<K, V>> F<K, V>(KeyValuePair<K, V> x, IEnumerable<KeyValuePair<K, V>> y)
+                    {
+                        return [x, ..y];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceB2, s_collectionExtensions],
+                references: [refA],
+                expectedOutput: "[2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<K, V>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<K, V>")]
+        public void KeyValuePairConversions_07(LanguageVersion languageVersion, string typeName)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                public class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public static implicit operator KeyValuePair<K, V>(MyKeyValuePair<K, V> kvp) => new(kvp.Key, kvp.Value);
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new MyKeyValuePair<int, string>(2, "two");
+                        var y = new MyKeyValuePair<int, string>[] { new(3, "three") };
+                        F(x, y).Report();
+                    }
+                    static {{typeName}} F<K, V>(MyKeyValuePair<K, V> x, IEnumerable<MyKeyValuePair<K, V>> y)
+                    {
+                        return [x, ..y];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceB, s_dictionaryExtensions],
+                references: [refA],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: "[2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_08()
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                public class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public static implicit operator KeyValuePair<K, V>(MyKeyValuePair<K, V> kvp) => new(kvp.Key, kvp.Value);
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<object, string>(1, "one");
+                        var y = new MyKeyValuePair<int, string>(2, "two");
+                        var z = new MyKeyValuePair<int, object>(3, "three");
+                        IDictionary<int, string> d;
+                        d = [x, y, z];
+                        var sx = new[] { x };
+                        var sy = new[] { y };
+                        var sz = new[] { z };
+                        d = [..sx, ..sy, ..sz];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (10,14): error CS0029: Cannot implicitly convert type 'object' to 'int'
+                //         d = [x, y, z];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("object", "int").WithLocation(10, 14),
+                // (10,20): error CS0029: Cannot implicitly convert type 'MyKeyValuePair<int, object>' to 'KeyValuePair<int, string>'
+                //         d = [x, y, z];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "z").WithArguments("MyKeyValuePair<int, object>", "System.Collections.Generic.KeyValuePair<int, string>").WithLocation(10, 20),
+                // (14,16): error CS0029: Cannot implicitly convert type 'object' to 'int'
+                //         d = [..sx, ..sy, ..sz];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "sx").WithArguments("object", "int").WithLocation(14, 16),
+                // (14,28): error CS0029: Cannot implicitly convert type 'MyKeyValuePair<int, object>' to 'KeyValuePair<int, string>'
+                //         d = [..sx, ..sy, ..sz];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "sz").WithArguments("MyKeyValuePair<int, object>", "System.Collections.Generic.KeyValuePair<int, string>").WithLocation(14, 28));
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<int, string>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<int, string>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<int, string>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<int, string>")]
+        public void KeyValuePairConversions_ConversionFromExpression(LanguageVersion languageVersion, string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        {{typeName}} c;
+                        c = [default];
+                        c.Report();
+                        c = [new()];
+                        c.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: "[0:null], [0:null], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_NotKeyValuePair()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static Dictionary<K, V> FromExpression<K, V>(K k) => [k];
+                    static Dictionary<K, V> FromSpread<K, V>(IEnumerable<V> e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (4,59): error CS0029: Cannot implicitly convert type 'K' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static Dictionary<K, V> FromExpression<K, V>(K k) => [k];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "k").WithArguments("K", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(4, 59),
+                // (5,70): error CS0029: Cannot implicitly convert type 'V' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static Dictionary<K, V> FromSpread<K, V>(IEnumerable<V> e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("V", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(5, 70));
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void KeyValuePairConversions_Dynamic_01(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        KeyValuePair<string, int> x = new("two", 2);
+                        IEnumerable<object> y = [new KeyValuePair<string, int>("three", 3)];
+                        FromExpression<string, int>(x).Report();
+                        FromSpread<string, int>(y).Report();
+                    }
+                    static List<KeyValuePair<K, V>> FromExpression<K, V>(dynamic d) => [d];
+                    static List<KeyValuePair<K, V>> FromSpread<K, V>(IEnumerable<dynamic> e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe,
+                targetFramework: TargetFramework.Net80);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    verify: Verification.Skipped,
+                    expectedOutput: IncludeExpectedOutput("[two:2], [three:3], "));
+                verifier.VerifyDiagnostics();
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<K, V>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<K, V>")]
+        public void KeyValuePairConversions_Dynamic_02(LanguageVersion languageVersion, string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>(3, "three");
+                        FromExpression<int, string>(x).Report();
+                        FromSpread<int, string>(new dynamic[] { y }).Report();
+                    }
+                    static {{typeName}} FromExpression<K, V>(dynamic d) => [d];
+                    static {{typeName}} FromSpread<K, V>(IEnumerable<dynamic> e) => [..e];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[2:two], [3:three], "));
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_Dynamic_03()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair1<string, int>("one", 1).Report();
+                        FromPair2<string, int>("two", 2).Report();
+                    }
+                    static Dictionary<K, V> FromPair1<K, V>(K k, dynamic d) => [k:d];
+                    static Dictionary<K, V> FromPair2<K, V>(dynamic d, V v) => [d:v];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[one:1], [two:2], "));
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.FromPair1<K, V>", """
+                {
+                  // Code size       77 (0x4d)
+                  .maxstack  6
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_000c:  brtrue.s   IL_0032
+                  IL_000e:  ldc.i4.0
+                  IL_000f:  ldtoken    "V"
+                  IL_0014:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0019:  ldtoken    "Program"
+                  IL_001e:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0023:  call       "System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)"
+                  IL_0028:  call       "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>>.Create(System.Runtime.CompilerServices.CallSiteBinder)"
+                  IL_002d:  stsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_0032:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_0037:  ldfld      "System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>>.Target"
+                  IL_003c:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_0041:  ldarg.1
+                  IL_0042:  callvirt   "V System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)"
+                  IL_0047:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_004c:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromPair2<K, V>", """
+                {
+                  // Code size       77 (0x4d)
+                  .maxstack  5
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_000b:  brtrue.s   IL_0031
+                  IL_000d:  ldc.i4.0
+                  IL_000e:  ldtoken    "K"
+                  IL_0013:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0018:  ldtoken    "Program"
+                  IL_001d:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0022:  call       "System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)"
+                  IL_0027:  call       "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>>.Create(System.Runtime.CompilerServices.CallSiteBinder)"
+                  IL_002c:  stsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_0031:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_0036:  ldfld      "System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>>.Target"
+                  IL_003b:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_0040:  ldarg.0
+                  IL_0041:  callvirt   "K System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)"
+                  IL_0046:  ldarg.1
+                  IL_0047:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_004c:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<K, V>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<K, V>")]
+        public void KeyValuePairConversions_Dynamic_04(LanguageVersion languageVersion, string typeName)
+        {
+            string source = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        FromSpread1<int, string>(y);
+                        FromSpread2<int, string>(y);
+                    }
+                    static {{typeName}}
+                        FromSpread1<K, V>(dynamic e) => [..e];
+                    static {{typeName}}
+                        FromSpread2<K, V>(IEnumerable e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyEmitDiagnostics(
+                // (12,44): error CS0029: Cannot implicitly convert type 'object' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         FromSpread1<K, V>(dynamic e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("object", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(12, 44),
+                // (14,48): error CS0029: Cannot implicitly convert type 'object' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         FromSpread2<K, V>(IEnumerable e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("object", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(14, 48));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_Dynamic_MultipleIndexers()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return _d[key]; }
+                        set { Console.WriteLine("{0}, {1}, {2}, {3}", typeof(K).Name, typeof(V).Name, key, value); _d[key] = value; }
+                    }
+                    public int this[string key]
+                    {
+                        get { return (int)(object)_d[(K)(object)key]; }
+                        set { Console.WriteLine("string, int, {0}, {1}", key, value); _d[(K)(object)key] = (V)(object)value; }
+                    }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair1A("one", 1);
+                        FromPair2A("two", 2);
+                        FromPair1B("one", 1);
+                        FromPair2B("two", 2);
+                    }
+                    static MyDictionary<object, object> FromPair1A(string k, dynamic v) => [k:v];
+                    static MyDictionary<object, object> FromPair2A(dynamic k, int v) => [k:v];
+                    static MyDictionary<object, object> FromPair1B(string k, dynamic v) { var d = new MyDictionary<object, object>(); d[k] = v; return d; }
+                    static MyDictionary<object, object> FromPair2B(dynamic k, int v) { var d = new MyDictionary<object, object>(); d[k] = v; return d; }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("""
+                    Object, Object, one, 1
+                    Object, Object, two, 2
+                    string, int, one, 1
+                    string, int, two, 2
+                    """));
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_MultipleIndexers_UnrelatedTypes()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return _d[key]; }
+                        set { Console.WriteLine("{0}, {1}, {2}, {3}", typeof(K).Name, typeof(V).Name, key, value); _d[key] = value; }
+                    }
+                    public V this[int key]
+                    {
+                        get { return default; }
+                        set { Console.WriteLine("int, {0}, {1}, {2}", typeof(V).Name, key, value); }
+                    }
+                }
+                """;
+            string sourceB = """
+                class A
+                {
+                    public static implicit operator uint?(A a) => 1;
+                    public static implicit operator int(A a) => 2;
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair1(new A(), "one");
+                        FromPair2(new A(), "two");
+                    }
+                    static MyDictionary<uint?, object> FromPair1(A k, object v) => [k:v];
+                    static MyDictionary<uint?, object> FromPair2(A k, object v) { var d = new MyDictionary<uint?, object>(); d[k] = v; return d; }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB],
+                verify: Verification.Skipped,
+                expectedOutput: """
+                    Nullable`1, Object, 1, one
+                    int, Object, 2, two
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_KeyValuePairConstraint()
+        {
+            string source = """
+                using System.Collections.Generic;
+                abstract class A<T>
+                {
+                    public abstract void F<U>(U u, IEnumerable<U> e) where U : T;
+                }
+                class B<K, V> : A<KeyValuePair<K, V>>
+                {
+                    public override void F<U>(U u, IEnumerable<U> e)
+                    {
+                        Dictionary<K, V> d;
+                        d = [u];
+                        d = [..e];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (11,14): error CS0029: Cannot implicitly convert type 'U' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         d = [u];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "u").WithArguments("U", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(11, 14),
+                // (12,16): error CS0029: Cannot implicitly convert type 'U' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         d = [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("U", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(12, 16));
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void KeyValuePairConversions_LanguageVersion(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromExpression(new KeyValuePair<string, int>("one", 1)).Report();
+                        FromSpread([new KeyValuePair<string, int>("two", 2)]).Report();
+                    }
+                    static KeyValuePair<K, V>[] FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    static KeyValuePair<K, V>[] FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[one:1], [two:2], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.FromExpression<K, V>", """
+                {
+                    // Code size       15 (0xf)
+                    .maxstack  4
+                    IL_0000:  ldc.i4.1
+                    IL_0001:  newarr     "System.Collections.Generic.KeyValuePair<K, V>"
+                    IL_0006:  dup
+                    IL_0007:  ldc.i4.0
+                    IL_0008:  ldarg.0
+                    IL_0009:  stelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                    IL_000e:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromSpread<K, V>", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "System.Collections.Generic.KeyValuePair<K, V>[] System.Linq.Enumerable.ToArray<System.Collections.Generic.KeyValuePair<K, V>>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>)"
+                  IL_0006:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void EvaluationOrder_01()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        IReadOnlyDictionary<int, string> d = [
+                            Identity(new KeyValuePair<int, string>(1, "one")),
+                            Identity(2):Identity("two"),
+                            ..Identity((KeyValuePair<int, string>[])[new(3, "three")])];
+                        d.Report();
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    [1, one]
+                    2
+                    two
+                    System.Collections.Generic.KeyValuePair`2[System.Int32,System.String][]
+                    [1:one, 2:two, 3:three], 
+                    """);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size      145 (0x91)
+                  .maxstack  5
+                  .locals init (System.Collections.Generic.Dictionary<int, string> V_0,
+                                System.Collections.Generic.KeyValuePair<int, string> V_1,
+                                System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                int V_3,
+                                System.Collections.Generic.KeyValuePair<int, string> V_4)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                  IL_0005:  stloc.0
+                  IL_0006:  ldc.i4.1
+                  IL_0007:  ldstr      "one"
+                  IL_000c:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                  IL_0011:  call       "System.Collections.Generic.KeyValuePair<int, string> Program.Identity<System.Collections.Generic.KeyValuePair<int, string>>(System.Collections.Generic.KeyValuePair<int, string>)"
+                  IL_0016:  stloc.1
+                  IL_0017:  ldloc.0
+                  IL_0018:  ldloca.s   V_1
+                  IL_001a:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_001f:  ldloca.s   V_1
+                  IL_0021:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0026:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                  IL_002b:  ldloc.0
+                  IL_002c:  ldc.i4.2
+                  IL_002d:  call       "int Program.Identity<int>(int)"
+                  IL_0032:  ldstr      "two"
+                  IL_0037:  call       "string Program.Identity<string>(string)"
+                  IL_003c:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                  IL_0041:  ldc.i4.1
+                  IL_0042:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0047:  dup
+                  IL_0048:  ldc.i4.0
+                  IL_0049:  ldc.i4.3
+                  IL_004a:  ldstr      "three"
+                  IL_004f:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                  IL_0054:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0059:  call       "System.Collections.Generic.KeyValuePair<int, string>[] Program.Identity<System.Collections.Generic.KeyValuePair<int, string>[]>(System.Collections.Generic.KeyValuePair<int, string>[])"
+                  IL_005e:  stloc.2
+                  IL_005f:  ldc.i4.0
+                  IL_0060:  stloc.3
+                  IL_0061:  br.s       IL_0084
+                  IL_0063:  ldloc.2
+                  IL_0064:  ldloc.3
+                  IL_0065:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_006a:  stloc.s    V_4
+                  IL_006c:  ldloc.0
+                  IL_006d:  ldloca.s   V_4
+                  IL_006f:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0074:  ldloca.s   V_4
+                  IL_0076:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_007b:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                  IL_0080:  ldloc.3
+                  IL_0081:  ldc.i4.1
+                  IL_0082:  add
+                  IL_0083:  stloc.3
+                  IL_0084:  ldloc.3
+                  IL_0085:  ldloc.2
+                  IL_0086:  ldlen
+                  IL_0087:  conv.i4
+                  IL_0088:  blt.s      IL_0063
+                  IL_008a:  ldloc.0
+                  IL_008b:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0090:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void EvaluationOrder_02()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var d = F(101, "A", 102, "B", 103, "C", true, 3);
+                        d.Report();
+                    }
+                    static IReadOnlyDictionary<K, V> F<K, V>(K k1, V v1, K k2, V v2, K k3, V v3, bool b, int i)
+                    {
+                        return [
+                            Identity(Identity(b) ? Identity(k1) : Identity(k2)) : Identity(v2),
+                            Identity(k3) : Identity(Identity(i) switch { 1 => Identity(v1), 2 => Identity(v2), _ => Identity(v3) })];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    True
+                    101
+                    101
+                    B
+                    103
+                    3
+                    C
+                    C
+                    [101:B, 103:C], 
+                    """);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<K, V>", """
+                {
+                  // Code size      119 (0x77)
+                  .maxstack  3
+                  .locals init (System.Collections.Generic.Dictionary<K, V> V_0,
+                                K V_1,
+                                V V_2,
+                                int V_3,
+                                System.Collections.Generic.Dictionary<K, V> V_4)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  stloc.s    V_4
+                  IL_0007:  ldloc.s    V_4
+                  IL_0009:  ldarg.s    V_6
+                  IL_000b:  call       "bool Program.Identity<bool>(bool)"
+                  IL_0010:  brtrue.s   IL_001a
+                  IL_0012:  ldarg.2
+                  IL_0013:  call       "K Program.Identity<K>(K)"
+                  IL_0018:  br.s       IL_0020
+                  IL_001a:  ldarg.0
+                  IL_001b:  call       "K Program.Identity<K>(K)"
+                  IL_0020:  call       "K Program.Identity<K>(K)"
+                  IL_0025:  ldarg.3
+                  IL_0026:  call       "V Program.Identity<V>(V)"
+                  IL_002b:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0030:  ldloc.s    V_4
+                  IL_0032:  stloc.0
+                  IL_0033:  ldarg.s    V_4
+                  IL_0035:  call       "K Program.Identity<K>(K)"
+                  IL_003a:  stloc.1
+                  IL_003b:  ldarg.s    V_7
+                  IL_003d:  call       "int Program.Identity<int>(int)"
+                  IL_0042:  stloc.3
+                  IL_0043:  ldloc.3
+                  IL_0044:  ldc.i4.1
+                  IL_0045:  beq.s      IL_004d
+                  IL_0047:  ldloc.3
+                  IL_0048:  ldc.i4.2
+                  IL_0049:  beq.s      IL_0056
+                  IL_004b:  br.s       IL_005f
+                  IL_004d:  ldarg.1
+                  IL_004e:  call       "V Program.Identity<V>(V)"
+                  IL_0053:  stloc.2
+                  IL_0054:  br.s       IL_0067
+                  IL_0056:  ldarg.3
+                  IL_0057:  call       "V Program.Identity<V>(V)"
+                  IL_005c:  stloc.2
+                  IL_005d:  br.s       IL_0067
+                  IL_005f:  ldarg.s    V_5
+                  IL_0061:  call       "V Program.Identity<V>(V)"
+                  IL_0066:  stloc.2
+                  IL_0067:  ldloc.0
+                  IL_0068:  ldloc.1
+                  IL_0069:  ldloc.2
+                  IL_006a:  call       "V Program.Identity<V>(V)"
+                  IL_006f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0074:  ldloc.s    V_4
+                  IL_0076:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void EvaluationOrder_03()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public static implicit operator KeyValuePair<K, V>(MyKeyValuePair<K, V> kvp)
+                    {
+                        Console.WriteLine("conversion to MyKeyValuePair<{0}, {1}>: {2}, {3}", typeof(K).Name, typeof(V).Name, kvp.Key, kvp.Value);
+                        return new(kvp.Key, kvp.Value);
+                    }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new MyKeyValuePair<int, string>(1, "one");
+                        var y = new MyKeyValuePair<int, string>[] { new(2, "two"), new(3, "three") };
+                        F(x, y).Report();
+                    }
+                    static IDictionary<K, V> F<K, V>(MyKeyValuePair<K, V> x, IEnumerable<MyKeyValuePair<K, V>> y)
+                    {
+                        return [Identity(x), ..Identity(y)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    MyKeyValuePair`2[System.Int32,System.String]
+                    conversion to MyKeyValuePair<Int32, String>: 1, one
+                    MyKeyValuePair`2[System.Int32,System.String][]
+                    conversion to MyKeyValuePair<Int32, String>: 2, two
+                    conversion to MyKeyValuePair<Int32, String>: 2, two
+                    conversion to MyKeyValuePair<Int32, String>: 3, three
+                    conversion to MyKeyValuePair<Int32, String>: 3, three
+                    [1:one, 2:two, 3:three], 
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void EvaluationOrder_04()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+                class A<T>
+                {
+                    public readonly T Value;
+                    public A(T value) { Value = value; }
+                    public static implicit operator A<T>(T value)
+                    {
+                        Console.WriteLine("conversion to A<{0}>: {1}", typeof(T).Name, value);
+                        return new(value);
+                    }
+                    public override string ToString() => Value.ToString();
+                    public class Comparer : IEqualityComparer<A<T>>
+                    {
+                        public Comparer()
+                        {
+                            Console.WriteLine("new Comparer<{0}>()", typeof(T).Name);
+                        }
+                        public bool Equals(A<T> x, A<T> y) => object.Equals(x.Value, y.Value);
+                        public int GetHashCode(A<T> a) => a.Value.GetHashCode();
+                    }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        var y = new KeyValuePair<int, string>[] { new(2, "two"), new(3, "three") };
+                        var d = F(x, y);
+                        d.Select(kvp => new KeyValuePair<int, string>(kvp.Key.Value, kvp.Value.Value)).Report();
+                    }
+                    static Dictionary<A<K>, A<V>> F<K, V>(KeyValuePair<K, V> x, IEnumerable<KeyValuePair<K, V>> y)
+                    {
+                        return [with(comparer: new A<K>.Comparer()), Identity(x), ..Identity(y)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                expectedOutput: """
+                    new Comparer<Int32>()
+                    [1, one]
+                    conversion to A<Int32>: 1
+                    conversion to A<String>: one
+                    System.Collections.Generic.KeyValuePair`2[System.Int32,System.String][]
+                    conversion to A<Int32>: 2
+                    conversion to A<String>: two
+                    conversion to A<Int32>: 3
+                    conversion to A<String>: three
+                    [[1, one], [2, two], [3, three]], 
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void InferredType_ExpressionElement()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d = [new()];
+                d.Report();
+                d = [default];
+                d.Report();
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[0:null], [0:null], ");
+            verifier.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var elements = tree.GetRoot().DescendantNodes().OfType<ExpressionElementSyntax>().ToArray();
+
+            var typeInfo = model.GetTypeInfo(elements[0].Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            typeInfo = model.GetTypeInfo(elements[1].Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void InferredType_KeyValueElement_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d = [default:default];
+                d.Report();
+                d = [new():null];
+                d.Report();
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[0:null], [0:null], ");
+            verifier.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var elements = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().ToArray();
+
+            var typeInfo = model.GetTypeInfo(elements[0].KeyExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(elements[0].ValueExpression);
+            Assert.Equal(SpecialType.System_String, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_String, typeInfo.ConvertedType.SpecialType);
+
+            typeInfo = model.GetTypeInfo(elements[1].KeyExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(elements[1].ValueExpression);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_String, typeInfo.ConvertedType.SpecialType);
+        }
+
+        [Fact]
+        public void InferredType_KeyValueElement_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<string, int> d = [null:new()];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var elements = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().ToArray();
+
+            var typeInfo = model.GetTypeInfo(elements[0].KeyExpression);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_String, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(elements[0].ValueExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.ConvertedType.SpecialType);
+        }
+
+        [Fact]
+        public void ConversionError_ExpressionElement()
+        {
+            string source = """
+                using System.Collections.Generic;
+                var x = new object();
+                IDictionary<int, int> d = [x, null];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (3,28): error CS0029: Cannot implicitly convert type 'object' to 'System.Collections.Generic.KeyValuePair<int, int>'
+                // IDictionary<int, int> d = [x, null];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("object", "System.Collections.Generic.KeyValuePair<int, int>").WithLocation(3, 28),
+                // (3,31): error CS0037: Cannot convert null to 'KeyValuePair<int, int>' because it is a non-nullable value type
+                // IDictionary<int, int> d = [x, null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("System.Collections.Generic.KeyValuePair<int, int>").WithLocation(3, 31));
+        }
+
+        [Fact]
+        public void ConversionError_KeyValueElement_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                var x = new object();
+                var y = new object();
+                IDictionary<string, int> d = [x:1, "2":y];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (4,31): error CS0029: Cannot implicitly convert type 'object' to 'string'
+                // IDictionary<string, int> d = [x:1, "2":y];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("object", "string").WithLocation(4, 31),
+                // (4,40): error CS0029: Cannot implicitly convert type 'object' to 'int'
+                // IDictionary<string, int> d = [x:1, "2":y];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "y").WithArguments("object", "int").WithLocation(4, 40));
+        }
+
+        [Fact]
+        public void ConversionError_KeyValueElement_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<string, int> d;
+                d = [new():1];
+                d = ["":null];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (3,6): error CS1729: 'string' does not contain a constructor that takes 0 arguments
+                // d = [new():1];
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "new()").WithArguments("string", "0").WithLocation(3, 6),
+                // (4,9): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
+                // d = ["":null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(4, 9));
+        }
+
+        [Fact]
+        public void ConversionError_KeyValueElement_03()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        IDictionary<object, object> d = [P:P];
+                    }
+                    static object P { set { } }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,42): error CS0154: The property or indexer 'Program.P' cannot be used in this context because it lacks the get accessor
+                //         IDictionary<object, object> d = [P:P];
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("Program.P").WithLocation(6, 42),
+                // (6,44): error CS0154: The property or indexer 'Program.P' cannot be used in this context because it lacks the get accessor
+                //         IDictionary<object, object> d = [P:P];
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("Program.P").WithLocation(6, 44));
+        }
+
+        [Fact]
+        public void ConversionError_SpreadElement()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<string, int> d = [..new()];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (2,33): error CS8754: There is no target type for 'new()'
+                // IDictionary<string, int> d = [..new()];
+                Diagnostic(ErrorCode.ERR_ImplicitObjectCreationNoTargetType, "new()").WithArguments("new()").WithLocation(2, 33));
+        }
+
+        [Theory]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        [InlineData("Dictionary")]
+        public void TypeInference(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([default:default]);
+                        Identity([default:"2"]);
+                        Identity([1:default]);
+                        Identity([1:default, default:"2"]);
+                    }
+                    static {{typeName}}<K, V> Identity<K, V>({{typeName}}<K, V> d) => d;
+                }
+                """;
+            var comp = CreateCompilation(source);
+            // https://github.com/dotnet/roslyn/issues/77873: Type inference should succeed for Identity([1:default, default:"2"]);.
+            comp.VerifyEmitDiagnostics(
+                // (6,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([default:default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(6, 9),
+                // (7,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([default:"2"]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(7, 9),
+                // (8,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([1:default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(8, 9),
+                // (9,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([1:default, default:"2"]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(9, 9));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void CustomDictionary_01([CombinatorialValues("class", "struct")] string typeKind, bool useCompilationReference)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                public {{typeKind}} MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d;
+                    public MyDictionary(IEqualityComparer<K> comparer = null) { _d = new(comparer); }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => GetDictionary().GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return GetDictionary()[key]; }
+                        set { GetDictionary()[key] = value; }
+                    }
+                    private Dictionary<K, V> GetDictionary() => _d ??= new();
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = AsReference(comp, useCompilationReference);
+
+            string sourceB = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Empty<string, int>().Report();
+                        Many(1, "one", new KeyValuePair<int, string>(2, "two"), new KeyValuePair<int, string>[] { new(3, "three") }).Report();
+                        WithComparer(StringComparer.OrdinalIgnoreCase, "ABC", 1, "ab", 2).Report();
+                    }
+                    static MyDictionary<K, V> Empty<K, V>() => [];
+                    static MyDictionary<K, V> Many<K, V>(K k, V v, KeyValuePair<K, V> e, KeyValuePair<K, V>[] s) => /*<bind>*/[with(null), k:v, e, ..s]/*</bind>*/;
+                    static MyDictionary<K, V> WithComparer<K, V>(IEqualityComparer<K> comparer, K k1, V v1, K k2, V v2) => [with(comparer), k1:v1, k2:v2];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceB, s_dictionaryExtensions],
+                references: [refA],
+                expectedOutput: "[], [1:one, 2:two, 3:three], [ab:2, ABC:1], ");
+            verifier.VerifyDiagnostics();
+            if (typeKind == "class")
+            {
+                verifier.VerifyIL("Program.Empty<K, V>", """
+                    {
+                      // Code size        7 (0x7)
+                      .maxstack  1
+                      IL_0000:  ldnull
+                      IL_0001:  newobj     "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0006:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.Many<K, V>", """
+                    {
+                      // Code size       84 (0x54)
+                      .maxstack  3
+                      .locals init (MyDictionary<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4)
+                      IL_0000:  ldnull
+                      IL_0001:  newobj     "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0006:  stloc.0
+                      IL_0007:  ldloc.0
+                      IL_0008:  ldarg.0
+                      IL_0009:  ldarg.1
+                      IL_000a:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_000f:  ldarg.2
+                      IL_0010:  stloc.1
+                      IL_0011:  ldloc.0
+                      IL_0012:  ldloca.s   V_1
+                      IL_0014:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0019:  ldloca.s   V_1
+                      IL_001b:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0020:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0025:  ldarg.3
+                      IL_0026:  stloc.2
+                      IL_0027:  ldc.i4.0
+                      IL_0028:  stloc.3
+                      IL_0029:  br.s       IL_004c
+                      IL_002b:  ldloc.2
+                      IL_002c:  ldloc.3
+                      IL_002d:  ldelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0032:  stloc.s    V_4
+                      IL_0034:  ldloc.0
+                      IL_0035:  ldloca.s   V_4
+                      IL_0037:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_003c:  ldloca.s   V_4
+                      IL_003e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0043:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0048:  ldloc.3
+                      IL_0049:  ldc.i4.1
+                      IL_004a:  add
+                      IL_004b:  stloc.3
+                      IL_004c:  ldloc.3
+                      IL_004d:  ldloc.2
+                      IL_004e:  ldlen
+                      IL_004f:  conv.i4
+                      IL_0050:  blt.s      IL_002b
+                      IL_0052:  ldloc.0
+                      IL_0053:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.WithComparer<K, V>", """
+                    {
+                      // Code size       24 (0x18)
+                      .maxstack  4
+                      IL_0000:  ldarg.0
+                      IL_0001:  newobj     "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0006:  dup
+                      IL_0007:  ldarg.1
+                      IL_0008:  ldarg.2
+                      IL_0009:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_000e:  dup
+                      IL_000f:  ldarg.3
+                      IL_0010:  ldarg.s    V_4
+                      IL_0012:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0017:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.Empty<K, V>", """
+                    {
+                      // Code size       10 (0xa)
+                      .maxstack  1
+                      .locals init (MyDictionary<K, V> V_0)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "MyDictionary<K, V>"
+                      IL_0008:  ldloc.0
+                      IL_0009:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.Many<K, V>", """
+                    {
+                      // Code size       88 (0x58)
+                      .maxstack  3
+                      .locals init (MyDictionary<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldnull
+                      IL_0003:  call       "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldarg.0
+                      IL_000b:  ldarg.1
+                      IL_000c:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_0011:  ldarg.2
+                      IL_0012:  stloc.1
+                      IL_0013:  ldloca.s   V_0
+                      IL_0015:  ldloca.s   V_1
+                      IL_0017:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_001c:  ldloca.s   V_1
+                      IL_001e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0023:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_0028:  ldarg.3
+                      IL_0029:  stloc.2
+                      IL_002a:  ldc.i4.0
+                      IL_002b:  stloc.3
+                      IL_002c:  br.s       IL_0050
+                      IL_002e:  ldloc.2
+                      IL_002f:  ldloc.3
+                      IL_0030:  ldelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0035:  stloc.s    V_4
+                      IL_0037:  ldloca.s   V_0
+                      IL_0039:  ldloca.s   V_4
+                      IL_003b:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0040:  ldloca.s   V_4
+                      IL_0042:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0047:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_004c:  ldloc.3
+                      IL_004d:  ldc.i4.1
+                      IL_004e:  add
+                      IL_004f:  stloc.3
+                      IL_0050:  ldloc.3
+                      IL_0051:  ldloc.2
+                      IL_0052:  ldlen
+                      IL_0053:  conv.i4
+                      IL_0054:  blt.s      IL_002e
+                      IL_0056:  ldloc.0
+                      IL_0057:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.WithComparer<K, V>", """
+                    {
+                      // Code size       29 (0x1d)
+                      .maxstack  3
+                      .locals init (MyDictionary<K, V> V_0)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldarg.0
+                      IL_0003:  call       "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldarg.1
+                      IL_000b:  ldarg.2
+                      IL_000c:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  ldarg.3
+                      IL_0014:  ldarg.s    V_4
+                      IL_0016:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_001b:  ldloc.0
+                      IL_001c:  ret
+                    }
+                    """);
+            }
+
+            comp = (CSharpCompilation)verifier.Compilation;
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (3 elements, ConstructMethod: MyDictionary<K, V>..ctor([System.Collections.Generic.IEqualityComparer<K> comparer = null])) (OperationKind.CollectionExpression, Type: MyDictionary<K, V>) (Syntax: '[with(null) ... :v, e, ..s]')
+                  Elements(3):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'e')
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<K, V>) (OperationKind.Spread, Type: null) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<K, V>[]) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """);
+        }
+
+        [Fact]
+        public void CustomDictionary_NoParameterlessConstructor()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private MyDictionary() { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (12,50): error CS0122: 'MyDictionary<K, V>.MyDictionary()' is inaccessible due to its protection level
+                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                Diagnostic(ErrorCode.ERR_BadAccess, "[default:default]").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(12, 50),
+                // (12,51): error CS8716: There is no target type for the default literal.
+                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(12, 51),
+                // (12,59): error CS8716: There is no target type for the default literal.
+                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(12, 59));
+        }
+
+        [Fact]
+        public void CustomDictionary_Params_LessAccessibleConstructor()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    internal MyDictionary() { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        var f1 = (params MyDictionary<string, int> args) => { };
+                        static void f2<K, V>(params MyDictionary<K, V> args) { }
+                        f1();
+                        f2<string, int>();
+                    }
+                    public static void F3<K, V>(params MyDictionary<K, V> args) { }
+                    internal static void F4<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (10,33): error CS9224: Method 'MyDictionary<K, V>.MyDictionary()' cannot be less visible than the member with params collection 'Program.F3<K, V>(params MyDictionary<K, V>)'.
+                //     public static void F3<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_ParamsMemberCannotBeLessVisibleThanDeclaringMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>.MyDictionary()", "Program.F3<K, V>(params MyDictionary<K, V>)").WithLocation(10, 33));
+        }
+
+        [Fact]
+        public void CustomDictionary_Params_ProtectedConstructor()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                internal class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected MyDictionary() { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        var f1 = (params MyDictionary<string, int> args) => { };
+                        static void f2<K, V>(params MyDictionary<K, V> args) { }
+                        f1();
+                        f2<string, int>();
+                    }
+                    static void F3<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (5,19): error CS0122: 'MyDictionary<string, int>.MyDictionary()' is inaccessible due to its protection level
+                //         var f1 = (params MyDictionary<string, int> args) => { };
+                Diagnostic(ErrorCode.ERR_BadAccess, "params MyDictionary<string, int> args").WithArguments("MyDictionary<string, int>.MyDictionary()").WithLocation(5, 19),
+                // (6,30): error CS0122: 'MyDictionary<K, V>.MyDictionary()' is inaccessible due to its protection level
+                //         static void f2<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_BadAccess, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(6, 30),
+                // (7,9): error CS7036: There is no argument given that corresponds to the required parameter 'obj' of 'Action<MyDictionary<string, int>>'
+                //         f1();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "f1").WithArguments("obj", "System.Action<MyDictionary<string, int>>").WithLocation(7, 9),
+                // (8,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'f2<K, V>(params MyDictionary<K, V>)'
+                //         f2<string, int>();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "f2<string, int>").WithArguments("args", "f2<K, V>(params MyDictionary<K, V>)").WithLocation(8, 9),
+                // (10,26): error CS0122: 'MyDictionary<K, V>.MyDictionary()' is inaccessible due to its protection level
+                //     static void F3<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_BadAccess, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(10, 26));
+        }
+
+        [Fact]
+        public void Params_Cycle_IncorrectSignature()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary(params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        F<int, string>();
+                        F(x);
+                        F<int, string>(x);
+                        F([x]);
+                        F<int, string>([2:"two"]);
+                    }
+                    static void F<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (5,25): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public MyDictionary(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(5, 25),
+                // (8,26): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(8, 26),
+                // (15,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.F<K, V>(params MyDictionary<K, V>)'
+                //         F<int, string>();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "F<int, string>").WithArguments("args", "Program.F<K, V>(params MyDictionary<K, V>)").WithLocation(15, 9),
+                // (16,9): error CS0411: The type arguments for method 'Program.F<K, V>(params MyDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         F(x);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("Program.F<K, V>(params MyDictionary<K, V>)").WithLocation(16, 9),
+                // (17,24): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params MyDictionary<int, string>'
+                //         F<int, string>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "params MyDictionary<int, string>").WithLocation(17, 24),
+                // (18,11): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F([x]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[x]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(18, 11),
+                // (19,24): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F<int, string>([2:"two"]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[2:""two""]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 24),
+                // (19,25): error CS9300: Collection expression type 'MyDictionary<int, string>' does not support key-value pair elements.
+                //         F<int, string>([2:"two"]);
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"2:""two""").WithArguments("MyDictionary<int, string>").WithLocation(19, 25),
+                // (21,25): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     static void F<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(21, 25));
+        }
+
+        [Fact]
+        public void Params_Cycle_Overloads()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary(params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        F<int, string>();
+                        F(x);
+                        F<int, string>(x);
+                        F([x]);
+                        F<int, string>([2:"two"]);
+                    }
+                    static void F<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (16,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F<int, string>();
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "F<int, string>()").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(16, 9),
+                // (17,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F(x);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "F(x)").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(17, 9),
+                // (18,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F<int, string>(x);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "F<int, string>(x)").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(18, 9),
+                // (19,11): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F([x]);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[x]").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(19, 11),
+                // (20,24): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F<int, string>([2:"two"]);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, @"[2:""two""]").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(20, 24));
+        }
+
+        [Fact]
+        public void Params_Cycle_ConstructorArguments()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary() { }
+                    public MyDictionary(object arg, params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        F<int, string>([with(null)]);
+                        F([with(null)], x);
+                        F<int, string>([with(null)], x);
+                        F([with(null)], [x]);
+                    }
+                    static void F<K, V>(MyDictionary<K, V> d, params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,37): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public MyDictionary(object arg, params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(6, 37),
+                // (9,26): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(9, 26),
+                // (16,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)'
+                //         F<int, string>([with(null)]);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "F<int, string>").WithArguments("args", "Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)").WithLocation(16, 9),
+                // (17,9): error CS0411: The type arguments for method 'Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         F([with(null)], x);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)").WithLocation(17, 9),
+                // (18,24): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F<int, string>([with(null)], x);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[with(null)]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(18, 24),
+                // (18,38): error CS1503: Argument 2: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params MyDictionary<int, string>'
+                //         F<int, string>([with(null)], x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("2", "System.Collections.Generic.KeyValuePair<int, string>", "params MyDictionary<int, string>").WithLocation(18, 38),
+                // (19,11): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F([with(null)], [x]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[with(null)]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 11),
+                // (19,25): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F([with(null)], [x]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[x]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 25),
+                // (21,47): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     static void F<K, V>(MyDictionary<K, V> d, params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(21, 47));
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void Params_Cycle_AddAndIndexer(LanguageVersion languageVersion)
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary(params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                    public void Add(KeyValuePair<K, V> kvp) { }
+                }
+                public static class Helpers
+                {
+                    public static void F<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular13);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        Helpers.F<int, string>();
+                        Helpers.F(x);
+                        Helpers.F([x]);
+                    }
+                }
+                """;
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyEmitDiagnostics(
+                // (7,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         Helpers.F<int, string>();
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "Helpers.F<int, string>()").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(7, 9),
+                // (8,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         Helpers.F(x);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "Helpers.F(x)").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(8, 9),
+                // (9,19): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         Helpers.F([x]);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[x]").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(9, 19));
+        }
+
+        [Theory]
+        [InlineData("public V this[K key] { get { return default; } set { } }", true)]
+        [InlineData("public K this[K key] { get { return default; } set { } }", false)]
+        [InlineData("public V this[V key] { get { return default; } set { } }", false)]
+        [InlineData("public V this[K x, K y = default] { get { return default; } set { } }", false)]
+        [InlineData("public V this[K key] { get { return default; } }", false)]
+        [InlineData("public V this[K key] { set { } }", false)]
+        [InlineData("public V this[K key, object arg = null] { get { return default; } set { } }", false)]
+        [InlineData("public V this[K key, params object[] args] { get { return default; } set { } }", false)]
+        [InlineData("public V this[params K[] key] { get { return default; } set { } }", false)]
+        public void IndexerSignature_01(string indexer, bool supported)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    {{indexer}}
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static MyDictionary<K, V> Empty<K, V>() => [];
+                    static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                    static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            if (supported)
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,59): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                    //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[k:v]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(5, 59),
+                    // (5,60): error CS9300: Collection expression type 'MyDictionary<K, V>' does not support key-value pair elements.
+                    //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("MyDictionary<K, V>").WithLocation(5, 60),
+                    // (6,77): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                    //     static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[e]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(6, 77),
+                    // (7,86): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                    //     static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..s]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(7, 86)); ;
+            }
+        }
+
+        [Fact]
+        public void IndexerSignature_02()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<Ke, Ve, Ki, Vi> : IEnumerable<KeyValuePair<Ke, Ve>>
+                {
+                    public IEnumerator<KeyValuePair<Ke, Ve>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public Vi this[Ki key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                class MyDictionary1<K, V> : MyDictionary<K, V, K, V> { }
+                class MyDictionary2 : MyDictionary<string, object, string, object> { }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1<string, object> d1 = [default:default];
+                        MyDictionary2 d2 = [default:default];
+                        MyDictionary<string, object, string, object> d3 = [default:default];
+                        MyDictionary<string, object, object, string> d4 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (10,59): error CS1061: 'MyDictionary<string, object, object, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object, object, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<string, object, object, string> d4 = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object, object, string>", "Add").WithLocation(10, 59),
+                // (10,60): error CS9300: Collection expression type 'MyDictionary<string, object, object, string>' does not support key-value pair elements.
+                //         MyDictionary<string, object, object, string> d4 = [default:default];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "default:default").WithArguments("MyDictionary<string, object, object, string>").WithLocation(10, 60));
+        }
+
+        [Fact]
+        public void IndexerSignature_03()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary1 : IEnumerable<KeyValuePair<object, object>>
+                {
+                    public IEnumerator<KeyValuePair<object, object>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public dynamic this[dynamic key] { get { return default; } set { } }
+                }
+                class MyDictionary2 : IEnumerable<KeyValuePair<(int X, int Y), (object, object)>>
+                {
+                    public IEnumerator<KeyValuePair<(int X, int Y), (object, object)>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public (object A, object B) this[(int, int) key] { get { return default; } set { } }
+                }
+                class MyDictionary3 : IEnumerable<KeyValuePair<System.IntPtr, nuint>>
+                {
+                    public IEnumerator<KeyValuePair<System.IntPtr, nuint>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public System.UIntPtr this[nint key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1 d1 = [default:default];
+                        MyDictionary2 d2 = [default:default];
+                        MyDictionary3 d3 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void IndexerSignature_04()
+        {
+            string source = """
+                #nullable enable
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary1 : IEnumerable<KeyValuePair<string?, object>>
+                {
+                    public IEnumerator<KeyValuePair<string?, object>> GetEnumerator() => null!;
+                    IEnumerator IEnumerable.GetEnumerator() => null!;
+                    public object? this[string key] { get { return default!; } set { } }
+                }
+                class MyDictionary2 : IEnumerable<KeyValuePair<string, object?>>
+                {
+                    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => null!;
+                    IEnumerator IEnumerable.GetEnumerator() => null!;
+                    public object this[string? key] { get { return default!; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1 d1 = [default:default];
+                        MyDictionary2 d2 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void IndexerSignature_MultipleIndexers()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public int this[string key]
+                    {
+                        get { return (int)(object)_d[(K)(object)key]; }
+                        set { Console.WriteLine("string:{0}, int:{1}", key, value); _d[(K)(object)key] = (V)(object)value; }
+                    }
+                    public object this[object key]
+                    {
+                        get { return _d[(K)key]; }
+                        set { Console.WriteLine("object:{0}, object:{1}", key, value); _d[(K)key] = (V)value; }
+                    }
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<string, object> d;
+                        d = ["one":1];
+                        d = ["two":(object)2];
+                        d = [(object)"three":(object)3];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB1]);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                //         d = ["one":1];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[""one"":1]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(6, 13),
+                // (6,14): error CS9300: Collection expression type 'MyDictionary<string, object>' does not support key-value pair elements.
+                //         d = ["one":1];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"""one"":1").WithArguments("MyDictionary<string, object>").WithLocation(6, 14),
+                // (7,13): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                //         d = ["two":(object)2];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[""two"":(object)2]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(7, 13),
+                // (7,14): error CS9300: Collection expression type 'MyDictionary<string, object>' does not support key-value pair elements.
+                //         d = ["two":(object)2];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"""two"":(object)2").WithArguments("MyDictionary<string, object>").WithLocation(7, 14),
+                // (8,13): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                //         d = [(object)"three":(object)3];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[(object)""three"":(object)3]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(8, 13),
+                // (8,14): error CS9300: Collection expression type 'MyDictionary<string, object>' does not support key-value pair elements.
+                //         d = [(object)"three":(object)3];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"(object)""three"":(object)3").WithArguments("MyDictionary<string, object>").WithLocation(8, 14));
+
+            string sourceB2 = """
+                class MyDictionary1 : MyDictionary<string, int> { }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1 d1 = ["one":1];
+                        d1.Report();
+                        MyDictionary<string, int> d2 = ["two":2];
+                        d2.Report();
+                        MyDictionary<object, object> d3 = ["three":3];
+                        d3.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB2, s_dictionaryExtensions],
+                expectedOutput: """
+                    string:one, int:1
+                    [one:1], string:two, int:2
+                    [two:2], object:three, object:3
+                    [three:3], 
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void IndexerSignature_ExplicitImplementation()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                interface IMyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    V this[K key] { get; set; }
+                }
+                class MyDictionary<K, V> : IMyDictionary<K, V>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    V IMyDictionary<K, V>.this[K key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (17,39): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<int, string> d = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(17, 39),
+                // (17,40): error CS9300: Collection expression type 'MyDictionary<int, string>' does not support key-value pair elements.
+                //         MyDictionary<int, string> d = [default:default];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "default:default").WithArguments("MyDictionary<int, string>").WithLocation(17, 40));
+        }
+
+        [Fact]
+        public void IndexerSignature_Static()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public static V this[K key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (7,21): error CS0106: The modifier 'static' is not valid for this item
+                //     public static V this[K key] { get { return default; } set { } }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "this").WithArguments("static").WithLocation(7, 21));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("in")]
+        [InlineData("ref readonly")]
+        [InlineData("ref")]
+        [InlineData("out")]
+        public void IndexerSignature_RefParameter(string refKind)
+        {
+            string assignIfOut = refKind == "out" ? "key = default;" : "              ";
+            string source = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[{{refKind}} K key] { get { {{assignIfOut}} return _d[key]; } set { {{assignIfOut}} _d[key] = value; } }
+                }
+                class Program
+                {
+                    static MyDictionary<K, V> Empty<K, V>() => [];
+                    static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                    static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                    static void Main()
+                    {
+                        Empty<string, int>().Report();
+                        FromPair(1, "one").Report();
+                        FromExpression(new KeyValuePair<int, string>(2, "two")).Report();
+                        FromSpread(new KeyValuePair<int, string>[] { new(3, "three") }).Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            switch (refKind)
+            {
+                case "":
+                case "in":
+                    var verifier = CompileAndVerify(comp,
+                        expectedOutput: "[], [1:one], [2:two], [3:three], ");
+                    verifier.VerifyDiagnostics();
+                    break;
+                case "ref readonly":
+                    comp.VerifyEmitDiagnostics(
+                        // (13,59): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[k:v]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(13, 59),
+                        // (13,60): error CS9300: Collection expression type 'MyDictionary<K, V>' does not support key-value pair elements.
+                        //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                        Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("MyDictionary<K, V>").WithLocation(13, 60),
+                        // (14,77): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[e]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(14, 77),
+                        // (15,86): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..s]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(15, 86));
+                    break;
+                case "ref":
+                case "out":
+                    comp.VerifyEmitDiagnostics(
+                        // (8,19): error CS0631: ref and out are not valid in this context
+                        //     public V this[ref K key] { get {                return _d[key]; } set {                _d[key] = value; } }
+                        Diagnostic(ErrorCode.ERR_IllegalRefParam, refKind).WithLocation(8, 19),
+                        // (13,59): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[k:v]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(13, 59),
+                        // (13,60): error CS9300: Collection expression type 'MyDictionary<K, V>' does not support key-value pair elements.
+                        //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                        Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("MyDictionary<K, V>").WithLocation(13, 60),
+                        // (14,77): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[e]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(14, 77),
+                        // (15,86): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..s]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(15, 86));
+                    break;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(refKind);
+            }
+        }
+
+        [Fact]
+        public void IndexerSignature_RefReturn()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary1<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public ref V this[K key] { get { throw null; } }
+                }
+                class MyDictionary2<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public ref V this[K key] { get { throw null; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1<int, string> d1 = [default];
+                        MyDictionary2<int, string> d2 = [default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (13,52): error CS8147: Properties which return by reference cannot have set accessors
+                //     public ref V this[K key] { get { throw null; } set { } }
+                Diagnostic(ErrorCode.ERR_RefPropertyCannotHaveSetAccessor, "set").WithLocation(13, 52),
+                // (19,41): error CS1061: 'MyDictionary1<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary1<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary1<int, string> d1 = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary1<int, string>", "Add").WithLocation(19, 41),
+                // (20,41): error CS1061: 'MyDictionary2<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary2<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary2<int, string> d2 = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary2<int, string>", "Add").WithLocation(20, 41));
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_01()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                    public V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[0:null], ");
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size       39 (0x27)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                  IL_0000:  newobj     "MyDictionary<int, string>..ctor()"
+                  IL_0005:  ldloca.s   V_0
+                  IL_0007:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_000d:  dup
+                  IL_000e:  ldloca.s   V_0
+                  IL_0010:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0015:  ldloca.s   V_0
+                  IL_0017:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_001c:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0021:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0026:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_02()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                    public V this[K key, int arg] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (15,39): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<int, string> d = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(15, 39));
+        }
+
+        // Use indexer with expected signature, even if a better overload exists.
+        [Fact]
+        public void IndexerSignature_Overloads_BetterOverload()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V, KDerived> : IEnumerable<KeyValuePair<K, V>>
+                    where KDerived : K
+                {
+                    protected List<KeyValuePair<K, V>> _list = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[KDerived key] { get { throw null; } set { throw null; } }
+                    public V this[K key] { get { throw null; } set { _list.Add(new(key, value)); } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair<object, string, int>(1, "one").Report();
+                        FromExpression<object, string, int>(new KeyValuePair<int, string>(2, "two")).Report();
+                        FromSpread<object, string, int>(new KeyValuePair<int, string>[] { new(3, "three") }).Report();
+                    }
+                    static MyDictionary<object, int, string> FromDefault() => [default];
+                    static MyDictionary<K, V, KDerived> FromPair<K, V, KDerived>(KDerived k, V v)
+                        where KDerived : K
+                    {
+                        return [k:v];
+                    }
+                    static MyDictionary<K, V, KDerived> FromExpression<K, V, KDerived>(KeyValuePair<KDerived, V> e)
+                        where KDerived : K
+                    {
+                        return [e];
+                    }
+                    static MyDictionary<K, V, KDerived> FromSpread<K, V, KDerived>(KeyValuePair<KDerived, V>[] s)
+                        where KDerived : K
+                    {
+                        return [..s];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[1:one], [2:two], [3:three], ");
+            verifier.VerifyIL("Program.FromPair<K, V, KDerived>", """
+                {
+                  // Code size       24 (0x18)
+                  .maxstack  4
+                  IL_0000:  newobj     "MyDictionary<K, V, KDerived>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  box        "KDerived"
+                  IL_000c:  unbox.any  "K"
+                  IL_0011:  ldarg.1
+                  IL_0012:  callvirt   "void MyDictionary<K, V, KDerived>.this[K].set"
+                  IL_0017:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromExpression<K, V, KDerived>", """
+                {
+                  // Code size       38 (0x26)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<KDerived, V> V_0)
+                  IL_0000:  newobj     "MyDictionary<K, V, KDerived>..ctor()"
+                  IL_0005:  ldarg.0
+                  IL_0006:  stloc.0
+                  IL_0007:  dup
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  call       "KDerived System.Collections.Generic.KeyValuePair<KDerived, V>.Key.get"
+                  IL_000f:  box        "KDerived"
+                  IL_0014:  unbox.any  "K"
+                  IL_0019:  ldloca.s   V_0
+                  IL_001b:  call       "V System.Collections.Generic.KeyValuePair<KDerived, V>.Value.get"
+                  IL_0020:  callvirt   "void MyDictionary<K, V, KDerived>.this[K].set"
+                  IL_0025:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromSpread<K, V, KDerived>", """
+                {
+                  // Code size       62 (0x3e)
+                  .maxstack  3
+                  .locals init (MyDictionary<K, V, KDerived> V_0,
+                                System.Collections.Generic.KeyValuePair<KDerived, V>[] V_1,
+                                int V_2,
+                                System.Collections.Generic.KeyValuePair<KDerived, V> V_3)
+                  IL_0000:  newobj     "MyDictionary<K, V, KDerived>..ctor()"
+                  IL_0005:  stloc.0
+                  IL_0006:  ldarg.0
+                  IL_0007:  stloc.1
+                  IL_0008:  ldc.i4.0
+                  IL_0009:  stloc.2
+                  IL_000a:  br.s       IL_0036
+                  IL_000c:  ldloc.1
+                  IL_000d:  ldloc.2
+                  IL_000e:  ldelem     "System.Collections.Generic.KeyValuePair<KDerived, V>"
+                  IL_0013:  stloc.3
+                  IL_0014:  ldloc.0
+                  IL_0015:  ldloca.s   V_3
+                  IL_0017:  call       "KDerived System.Collections.Generic.KeyValuePair<KDerived, V>.Key.get"
+                  IL_001c:  box        "KDerived"
+                  IL_0021:  unbox.any  "K"
+                  IL_0026:  ldloca.s   V_3
+                  IL_0028:  call       "V System.Collections.Generic.KeyValuePair<KDerived, V>.Value.get"
+                  IL_002d:  callvirt   "void MyDictionary<K, V, KDerived>.this[K].set"
+                  IL_0032:  ldloc.2
+                  IL_0033:  ldc.i4.1
+                  IL_0034:  add
+                  IL_0035:  stloc.2
+                  IL_0036:  ldloc.2
+                  IL_0037:  ldloc.1
+                  IL_0038:  ldlen
+                  IL_0039:  conv.i4
+                  IL_003a:  blt.s      IL_000c
+                  IL_003c:  ldloc.0
+                  IL_003d:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_BaseAndDerived_01()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionaryBase<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                }
+                class MyDictionary<K, V> : MyDictionaryBase<K, V>
+                {
+                    public V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[0:null], ");
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size       39 (0x27)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                  IL_0000:  newobj     "MyDictionary<int, string>..ctor()"
+                  IL_0005:  ldloca.s   V_0
+                  IL_0007:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_000d:  dup
+                  IL_000e:  ldloca.s   V_0
+                  IL_0010:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0015:  ldloca.s   V_0
+                  IL_0017:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_001c:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0021:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0026:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_BaseAndDerived_02()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionaryBase<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class MyDictionary<K, V> : MyDictionaryBase<K, V>
+                {
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (18,39): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<int, string> d = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(18, 39));
+        }
+
+        [Fact]
+        public void IndexerSignature_Overridden()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public virtual V this[K key] { get { return default; } set { } }
+                }
+                class MyDictionary1<K, V> : MyDictionary<K, V>
+                {
+                    public override V this[K key] { get { return _d[key]; } }
+                }
+                class MyDictionary2<K, V> : MyDictionary<K, V>
+                {
+                    public override V this[K key] { set { _d[key] = value; } }
+                }
+                class MyDictionary3<K, V> : MyDictionary<K, V>
+                {
+                    public override V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1<int, string> d1 = [default];
+                        d1.Report();
+                        MyDictionary2<int, string> d2 = [default];
+                        d2.Report();
+                        MyDictionary3<int, string> d3 = [default];
+                        d3.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB, s_dictionaryExtensions],
+                expectedOutput: "[], [0:null], [0:null], ");
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size      115 (0x73)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                  IL_0000:  newobj     "MyDictionary1<int, string>..ctor()"
+                  IL_0005:  ldloca.s   V_0
+                  IL_0007:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_000d:  dup
+                  IL_000e:  ldloca.s   V_0
+                  IL_0010:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0015:  ldloca.s   V_0
+                  IL_0017:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_001c:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0021:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0026:  newobj     "MyDictionary2<int, string>..ctor()"
+                  IL_002b:  ldloca.s   V_0
+                  IL_002d:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0033:  dup
+                  IL_0034:  ldloca.s   V_0
+                  IL_0036:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_003b:  ldloca.s   V_0
+                  IL_003d:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0042:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0047:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_004c:  newobj     "MyDictionary3<int, string>..ctor()"
+                  IL_0051:  ldloca.s   V_0
+                  IL_0053:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0059:  dup
+                  IL_005a:  ldloca.s   V_0
+                  IL_005c:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0061:  ldloca.s   V_0
+                  IL_0063:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0068:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_006d:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0072:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_New()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key] { get { return default; } set { } }
+                }
+                """;
+
+            string sourceB1 = """
+                class MyDictionary1<K, V> : MyDictionary<K, V>
+                {
+                    public new V this[K key] { get { return _d[key]; } }
+                }
+                class MyDictionary2<K, V> : MyDictionary<K, V>
+                {
+                    public new V this[K key] { set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void F<K, V>()
+                    {
+                        MyDictionary1<K, V> d1 = [default:default];
+                        MyDictionary2<K, V> d2 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB1]);
+            comp.VerifyEmitDiagnostics(
+                // (13,34): error CS1061: 'MyDictionary1<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary1<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary1<K, V> d1 = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary1<K, V>", "Add").WithLocation(13, 34),
+                // (13,35): error CS9300: Collection expression type 'MyDictionary1<K, V>' does not support key-value pair elements.
+                //         MyDictionary1<K, V> d1 = [default:default];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "default:default").WithArguments("MyDictionary1<K, V>").WithLocation(13, 35),
+                // (14,34): error CS1061: 'MyDictionary2<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary2<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary2<K, V> d2 = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary2<K, V>", "Add").WithLocation(14, 34),
+                // (14,35): error CS9300: Collection expression type 'MyDictionary2<K, V>' does not support key-value pair elements.
+                //         MyDictionary2<K, V> d2 = [default:default];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "default:default").WithArguments("MyDictionary2<K, V>").WithLocation(14, 35));
+
+            string sourceB2 = """
+                class MyDictionary3<K, V> : MyDictionary<K, V>
+                {
+                    public new V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        F<int, string>().Report();
+                    }
+                    static MyDictionary3<K, V> F<K, V>()
+                    {
+                        return [default:default];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB2, s_dictionaryExtensions],
+                expectedOutput: "[0:null], ");
+            verifier.VerifyIL("Program.F<K, V>", """
+                {
+                  // Code size       30 (0x1e)
+                  .maxstack  4
+                  .locals init (K V_0,
+                                V V_1)
+                  IL_0000:  newobj     "MyDictionary3<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldloca.s   V_0
+                  IL_0008:  initobj    "K"
+                  IL_000e:  ldloc.0
+                  IL_000f:  ldloca.s   V_1
+                  IL_0011:  initobj    "V"
+                  IL_0017:  ldloc.1
+                  IL_0018:  callvirt   "void MyDictionary3<K, V>.this[K].set"
+                  IL_001d:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void IndexerAccessibility_01(
+            [CombinatorialValues("", "public", "internal")] string typeAccessibility,
+            [CombinatorialValues("", "public", "internal")] string indexerAccessibility)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                {{typeAccessibility}} class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    {{indexerAccessibility}} V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                MyDictionary<string, object> d = [default:default];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            if (indexerAccessibility == "public")
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,34): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                    // MyDictionary<string, object> d = [default:default];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(1, 34),
+                    // (1,35): error CS9300: Collection expression type 'MyDictionary<string, object>' does not support key-value pair elements.
+                    // MyDictionary<string, object> d = [default:default];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "default:default").WithArguments("MyDictionary<string, object>").WithLocation(1, 35));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void IndexerAccessibility_02(
+            [CombinatorialValues("private", "protected")] string indexerAccessibility)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    {{indexerAccessibility}} V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                MyDictionary<string, object> d = [default:default];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (1,34): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                // MyDictionary<string, object> d = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(1, 34),
+                // (1,35): error CS9300: Collection expression type 'MyDictionary<string, object>' does not support key-value pair elements.
+                // MyDictionary<string, object> d = [default:default];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "default:default").WithArguments("MyDictionary<string, object>").WithLocation(1, 35));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void IndexerAccessibility_03(
+            [CombinatorialValues("internal", "private", "protected")] string indexerAccessibility, bool modifyGetter)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key]
+                    {
+                        {{(modifyGetter ? indexerAccessibility : "")}} get { return default; }
+                        {{(modifyGetter ? "" : indexerAccessibility)}} set { }
+                    }
+                }
+                """;
+            string sourceB = """
+                MyDictionary<string, object> d = [default:default];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (1,34): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                // MyDictionary<string, object> d = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(1, 34),
+                // (1,35): error CS9300: Collection expression type 'MyDictionary<string, object>' does not support key-value pair elements.
+                // MyDictionary<string, object> d = [default:default];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "default:default").WithArguments("MyDictionary<string, object>").WithLocation(1, 35));
+        }
+
+        [Fact]
+        public void Lock()
+        {
+            string source = """
+                using System.Collections.Generic;
+                using System.Threading;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new Lock();
+                        var y = new Lock();
+                        object[] a = [x];
+                        IDictionary<object, object> d = [x:y];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net90);
+            comp.VerifyEmitDiagnostics(
+                // (9,23): warning CS9216: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+                //         object[] a = [x];
+                Diagnostic(ErrorCode.WRN_ConvertingLock, "x").WithLocation(9, 23),
+                // (10,42): warning CS9216: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+                //         IDictionary<object, object> d = [x:y];
+                Diagnostic(ErrorCode.WRN_ConvertingLock, "x").WithLocation(10, 42),
+                // (10,44): warning CS9216: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+                //         IDictionary<object, object> d = [x:y];
+                Diagnostic(ErrorCode.WRN_ConvertingLock, "y").WithLocation(10, 44));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -223,6 +223,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private static Syntax.InternalSyntax.SpreadElementSyntax GenerateSpreadElement()
             => InternalSyntaxFactory.SpreadElement(InternalSyntaxFactory.Token(SyntaxKind.DotDotToken), GenerateIdentifierName());
 
+        private static Syntax.InternalSyntax.KeyValuePairElementSyntax GenerateKeyValuePairElement()
+            => InternalSyntaxFactory.KeyValuePairElement(GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.ColonToken), GenerateIdentifierName());
+
+        private static Syntax.InternalSyntax.WithElementSyntax GenerateWithElement()
+            => InternalSyntaxFactory.WithElement(InternalSyntaxFactory.Token(SyntaxKind.WithKeyword), GenerateArgumentList());
+
         private static Syntax.InternalSyntax.QueryExpressionSyntax GenerateQueryExpression()
             => InternalSyntaxFactory.QueryExpression(GenerateFromClause(), GenerateQueryBody());
 
@@ -1584,6 +1590,29 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DotDotToken, node.OperatorToken.Kind);
             Assert.NotNull(node.Expression);
+
+            AttachAndCheckDiagnostics(node);
+        }
+
+        [Fact]
+        public void TestKeyValuePairElementFactoryAndProperties()
+        {
+            var node = GenerateKeyValuePairElement();
+
+            Assert.NotNull(node.KeyExpression);
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
+            Assert.NotNull(node.ValueExpression);
+
+            AttachAndCheckDiagnostics(node);
+        }
+
+        [Fact]
+        public void TestWithElementFactoryAndProperties()
+        {
+            var node = GenerateWithElement();
+
+            Assert.Equal(SyntaxKind.WithKeyword, node.WithKeyword.Kind);
+            Assert.NotNull(node.ArgumentList);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -5755,6 +5784,58 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestSpreadElementIdentityRewriter()
         {
             var oldNode = GenerateSpreadElement();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestKeyValuePairElementTokenDeleteRewriter()
+        {
+            var oldNode = GenerateKeyValuePairElement();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestKeyValuePairElementIdentityRewriter()
+        {
+            var oldNode = GenerateKeyValuePairElement();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestWithElementTokenDeleteRewriter()
+        {
+            var oldNode = GenerateWithElement();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestWithElementIdentityRewriter()
+        {
+            var oldNode = GenerateWithElement();
             var rewriter = new IdentityRewriter();
             var newNode = rewriter.Visit(oldNode);
 
@@ -10529,6 +10610,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private static SpreadElementSyntax GenerateSpreadElement()
             => SyntaxFactory.SpreadElement(SyntaxFactory.Token(SyntaxKind.DotDotToken), GenerateIdentifierName());
 
+        private static KeyValuePairElementSyntax GenerateKeyValuePairElement()
+            => SyntaxFactory.KeyValuePairElement(GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.ColonToken), GenerateIdentifierName());
+
+        private static WithElementSyntax GenerateWithElement()
+            => SyntaxFactory.WithElement(SyntaxFactory.Token(SyntaxKind.WithKeyword), GenerateArgumentList());
+
         private static QueryExpressionSyntax GenerateQueryExpression()
             => SyntaxFactory.QueryExpression(GenerateFromClause(), GenerateQueryBody());
 
@@ -11891,6 +11978,29 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.DotDotToken, node.OperatorToken.Kind());
             Assert.NotNull(node.Expression);
             var newNode = node.WithOperatorToken(node.OperatorToken).WithExpression(node.Expression);
+            Assert.Equal(node, newNode);
+        }
+
+        [Fact]
+        public void TestKeyValuePairElementFactoryAndProperties()
+        {
+            var node = GenerateKeyValuePairElement();
+
+            Assert.NotNull(node.KeyExpression);
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
+            Assert.NotNull(node.ValueExpression);
+            var newNode = node.WithKeyExpression(node.KeyExpression).WithColonToken(node.ColonToken).WithValueExpression(node.ValueExpression);
+            Assert.Equal(node, newNode);
+        }
+
+        [Fact]
+        public void TestWithElementFactoryAndProperties()
+        {
+            var node = GenerateWithElement();
+
+            Assert.Equal(SyntaxKind.WithKeyword, node.WithKeyword.Kind());
+            Assert.NotNull(node.ArgumentList);
+            var newNode = node.WithWithKeyword(node.WithKeyword).WithArgumentList(node.ArgumentList);
             Assert.Equal(node, newNode);
         }
 
@@ -16061,6 +16171,58 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestSpreadElementIdentityRewriter()
         {
             var oldNode = GenerateSpreadElement();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestKeyValuePairElementTokenDeleteRewriter()
+        {
+            var oldNode = GenerateKeyValuePairElement();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestKeyValuePairElementIdentityRewriter()
+        {
+            var oldNode = GenerateKeyValuePairElement();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestWithElementTokenDeleteRewriter()
+        {
+            var oldNode = GenerateWithElement();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestWithElementIdentityRewriter()
+        {
+            var oldNode = GenerateWithElement();
             var rewriter = new IdentityRewriter();
             var newNode = rewriter.Visit(oldNode);
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionExpressionParsingTests.cs
@@ -165,13 +165,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void TopLevelDotAccess_GlobalAttributeAmbiguity1()
     {
-        UsingTree("[assembly: A, B].C();",
-            // (1,10): error CS1003: Syntax error, ',' expected
-            // [assembly: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 10),
-            // (1,12): error CS1003: Syntax error, ',' expected
-            // [assembly: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "A").WithArguments(",").WithLocation(1, 12));
+        UsingTree("[assembly: A, B].C();");
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -186,16 +180,13 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                             N(SyntaxKind.CollectionExpression);
                             {
                                 N(SyntaxKind.OpenBracketToken);
-                                N(SyntaxKind.ExpressionElement);
+                                N(SyntaxKind.KeyValuePairElement);
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
                                         N(SyntaxKind.IdentifierToken, "assembly");
                                     }
-                                }
-                                M(SyntaxKind.CommaToken);
-                                N(SyntaxKind.ExpressionElement);
-                                {
+                                    N(SyntaxKind.ColonToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
                                         N(SyntaxKind.IdentifierToken, "A");
@@ -235,27 +226,9 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     public void TopLevelDotAccess_AttributeAmbiguity2A()
     {
         UsingTree("[return: A, B].C();",
-            // (1,2): error CS1003: Syntax error, ']' expected
+            // (1,2): error CS1041: Identifier expected; 'return' is a keyword
             // [return: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "return").WithArguments("]").WithLocation(1, 2),
-            // (1,2): error CS1002: ; expected
-            // [return: A, B].C();
-            Diagnostic(ErrorCode.ERR_SemicolonExpected, "return").WithLocation(1, 2),
-            // (1,8): error CS1525: Invalid expression term ':'
-            // [return: A, B].C();
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 8),
-            // (1,8): error CS1002: ; expected
-            // [return: A, B].C();
-            Diagnostic(ErrorCode.ERR_SemicolonExpected, ":").WithLocation(1, 8),
-            // (1,8): error CS1022: Type or namespace definition, or end-of-file expected
-            // [return: A, B].C();
-            Diagnostic(ErrorCode.ERR_EOFExpected, ":").WithLocation(1, 8),
-            // (1,11): error CS1001: Identifier expected
-            // [return: A, B].C();
-            Diagnostic(ErrorCode.ERR_IdentifierExpected, ",").WithLocation(1, 11),
-            // (1,14): error CS1003: Syntax error, ',' expected
-            // [return: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "]").WithArguments(",").WithLocation(1, 14));
+            Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "return").WithArguments("", "return").WithLocation(1, 2));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -263,44 +236,45 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
             {
                 N(SyntaxKind.ExpressionStatement);
                 {
-                    N(SyntaxKind.CollectionExpression);
+                    N(SyntaxKind.InvocationExpression);
                     {
-                        N(SyntaxKind.OpenBracketToken);
-                        M(SyntaxKind.CloseBracketToken);
-                    }
-                    M(SyntaxKind.SemicolonToken);
-                }
-            }
-            N(SyntaxKind.GlobalStatement);
-            {
-                N(SyntaxKind.ReturnStatement);
-                {
-                    N(SyntaxKind.ReturnKeyword);
-                    M(SyntaxKind.IdentifierName);
-                    {
-                        M(SyntaxKind.IdentifierToken);
-                    }
-                    M(SyntaxKind.SemicolonToken);
-                }
-            }
-            N(SyntaxKind.GlobalStatement);
-            {
-                N(SyntaxKind.LocalDeclarationStatement);
-                {
-                    N(SyntaxKind.VariableDeclaration);
-                    {
-                        N(SyntaxKind.IdentifierName);
+                        N(SyntaxKind.SimpleMemberAccessExpression);
                         {
-                            N(SyntaxKind.IdentifierToken, "A");
+                            N(SyntaxKind.CollectionExpression);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.KeyValuePairElement);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "return");
+                                    }
+                                    N(SyntaxKind.ColonToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "A");
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.ExpressionElement);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "B");
+                                    }
+                                }
+                                N(SyntaxKind.CloseBracketToken);
+                            }
+                            N(SyntaxKind.DotToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "C");
+                            }
                         }
-                        M(SyntaxKind.VariableDeclarator);
+                        N(SyntaxKind.ArgumentList);
                         {
-                            M(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.CommaToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        {
-                            N(SyntaxKind.IdentifierToken, "B");
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
                         }
                     }
                     N(SyntaxKind.SemicolonToken);
@@ -372,13 +346,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void TopLevelDotAccess_AttributeAmbiguity3A()
     {
-        UsingTree("[method: A, B].C();",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // [method: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 8),
-            // (1,10): error CS1003: Syntax error, ',' expected
-            // [method: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "A").WithArguments(",").WithLocation(1, 10));
+        UsingTree("[method: A, B].C();");
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -393,16 +361,13 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                             N(SyntaxKind.CollectionExpression);
                             {
                                 N(SyntaxKind.OpenBracketToken);
-                                N(SyntaxKind.ExpressionElement);
+                                N(SyntaxKind.KeyValuePairElement);
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
                                         N(SyntaxKind.IdentifierToken, "method");
                                     }
-                                }
-                                M(SyntaxKind.CommaToken);
-                                N(SyntaxKind.ExpressionElement);
-                                {
+                                    N(SyntaxKind.ColonToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
                                         N(SyntaxKind.IdentifierToken, "A");
@@ -500,27 +465,9 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     public void TopLevelDotAccess_AttributeAmbiguity4A()
     {
         UsingTree("[return: A].C();",
-            // (1,2): error CS1003: Syntax error, ']' expected
+            // (1,2): error CS1041: Identifier expected; 'return' is a keyword
             // [return: A].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "return").WithArguments("]").WithLocation(1, 2),
-            // (1,2): error CS1002: ; expected
-            // [return: A].C();
-            Diagnostic(ErrorCode.ERR_SemicolonExpected, "return").WithLocation(1, 2),
-            // (1,8): error CS1525: Invalid expression term ':'
-            // [return: A].C();
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 8),
-            // (1,8): error CS1002: ; expected
-            // [return: A].C();
-            Diagnostic(ErrorCode.ERR_SemicolonExpected, ":").WithLocation(1, 8),
-            // (1,8): error CS1022: Type or namespace definition, or end-of-file expected
-            // [return: A].C();
-            Diagnostic(ErrorCode.ERR_EOFExpected, ":").WithLocation(1, 8),
-            // (1,11): error CS1001: Identifier expected
-            // [return: A].C();
-            Diagnostic(ErrorCode.ERR_IdentifierExpected, "]").WithLocation(1, 11),
-            // (1,11): error CS1003: Syntax error, ',' expected
-            // [return: A].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "]").WithArguments(",").WithLocation(1, 11));
+            Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "return").WithArguments("", "return").WithLocation(1, 2));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -528,39 +475,37 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
             {
                 N(SyntaxKind.ExpressionStatement);
                 {
-                    N(SyntaxKind.CollectionExpression);
+                    N(SyntaxKind.InvocationExpression);
                     {
-                        N(SyntaxKind.OpenBracketToken);
-                        M(SyntaxKind.CloseBracketToken);
-                    }
-                    M(SyntaxKind.SemicolonToken);
-                }
-            }
-            N(SyntaxKind.GlobalStatement);
-            {
-                N(SyntaxKind.ReturnStatement);
-                {
-                    N(SyntaxKind.ReturnKeyword);
-                    M(SyntaxKind.IdentifierName);
-                    {
-                        M(SyntaxKind.IdentifierToken);
-                    }
-                    M(SyntaxKind.SemicolonToken);
-                }
-            }
-            N(SyntaxKind.GlobalStatement);
-            {
-                N(SyntaxKind.LocalDeclarationStatement);
-                {
-                    N(SyntaxKind.VariableDeclaration);
-                    {
-                        N(SyntaxKind.IdentifierName);
+                        N(SyntaxKind.SimpleMemberAccessExpression);
                         {
-                            N(SyntaxKind.IdentifierToken, "A");
+                            N(SyntaxKind.CollectionExpression);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.KeyValuePairElement);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "return");
+                                    }
+                                    N(SyntaxKind.ColonToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "A");
+                                    }
+                                }
+                                N(SyntaxKind.CloseBracketToken);
+                            }
+                            N(SyntaxKind.DotToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "C");
+                            }
                         }
-                        M(SyntaxKind.VariableDeclarator);
+                        N(SyntaxKind.ArgumentList);
                         {
-                            M(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
                         }
                     }
                     N(SyntaxKind.SemicolonToken);
@@ -624,13 +569,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void TopLevelDotAccess_GlobalAttributeAmbiguity2()
     {
-        UsingTree("[module: A, B].C();",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // [module: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 8),
-            // (1,10): error CS1003: Syntax error, ',' expected
-            // [module: A, B].C();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "A").WithArguments(",").WithLocation(1, 10));
+        UsingTree("[module: A, B].C();");
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -645,16 +584,13 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                             N(SyntaxKind.CollectionExpression);
                             {
                                 N(SyntaxKind.OpenBracketToken);
-                                N(SyntaxKind.ExpressionElement);
+                                N(SyntaxKind.KeyValuePairElement);
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
                                         N(SyntaxKind.IdentifierToken, "module");
                                     }
-                                }
-                                M(SyntaxKind.CommaToken);
-                                N(SyntaxKind.ExpressionElement);
-                                {
+                                    N(SyntaxKind.ColonToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
                                         N(SyntaxKind.IdentifierToken, "A");
@@ -1614,13 +1550,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryOfEmptyCollections()
     {
-        UsingTree("_ = [[]: []];",
-            // (1,8): error CS1003: Syntax error, ',' expected
-            // _ = [[]: []];
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 8),
-            // (1,10): error CS1003: Syntax error, ',' expected
-            // _ = [[]: []];
-            Diagnostic(ErrorCode.ERR_SyntaxError, "[").WithArguments(",").WithLocation(1, 10));
+        UsingTree("_ = [[]: []];");
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1638,17 +1568,14 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.CollectionExpression);
                         {
                             N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.ExpressionElement);
+                            N(SyntaxKind.KeyValuePairElement);
                             {
                                 N(SyntaxKind.CollectionExpression);
                                 {
                                     N(SyntaxKind.OpenBracketToken);
                                     N(SyntaxKind.CloseBracketToken);
                                 }
-                            }
-                            M(SyntaxKind.CommaToken);
-                            N(SyntaxKind.ExpressionElement);
-                            {
+                                N(SyntaxKind.ColonToken);
                                 N(SyntaxKind.CollectionExpression);
                                 {
                                     N(SyntaxKind.OpenBracketToken);
@@ -1671,9 +1598,9 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     {
         UsingTree(
             "_ = [:B];",
-            // (1,6): error CS1001: Identifier expected
+            // (1,6): error CS1525: Invalid expression term ':'
             // _ = [:B];
-            Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 6));
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 6));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1691,8 +1618,13 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.CollectionExpression);
                         {
                             N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.ExpressionElement);
+                            N(SyntaxKind.KeyValuePairElement);
                             {
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                                N(SyntaxKind.ColonToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
                                     N(SyntaxKind.IdentifierToken, "B");
@@ -1714,9 +1646,9 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     {
         UsingTree(
             "_ = [A:];",
-            // (1,7): error CS1003: Syntax error, ',' expected
+            // (1,8): error CS1525: Invalid expression term ']'
             // _ = [A:];
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 7));
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "]").WithArguments("]").WithLocation(1, 8));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1734,11 +1666,16 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.CollectionExpression);
                         {
                             N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.ExpressionElement);
+                            N(SyntaxKind.KeyValuePairElement);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
                                     N(SyntaxKind.IdentifierToken, "A");
+                                }
+                                N(SyntaxKind.ColonToken);
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
                             N(SyntaxKind.CloseBracketToken);
@@ -1757,9 +1694,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     {
         UsingTree(
             "_ = [:];",
-            // (1,6): error CS1001: Identifier expected
+            // (1,6): error CS1525: Invalid expression term ':'
             // _ = [:];
-            Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 6));
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 6),
+            // (1,7): error CS1525: Invalid expression term ']'
+            // _ = [:];
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "]").WithArguments("]").WithLocation(1, 7));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1777,6 +1717,18 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.CollectionExpression);
                         {
                             N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.KeyValuePairElement);
+                            {
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                                N(SyntaxKind.ColonToken);
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                            }
                             N(SyntaxKind.CloseBracketToken);
                         }
                     }
@@ -1791,13 +1743,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithTypeExpressions()
     {
-        UsingTree("_ = [A::B: C::D];",
-            // (1,10): error CS1003: Syntax error, ',' expected
-            // _ = [A::B: C::D];
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 10),
-            // (1,12): error CS1003: Syntax error, ',' expected
-            // _ = [A::B: C::D];
-            Diagnostic(ErrorCode.ERR_SyntaxError, "C").WithArguments(",").WithLocation(1, 12));
+        UsingTree("_ = [A::B: C::D];");
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1815,7 +1761,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.CollectionExpression);
                         {
                             N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.ExpressionElement);
+                            N(SyntaxKind.KeyValuePairElement);
                             {
                                 N(SyntaxKind.AliasQualifiedName);
                                 {
@@ -1829,10 +1775,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                                         N(SyntaxKind.IdentifierToken, "B");
                                     }
                                 }
-                            }
-                            M(SyntaxKind.CommaToken);
-                            N(SyntaxKind.ExpressionElement);
-                            {
+                                N(SyntaxKind.ColonToken);
                                 N(SyntaxKind.AliasQualifiedName);
                                 {
                                     N(SyntaxKind.IdentifierName);
@@ -1860,18 +1803,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithConditional1()
     {
-        UsingExpression("[a ? b : c : d]",
-            // (1,12): error CS1003: Syntax error, ',' expected
-            // [a ? b : c : d]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 12),
-            // (1,14): error CS1003: Syntax error, ',' expected
-            // [a ? b : c : d]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "d").WithArguments(",").WithLocation(1, 14));
+        UsingExpression("[a ? b : c : d]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.ConditionalExpression);
                 {
@@ -1890,10 +1827,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.IdentifierToken, "c");
                     }
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.IdentifierName);
                 {
                     N(SyntaxKind.IdentifierToken, "d");
@@ -1907,27 +1841,18 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithConditional2()
     {
-        UsingExpression("[a : b ? c : d]",
-            // (1,4): error CS1003: Syntax error, ',' expected
-            // [a : b ? c : d]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 4),
-            // (1,6): error CS1003: Syntax error, ',' expected
-            // [a : b ? c : d]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "b").WithArguments(",").WithLocation(1, 6));
+        UsingExpression("[a : b ? c : d]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.IdentifierName);
                 {
                     N(SyntaxKind.IdentifierToken, "a");
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.ConditionalExpression);
                 {
                     N(SyntaxKind.IdentifierName);
@@ -1954,18 +1879,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithConditional3()
     {
-        UsingExpression("[a ? b : c : d ? e : f]",
-            // (1,12): error CS1003: Syntax error, ',' expected
-            // [a ? b : c : d ? e : f]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 12),
-            // (1,14): error CS1003: Syntax error, ',' expected
-            // [a ? b : c : d ? e : f]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "d").WithArguments(",").WithLocation(1, 14));
+        UsingExpression("[a ? b : c : d ? e : f]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.ConditionalExpression);
                 {
@@ -1984,10 +1903,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.IdentifierToken, "c");
                     }
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.ConditionalExpression);
                 {
                     N(SyntaxKind.IdentifierName);
@@ -2014,18 +1930,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithNullCoalesce1()
     {
-        UsingExpression("[a ?? b : c]",
-            // (1,9): error CS1003: Syntax error, ',' expected
-            // [a ?? b : c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 9),
-            // (1,11): error CS1003: Syntax error, ',' expected
-            // [a ?? b : c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "c").WithArguments(",").WithLocation(1, 11));
+        UsingExpression("[a ?? b : c]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.CoalesceExpression);
                 {
@@ -2039,10 +1949,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.IdentifierToken, "b");
                     }
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.IdentifierName);
                 {
                     N(SyntaxKind.IdentifierToken, "c");
@@ -2056,27 +1963,18 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithNullCoalesce2()
     {
-        UsingExpression("[a : b ?? c]",
-            // (1,4): error CS1003: Syntax error, ',' expected
-            // [a : b ?? c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 4),
-            // (1,6): error CS1003: Syntax error, ',' expected
-            // [a : b ?? c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "b").WithArguments(",").WithLocation(1, 6));
+        UsingExpression("[a : b ?? c]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.IdentifierName);
                 {
                     N(SyntaxKind.IdentifierToken, "a");
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.CoalesceExpression);
                 {
                     N(SyntaxKind.IdentifierName);
@@ -2098,18 +1996,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithNullCoalesce3()
     {
-        UsingExpression("[a ?? b : c ?? d]",
-            // (1,9): error CS1003: Syntax error, ',' expected
-            // [a ?? b : c ?? d]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 9),
-            // (1,11): error CS1003: Syntax error, ',' expected
-            // [a ?? b : c ?? d]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "c").WithArguments(",").WithLocation(1, 11));
+        UsingExpression("[a ?? b : c ?? d]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.CoalesceExpression);
                 {
@@ -2123,10 +2015,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         N(SyntaxKind.IdentifierToken, "b");
                     }
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.CoalesceExpression);
                 {
                     N(SyntaxKind.IdentifierName);
@@ -2148,18 +2037,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithQuery1()
     {
-        UsingExpression("[from x in y select x : c]",
-            // (1,23): error CS1003: Syntax error, ',' expected
-            // [from x in y select x : c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 23),
-            // (1,25): error CS1003: Syntax error, ',' expected
-            // [from x in y select x : c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "c").WithArguments(",").WithLocation(1, 25));
+        UsingExpression("[from x in y select x : c]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.QueryExpression);
                 {
@@ -2185,10 +2068,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         }
                     }
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.IdentifierName);
                 {
                     N(SyntaxKind.IdentifierToken, "c");
@@ -2202,27 +2082,18 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithQuery2()
     {
-        UsingExpression("[a : from x in y select x]",
-            // (1,4): error CS1003: Syntax error, ',' expected
-            // [a : from x in y select x]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 4),
-            // (1,6): error CS1003: Syntax error, ',' expected
-            // [a : from x in y select x]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "from").WithArguments(",").WithLocation(1, 6));
+        UsingExpression("[a : from x in y select x]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.IdentifierName);
                 {
                     N(SyntaxKind.IdentifierToken, "a");
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.QueryExpression);
                 {
                     N(SyntaxKind.FromClause);
@@ -2256,18 +2127,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void DictionaryWithQuery3()
     {
-        UsingExpression("[from a in b select a : from x in y select x]",
-            // (1,23): error CS1003: Syntax error, ',' expected
-            // [from a in b select a : from x in y select x]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 23),
-            // (1,25): error CS1003: Syntax error, ',' expected
-            // [from a in b select a : from x in y select x]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "from").WithArguments(",").WithLocation(1, 25));
+        UsingExpression("[from a in b select a : from x in y select x]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.QueryExpression);
                 {
@@ -2293,10 +2158,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                         }
                     }
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.QueryExpression);
                 {
                     N(SyntaxKind.FromClause);
@@ -2459,18 +2321,12 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
     [Fact]
     public void ConditionalAmbiguity2()
     {
-        UsingExpression("[(a ? [b]) : c]",
-            // (1,12): error CS1003: Syntax error, ',' expected
-            // [(a ? [b]) : c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 12),
-            // (1,14): error CS1003: Syntax error, ',' expected
-            // [(a ? [b]) : c]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "c").WithArguments(",").WithLocation(1, 14));
+        UsingExpression("[(a ? [b]) : c]");
 
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
-            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.KeyValuePairElement);
             {
                 N(SyntaxKind.ParenthesizedExpression);
                 {
@@ -2500,10 +2356,7 @@ public sealed class CollectionExpressionParsingTests : ParsingTests
                     }
                     N(SyntaxKind.CloseParenToken);
                 }
-            }
-            M(SyntaxKind.CommaToken);
-            N(SyntaxKind.ExpressionElement);
-            {
+                N(SyntaxKind.ColonToken);
                 N(SyntaxKind.IdentifierName);
                 {
                     N(SyntaxKind.IdentifierToken, "c");
@@ -7323,13 +7176,7 @@ class C
     [Fact]
     public void Interpolation1()
     {
-        UsingExpression(""" $"{[A:B]}" """,
-            // (1,7): error CS1003: Syntax error, ',' expected
-            //  $"{[A:B]}" 
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 7),
-            // (1,8): error CS1003: Syntax error, ',' expected
-            //  $"{[A:B]}" 
-            Diagnostic(ErrorCode.ERR_SyntaxError, "B").WithArguments(",").WithLocation(1, 8));
+        UsingExpression(""" $"{[A:B]}" """);
 
         N(SyntaxKind.InterpolatedStringExpression);
         {
@@ -7340,16 +7187,13 @@ class C
                 N(SyntaxKind.CollectionExpression);
                 {
                     N(SyntaxKind.OpenBracketToken);
-                    N(SyntaxKind.ExpressionElement);
+                    N(SyntaxKind.KeyValuePairElement);
                     {
                         N(SyntaxKind.IdentifierName);
                         {
                             N(SyntaxKind.IdentifierToken, "A");
                         }
-                    }
-                    M(SyntaxKind.CommaToken);
-                    N(SyntaxKind.ExpressionElement);
-                    {
+                        N(SyntaxKind.ColonToken);
                         N(SyntaxKind.IdentifierName);
                         {
                             N(SyntaxKind.IdentifierToken, "B");
@@ -7368,9 +7212,12 @@ class C
     public void Interpolation2()
     {
         UsingExpression(""" $"{[:]}" """,
-            // (1,6): error CS1001: Identifier expected
+            // (1,6): error CS1525: Invalid expression term ':'
             //  $"{[:]}" 
-            Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 6));
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 6),
+            // (1,7): error CS1525: Invalid expression term ']'
+            //  $"{[:]}" 
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "]").WithArguments("]").WithLocation(1, 7));
 
         N(SyntaxKind.InterpolatedStringExpression);
         {
@@ -7381,6 +7228,18 @@ class C
                 N(SyntaxKind.CollectionExpression);
                 {
                     N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.KeyValuePairElement);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        N(SyntaxKind.ColonToken);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
                     N(SyntaxKind.CloseBracketToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
@@ -7496,13 +7355,7 @@ class C
     [Fact]
     public void Addressof4()
     {
-        UsingExpression("&[A:B]",
-            // (1,4): error CS1003: Syntax error, ',' expected
-            // &[A:B]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 4),
-            // (1,5): error CS1003: Syntax error, ',' expected
-            // &[A:B]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "B").WithArguments(",").WithLocation(1, 5));
+        UsingExpression("&[A:B]");
 
         N(SyntaxKind.AddressOfExpression);
         {
@@ -7510,16 +7363,13 @@ class C
             N(SyntaxKind.CollectionExpression);
             {
                 N(SyntaxKind.OpenBracketToken);
-                N(SyntaxKind.ExpressionElement);
+                N(SyntaxKind.KeyValuePairElement);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "A");
                     }
-                }
-                M(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
+                    N(SyntaxKind.ColonToken);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "B");
@@ -7654,13 +7504,7 @@ class C
     [Fact]
     public void Deref5()
     {
-        UsingExpression("*[A:B]",
-            // (1,4): error CS1003: Syntax error, ',' expected
-            // *[A:B]
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 4),
-            // (1,5): error CS1003: Syntax error, ',' expected
-            // *[A:B]
-            Diagnostic(ErrorCode.ERR_SyntaxError, "B").WithArguments(",").WithLocation(1, 5));
+        UsingExpression("*[A:B]");
 
         N(SyntaxKind.PointerIndirectionExpression);
         {
@@ -7668,16 +7512,13 @@ class C
             N(SyntaxKind.CollectionExpression);
             {
                 N(SyntaxKind.OpenBracketToken);
-                N(SyntaxKind.ExpressionElement);
+                N(SyntaxKind.KeyValuePairElement);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "A");
                     }
-                }
-                M(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
+                    N(SyntaxKind.ColonToken);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "B");
@@ -10647,13 +10488,7 @@ class C
                     [A:B]!.GetHashCode();
                 }
             }
-            """,
-            // (5,11): error CS1003: Syntax error, ',' expected
-            //         [A:B]!.GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(5, 11),
-            // (5,12): error CS1003: Syntax error, ',' expected
-            //         [A:B]!.GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "B").WithArguments(",").WithLocation(5, 12));
+            """);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -10689,16 +10524,13 @@ class C
                                         N(SyntaxKind.CollectionExpression);
                                         {
                                             N(SyntaxKind.OpenBracketToken);
-                                            N(SyntaxKind.ExpressionElement);
+                                            N(SyntaxKind.KeyValuePairElement);
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
                                                     N(SyntaxKind.IdentifierToken, "A");
                                                 }
-                                            }
-                                            M(SyntaxKind.CommaToken);
-                                            N(SyntaxKind.ExpressionElement);
-                                            {
+                                                N(SyntaxKind.ColonToken);
                                                 N(SyntaxKind.IdentifierName);
                                                 {
                                                     N(SyntaxKind.IdentifierToken, "B");
@@ -10737,13 +10569,7 @@ class C
     {
         UsingTree("""
             [A:B]!.GetHashCode();
-            """,
-            // (1,3): error CS1003: Syntax error, ',' expected
-            // [A:B]!.GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 3),
-            // (1,4): error CS1003: Syntax error, ',' expected
-            // [A:B]!.GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "B").WithArguments(",").WithLocation(1, 4));
+            """);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -10760,16 +10586,13 @@ class C
                                 N(SyntaxKind.CollectionExpression);
                                 {
                                     N(SyntaxKind.OpenBracketToken);
-                                    N(SyntaxKind.ExpressionElement);
+                                    N(SyntaxKind.KeyValuePairElement);
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
                                             N(SyntaxKind.IdentifierToken, "A");
                                         }
-                                    }
-                                    M(SyntaxKind.CommaToken);
-                                    N(SyntaxKind.ExpressionElement);
-                                    {
+                                        N(SyntaxKind.ColonToken);
                                         N(SyntaxKind.IdentifierName);
                                         {
                                             N(SyntaxKind.IdentifierToken, "B");
@@ -11293,13 +11116,7 @@ class C
                     [A:B][C:D].GetHashCode();
                 }
             }
-            """,
-            // (5,11): error CS1003: Syntax error, ',' expected
-            //         [A:B][C:D].GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(5, 11),
-            // (5,12): error CS1003: Syntax error, ',' expected
-            //         [A:B][C:D].GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "B").WithArguments(",").WithLocation(5, 12));
+            """);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -11335,16 +11152,13 @@ class C
                                         N(SyntaxKind.CollectionExpression);
                                         {
                                             N(SyntaxKind.OpenBracketToken);
-                                            N(SyntaxKind.ExpressionElement);
+                                            N(SyntaxKind.KeyValuePairElement);
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
                                                     N(SyntaxKind.IdentifierToken, "A");
                                                 }
-                                            }
-                                            M(SyntaxKind.CommaToken);
-                                            N(SyntaxKind.ExpressionElement);
-                                            {
+                                                N(SyntaxKind.ColonToken);
                                                 N(SyntaxKind.IdentifierName);
                                                 {
                                                     N(SyntaxKind.IdentifierToken, "B");
@@ -11402,13 +11216,7 @@ class C
     {
         UsingTree("""
             [A:B][C:D].GetHashCode();
-            """,
-            // (1,3): error CS1003: Syntax error, ',' expected
-            // [A:B][C:D].GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 3),
-            // (1,4): error CS1003: Syntax error, ',' expected
-            // [A:B][C:D].GetHashCode();
-            Diagnostic(ErrorCode.ERR_SyntaxError, "B").WithArguments(",").WithLocation(1, 4));
+            """);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -11425,16 +11233,13 @@ class C
                                 N(SyntaxKind.CollectionExpression);
                                 {
                                     N(SyntaxKind.OpenBracketToken);
-                                    N(SyntaxKind.ExpressionElement);
+                                    N(SyntaxKind.KeyValuePairElement);
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
                                             N(SyntaxKind.IdentifierToken, "A");
                                         }
-                                    }
-                                    M(SyntaxKind.CommaToken);
-                                    N(SyntaxKind.ExpressionElement);
-                                    {
+                                        N(SyntaxKind.ColonToken);
                                         N(SyntaxKind.IdentifierName);
                                         {
                                             N(SyntaxKind.IdentifierToken, "B");
@@ -18613,5 +18418,2575 @@ class C
                 }
             }
             """).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey1()
+    {
+        UsingExpression("[default:0]");
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.DefaultLiteralExpression);
+                {
+                    N(SyntaxKind.DefaultKeyword);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey2()
+    {
+        UsingExpression("[false:0]");
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.FalseLiteralExpression);
+                {
+                    N(SyntaxKind.FalseKeyword);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey3()
+    {
+        UsingExpression("[this:0]");
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.ThisExpression);
+                {
+                    N(SyntaxKind.ThisKeyword);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey4()
+    {
+        UsingExpression("[true:0]");
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.TrueLiteralExpression);
+                {
+                    N(SyntaxKind.TrueKeyword);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey5()
+    {
+        UsingExpression("[null:0]");
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.NullLiteralExpression);
+                {
+                    N(SyntaxKind.NullKeyword);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey6()
+    {
+        UsingExpression("[base:0]");
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.BaseExpression);
+                {
+                    N(SyntaxKind.BaseKeyword);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey_Illegal1()
+    {
+        UsingExpression("[throw:0]",
+            // (1,7): error CS1525: Invalid expression term ':'
+            // [throw:0]
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 7));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.ThrowExpression);
+                {
+                    N(SyntaxKind.ThrowKeyword);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey_Illegal2()
+    {
+        UsingExpression("[new:0]",
+            // (1,5): error CS1526: A new expression requires an argument list or (), [], or {} after type
+            // [new:0]
+            Diagnostic(ErrorCode.ERR_BadNewExpr, ":").WithLocation(1, 5));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.ObjectCreationExpression);
+                {
+                    N(SyntaxKind.NewKeyword);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.ArgumentList);
+                    {
+                        M(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.CloseParenToken);
+                    }
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey_Illegal3()
+    {
+        UsingExpression("[typeof:0]",
+            // (1,8): error CS1003: Syntax error, '(' expected
+            // [typeof:0]
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("(").WithLocation(1, 8),
+            // (1,8): error CS1031: Type expected
+            // [typeof:0]
+            Diagnostic(ErrorCode.ERR_TypeExpected, ":").WithLocation(1, 8),
+            // (1,8): error CS1026: ) expected
+            // [typeof:0]
+            Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 8));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.TypeOfExpression);
+                {
+                    N(SyntaxKind.TypeOfKeyword);
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey_Illegal4()
+    {
+        UsingExpression("[sizeof:0]",
+            // (1,8): error CS1003: Syntax error, '(' expected
+            // [sizeof:0]
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("(").WithLocation(1, 8),
+            // (1,8): error CS1031: Type expected
+            // [sizeof:0]
+            Diagnostic(ErrorCode.ERR_TypeExpected, ":").WithLocation(1, 8),
+            // (1,8): error CS1026: ) expected
+            // [sizeof:0]
+            Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 8));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.SizeOfExpression);
+                {
+                    N(SyntaxKind.SizeOfKeyword);
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CollectionExpression_KeywordKey_Illegal5()
+    {
+        UsingExpression("[checked:0]",
+            // (1,9): error CS1003: Syntax error, '(' expected
+            // [checked:0]
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("(").WithLocation(1, 9),
+            // (1,9): error CS1525: Invalid expression term ':'
+            // [checked:0]
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 9),
+            // (1,9): error CS1026: ) expected
+            // [checked:0]
+            Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 9));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.CheckedExpression);
+                {
+                    N(SyntaxKind.CheckedKeyword);
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+}
+
+public class CollectionArgumentsParsingTests : ParsingTests
+{
+    public CollectionArgumentsParsingTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public static readonly TheoryData<LanguageVersion> CollectionArgumentsLanguageVersions = new([LanguageVersion.CSharp13, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
+
+    private void CollectionArgumentsOrInvocation(LanguageVersion languageVersion)
+    {
+        if (languageVersion > LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.WithElement);
+            N(SyntaxKind.WithKeyword);
+        }
+        else
+        {
+            N(SyntaxKind.ExpressionElement);
+            N(SyntaxKind.InvocationExpression);
+            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.IdentifierToken, "with");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement1(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "with");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement2(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with: with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "with");
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "with");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement3(LanguageVersion languageVersion)
+    {
+        UsingExpression("[.. with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.SpreadElement);
+            {
+                N(SyntaxKind.DotDotToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "with");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement4(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with + with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.AddExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement5(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with.X]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.SimpleMemberAccessExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.DotToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "X");
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement6(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with[X]]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.ElementAccessExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.BracketedArgumentList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Argument);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "X");
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement7(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with ? with : with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.ConditionalExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.QuestionToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.ColonToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement8(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with?.with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.ConditionalAccessExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.QuestionToken);
+                    N(SyntaxKind.MemberBindingExpression);
+                    {
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement9(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with++]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.PostIncrementExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.PlusPlusToken);
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement10(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,6): error CS1003: Syntax error, ',' expected
+            // [with)]
+            Diagnostic(ErrorCode.ERR_SyntaxError, ")").WithArguments(",").WithLocation(1, 6));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "with");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement11(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with..with]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.RangeExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.DotDotToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement12(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with..with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.RangeExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.DotDotToken);
+                    N(SyntaxKind.InvocationExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement13(LanguageVersion languageVersion)
+    {
+        UsingExpression("[@with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.InvocationExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "@with");
+                    }
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement14(LanguageVersion languageVersion)
+    {
+        UsingExpression("with()",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.InvocationExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "with");
+            }
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement15(LanguageVersion languageVersion)
+    {
+        UsingExpression("a with()",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,1): error CS1073: Unexpected token 'with'
+            // a with()
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "a").WithArguments("with").WithLocation(1, 1));
+
+        N(SyntaxKind.IdentifierName);
+        {
+            N(SyntaxKind.IdentifierToken, "a");
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement16(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with()] a => b",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.SimpleLambdaExpression);
+        {
+            N(SyntaxKind.AttributeList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Attribute);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.AttributeArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            N(SyntaxKind.Parameter);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            N(SyntaxKind.EqualsGreaterThanToken);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "b");
+            }
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement17(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with()] async a => b",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.SimpleLambdaExpression);
+        {
+            N(SyntaxKind.AttributeList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Attribute);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.AttributeArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.Parameter);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            N(SyntaxKind.EqualsGreaterThanToken);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "b");
+            }
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement18(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with()] (a) => b",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.ParenthesizedLambdaExpression);
+        {
+            N(SyntaxKind.AttributeList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Attribute);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.AttributeArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.EqualsGreaterThanToken);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "b");
+            }
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement1(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,7): error CS1026: ) expected
+            // [with(]
+            Diagnostic(ErrorCode.ERR_CloseParenExpected, "]").WithLocation(1, 7),
+            // (1,8): error CS1003: Syntax error, ']' expected
+            // [with(]
+            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(1, 8));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                M(SyntaxKind.CloseParenToken);
+            }
+            M(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement2(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement3(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(,)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,7): error CS0839: Argument missing
+            // [with(,)]
+            Diagnostic(ErrorCode.ERR_MissingArgument, ",").WithLocation(1, 7),
+            // (1,8): error CS1525: Invalid expression term ')'
+            // [with(,)]
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 8));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                M(SyntaxKind.Argument);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                M(SyntaxKind.Argument);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement4(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement5(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(ref a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement6(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(out a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.OutKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement7(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(out var a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.OutKeyword);
+                    N(SyntaxKind.DeclarationExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "var");
+                        }
+                        N(SyntaxKind.SingleVariableDesignation);
+                        {
+                            N(SyntaxKind.IdentifierToken, "a");
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement8(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(name: value)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.NameColon);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "name");
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "value");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement9(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(a, b)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement10(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(), with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CommaToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement11(LanguageVersion languageVersion)
+    {
+        UsingExpression("[a, with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement12(LanguageVersion languageVersion)
+    {
+        UsingExpression("[a:b, with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "b");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement13(LanguageVersion languageVersion)
+    {
+        UsingExpression("[..a, with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.SpreadElement);
+            {
+                N(SyntaxKind.DotDotToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement14(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(), a]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement15(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(), a:b]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "b");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement16(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(), ..a]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SpreadElement);
+            {
+                N(SyntaxKind.DotDotToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement17(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with([])]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.CollectionExpression);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement18(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(() => {})]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.ParenthesizedLambdaExpression);
+                    {
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement19(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(async () => {})]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.ParenthesizedLambdaExpression);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement20(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(from x in y select x)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.QueryExpression);
+                    {
+                        N(SyntaxKind.FromClause);
+                        {
+                            N(SyntaxKind.FromKeyword);
+                            N(SyntaxKind.IdentifierToken, "x");
+                            N(SyntaxKind.InKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "y");
+                            }
+                        }
+                        N(SyntaxKind.QueryBody);
+                        {
+                            N(SyntaxKind.SelectClause);
+                            {
+                                N(SyntaxKind.SelectKeyword);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "x");
+                                }
+                            }
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement21(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with([with()])]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.CollectionExpression);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        CollectionArgumentsOrInvocation(languageVersion);
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement22(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(with: with)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.NameColon);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement23(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(out _)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.OutKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "_");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement24(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(in a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.InKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement25(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(name: ref a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.NameColon);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "name");
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement26(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(ref int () => { })]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.ParenthesizedLambdaExpression);
+                    {
+                        N(SyntaxKind.RefType);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                        }
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement27(LanguageVersion languageVersion)
+    {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with()..x]
+                Diagnostic(ErrorCode.ERR_SyntaxError, ".").WithArguments(",").WithLocation(1, 8)
+            };
+        UsingExpression("[with()..x]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
+
+        if (languageVersion == LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.RangeExpression);
+                    {
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "with");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.DotDotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "x");
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.SpreadElement);
+                {
+                    N(SyntaxKind.DotDotToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement28(LanguageVersion languageVersion)
+    {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with().x]
+                Diagnostic(ErrorCode.ERR_SyntaxError, ".").WithArguments(",").WithLocation(1, 8),
+                // (1,9): error CS1003: Syntax error, ',' expected
+                // [with().x]
+                Diagnostic(ErrorCode.ERR_SyntaxError, "x").WithArguments(",").WithLocation(1, 9)
+            };
+        UsingExpression("[with().x]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
+
+        if (languageVersion == LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.SimpleMemberAccessExpression);
+                    {
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "with");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "x");
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement29(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with()",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,8): error CS1003: Syntax error, ']' expected
+            // [with()
+            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(1, 8));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            M(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement30(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(),",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,9): error CS1003: Syntax error, ']' expected
+            // [with(),
+            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(1, 9));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CommaToken);
+            M(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement31(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(_)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "_");
+                    }
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement32(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(a,)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,9): error CS1525: Invalid expression term ')'
+            // [with(a,)]
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 9));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    M(SyntaxKind.Argument);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement33(LanguageVersion languageVersion)
+    {
+        UsingExpression("[with(,a)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,7): error CS0839: Argument missing
+            // [with(,a)]
+            Diagnostic(ErrorCode.ERR_MissingArgument, ",").WithLocation(1, 7));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                M(SyntaxKind.Argument);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Argument);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "a");
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement34(LanguageVersion languageVersion)
+    {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with():y]
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 8),
+                // (1,8): error CS1525: Invalid expression term ':'
+                // [with():y]
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ":").WithArguments(":").WithLocation(1, 8)
+            };
+        UsingExpression("[with():y]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
+
+        if (languageVersion == LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.KeyValuePairElement);
+                {
+                    N(SyntaxKind.InvocationExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                    N(SyntaxKind.ColonToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.KeyValuePairElement);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.ColonToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement35(LanguageVersion languageVersion)
+    {
+        UsingExpression("[x:with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.KeyValuePairElement);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.ColonToken);
+                N(SyntaxKind.InvocationExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement36(LanguageVersion languageVersion)
+    {
+        UsingExpression("[..with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.SpreadElement);
+            {
+                N(SyntaxKind.DotDotToken);
+                N(SyntaxKind.InvocationExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement37(LanguageVersion languageVersion)
+    {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with()++]
+                Diagnostic(ErrorCode.ERR_SyntaxError, "++").WithArguments(",").WithLocation(1, 8),
+                // (1,10): error CS1525: Invalid expression term ']'
+                // [with()++]
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "]").WithArguments("]").WithLocation(1, 10),
+            };
+        UsingExpression("[with()++]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
+
+        if (languageVersion == LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.PostIncrementExpression);
+                    {
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "with");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.PlusPlusToken);
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.PreIncrementExpression);
+                    {
+                        N(SyntaxKind.PlusPlusToken);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement38(LanguageVersion languageVersion)
+    {
+        var expectedDiagnostics = (languageVersion == LanguageVersion.CSharp13) ?
+            [] :
+            new[]
+            {
+                // (1,8): error CS1003: Syntax error, ',' expected
+                // [with()[0]]
+                Diagnostic(ErrorCode.ERR_SyntaxError, "[").WithArguments(",").WithLocation(1, 8)
+            };
+        UsingExpression("[with()[0]]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedDiagnostics);
+
+        if (languageVersion == LanguageVersion.CSharp13)
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.ElementAccessExpression);
+                    {
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "with");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.BracketedArgumentList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+        else
+        {
+            N(SyntaxKind.CollectionExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.WithElement);
+                {
+                    N(SyntaxKind.WithKeyword);
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.CollectionExpression);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.ExpressionElement);
+                        {
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "0");
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            EOF();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement39(LanguageVersion languageVersion)
+    {
+        UsingTree("""
+            void M()
+            {
+                var v = [await with()];
+            }
+            """,
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (3,20): error CS1003: Syntax error, ',' expected
+            //     var v = [await with()];
+            Diagnostic(ErrorCode.ERR_SyntaxError, "with").WithArguments(",").WithLocation(3, 20));
+
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.GlobalStatement);
+            {
+                N(SyntaxKind.LocalFunctionStatement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.LocalDeclarationStatement);
+                        {
+                            N(SyntaxKind.VariableDeclaration);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "var");
+                                }
+                                N(SyntaxKind.VariableDeclarator);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "v");
+                                    N(SyntaxKind.EqualsValueClause);
+                                    {
+                                        N(SyntaxKind.EqualsToken);
+                                        N(SyntaxKind.CollectionExpression);
+                                        {
+                                            N(SyntaxKind.OpenBracketToken);
+                                            N(SyntaxKind.ExpressionElement);
+                                            {
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "await");
+                                                }
+                                            }
+                                            M(SyntaxKind.CommaToken);
+                                            CollectionArgumentsOrInvocation(languageVersion);
+                                            N(SyntaxKind.ArgumentList);
+                                            {
+                                                N(SyntaxKind.OpenParenToken);
+                                                N(SyntaxKind.CloseParenToken);
+                                            }
+                                            N(SyntaxKind.CloseBracketToken);
+                                        }
+                                    }
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void WithElement40(LanguageVersion languageVersion)
+    {
+        UsingTree("""
+            async void M()
+            {
+                var v = [await with()];
+            }
+            """,
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.GlobalStatement);
+            {
+                N(SyntaxKind.LocalFunctionStatement);
+                {
+                    N(SyntaxKind.AsyncKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.LocalDeclarationStatement);
+                        {
+                            N(SyntaxKind.VariableDeclaration);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "var");
+                                }
+                                N(SyntaxKind.VariableDeclarator);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "v");
+                                    N(SyntaxKind.EqualsValueClause);
+                                    {
+                                        N(SyntaxKind.EqualsToken);
+                                        N(SyntaxKind.CollectionExpression);
+                                        {
+                                            N(SyntaxKind.OpenBracketToken);
+                                            N(SyntaxKind.ExpressionElement);
+                                            {
+                                                N(SyntaxKind.AwaitExpression);
+                                                {
+                                                    N(SyntaxKind.AwaitKeyword);
+                                                    N(SyntaxKind.InvocationExpression);
+                                                    {
+                                                        N(SyntaxKind.IdentifierName);
+                                                        {
+                                                            N(SyntaxKind.IdentifierToken, "with");
+                                                        }
+                                                        N(SyntaxKind.ArgumentList);
+                                                        {
+                                                            N(SyntaxKind.OpenParenToken);
+                                                            N(SyntaxKind.CloseParenToken);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            N(SyntaxKind.CloseBracketToken);
+                                        }
+                                    }
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaAttributeParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaAttributeParsingTests.cs
@@ -3605,8 +3605,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 N(SyntaxKind.CollectionExpression);
                 {
                     N(SyntaxKind.OpenBracketToken);
-                    N(SyntaxKind.ExpressionElement);
+                    N(SyntaxKind.KeyValuePairElement);
                     {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "return");
+                        }
+                        N(SyntaxKind.ColonToken);
                         N(SyntaxKind.IdentifierName);
                         {
                             N(SyntaxKind.IdentifierToken, "A");

--- a/src/Compilers/Core/Portable/MemberDescriptor.cs
+++ b/src/Compilers/Core/Portable/MemberDescriptor.cs
@@ -19,13 +19,14 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
         Field = 0x02,
         Constructor = 0x04,
         PropertyGet = 0x08,
-        Property = 0x10,
+        PropertySet = 0x10,
+        Property = 0x20,
         // END Mutually exclusive Member kinds
 
-        KindMask = 0x1F,
+        KindMask = 0x3F,
 
-        Static = 0x20,
-        Virtual = 0x40, // Virtual in CLR terms, i.e. sealed should be accepted.
+        Static = 0x40,
+        Virtual = 0x80, // Virtual in CLR terms, i.e. sealed should be accepted.
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -718,6 +718,11 @@ namespace Microsoft.CodeAnalysis
         System_Text_Encoding__get_UTF8,
         System_Text_Encoding__GetString,
 
+        System_Collections_Generic_Dictionary_KV__ctor,
+        System_Collections_Generic_Dictionary_KV__set_Item,
+        System_Collections_Generic_KeyValuePair_KV__get_Key,
+        System_Collections_Generic_KeyValuePair_KV__get_Value,
+
         Count,
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -5197,6 +5197,36 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,                                    // Return Type
                     (byte)SignatureTypeCode.Pointer, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Byte,     // Argument: byte*
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,                                     // Argument: int
+
+                // System_Collections_Generic_Dictionary_KV__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_Dictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+
+                // System_Collections_Generic_Dictionary_KV__set_Item
+                (byte)MemberFlags.PropertySet,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_Dictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+
+                // System_Collections_Generic_KeyValuePair_KV__get_Key
+                (byte)MemberFlags.PropertyGet,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_KeyValuePair_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0, // Return Type
+
+                // System_Collections_Generic_KeyValuePair_KV__get_Value
+                (byte)MemberFlags.PropertyGet,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_KeyValuePair_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1, // Return Type
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -5823,6 +5853,10 @@ namespace Microsoft.CodeAnalysis
                 "Power",                                    // System_Linq_Expressions_Expression__Power_MethodInfo,
                 "get_UTF8",                                 // System_Text_Encoding__get_UTF8
                 "GetString",                                // System_Text_Encoding__GetString
+                ".ctor",                                    // System_Collections_Generic_Dictionary_KV__ctor,
+                "set_Item",                                 // System_Collections_Generic_Dictionary_KV__set_Item
+                "get_Key",                                  // System_Collections_Generic_KeyValuePair_KV__get_Key
+                "get_Value",                                // System_Collections_Generic_KeyValuePair_KV__get_Value
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -357,6 +357,9 @@ namespace Microsoft.CodeAnalysis
 
         System_Text_Encoding,
 
+        System_Collections_Generic_Dictionary_KV,
+        System_Collections_Generic_KeyValuePair_KV,
+
         NextAvailable,
         // Remember to update the AllWellKnownTypes tests when making changes here
     }
@@ -699,6 +702,9 @@ namespace Microsoft.CodeAnalysis
             "System.Linq.Expressions.DefaultExpression",
 
             "System.Text.Encoding",
+
+            "System.Collections.Generic.Dictionary`2",
+            "System.Collections.Generic.KeyValuePair`2",
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/Test/Core/TestResource.resx
+++ b/src/Compilers/Test/Core/TestResource.resx
@@ -758,6 +758,15 @@ namespace ConsoleApplication1
             List&lt;int&gt; i = null;
             int c = i.Count;
         }
+
+        static void DictionaryExpressions&lt;K, V&gt;(K k, V v, KeyValuePair&lt;K, V&gt; e, IEnumerable&lt;KeyValuePair&lt;K, V&gt;&gt; s)
+        {
+            IDictionary&lt;K, V&gt; d;
+            d = [e];
+            d = [.. s];
+            d = [k:v];
+            d = [with()];
+        }
     }
 }
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -442,6 +442,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     targetSymbolKind = SymbolKind.Method
                     targetMethodKind = MethodKind.PropertyGet
 
+                Case MemberFlags.PropertySet
+                    targetSymbolKind = SymbolKind.Method
+                    targetMethodKind = MethodKind.PropertySet
+
                 Case MemberFlags.Field
                     targetSymbolKind = SymbolKind.Field
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
@@ -29,7 +30,9 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
 {
     protected const string NonBreakingSpaceString = "\x00A0";
 
-    protected static string GetMarkup(string source, LanguageVersion languageVersion)
+    protected static string GetMarkup(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string source,
+        LanguageVersion languageVersion)
         => $@"<Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"" LanguageVersion=""{languageVersion.ToDisplayString()}"">
         <Document FilePath=""Test2.cs"">
@@ -40,15 +43,15 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
     </Project>
 </Workspace>";
 
-    protected override EditorTestWorkspace CreateWorkspace(string fileContents)
+    protected override EditorTestWorkspace CreateWorkspace([StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string fileContents)
         => EditorTestWorkspace.CreateCSharp(fileContents, composition: GetComposition());
 
     internal override CompletionService GetCompletionService(Project project)
         => Assert.IsType<CSharpCompletionService>(base.GetCompletionService(project));
 
     private protected override Task BaseVerifyWorkerAsync(
-        string code, int position,
-        string expectedItemOrNull, string expectedDescriptionOrNull,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        int position, string expectedItemOrNull, string expectedDescriptionOrNull,
         SourceCodeKind sourceCodeKind, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool checkForAbsence,
         int? glyph, int? matchPriority, bool? hasSuggestionItem, string displayTextSuffix,
         string displayTextPrefix, string inlineDescription = null, bool? isComplexTextEdit = null,
@@ -63,8 +66,9 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
     }
 
     private protected override Task BaseVerifyWorkerAsync(
-        string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
-            SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger, bool? hasSuggestionItem,
+        SourceCodeKind sourceCodeKind, ItemExpectation[] expectedResults,
         List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
     {
         return base.VerifyWorkerAsync(
@@ -73,8 +77,8 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
     }
 
     private protected override async Task VerifyWorkerAsync(
-        string code, int position,
-        string expectedItemOrNull, string expectedDescriptionOrNull,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        int position, string expectedItemOrNull, string expectedDescriptionOrNull,
         SourceCodeKind sourceCodeKind, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
         bool checkForAbsence, int? glyph, int? matchPriority,
         bool? hasSuggestionItem, string displayTextSuffix, string displayTextPrefix, string inlineDescription = null,
@@ -99,7 +103,8 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
         => expectedItemOrNull[0] == '@' ? expectedItemOrNull.Substring(1, 1) : expectedItemOrNull[..1];
 
     private async Task VerifyInFrontOfCommentAsync(
-        string code, int position, string insertText, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        int position, string insertText, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
         string expectedItemOrNull, string expectedDescriptionOrNull,
         SourceCodeKind sourceCodeKind, bool checkForAbsence, int? glyph,
         int? matchPriority, bool? hasSuggestionItem, string displayTextSuffix,
@@ -118,7 +123,8 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
     }
 
     private async Task VerifyInFrontOfCommentAsync(
-        string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
         string expectedItemOrNull, string expectedDescriptionOrNull,
         SourceCodeKind sourceCodeKind, bool checkForAbsence, int? glyph,
         int? matchPriority, bool? hasSuggestionItem, string displayTextSuffix,
@@ -133,7 +139,8 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
     }
 
     private protected async Task VerifyInFrontOfComment_ItemPartiallyWrittenAsync(
-        string code, int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string code,
+        int position, bool usePreviousCharAsTrigger, char? deletedCharTrigger,
         string expectedItemOrNull, string expectedDescriptionOrNull,
         SourceCodeKind sourceCodeKind, bool checkForAbsence, int? glyph,
         int? matchPriority, bool? hasSuggestionItem, string displayTextSuffix,
@@ -147,7 +154,7 @@ public abstract class AbstractCSharpCompletionProviderTests<TWorkspaceFixture> :
             displayTextPrefix, inlineDescription, isComplexTextEdit, matchingFilters, options, skipSpeculation: skipSpeculation);
     }
 
-    protected static string AddInsideMethod(string text)
+    protected static string AddInsideMethod([StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string text)
     {
         return
             """
@@ -172,7 +179,10 @@ usingDirectives +
 text;
     }
 
-    protected async Task VerifySendEnterThroughToEnterAsync(string initialMarkup, string textTypedSoFar, EnterKeyRule sendThroughEnterOption, bool expected)
+    protected async Task VerifySendEnterThroughToEnterAsync(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string textTypedSoFar,
+        EnterKeyRule sendThroughEnterOption, bool expected)
     {
         using var workspace = CreateWorkspace(initialMarkup);
         var hostDocument = workspace.DocumentWithCursor;

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -14,7 +15,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSetSources;
 
 [Trait(Traits.Feature, Traits.Features.Completion)]
-public class NamedParameterCompletionProviderTests : AbstractCSharpCompletionProviderTests
+public sealed class NamedParameterCompletionProviderTests : AbstractCSharpCompletionProviderTests
 {
     internal override Type GetCompletionProviderType()
         => typeof(NamedParameterCompletionProvider);
@@ -524,5 +525,161 @@ public class NamedParameterCompletionProviderTests : AbstractCSharpCompletionPro
             }
             """;
         await VerifyProviderCommitAsync(markup, "args:", expected, ':');
+    }
+
+    [Theory]
+    [InlineData("IList<int>")]
+    [InlineData("ICollection<int>")]
+    public async Task TestMutableInterfaces(string type)
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Goo()
+                {
+                    {{type}} list = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await VerifyItemExistsAsync(markup, "capacity", displayTextSuffix: ":");
+    }
+
+    [Theory]
+    [InlineData("IReadOnlyList<int>")]
+    [InlineData("IReadOnlyCollection<int>")]
+    [InlineData("IEnumerable<int>")]
+    [InlineData("IEnumerable")]
+    public async Task TestReadOnlyInterfaces(string type)
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Goo()
+                {
+                    {{type}} list = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await VerifyItemIsAbsentAsync(markup, "capacity", displayTextSuffix: ":");
+    }
+
+    [Fact]
+    public async Task TestConstructibleType1()
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Goo()
+                {
+                    HashSet<int> set = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await VerifyItemExistsAsync(markup, "comparer", displayTextSuffix: ":");
+        await VerifyItemExistsAsync(markup, "collection", displayTextSuffix: ":");
+    }
+
+    [Fact]
+    public async Task TestConstructibleType2()
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Goo()
+                {
+                    HashSet<int> set = [with(comparer: null, $$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await VerifyItemIsAbsentAsync(markup, "comparer", displayTextSuffix: ":");
+        await VerifyItemExistsAsync(markup, "collection", displayTextSuffix: ":");
+    }
+
+    [Fact]
+    public async Task TestBuilder1()
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+
+            namespace System
+            {
+                public readonly ref struct ReadOnlySpan<T> { }
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+                internal sealed class CollectionBuilderAttribute : Attribute
+                {
+                    public CollectionBuilderAttribute(Type builderType, string methodName) { }
+                }
+            }
+
+            [CollectionBuilder(typeof(MyCollectionBuilder), "Create")]
+            class MyCollection<T> : IEnumerable<T>
+            {
+                public IEnumerator<T> GetEnumerator() => new System.NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => new System.NotImplementedException();
+            }
+
+            static class MyCollectionBuilder
+            {
+                public static MyCollection<T> Create<T>(ReadOnlySpan<T> values, int capacity, int extra) => new System.NotImplementedException();
+                public static MyCollection<T> Create<T>(string capacity, string extra, ReadOnlySpan<T> values) => new System.NotImplementedException();
+            }
+
+            class C
+            {
+                public void Test()
+                {
+                    MyCollection<int> z = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+        await VerifyItemExistsAsync(markup, "capacity", displayTextSuffix: ":");
+        await VerifyItemExistsAsync(markup, "extra", displayTextSuffix: ":");
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -47,11 +47,9 @@ public class DiagnosticAnalyzerDriverTests
             // https://github.com/dotnet/roslyn/issues/44682 - Add to all in one
             SyntaxKind.WithExpression,
             SyntaxKind.RecordDeclaration,
-            SyntaxKind.CollectionExpression,
-            SyntaxKind.ExpressionElement,
-            SyntaxKind.SpreadElement,
             // Tracked by https://github.com/dotnet/roslyn/issues/76130 Add to all-in-one
             SyntaxKind.ExtensionDeclaration,
+            SyntaxKind.WithElement, // Needed when language version is updated.
         };
 
         var analyzer = new CSharpTrackingDiagnosticAnalyzer();

--- a/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Xunit.Combinatorial" PrivateAssets="all" />
     <PackageReference Include="Basic.Reference.Assemblies.Net60" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
@@ -45,7 +45,7 @@ public sealed class ObjectCreationExpressionSignatureHelpProviderTests : Abstrac
         var markup = """
             <Workspace>
                 <Project Language="C#" LanguageVersion="Preview" CommonReferences="true">
-                    <Document FilePath="SourceDocument"><![CDATA[
+                    <Document FilePath="SourceDocument">
             class C
             {
                 void M()

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/WithElementSignatureHelpProviderTests.cs
@@ -1,0 +1,154 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
+using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp;
+
+[Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+public sealed class WithElementSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
+{
+    internal override Type GetSignatureHelpProviderType()
+        => typeof(WithElementSignatureHelpProvider);
+
+    [Theory]
+    [InlineData("IList<int>")]
+    [InlineData("ICollection<int>")]
+    public async Task TestMutableInterfaces(string type)
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Goo()
+                {
+                    {{type}} list = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await TestAsync(markup, [new("List<int>(int capacity)", string.Empty, null, currentParameterIndex: 0)]);
+    }
+
+    [Theory]
+    [InlineData("IReadOnlyList<int>")]
+    [InlineData("IReadOnlyCollection<int>")]
+    [InlineData("IEnumerable<int>")]
+    [InlineData("IEnumerable")]
+    public async Task TestReadOnlyInterfaces(string type)
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Goo()
+                {
+                    {{type}} list = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await TestAsync(markup, []);
+    }
+
+    [Fact]
+    public async Task TestConstructibleType()
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Goo()
+                {
+                    HashSet<int> set = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await TestAsync(markup, [
+            new("HashSet<int>()", string.Empty, null, currentParameterIndex: 0),
+            new("HashSet<int>(IEnumerable<int> collection)", string.Empty, null, currentParameterIndex: 0),
+            new("HashSet<int>(IEqualityComparer<int> comparer)", string.Empty, null, currentParameterIndex: 0),
+            new("HashSet<int>(IEnumerable<int> collection, IEqualityComparer<int> comparer)", string.Empty, null, currentParameterIndex: 0)]);
+    }
+
+    [Fact]
+    public async Task TestBuilder1()
+    {
+        var markup = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="{{LanguageVersionExtensions.CSharpNext}}">
+                    <Document><![CDATA[
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+
+            namespace System
+            {
+                public readonly ref struct ReadOnlySpan<T> { }
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+                internal sealed class CollectionBuilderAttribute : Attribute
+                {
+                    public CollectionBuilderAttribute(Type builderType, string methodName) { }
+                }
+            }
+
+            [CollectionBuilder(typeof(MyCollectionBuilder), "Create")]
+            class MyCollection<T> : IEnumerable<T>
+            {
+                public IEnumerator<T> GetEnumerator() => new System.NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => new System.NotImplementedException();
+            }
+
+            static class MyCollectionBuilder
+            {
+                public static MyCollection<T> Create<T>(ReadOnlySpan<T> values, int capacity, int extra) => new System.NotImplementedException();
+                public static MyCollection<T> Create<T>(string capacity, string extra, ReadOnlySpan<T> values) => new System.NotImplementedException();
+            }
+
+            class C
+            {
+                public void Test()
+                {
+                    MyCollection<int> z = [with($$)];
+                }
+            }]]></Document>
+                </Project>
+            </Workspace>
+            """;
+        await TestAsync(markup, [
+            new("MyCollection<int> MyCollectionBuilder.Create<T>(int capacity, int extra)", string.Empty, null, currentParameterIndex: 0),
+            new("MyCollection<int> MyCollectionBuilder.Create<T>(string capacity, string extra)", string.Empty, null, currentParameterIndex: 0)]);
+    }
+}

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
@@ -211,7 +211,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
             }
         }
 
-        protected static string AddInsideMethod(string text, bool isAsync = false, string returnType = "void", bool topLevelStatement = false)
+        protected static string AddInsideMethod(
+            [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string text,
+            bool isAsync = false, string returnType = "void", bool topLevelStatement = false)
         {
             if (topLevelStatement)
             {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/WithKeywordRecommenderTests.cs
@@ -7,303 +7,362 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations;
+
+[Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+public sealed class WithKeywordRecommenderTests : KeywordRecommenderTests
 {
-    [Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-    public class WithKeywordRecommenderTests : KeywordRecommenderTests
+    [Fact]
+    public async Task TestNotAfterWith()
     {
-        [Fact]
-        public async Task TestNotAfterWith()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
-@"var q = goo with $$"));
-        }
+        await VerifyAbsenceAsync(AddInsideMethod(
+            @"var q = goo with $$"));
+    }
 
-        [Fact]
-        public async Task TestNotAtRoot_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-@"$$");
-        }
+    [Fact]
+    public async Task TestNotAtRoot_Interactive()
+    {
+        await VerifyAbsenceAsync(SourceCodeKind.Script,
+            @"$$");
+    }
 
-        [Fact]
-        public async Task TestNotAfterClass_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-                """
-                class C { }
-                $$
-                """);
-        }
+    [Fact]
+    public async Task TestNotAfterClass_Interactive()
+    {
+        await VerifyAbsenceAsync(SourceCodeKind.Script,
+            """
+            class C { }
+            $$
+            """);
+    }
 
-        [Fact]
-        public async Task TestNotAfterGlobalStatement_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-                """
-                System.Console.WriteLine();
-                $$
-                """);
-        }
+    [Fact]
+    public async Task TestNotAfterGlobalStatement_Interactive()
+    {
+        await VerifyAbsenceAsync(SourceCodeKind.Script,
+            """
+            System.Console.WriteLine();
+            $$
+            """);
+    }
 
-        [Fact]
-        public async Task TestNotAfterGlobalVariableDeclaration_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-                """
-                int i = 0;
-                $$
-                """);
-        }
+    [Fact]
+    public async Task TestNotAfterGlobalVariableDeclaration_Interactive()
+    {
+        await VerifyAbsenceAsync(SourceCodeKind.Script,
+            """
+            int i = 0;
+            $$
+            """);
+    }
 
-        [Fact]
-        public async Task TestNotInUsingAlias()
-        {
-            await VerifyAbsenceAsync(
+    [Fact]
+    public async Task TestNotInUsingAlias()
+    {
+        await VerifyAbsenceAsync(
 @"using Goo = $$");
-        }
+    }
 
-        [Fact]
-        public async Task TestNotInGlobalUsingAlias()
-        {
-            await VerifyAbsenceAsync(
+    [Fact]
+    public async Task TestNotInGlobalUsingAlias()
+    {
+        await VerifyAbsenceAsync(
 @"global using Goo = $$");
-        }
+    }
 
-        [Fact]
-        public async Task TestNotInEmptyStatement()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
+    [Fact]
+    public async Task TestNotInEmptyStatement()
+    {
+        await VerifyAbsenceAsync(AddInsideMethod(
 @"$$"));
-        }
+    }
 
-        [Fact]
-        public async Task TestAfterExpr()
-        {
-            await VerifyKeywordAsync(AddInsideMethod(
+    [Fact]
+    public async Task TestAfterExpr()
+    {
+        await VerifyKeywordAsync(AddInsideMethod(
 @"var q = goo $$"));
-        }
+    }
 
-        [Fact]
-        public async Task TestAfterDottedName()
-        {
-            await VerifyKeywordAsync(AddInsideMethod(
+    [Fact]
+    public async Task TestAfterDottedName()
+    {
+        await VerifyKeywordAsync(AddInsideMethod(
 @"var q = goo.Current $$"));
-        }
+    }
 
-        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543041")]
-        public async Task TestNotAfterVarInForLoop()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
+    [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543041")]
+    public async Task TestNotAfterVarInForLoop()
+    {
+        await VerifyAbsenceAsync(AddInsideMethod(
 @"for (var $$"));
-        }
+    }
 
-        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
-        public async Task TestNotBeforeFirstStringHole()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
-                """
-                var x = "\{0}$$\{1}\{2}"
-                """));
-        }
+    [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+    public async Task TestNotBeforeFirstStringHole()
+    {
+        await VerifyAbsenceAsync(AddInsideMethod(
+            """
+            var x = "\{0}$$\{1}\{2}"
+            """));
+    }
 
-        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
-        public async Task TestNotBetweenStringHoles()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
-                """
-                var x = "\{0}\{1}$$\{2}"
-                """));
-        }
+    [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+    public async Task TestNotBetweenStringHoles()
+    {
+        await VerifyAbsenceAsync(AddInsideMethod(
+            """
+            var x = "\{0}\{1}$$\{2}"
+            """));
+    }
 
-        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
-        public async Task TestNotAfterStringHoles()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
-                """
-                var x = "\{0}\{1}\{2}$$"
-                """));
-        }
+    [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+    public async Task TestNotAfterStringHoles()
+    {
+        await VerifyAbsenceAsync(AddInsideMethod(
+            """
+            var x = "\{0}\{1}\{2}$$"
+            """));
+    }
 
-        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
-        public async Task TestAfterLastStringHole()
-        {
-            await VerifyKeywordAsync(AddInsideMethod(
+    [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064811")]
+    public async Task TestAfterLastStringHole()
+    {
+        await VerifyKeywordAsync(AddInsideMethod(
 @"var x = ""\{0}\{1}\{2}"" $$"));
-        }
+    }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1736")]
-        public async Task TestNotWithinNumericLiteral()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1736")]
+    public async Task TestNotWithinNumericLiteral()
+    {
+        await VerifyAbsenceAsync(AddInsideMethod(
 @"var x = .$$0;"));
-        }
+    }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/28586")]
-        public async Task TestNotAfterAsync()
-        {
-            await VerifyAbsenceAsync(
-                """
-                using System;
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/28586")]
+    public async Task TestNotAfterAsync()
+    {
+        await VerifyAbsenceAsync(
+            """
+            using System;
 
-                class C
+            class C
+            {
+                void Goo()
                 {
-                    void Goo()
-                    {
-                        Bar(async $$
-                    }
+                    Bar(async $$
+                }
 
-                    void Bar(Func<int, string> f)
+                void Bar(Func<int, string> f)
+                {
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
+    public async Task TestNotAfterMethodReference()
+    {
+        await VerifyAbsenceAsync(
+            """
+            using System;
+
+            class C {
+                void M() {
+                    var v = Console.WriteLine $$
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
+    public async Task TestNotAfterAnonymousMethod()
+    {
+        await VerifyAbsenceAsync(
+            """
+            using System;
+
+            class C {
+                void M() {
+                    Action a = delegate { } $$
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
+    public async Task TestNotAfterLambda1()
+    {
+        await VerifyAbsenceAsync(
+            """
+            using System;
+
+            class C {
+                void M() {
+                    Action b = (() => 0) $$
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
+    public async Task TestNotAfterLambda2()
+    {
+        await VerifyAbsenceAsync(
+            """
+            using System;
+
+            class C {
+                void M() {
+                    Action b = () => {} $$
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48573")]
+    public async Task TestMissingAfterNumericLiteral()
+    {
+        await VerifyAbsenceAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var x = 1$$
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48573")]
+    public async Task TestMissingAfterNumericLiteralAndDot()
+    {
+        await VerifyAbsenceAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var x = 1.$$
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48573")]
+    public async Task TestMissingAfterNumericLiteralDotAndSpace()
+    {
+        await VerifyAbsenceAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var x = 1. $$
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/31367")]
+    public async Task TestMissingInCaseClause1()
+    {
+        await VerifyAbsenceAsync(
+            """
+            class A
+            {
+
+            }
+
+            class C
+            {
+                void M(object o)
+                {
+                    switch (o)
                     {
+                        case A $$
                     }
                 }
-                """);
-        }
+            }
+            """);
+    }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
-        public async Task TestNotAfterMethodReference()
-        {
-            await VerifyAbsenceAsync(
-                """
-                using System;
-
-                class C {
-                    void M() {
-                        var v = Console.WriteLine $$
-                """);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
-        public async Task TestNotAfterAnonymousMethod()
-        {
-            await VerifyAbsenceAsync(
-                """
-                using System;
-
-                class C {
-                    void M() {
-                        Action a = delegate { } $$
-                """);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
-        public async Task TestNotAfterLambda1()
-        {
-            await VerifyAbsenceAsync(
-                """
-                using System;
-
-                class C {
-                    void M() {
-                        Action b = (() => 0) $$
-                """);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8319")]
-        public async Task TestNotAfterLambda2()
-        {
-            await VerifyAbsenceAsync(
-                """
-                using System;
-
-                class C {
-                    void M() {
-                        Action b = () => {} $$
-                """);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48573")]
-        public async Task TestMissingAfterNumericLiteral()
-        {
-            await VerifyAbsenceAsync(
-                """
-                class C
-                {
-                    void M()
-                    {
-                        var x = 1$$
-                    }
-                }
-                """);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48573")]
-        public async Task TestMissingAfterNumericLiteralAndDot()
-        {
-            await VerifyAbsenceAsync(
-                """
-                class C
-                {
-                    void M()
-                    {
-                        var x = 1.$$
-                    }
-                }
-                """);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48573")]
-        public async Task TestMissingAfterNumericLiteralDotAndSpace()
-        {
-            await VerifyAbsenceAsync(
-                """
-                class C
-                {
-                    void M()
-                    {
-                        var x = 1. $$
-                    }
-                }
-                """);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/31367")]
-        public async Task TestMissingInCaseClause1()
-        {
-            await VerifyAbsenceAsync(
-                """
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/31367")]
+    public async Task TestMissingInCaseClause2()
+    {
+        await VerifyAbsenceAsync(
+            """
+            namespace N
+            {
                 class A
                 {
 
                 }
+            }
 
-                class C
+            class C
+            {
+                void M(object o)
                 {
-                    void M(object o)
+                    switch (o)
                     {
-                        switch (o)
-                        {
-                            case A $$
-                        }
+                        case N.A $$
                     }
                 }
-                """);
-        }
+            }
+            """);
+    }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/31367")]
-        public async Task TestMissingInCaseClause2()
-        {
-            await VerifyAbsenceAsync(
-                """
-                namespace N
-                {
-                    class A
-                    {
+    [Fact]
+    public async Task TestInCollectionExpression1()
+    {
+        await VerifyKeywordAsync(
+            """
+            var v = [$$];
+            """);
+    }
 
-                    }
-                }
+    [Fact]
+    public async Task TestInCollectionExpression2()
+    {
+        await VerifyKeywordAsync(
+            """
+            var v = [$$, 1];
+            """);
+    }
 
-                class C
-                {
-                    void M(object o)
-                    {
-                        switch (o)
-                        {
-                            case N.A $$
-                        }
-                    }
-                }
-                """);
-        }
+    [Fact]
+    public async Task TestInCollectionExpression3()
+    {
+        await VerifyAbsenceAsync(
+            """
+            var v = [1, $$];
+            """);
+    }
+
+    [Fact]
+    public async Task TestInCollectionExpression4()
+    {
+        await VerifyAbsenceAsync(
+            """
+            var v = [1, $$
+            """);
+    }
+
+    [Fact]
+    public async Task TestInCollectionExpression5()
+    {
+        await VerifyKeywordAsync(
+            """
+            void M()
+            {
+                Goo([$$
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestInCollectionExpression6()
+    {
+        await VerifyKeywordAsync(
+            """
+            void M()
+            {
+                Goo([$$]);
+            }
+            """);
     }
 }

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -72,21 +72,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             bool usePreviousCharAsTrigger = false)
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+            var workspace = workspaceFixture.Target.GetWorkspace(markupWithPositionAndOptSpan);
+
             var options = new MemberDisplayOptions();
 
-            markupWithPositionAndOptSpan = markupWithPositionAndOptSpan.NormalizeLineEndings();
-
-            TextSpan? textSpan = null;
-            MarkupTestFile.GetPositionAndSpans(
-                markupWithPositionAndOptSpan,
-                out var code,
-                out var cursorPosition,
-                out var textSpans);
-
-            if (textSpans.Any())
-            {
-                textSpan = textSpans.First();
-            }
+            var code = workspaceFixture.Target.Code;
+            var position = workspaceFixture.Target.Position;
+            var textSpan = workspaceFixture.Target.Spans.FirstOrNull();
 
             var parseOptions = CreateExperimentalParseOptions();
 
@@ -97,10 +90,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
                 document1 = document1.Project.WithParseOptions(parseOptions).GetDocument(document1.Id);
             }
 
-            await TestSignatureHelpWorkerSharedAsync(workspaceFixture.Target.GetWorkspace(), code, cursorPosition, document1, options, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
+            await TestSignatureHelpWorkerSharedAsync(workspaceFixture.Target.GetWorkspace(), code, position, document1, options, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
 
             // speculative semantic model
-            if (await CanUseSpeculativeSemanticModelAsync(document1, cursorPosition))
+            if (await CanUseSpeculativeSemanticModelAsync(document1, position))
             {
                 var document2 = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind, cleanBeforeUpdate: false);
                 if (experimental)
@@ -108,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
                     document2 = document2.Project.WithParseOptions(parseOptions).GetDocument(document2.Id);
                 }
 
-                await TestSignatureHelpWorkerSharedAsync(workspaceFixture.Target.GetWorkspace(), code, cursorPosition, document2, options, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
+                await TestSignatureHelpWorkerSharedAsync(workspaceFixture.Target.GetWorkspace(), code, position, document2, options, textSpan, expectedOrderedItemsOrNull, usePreviousCharAsTrigger);
             }
         }
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
@@ -6,8 +6,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
 
@@ -17,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         public int Position;
         public string Code;
+        public ImmutableArray<TextSpan> Spans;
 
         private EditorTestWorkspace _workspace;
         private EditorTestHostDocument _currentDocument;
@@ -42,12 +45,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _workspace = EditorTestWorkspace.CreateWorkspace(XElement.Parse(markup), composition: composition, workspaceKind: workspaceKind);
                 _currentDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);
                 Position = _currentDocument.CursorPosition.Value;
+                Spans = [.. CurrentDocument.SelectedSpans];
                 Code = _currentDocument.GetTextBuffer().CurrentSnapshot.GetText();
                 return _workspace;
             }
             else
             {
-                MarkupTestFile.GetPosition(markup.NormalizeLineEndings(), out Code, out Position);
+                MarkupTestFile.GetPositionAndSpans(markup.NormalizeLineEndings(), out Code, out Position, out Spans);
                 var workspace = GetWorkspace(composition);
                 _currentDocument = workspace.Documents.Single();
                 return workspace;

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WithKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WithKeywordRecommender.cs
@@ -4,11 +4,27 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders;
 
 internal sealed class WithKeywordRecommender() : AbstractSyntacticSingleKeywordRecommender(SyntaxKind.WithKeyword)
 {
     protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        => !context.IsInNonUserCode && context.IsIsOrAsOrSwitchOrWithExpressionContext;
+    {
+        if (context.IsInNonUserCode)
+            return false;
+
+        if (context.IsIsOrAsOrSwitchOrWithExpressionContext)
+            return true;
+
+        var targetToken = context.TargetToken;
+        if (targetToken.Kind() == SyntaxKind.OpenBracketToken &&
+            targetToken.Parent is CollectionExpressionSyntax)
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.cs
@@ -41,7 +41,8 @@ internal abstract class AbstractOrdinaryMethodSignatureHelpProvider : AbstractCS
             GetSeparatorParts(),
             GetMethodGroupPostambleParts(),
             [.. method.Parameters.Select(p => Convert(p, semanticModel, position, documentationCommentFormattingService))],
-            descriptionParts: descriptionParts);
+            descriptionParts: descriptionParts,
+            static symbol => symbol is null ? null : SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.MinimallyQualifiedFormat));
     }
 
     private static IList<SymbolDisplayPart> GetMethodGroupPreambleParts(
@@ -78,7 +79,7 @@ internal abstract class AbstractOrdinaryMethodSignatureHelpProvider : AbstractCS
             result.Add(Space());
         }
 
-        result.AddRange(method.ToMinimalDisplayParts(semanticModel, position, MinimallyQualifiedWithoutParametersFormat));
+        result.AddRange(SymbolDisplay.ToMinimalDisplayParts(method, semanticModel, position, MinimallyQualifiedWithoutParametersFormat));
         result.Add(Punctuation(SyntaxKind.OpenParenToken));
 
         return result;

--- a/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
@@ -41,19 +41,10 @@ internal sealed partial class ConstructorInitializerSignatureHelpProvider : Abst
         SignatureHelpTriggerReason triggerReason,
         CancellationToken cancellationToken)
     {
-        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+        var initializer = await CommonSignatureHelpUtilities.TryGetSyntaxAsync<ConstructorInitializerSyntax>(
+            document, position, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken).ConfigureAwait(false);
 
-        if (!CommonSignatureHelpUtilities.TryGetSyntax(
-                root, position, syntaxFacts, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken, out ConstructorInitializerSyntax? initializer))
-        {
-            return null;
-        }
-
-        if (initializer.ArgumentList is null)
-            return null;
-
-        return initializer;
+        return initializer?.ArgumentList is null ? null : initializer;
     }
 
     private bool IsTriggerToken(SyntaxToken token)

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
@@ -38,19 +38,10 @@ internal partial class InvocationExpressionSignatureHelpProviderBase : AbstractO
 
     private async Task<InvocationExpressionSyntax?> TryGetInvocationExpressionAsync(Document document, int position, SignatureHelpTriggerReason triggerReason, CancellationToken cancellationToken)
     {
-        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+        var expression = await CommonSignatureHelpUtilities.TryGetSyntaxAsync<InvocationExpressionSyntax>(
+            document, position, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken).ConfigureAwait(false);
 
-        if (!CommonSignatureHelpUtilities.TryGetSyntax(
-                root, position, syntaxFacts, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken, out InvocationExpressionSyntax? expression))
-        {
-            return null;
-        }
-
-        if (expression.ArgumentList is null)
-            return null;
-
-        return expression;
+        return expression?.ArgumentList is null ? null : expression;
     }
 
     private bool IsTriggerToken(SyntaxToken token)

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.cs
@@ -34,19 +34,10 @@ internal sealed partial class ObjectCreationExpressionSignatureHelpProvider() : 
         SignatureHelpTriggerReason triggerReason,
         CancellationToken cancellationToken)
     {
-        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+        var expression = await CommonSignatureHelpUtilities.TryGetSyntaxAsync<BaseObjectCreationExpressionSyntax>(
+            document, position, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken).ConfigureAwait(false);
 
-        if (!CommonSignatureHelpUtilities.TryGetSyntax(
-                root, position, syntaxFacts, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken, out BaseObjectCreationExpressionSyntax? expression))
-        {
-            return null;
-        }
-
-        if (expression.ArgumentList is null)
-            return null;
-
-        return expression;
+        return expression?.ArgumentList is null ? null : expression;
     }
 
     private bool IsTriggerToken(SyntaxToken token)
@@ -98,7 +89,7 @@ internal sealed partial class ObjectCreationExpressionSignatureHelpProvider() : 
         var documentationCommentFormattingService = document.GetRequiredLanguageService<IDocumentationCommentFormattingService>();
 
         var items = methods.SelectAsArray(c =>
-            ConvertNormalTypeConstructor(c, objectCreationExpression, semanticModel, structuralTypeDisplayService, documentationCommentFormattingService));
+            ConvertNormalTypeConstructor(c, objectCreationExpression.SpanStart, semanticModel, structuralTypeDisplayService, documentationCommentFormattingService));
 
         var selectedItem = TryGetSelectedIndex(methods, currentSymbol);
 

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -15,14 +14,13 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 
 internal sealed partial class ObjectCreationExpressionSignatureHelpProvider
 {
-    private static SignatureHelpItem ConvertNormalTypeConstructor(
+    public static SignatureHelpItem ConvertNormalTypeConstructor(
         IMethodSymbol constructor,
-        BaseObjectCreationExpressionSyntax objectCreationExpression,
+        int position,
         SemanticModel semanticModel,
         IStructuralTypeDisplayService structuralTypeDisplayService,
         IDocumentationCommentFormattingService documentationCommentFormattingService)
     {
-        var position = objectCreationExpression.SpanStart;
         var item = CreateItem(
             constructor, semanticModel, position,
             structuralTypeDisplayService,

--- a/src/Features/CSharp/Portable/SignatureHelp/WithElementSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/WithElementSignatureHelpProvider.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.DocumentationComments;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp;
+
+[ExportSignatureHelpProvider("WithElementSignatureHelpProvider", LanguageNames.CSharp), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed partial class WithElementSignatureHelpProvider() : AbstractCSharpSignatureHelpProvider
+{
+    public override bool IsTriggerCharacter(char ch)
+        => ch is '(' or ',';
+
+    public override bool IsRetriggerCharacter(char ch)
+        => ch == ')';
+
+    private async Task<WithElementSyntax?> TryGetWithElementAsync(
+        Document document,
+        int position,
+        SignatureHelpTriggerReason triggerReason,
+        CancellationToken cancellationToken)
+    {
+        var withElement = await CommonSignatureHelpUtilities.TryGetSyntaxAsync<WithElementSyntax>(
+            document, position, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken).ConfigureAwait(false);
+
+        return withElement?.ArgumentList is null ? null : withElement;
+    }
+
+    private bool IsTriggerToken(SyntaxToken token)
+        => SignatureHelpUtilities.IsTriggerParenOrComma<WithElementSyntax>(token, IsTriggerCharacter);
+
+    private static bool IsArgumentListToken(WithElementSyntax expression, SyntaxToken token)
+    {
+        return expression.ArgumentList != null &&
+            expression.ArgumentList.Span.Contains(token.SpanStart) &&
+            token != expression.ArgumentList.CloseParenToken;
+    }
+
+    protected override async Task<SignatureHelpItems?> GetItemsWorkerAsync(Document document, int position, SignatureHelpTriggerInfo triggerInfo, MemberDisplayOptions options, CancellationToken cancellationToken)
+    {
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var withElement = await TryGetWithElementAsync(
+            document, position, triggerInfo.TriggerReason, cancellationToken).ConfigureAwait(false);
+        if (withElement?.Parent is not CollectionExpressionSyntax collectionExpression)
+            return null;
+
+        var semanticModel = await document.ReuseExistingSpeculativeModelAsync(withElement, cancellationToken).ConfigureAwait(false);
+        if (semanticModel.GetTypeInfo(collectionExpression, cancellationToken).ConvertedType is not INamedTypeSymbol collectionExpressionType)
+            return null;
+
+        var within = semanticModel.GetEnclosingNamedType(position, cancellationToken);
+        if (within == null)
+            return null;
+
+        var creationMethods = withElement
+            .GetCreationMethods(semanticModel, cancellationToken)
+            .WhereAsArray(s => s.IsEditorBrowsable(options.HideAdvancedMembers, semanticModel.Compilation))
+            .Sort(semanticModel, withElement.SpanStart);
+
+        if (creationMethods.IsEmpty)
+            return null;
+
+        // guess the best candidate if needed and determine parameter index
+        //
+        // Can add this back in once the compiler supports getting the SymbolInfo for a WithElement.
+        // 
+        // var (currentSymbol, parameterIndexOverride) = new LightweightOverloadResolution(semanticModel, position, withElement.ArgumentList.Arguments)
+        //    .RefineOverloadAndPickParameter(semanticModel.GetSymbolInfo(withElement, cancellationToken), methods);
+        ISymbol? currentSymbol = null;
+        var parameterIndexOverride = -1;
+
+        var structuralTypeDisplayService = document.Project.Services.GetRequiredService<IStructuralTypeDisplayService>();
+        var documentationCommentFormattingService = document.GetRequiredLanguageService<IDocumentationCommentFormattingService>();
+
+        var items = creationMethods.SelectAsArray(c => c.MethodKind == MethodKind.Constructor
+            ? ObjectCreationExpressionSignatureHelpProvider.ConvertNormalTypeConstructor(c, withElement.SpanStart, semanticModel, structuralTypeDisplayService, documentationCommentFormattingService)
+            : AbstractOrdinaryMethodSignatureHelpProvider.ConvertMethodGroupMethod(document, c, withElement.SpanStart, semanticModel));
+
+        var selectedItem = TryGetSelectedIndex(creationMethods, currentSymbol);
+
+        var textSpan = SignatureHelpUtilities.GetSignatureHelpSpan(withElement.ArgumentList);
+        var argumentState = await GetCurrentArgumentStateAsync(
+            document, position, textSpan, cancellationToken).ConfigureAwait(false);
+        return CreateSignatureHelpItems(items, textSpan, argumentState, selectedItem, parameterIndexOverride);
+    }
+
+    private async Task<SignatureHelpState?> GetCurrentArgumentStateAsync(
+        Document document, int position, TextSpan currentSpan, CancellationToken cancellationToken)
+    {
+        var expression = await TryGetWithElementAsync(
+            document, position, SignatureHelpTriggerReason.InvokeSignatureHelpCommand, cancellationToken).ConfigureAwait(false);
+        if (expression != null &&
+            currentSpan.Start == SignatureHelpUtilities.GetSignatureHelpSpan(expression.ArgumentList).Start)
+        {
+            return SignatureHelpUtilities.GetSignatureHelpState(expression.ArgumentList, position);
+        }
+
+        return null;
+    }
+}

--- a/src/Features/CSharpTest/Microsoft.CodeAnalysis.CSharp.Features.UnitTests.csproj
+++ b/src/Features/CSharpTest/Microsoft.CodeAnalysis.CSharp.Features.UnitTests.csproj
@@ -27,6 +27,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.Net60" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" />
   </ItemGroup>
   <Import Project="..\..\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems" Label="Shared" />
 

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -86,7 +86,10 @@ public readonly record struct TaggedText
 internal static class TaggedTextExtensions
 {
     public static ImmutableArray<TaggedText> ToTaggedText(
-        this IEnumerable<SymbolDisplayPart>? displayParts, TaggedTextStyle style = TaggedTextStyle.None, Func<ISymbol?, string?>? getNavigationHint = null, bool includeNavigationHints = true)
+        this IEnumerable<SymbolDisplayPart>? displayParts,
+        TaggedTextStyle style = TaggedTextStyle.None,
+        Func<ISymbol?, string?>? getNavigationHint = null,
+        bool includeNavigationHints = true)
     {
         if (displayParts == null)
             return [];

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -175,7 +175,8 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
         IList<SymbolDisplayPart> separatorParts,
         IList<SymbolDisplayPart> suffixParts,
         IList<SignatureHelpSymbolParameter> parameters,
-        IList<SymbolDisplayPart>? descriptionParts)
+        IList<SymbolDisplayPart>? descriptionParts,
+        Func<ISymbol?, string?>? getNavigationHint = null)
     {
         descriptionParts = descriptionParts == null
             ? SpecializedCollections.EmptyList<SymbolDisplayPart>()
@@ -218,11 +219,11 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
             orderSymbol,
             isVariadic,
             documentationFactory,
-            prefixParts.ToTaggedText(),
-            separatorParts.ToTaggedText(),
-            suffixParts.ToTaggedText(),
+            prefixParts.ToTaggedText(getNavigationHint: getNavigationHint),
+            separatorParts.ToTaggedText(getNavigationHint: getNavigationHint),
+            suffixParts.ToTaggedText(getNavigationHint: getNavigationHint),
             parameters.Select(p => (SignatureHelpParameter)p),
-            descriptionParts.ToTaggedText());
+            descriptionParts.ToTaggedText(getNavigationHint: getNavigationHint));
     }
 
     private static SignatureHelpSymbolParameter ReplaceStructuralTypes(

--- a/src/Features/Core/Portable/SignatureHelp/CommonSignatureHelpUtilities.cs
+++ b/src/Features/Core/Portable/SignatureHelp/CommonSignatureHelpUtilities.cs
@@ -100,6 +100,22 @@ internal static class CommonSignatureHelpUtilities
         return TextSpan.FromBounds(start, nextToken.SpanStart);
     }
 
+    internal static async Task<TSyntax?> TryGetSyntaxAsync<TSyntax>(
+        Document document,
+        int position,
+        SignatureHelpTriggerReason triggerReason,
+        Func<SyntaxToken, bool> isTriggerToken,
+        Func<TSyntax, SyntaxToken, bool> isArgumentListToken,
+        CancellationToken cancellationToken)
+        where TSyntax : SyntaxNode
+    {
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+
+        return TryGetSyntax(
+            root, position, syntaxFacts, triggerReason, isTriggerToken, isArgumentListToken, cancellationToken, out var syntax) ? syntax : null;
+    }
+
     internal static bool TryGetSyntax<TSyntax>(
         SyntaxNode root,
         int position,

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.CSharp.txt
@@ -450,6 +450,7 @@ Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitInvocationExpression(Mic
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitIsPatternExpression(Microsoft.CodeAnalysis.CSharp.Syntax.IsPatternExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitJoinClause(Microsoft.CodeAnalysis.CSharp.Syntax.JoinClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitJoinIntoClause(Microsoft.CodeAnalysis.CSharp.Syntax.JoinIntoClauseSyntax)
+Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitLabeledStatement(Microsoft.CodeAnalysis.CSharp.Syntax.LabeledStatementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitLetClause(Microsoft.CodeAnalysis.CSharp.Syntax.LetClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitLineDirectivePosition(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax)
@@ -564,6 +565,7 @@ Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitWarningDirectiveTrivia(M
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitWhenClause(Microsoft.CodeAnalysis.CSharp.Syntax.WhenClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitWhereClause(Microsoft.CodeAnalysis.CSharp.Syntax.WhereClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitWhileStatement(Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax)
+Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitWithElement(Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitWithExpression(Microsoft.CodeAnalysis.CSharp.Syntax.WithExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitXmlCDataSection(Microsoft.CodeAnalysis.CSharp.Syntax.XmlCDataSectionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitXmlComment(Microsoft.CodeAnalysis.CSharp.Syntax.XmlCommentSyntax)
@@ -746,6 +748,7 @@ Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitInvocationExpression(Micr
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitIsPatternExpression(Microsoft.CodeAnalysis.CSharp.Syntax.IsPatternExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitJoinClause(Microsoft.CodeAnalysis.CSharp.Syntax.JoinClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitJoinIntoClause(Microsoft.CodeAnalysis.CSharp.Syntax.JoinIntoClauseSyntax)
+Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitLabeledStatement(Microsoft.CodeAnalysis.CSharp.Syntax.LabeledStatementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitLetClause(Microsoft.CodeAnalysis.CSharp.Syntax.LetClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitLineDirectivePosition(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax)
@@ -851,6 +854,7 @@ Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitWarningDirectiveTrivia(Mi
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitWhenClause(Microsoft.CodeAnalysis.CSharp.Syntax.WhenClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitWhereClause(Microsoft.CodeAnalysis.CSharp.Syntax.WhereClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitWhileStatement(Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax)
+Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitWithElement(Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitWithExpression(Microsoft.CodeAnalysis.CSharp.Syntax.WithExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitXmlCDataSection(Microsoft.CodeAnalysis.CSharp.Syntax.XmlCDataSectionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitXmlComment(Microsoft.CodeAnalysis.CSharp.Syntax.XmlCommentSyntax)
@@ -996,6 +1000,7 @@ Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitInvocationExpression(Mi
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitIsPatternExpression(Microsoft.CodeAnalysis.CSharp.Syntax.IsPatternExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitJoinClause(Microsoft.CodeAnalysis.CSharp.Syntax.JoinClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitJoinIntoClause(Microsoft.CodeAnalysis.CSharp.Syntax.JoinIntoClauseSyntax)
+Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitLabeledStatement(Microsoft.CodeAnalysis.CSharp.Syntax.LabeledStatementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitLetClause(Microsoft.CodeAnalysis.CSharp.Syntax.LetClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitLineDirectivePosition(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax)
@@ -1101,6 +1106,7 @@ Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitWarningDirectiveTrivia(
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitWhenClause(Microsoft.CodeAnalysis.CSharp.Syntax.WhenClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitWhereClause(Microsoft.CodeAnalysis.CSharp.Syntax.WhereClauseSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitWhileStatement(Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax)
+Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitWithElement(Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitWithExpression(Microsoft.CodeAnalysis.CSharp.Syntax.WithExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitXmlCDataSection(Microsoft.CodeAnalysis.CSharp.Syntax.XmlCDataSectionSyntax)
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor`1.VisitXmlComment(Microsoft.CodeAnalysis.CSharp.Syntax.XmlCommentSyntax)
@@ -3084,6 +3090,16 @@ Microsoft.CodeAnalysis.CSharp.Syntax.JoinIntoClauseSyntax.WithIdentifier(Microso
 Microsoft.CodeAnalysis.CSharp.Syntax.JoinIntoClauseSyntax.WithIntoKeyword(Microsoft.CodeAnalysis.SyntaxToken)
 Microsoft.CodeAnalysis.CSharp.Syntax.JoinIntoClauseSyntax.get_Identifier
 Microsoft.CodeAnalysis.CSharp.Syntax.JoinIntoClauseSyntax.get_IntoKeyword
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor)
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept``1(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor{``0})
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax)
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithColonToken(Microsoft.CodeAnalysis.SyntaxToken)
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithKeyExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax)
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithValueExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax)
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.get_ColonToken
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.get_KeyExpression
+Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.get_ValueExpression
 Microsoft.CodeAnalysis.CSharp.Syntax.LabeledStatementSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.LabeledStatementSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor)
 Microsoft.CodeAnalysis.CSharp.Syntax.LabeledStatementSyntax.Accept``1(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor{``0})
@@ -4542,6 +4558,15 @@ Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax.get_Condition
 Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax.get_OpenParenToken
 Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax.get_Statement
 Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax.get_WhileKeyword
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor)
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.Accept``1(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor{``0})
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.AddArgumentListArguments(Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax[])
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax)
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.WithArgumentList(Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax)
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.WithWithKeyword(Microsoft.CodeAnalysis.SyntaxToken)
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.get_ArgumentList
+Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax.get_WithKeyword
 Microsoft.CodeAnalysis.CSharp.Syntax.WithExpressionSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.WithExpressionSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor)
 Microsoft.CodeAnalysis.CSharp.Syntax.WithExpressionSyntax.Accept``1(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor{``0})
@@ -5126,6 +5151,8 @@ Microsoft.CodeAnalysis.CSharp.SyntaxFactory.JoinClause(System.String,Microsoft.C
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.JoinIntoClause(Microsoft.CodeAnalysis.SyntaxToken)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.JoinIntoClause(Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.SyntaxToken)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.JoinIntoClause(System.String)
+Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax)
+Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LabeledStatement(Microsoft.CodeAnalysis.SyntaxList{Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax},Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LabeledStatement(Microsoft.CodeAnalysis.SyntaxList{Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax},Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LabeledStatement(Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax)
@@ -5512,6 +5539,8 @@ Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WhileStatement(Microsoft.CodeAnalysi
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WhileStatement(Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Whitespace(System.String)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Whitespace(System.String,System.Boolean)
+Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WithElement(Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax)
+Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WithElement(Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WithExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.WithExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax)
 Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlCDataSection(Microsoft.CodeAnalysis.SyntaxToken,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.SyntaxToken)
@@ -5970,6 +5999,7 @@ Microsoft.CodeAnalysis.CSharp.SyntaxKind.IsPatternExpression
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.JoinClause
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.JoinIntoClause
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.JoinKeyword
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.KeyValuePairElement
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LabeledStatement
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LeftShiftAssignmentExpression
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LeftShiftExpression
@@ -6237,6 +6267,7 @@ Microsoft.CodeAnalysis.CSharp.SyntaxKind.WhereKeyword
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.WhileKeyword
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.WhileStatement
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.WhitespaceTrivia
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.WithElement
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.WithExpression
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.WithInitializerExpression
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.WithKeyword

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -1688,8 +1688,8 @@ namespace CSharpSyntaxGenerator
 
             var hasOptional = minimalFactoryfields.Any(f => !IsRequiredFactoryField(nd, f));
             var hasAttributeOrModifiersList = nd.Fields.Any(f => IsAttributeOrModifiersList(f));
-
-            if (hasOptional && hasAttributeOrModifiersList)
+            var writePragma = hasOptional && (hasAttributeOrModifiersList || nd.Name == "WithElementSyntax");
+            if (writePragma)
             {
                 WriteLineWithoutIndent("#pragma warning disable RS0027");
             }
@@ -1748,7 +1748,7 @@ namespace CSharpSyntaxGenerator
 
             WriteLine(");");
 
-            if (hasOptional && hasAttributeOrModifiersList)
+            if (writePragma)
             {
                 WriteLineWithoutIndent("#pragma warning restore RS0027");
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -12544,4 +12544,76 @@ public sealed class FormattingTests : CSharpFormattingTestBase
             """,
             parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
     }
+
+    [Fact]
+    public async Task FormatWithElement1()
+    {
+        await AssertFormatAsync(
+            expected: """
+                var v = [with()];
+                """,
+            code: """
+                var v = [ with ( ) ];
+                """);
+    }
+
+    [Fact]
+    public async Task FormatWithElement2()
+    {
+        await AssertFormatAsync(
+            expected: """
+                var v = [with(1, 2)];
+                """,
+            code: """
+                var v = [ with ( 1 , 2 ) ];
+                """);
+    }
+
+    [Fact]
+    public async Task FormatWithElement3()
+    {
+        await AssertFormatAsync(
+            expected: """
+                var v = [with(1, 2), 3];
+                """,
+            code: """
+                var v = [ with ( 1 , 2 ) , 3];
+                """);
+    }
+
+    [Fact]
+    public async Task FormatKeyValuePair1()
+    {
+        await AssertFormatAsync(
+            expected: """
+                var v = [k: v];
+                """,
+            code: """
+                var v = [ k :  v ];
+                """);
+    }
+
+    [Fact]
+    public async Task FormatKeyValuePair2()
+    {
+        await AssertFormatAsync(
+            expected: """
+                var v = [k: v, k: v];
+                """,
+            code: """
+                var v = [ k :  v , k :  v ];
+                """);
+    }
+
+    [Fact]
+    public async Task FormatKeyValuePair3()
+    {
+        await AssertFormatAsync(
+            expected: """
+                var v = [null: 1 + 1, (x.y): from x in y select z];
+                """,
+            code: """
+                var v = [ null :  1  +  1 , ( x . y ) :  from   x    in   y    select  z ];
+                """);
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -395,19 +395,19 @@ internal sealed class TokenBasedFormattingRule : BaseFormattingRule
         // default:
         // <label> :
         // { Property1.Property2: ... }
-        if (currentToken.IsKind(SyntaxKind.ColonToken))
+        if (currentToken.IsKind(SyntaxKind.ColonToken) &&
+            currentToken.Parent is (kind:
+                SyntaxKind.AttributeTargetSpecifier or
+                SyntaxKind.CaseSwitchLabel or
+                SyntaxKind.CasePatternSwitchLabel or
+                SyntaxKind.DefaultSwitchLabel or
+                SyntaxKind.ExpressionColon or
+                SyntaxKind.KeyValuePairElement or
+                SyntaxKind.LabeledStatement or
+                SyntaxKind.NameColon or
+                SyntaxKind.SwitchExpressionArm))
         {
-            if (currentToken.Parent is (kind:
-                    SyntaxKind.CaseSwitchLabel or
-                    SyntaxKind.CasePatternSwitchLabel or
-                    SyntaxKind.DefaultSwitchLabel or
-                    SyntaxKind.LabeledStatement or
-                    SyntaxKind.AttributeTargetSpecifier or
-                    SyntaxKind.NameColon or
-                    SyntaxKind.ExpressionColon or SyntaxKind.SwitchExpressionArm))
-            {
-                return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
-            }
+            return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
         }
 
         // [cast expression] * case

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -80,6 +80,9 @@ internal class CSharpSyntaxFacts : AbstractSyntaxFacts, ISyntaxFacts
     public bool SupportsNullConditionalAssignment(ParseOptions options)
         => options.LanguageVersion().IsCSharp14OrAbove();
 
+    public bool SupportsKeyValuePairElement(ParseOptions options)
+        => options.LanguageVersion() >= LanguageVersionExtensions.CSharpNext;
+
     public SyntaxToken ParseToken(string text)
         => SyntaxFactory.ParseToken(text);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -236,6 +236,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\VirtualChars\VirtualCharSequence.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\VirtualChars\VirtualCharSequence.Enumerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AnalysisContextExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\CollectionExpressionUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticAnalyzerExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticDescriptorExtensions.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/CollectionExpressionUtilities.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/CollectionExpressionUtilities.cs
@@ -1,0 +1,172 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.Shared.Extensions;
+
+internal static class CollectionExpressionUtilities
+{
+    public static bool IsWellKnownCollectionInterface(ITypeSymbol type)
+        => IsWellKnownCollectionReadOnlyInterface(type) || IsWellKnownCollectionReadWriteInterface(type);
+
+    public static bool IsWellKnownCollectionReadOnlyInterface(ITypeSymbol type)
+    {
+        return type.OriginalDefinition.SpecialType
+            is SpecialType.System_Collections_Generic_IEnumerable_T
+            or SpecialType.System_Collections_Generic_IReadOnlyCollection_T
+            or SpecialType.System_Collections_Generic_IReadOnlyList_T;
+    }
+
+    public static bool IsWellKnownCollectionReadWriteInterface(ITypeSymbol type)
+    {
+        return type.OriginalDefinition.SpecialType
+            is SpecialType.System_Collections_Generic_ICollection_T
+            or SpecialType.System_Collections_Generic_IList_T;
+    }
+
+    public static bool IsConstructibleCollectionType(
+        Compilation compilation,
+        [NotNullWhen(true)] ITypeSymbol? type)
+    {
+        return IsConstructibleCollectionType(compilation, type, out _);
+    }
+
+    public static bool IsConstructibleCollectionType(
+        Compilation compilation,
+        [NotNullWhen(true)] ITypeSymbol? type,
+        [NotNullWhen(true)] out ITypeSymbol? elementType)
+    {
+        if (type is null)
+        {
+            elementType = null;
+            return false;
+        }
+
+        // Arrays are always a valid collection expression type.
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            elementType = arrayType.ElementType;
+            return true;
+        }
+
+        // Has to be a real named type at this point.
+        if (type is INamedTypeSymbol namedType)
+        {
+            // Span<T> and ReadOnlySpan<T> are always valid collection expression types.
+            if (namedType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
+                namedType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))
+            {
+                elementType = namedType.TypeArguments.Single();
+                return true;
+            }
+
+            var ienumerableOfTType = compilation.IEnumerableOfTType();
+            var ienumerableType = compilation.IEnumerableType();
+            var foundType =
+                namedType.AllInterfaces.FirstOrDefault(i => i.OriginalDefinition.Equals(ienumerableOfTType)) ??
+                namedType.AllInterfaces.FirstOrDefault(i => i.OriginalDefinition.Equals(ienumerableType));
+            elementType = foundType?.TypeArguments.FirstOrDefault() ?? compilation.ObjectType;
+
+            // If it has a [CollectionBuilder] attribute on it, it is a valid collection expression type.
+            var collectionBuilderMethods = TryGetCollectionBuilderFactoryMethods(
+                compilation, namedType);
+            if (collectionBuilderMethods is [var builderMethod, ..])
+                return true;
+
+            if (IsWellKnownCollectionInterface(namedType))
+                return true;
+
+            // At this point, all that is left are collection-initializer types.  These need to derive from
+            // System.Collections.IEnumerable, and have an invokable no-arg constructor.
+
+            // Abstract type don't have invokable constructors at all.
+            if (namedType.IsAbstract)
+                return false;
+
+            if (foundType != null)
+            {
+                // If they have an accessible `public C(int capacity)` constructor, the lang prefers calling that.
+                var constructors = namedType.Constructors;
+                var capacityConstructor = GetAccessibleInstanceConstructor(constructors, c => c.Parameters is [{ Name: "capacity", Type.SpecialType: SpecialType.System_Int32 }]);
+                if (capacityConstructor != null)
+                    return true;
+
+                var noArgConstructor =
+                    GetAccessibleInstanceConstructor(constructors, c => c.Parameters.IsEmpty) ??
+                    GetAccessibleInstanceConstructor(constructors, c => c.Parameters.All(p => p.IsOptional || p.IsParams));
+                if (noArgConstructor != null)
+                {
+                    // If we have a struct, and the constructor we find is implicitly declared, don't consider this
+                    // a constructible type.  It's likely the user would just get the `default` instance of the
+                    // collection (like with ImmutableArray<T>) which would then not actually work.  If the struct
+                    // does have an explicit constructor though, that's a good sign it can actually be constructed
+                    // safely with the no-arg `new S()` call.
+                    if (!(namedType.TypeKind == TypeKind.Struct && noArgConstructor.IsImplicitlyDeclared))
+                        return true;
+                }
+            }
+        }
+
+        // Anything else is not constructible.
+        elementType = null;
+        return false;
+
+        IMethodSymbol? GetAccessibleInstanceConstructor(ImmutableArray<IMethodSymbol> constructors, Func<IMethodSymbol, bool> predicate)
+        {
+            var constructor = constructors.FirstOrDefault(c => !c.IsStatic && predicate(c));
+            return constructor is not null && constructor.IsAccessibleWithin(compilation.Assembly) ? constructor : null;
+        }
+    }
+
+    public static ImmutableArray<IMethodSymbol>? TryGetCollectionBuilderFactoryMethods(
+        Compilation compilation, INamedTypeSymbol collectionExpressionType)
+    {
+        var readonlySpanOfTType = compilation.ReadOnlySpanOfTType();
+        var attribute = collectionExpressionType.GetAttributes().FirstOrDefault(
+            static a => a.AttributeClass.IsCollectionBuilderAttribute());
+
+        // https://github.com/dotnet/csharplang/blob/main/proposals/collection-expression-arguments.md#create-method-candidates
+        // A [CollectionBuilder(...)] attribute specifies the builder type and method name of a method to be invoked
+        // to construct an instance of the collection type.
+        if (attribute is not { ConstructorArguments: [{ Value: INamedTypeSymbol builderType }, { Value: string builderMethodName }] })
+            return null;
+
+        // Find all the methods in the builder type with the given name that have a ReadOnlySpan<T> as either their
+        // first or last parameter.
+        var builderMethods = builderType
+            // The method must have the name specified in the [CollectionBuilder(...)] attribute.
+            .GetMembers(builderMethodName)
+            .OfType<IMethodSymbol>()
+            .Where(m =>
+                // The method must be static.
+                m.IsStatic &&
+                // The arity of the method must match the arity of the collection type.
+                m.Arity == collectionExpressionType.Arity &&
+                m.Parameters.Length >= 1 &&
+                // The method must have a first (or last) parameter of type System.ReadOnlySpan<E>, passed by value.
+                (Equals(m.Parameters[0].Type.OriginalDefinition, readonlySpanOfTType) ||
+                 Equals(m.Parameters.Last().Type.OriginalDefinition, readonlySpanOfTType)))
+            .ToImmutableArray();
+
+        // Instance the construction method if generic. And filter to only those that return the collection type
+        // being created.
+        var constructedBuilderMethods = builderMethods
+            .Select(m => m.Construct([.. collectionExpressionType.TypeArguments]))
+            .Where(m =>
+            {
+                // There is an identity conversion, implicit reference conversion, or boxing conversion from the method return type to the collection type.
+                var conversion = compilation.ClassifyCommonConversion(m.ReturnType, collectionExpressionType);
+                return conversion.IsIdentity || (conversion.IsImplicit && conversion.IsReference);
+            })
+            .ToImmutableArray();
+
+        return constructedBuilderMethods;
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
@@ -149,6 +149,9 @@ internal static class ICompilationExtensions
     public static INamedTypeSymbol? ValueTaskOfTType(this Compilation compilation)
         => compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
 
+    public static INamedTypeSymbol? ICollectionOfTType(this Compilation compilation)
+        => compilation.GetTypeByMetadataName(typeof(ICollection<>).FullName!);
+
     public static INamedTypeSymbol? IEnumerableType(this Compilation compilation)
         => compilation.GetTypeByMetadataName(typeof(System.Collections.IEnumerable).FullName!);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -668,7 +669,7 @@ internal static partial class INamedTypeSymbolExtensions
     public static bool IsCollectionBuilderAttribute([NotNullWhen(true)] this INamedTypeSymbol? type)
         => type is
         {
-            Name: "CollectionBuilderAttribute",
+            Name: nameof(CollectionBuilderAttribute),
             ContainingNamespace:
             {
                 Name: nameof(System.Runtime.CompilerServices),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -98,6 +98,7 @@ internal interface ISyntaxFacts
     bool SupportsImplicitImplementationOfNonPublicInterfaceMembers(ParseOptions options);
     bool SupportsIndexingInitializer(ParseOptions options);
     bool SupportsIsNotTypeExpression(ParseOptions options);
+    bool SupportsKeyValuePairElement(ParseOptions options);
     bool SupportsLocalFunctionDeclaration(ParseOptions options);
     bool SupportsNotPattern(ParseOptions options);
     bool SupportsNullConditionalAssignment(ParseOptions options);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -90,6 +90,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return False
         End Function
 
+        Public Function SupportsKeyValuePairElement(options As ParseOptions) As Boolean Implements ISyntaxFacts.SupportsKeyValuePairElement
+            Return False
+        End Function
+
         Public Function ParseToken(text As String) As SyntaxToken Implements ISyntaxFacts.ParseToken
             Return SyntaxFactory.ParseToken(text, startStatement:=True)
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CSharpWorkspaceExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CSharpWorkspaceExtensions.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TypeDeclarationSyntaxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TypeSyntaxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\UsingDirectiveSyntaxExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\WithElementSyntaxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Indentation\CSharpIndentationService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Indentation\CSharpIndentationService.Indenter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LanguageServices\CSharpAddImportsService.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/WithElementSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/WithElementSyntaxExtensions.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.Extensions;
+
+internal static class WithElementSyntaxExtensions
+{
+    public static ImmutableArray<IMethodSymbol> GetCreationMethods(
+        this WithElementSyntax? withElement, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        if (withElement?.Parent is not CollectionExpressionSyntax collectionExpression)
+            return [];
+
+        var position = withElement.SpanStart;
+        var within = semanticModel.GetEnclosingNamedType(position, cancellationToken);
+        if (within == null)
+            return [];
+
+        if (semanticModel.GetTypeInfo(collectionExpression, cancellationToken).ConvertedType is not INamedTypeSymbol collectionExpressionType)
+            return [];
+
+        var result = TryGetInterfaceItems() ??
+            TryGetCollectionBuilderItems() ??
+            collectionExpressionType.InstanceConstructors;
+
+        return result.WhereAsArray(c => c.IsAccessibleWithin(within: within, throughType: c.ContainingType));
+
+        ImmutableArray<IMethodSymbol>? TryGetInterfaceItems()
+        {
+            // When the type is IList<T> or ICollection<T>, we can provide a signature help item for the `(int capacity)`
+            // constructor of List<T>, as that's what the compiler will call into.
+
+            var ilistOfTType = semanticModel.Compilation.IListOfTType();
+            var icollectionOfTType = semanticModel.Compilation.ICollectionOfTType();
+
+            if (!Equals(ilistOfTType, collectionExpressionType.OriginalDefinition) &&
+                !Equals(icollectionOfTType, collectionExpressionType.OriginalDefinition))
+            {
+                return null;
+            }
+
+            var listOfTType = semanticModel.Compilation.ListOfTType();
+            if (listOfTType is null)
+                return [];
+
+            var constructedListType = listOfTType.Construct(collectionExpressionType.TypeArguments.Single());
+            var constructor = constructedListType.InstanceConstructors.FirstOrDefault(
+                static m => m.Parameters is [{ Type.SpecialType: SpecialType.System_Int32, Name: "capacity" }]);
+
+            return constructor is null ? [] : [constructor];
+        }
+
+        ImmutableArray<IMethodSymbol>? TryGetCollectionBuilderItems()
+        {
+            // If the type has a [CollectionBuilder(typeof(...), "...")] attribute on it, find the method it points to, and
+            // produce the synthesized signature help items for it (e.g. without the ReadOnlySpan<T> parameter).
+            var constructedBuilderMethods = CollectionExpressionUtilities.TryGetCollectionBuilderFactoryMethods(
+                semanticModel.Compilation, collectionExpressionType);
+            if (constructedBuilderMethods is null)
+                return null;
+
+            var readonlySpanOfTType = semanticModel.Compilation.ReadOnlySpanOfTType();
+            return constructedBuilderMethods.Value.SelectAsArray(constructedMethod =>
+            {
+                // Create a synthesized method with the ReadOnlySpan<T> parameter removed.  This corresponds to the parameters
+                // that actually have to be passed to the with element.
+                var slicedParameters = Equals(constructedMethod.Parameters[0].Type.OriginalDefinition, readonlySpanOfTType)
+                    ? constructedMethod.Parameters[1..]
+                    : constructedMethod.Parameters[..^1];
+
+                return CodeGenerationSymbolFactory.CreateMethodSymbol(
+                    constructedMethod,
+                    parameters: slicedParameters,
+                    containingType: constructedMethod.ContainingType);
+            });
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -155,6 +155,7 @@ internal partial class CSharpTypeInferenceService
                 DoStatementSyntax doStatement => InferTypeInDoStatement(doStatement),
                 EqualsValueClauseSyntax equalsValue => InferTypeInEqualsValueClause(equalsValue),
                 ExpressionColonSyntax expressionColon => InferTypeInExpressionColon(expressionColon),
+                ExpressionElementSyntax expressionElement => InferTypeInExpressionElement(expressionElement),
                 ExpressionStatementSyntax _ => InferTypeInExpressionStatement(),
                 ForEachStatementSyntax forEachStatement => InferTypeInForEachStatement(forEachStatement, expression),
                 ForStatementSyntax forStatement => InferTypeInForStatement(forStatement, expression),
@@ -162,6 +163,7 @@ internal partial class CSharpTypeInferenceService
                 InitializerExpressionSyntax initializerExpression => InferTypeInInitializerExpression(initializerExpression, expression),
                 IsPatternExpressionSyntax isPatternExpression => InferTypeInIsPatternExpression(isPatternExpression, node),
                 LockStatementSyntax lockStatement => InferTypeInLockStatement(lockStatement),
+                KeyValuePairElementSyntax keyValuePairElement => InferTypeInKeyValuePairElement(keyValuePairElement, expression),
                 MemberAccessExpressionSyntax memberAccessExpression => InferTypeInMemberAccessExpression(memberAccessExpression, expression),
                 NameColonSyntax nameColon => InferTypeInNameColon(nameColon),
                 NameEqualsSyntax nameEquals => InferTypeInNameEquals(nameEquals),
@@ -1231,6 +1233,74 @@ internal partial class CSharpTypeInferenceService
 
             var typeInfo = SemanticModel.GetTypeInfo(propertyDeclaration.Type);
             return CreateResult(typeInfo.Type);
+        }
+
+        private IEnumerable<TypeInferenceInfo> InferTypeInExpressionElement(ExpressionElementSyntax expressionElement)
+        {
+            if (expressionElement.Parent is CollectionExpressionSyntax collectionExpression)
+            {
+                var collectionType = SemanticModel.GetTypeInfo(collectionExpression, CancellationToken).ConvertedType;
+
+                // Try to figure out the type based on the type of the collection itself.
+                if (CollectionExpressionUtilities.IsConstructibleCollectionType(
+                        SemanticModel.Compilation, collectionType, out var elementType))
+                {
+                    return [new(elementType)];
+                }
+
+                // If that fails, see if we can figure out from one of our siblings.
+                foreach (var element in collectionExpression.Elements)
+                {
+                    if (element != expressionElement && element is ExpressionElementSyntax siblingElement)
+                    {
+                        var types = GetTypes(siblingElement.Expression, objectAsDefault: false);
+                        if (types.Any())
+                            return types;
+                    }
+                }
+            }
+
+            return [];
+        }
+
+        private IEnumerable<TypeInferenceInfo> InferTypeInKeyValuePairElement(
+            KeyValuePairElementSyntax keyValuePairElement, ExpressionSyntax expression)
+        {
+            var isKey = expression == keyValuePairElement.KeyExpression;
+            var types = InferTypes();
+            return types.Select(t => new TypeInferenceInfo(t));
+
+            IEnumerable<ITypeSymbol> InferTypes()
+            {
+                if (keyValuePairElement.Parent is CollectionExpressionSyntax collectionExpression)
+                {
+                    var collectionType = SemanticModel.GetTypeInfo(collectionExpression, CancellationToken).ConvertedType;
+
+                    // Try to figure out the type based on the type of hte collection itself.
+                    if (CollectionExpressionUtilities.IsConstructibleCollectionType(SemanticModel.Compilation, collectionType, out var elementType) &&
+                        elementType is INamedTypeSymbol
+                        {
+                            Name: nameof(KeyValuePair<int, int>),
+                            TypeArguments: [var keyType, var valueType]
+                        })
+                    {
+                        return [isKey ? keyType : valueType];
+                    }
+
+                    // If that fails, see if we can figure out from one of our siblings.
+                    foreach (var element in collectionExpression.Elements)
+                    {
+                        if (element != keyValuePairElement && element is KeyValuePairElementSyntax siblingElement)
+                        {
+                            var types = GetTypes(isKey ? siblingElement.KeyExpression : siblingElement.ValueExpression, objectAsDefault: false);
+                            if (types.Any())
+                                return types.Select(t => t.InferredType);
+                        }
+                    }
+                }
+
+                return [];
+            }
         }
 
         private IEnumerable<TypeInferenceInfo> InferTypeInExpressionStatement(SyntaxToken? previousToken = null)


### PR DESCRIPTION
See [proposals/dictionary-expressions.md](https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md), [proposals/collection-expression-arguments.md](https://github.com/dotnet/csharplang/blob/main/proposals/collection-expression-arguments.md).

Includes:
- Collection arguments for collection expressions that target concrete types that do not use `[CollectionBuilderAttribute]`.
- Support for concrete dictionary target types such as `System.Collections.Generic.Dictionary<TKey, TValue>` that do not use `[CollectionBuilderAttribute]`.
- Support for dictionary interface target types: `IDictionary<TKey, TValue>`, `IReadOnlyDictionary<TKey, TValue>`.
- Support for *key-value elements* using `k:v` syntax in collection expressions targeting recognized dictionary types.
- Variance conversions for *expression elements* and *spread elements* with `KeyValuePair<,>` type in collection expressions targeting dictionary types.

Does *not* include:
- Support for `k:v` elements or variance conversions of elements with `KeyValuePair<,>` type in non-dictionary collections of `KeyValuePair<,>`, including types that use `[CollectionBuilderAttribute]`.
- Target type inference from keys and values.
- Overload resolution based on key and value types.
- Collection arguments for dictionary interface target types.
- Semantic model support for dictionary target types.
- Nullable analysis for dictionary target types.