### PR TITLE
Move MiscellaneousFilesWorkspace construction to background thread

### DIFF
--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage`2.cs
@@ -60,7 +60,9 @@ internal abstract partial class AbstractPackage<TPackage, TLanguageService> : Ab
         }
 
         // Ensure the OpenTextBufferProvider is created on the main thread. This is important because
-        // it performs various RDT operations in it's constructor, and those are not thread-safe.
+        // it potentially creates the RDT in it's constructor, and that is not thread-safe until
+        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441480 is fixed. Once that is merged,
+        // we can remove the following statement.
         this.ComponentModel.GetService<OpenTextBufferProvider>();
 
         // awaiting an IVsTask guarantees to return on the captured context

--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -31,7 +31,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     private readonly IThreadingContext _threadingContext;
     private readonly IVsService<IVsTextManager> _textManagerService;
     private readonly OpenTextBufferProvider _openTextBufferProvider;
-    private readonly IMetadataAsSourceFileService _fileTrackingMetadataAsSourceService;
+    private readonly Lazy<IMetadataAsSourceFileService> _fileTrackingMetadataAsSourceService;
 
     private readonly ConcurrentDictionary<Guid, LanguageInformation> _languageInformationByLanguageGuid = [];
 
@@ -47,7 +47,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     /// </summary>
     private readonly Dictionary<string, (ProjectId projectId, SourceTextContainer textContainer)> _monikersToProjectIdAndContainer = [];
 
-    private readonly ImmutableArray<MetadataReference> _metadataReferences;
+    private readonly Lazy<ImmutableArray<MetadataReference>> _metadataReferences;
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -55,16 +55,16 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
         IThreadingContext threadingContext,
         IVsService<SVsTextManager, IVsTextManager> textManagerService,
         OpenTextBufferProvider openTextBufferProvider,
-        IMetadataAsSourceFileService fileTrackingMetadataAsSourceService,
-        VisualStudioWorkspace visualStudioWorkspace)
-        : base(visualStudioWorkspace.Services.HostServices, WorkspaceKind.MiscellaneousFiles)
+        Lazy<IMetadataAsSourceFileService> fileTrackingMetadataAsSourceService,
+        Composition.ExportProvider exportProvider)
+        : base(VisualStudioMefHostServices.Create(exportProvider), WorkspaceKind.MiscellaneousFiles)
     {
         _threadingContext = threadingContext;
         _textManagerService = textManagerService;
         _openTextBufferProvider = openTextBufferProvider;
         _fileTrackingMetadataAsSourceService = fileTrackingMetadataAsSourceService;
 
-        _metadataReferences = [.. CreateMetadataReferences()];
+        _metadataReferences = new(() => [.. CreateMetadataReferences()]);
 
         _openTextBufferProvider.AddListener(this);
     }
@@ -122,6 +122,10 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
 
     private IEnumerable<MetadataReference> CreateMetadataReferences()
     {
+        // VisualStudioMetadataReferenceManager construction requires the main thread
+        // TODO: Determine if main thread affinity can be removed: https://github.com/dotnet/roslyn/issues/77791
+        _threadingContext.ThrowIfNotOnUIThread();
+
         var manager = this.Services.GetService<VisualStudioMetadataReferenceManager>();
         var searchPaths = VisualStudioMetadataReferenceManager.GetReferencePaths();
 
@@ -261,7 +265,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     {
         _threadingContext.ThrowIfNotOnUIThread();
 
-        if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer.AsTextContainer(), out var _))
+        if (_fileTrackingMetadataAsSourceService.Value.TryAddDocumentToWorkspace(moniker, textBuffer.AsTextContainer(), out var _))
         {
             // We already added it, so we will keep it excluded from the misc files workspace
             return;
@@ -282,6 +286,10 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     /// </summary>
     private ProjectInfo CreateProjectInfoForDocument(string filePath)
     {
+        // Potential calculation of _metadataReferences requires being on the main thread
+        // TODO: Determine if main thread affinity can be removed: https://github.com/dotnet/roslyn/issues/77791
+        _threadingContext.ThrowIfNotOnUIThread();
+
         // This should always succeed since we only got here if we already confirmed the moniker is acceptable
         var languageInformation = TryGetLanguageInformation(filePath);
         Contract.ThrowIfNull(languageInformation);
@@ -289,13 +297,13 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
         var checksumAlgorithm = SourceHashAlgorithms.Default;
         var fileLoader = new WorkspaceFileTextLoader(Services.SolutionServices, filePath, defaultEncoding: null);
         return MiscellaneousFileUtilities.CreateMiscellaneousProjectInfoForDocument(
-            this, filePath, fileLoader, languageInformation, checksumAlgorithm, Services.SolutionServices, _metadataReferences);
+            this, filePath, fileLoader, languageInformation, checksumAlgorithm, Services.SolutionServices, _metadataReferences.Value);
     }
 
     private void DetachFromDocument(string moniker)
     {
         _threadingContext.ThrowIfNotOnUIThread();
-        if (_fileTrackingMetadataAsSourceService.TryRemoveDocumentFromWorkspace(moniker))
+        if (_fileTrackingMetadataAsSourceService.Value.TryRemoveDocumentFromWorkspace(moniker))
         {
             return;
         }


### PR DESCRIPTION
This PR restores behavior introduced in https://github.com/dotnet/roslyn/pull/77768 that were reverted in PR https://github.com/dotnet/roslyn/pull/77983. 
The revert occurred as it was flagged for causing ddrit regressions in some of the WinformsVS64.Designer tests. I was unable to reproduce this scenario locally,
but the RPS tests are able to reliably hit this issue. 

[Insertion PR](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/625980) demonstrating no regressions in WinformsVS64.Designer DDRIT tests.

Digging into it a bit indicated that creating the OpenTextBufferProvider on a bg thread somehow created a thread affinity that caused 
microsoft.visualstudio.shell.design.ni!DocData.CreateNativeDocData's call to msenv!CEditorManager::RegisterInvisibleEditor's to require an RPC main->bg thread switch.
This breaks the assumptions of RegisterInvisibleEditor and weird things start happening.

Instead, we explicitly create the OpenTextBufferProvider on the main thread.

Compare by commit:

Commit 1:
    Restore changes from PR https://github.com/dotnet/roslyn/pull/77768 that were reverted in PR https://github.com/dotnet/roslyn/pull/77983

Commit 2:
    1) Force OpenTextBufferProvider to be created on main thread
    2) Move MiscellaneousFilesWorkspace to still be on bgthread, but ensure it occurs after OpenTextBufferProvider construction
    3) Remove a misleading comment from OpenTextBufferProvider.ctor and add a verification that it's called on the main thread
    4) Change CheckForExistingOpenDocumentsAsync to yield the thread so it doesn't block the caller if the work could have been done synchronously.