### PR TITLE
Extensions: ref safety analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2150,8 +2150,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             methodInfo = replacedMethodInfo;
 
+            var extensionParameter = symbol.ContainingType.ExtensionParameter;
+            Debug.Assert(extensionParameter is not null);
+            parameters = parameters.IsDefault ? [extensionParameter] : [extensionParameter, .. parameters];
+
             Debug.Assert(receiver is not null);
-            parameters = methodInfo.Symbol.GetParameters();
             argsOpt = argsOpt.IsDefault ? [receiver] : [receiver, .. argsOpt];
             receiver = null;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -93,6 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 wasError = (Method is not null && method is null) || (SetMethod is not null && setMethod is null);
 
+                // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Test with indexers (ie. "method") and in compound assignment (ie. "setMethod")
                 return new MethodInfo(symbol, method, setMethod);
 
                 static MethodSymbol? replace(MethodSymbol? method)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2137,14 +2137,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref ImmutableArray<int> argsToParamsOpt)
         {
             Symbol? symbol = methodInfo.Symbol;
-            if (symbol?.GetIsNewExtensionMember() != true)
+            if (symbol?.GetIsNewExtensionMember() != true || symbol.IsStatic)
             {
                 return;
             }
 
-            var extensionParameter = symbol.ContainingType.ExtensionParameter;
-            Debug.Assert(extensionParameter is not null);
-            Debug.Assert(receiver is not null);
             MethodInfo replacedMethodInfo = methodInfo.ReplaceWithExtensionImplementation(out bool wasError);
             if (wasError)
             {
@@ -2152,7 +2149,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             methodInfo = replacedMethodInfo;
-            parameters = parameters.IsDefault ? [extensionParameter] : [extensionParameter, .. parameters];
+
+            Debug.Assert(receiver is not null);
+            parameters = methodInfo.Symbol.GetParameters();
             argsOpt = argsOpt.IsDefault ? [receiver] : [receiver, .. argsOpt];
             receiver = null;
 


### PR DESCRIPTION
Analyze the receiver for an extension as an argument.
Properties are already analyzed as invocations.

Relates to test plan https://github.com/dotnet/roslyn/issues/76130