### PR TITLE
Avoid potential disposal exception during MEF shutdown

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -705,7 +705,7 @@ public abstract partial class Workspace : IDisposable
             // tearing ourselves down.
             this.ClearSolution(reportChangeEvent: false);
 
-            this.Services.GetService<IWorkspaceEventListenerService>()?.Stop();
+            _workspaceEventListenerService?.Stop();
         }
 
         _legacyOptions.UnregisterWorkspace(this);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -27,7 +27,7 @@ public abstract partial class Workspace
     private const string TextDocumentOpenedEventName = "TextDocumentOpened";
     private const string TextDocumentClosedEventName = "TextDocumentClosed";
 
-    private IWorkspaceEventListenerService? _workspaceEventListenerService;
+    private IWorkspaceEventListenerService _workspaceEventListenerService;
 
     /// <summary>
     /// An event raised whenever the current solution is changed.

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -27,6 +27,8 @@ public abstract partial class Workspace
     private const string TextDocumentOpenedEventName = "TextDocumentOpened";
     private const string TextDocumentClosedEventName = "TextDocumentClosed";
 
+    private IWorkspaceEventListenerService? _workspaceEventListenerService;
+
     /// <summary>
     /// An event raised whenever the current solution is changed.
     /// </summary>
@@ -289,6 +291,9 @@ public abstract partial class Workspace
 
     private void EnsureEventListeners()
     {
-        this.Services.GetService<IWorkspaceEventListenerService>()?.EnsureListeners();
+        // Cache this service so it doesn't need to be retrieved from MEF during disposal.
+        _workspaceEventListenerService ??= this.Services.GetService<IWorkspaceEventListenerService>();
+
+        _workspaceEventListenerService?.EnsureListeners();
     }
 }


### PR DESCRIPTION
Previously, if VS was shutdown before Workspace.EnsureEventListeners was invoked, we would cause an exception during MEF disposal. This would happen because our workspace disposal would attempt to get a service that hadn't already been cached, and thus would ask MEF to compose the item during MEF disposal (which doesn't work).

Instead, just cache the IWorkspaceEventListenerService for use during the dispose.