### PR TITLE
Disable TransitiveVersioningPinning for RoslynAnalyzers.

### DIFF
--- a/src/RoslynAnalyzers/Directory.Build.props
+++ b/src/RoslynAnalyzers/Directory.Build.props
@@ -8,6 +8,12 @@
 
     <!-- Set 'NoDefaultExcludes' to ensure that we can package .editorconfig files into our analyzer NuGet packages -->
     <NoDefaultExcludes>true</NoDefaultExcludes>
+
+    <!--
+      Disabled TransitivePinning to workaround source-build issues in SDK insertions.
+      A proper fix is being tracked by https://github.com/dotnet/roslyn/issues/78036
+    -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!--

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
@@ -23,7 +23,6 @@ RS1018 |  | DiagnosticId for analyzers must be in specified format |
 RS1019 |  | DiagnosticId must be unique across analyzers |
 RS1020 |  | Category for analyzers must be from the specified values |
 RS1021 |  | Invalid entry in analyzer category and diagnostic ID range specification file |
-RS1022 | <https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1022.md> | Do not use types from Workspaces assembly in an analyzer |
 RS1024 |  | Symbols should be compared for equality |
 RS1025 |  | Configure generated code analysis |
 RS1026 |  | Enable concurrent execution |
@@ -38,18 +37,7 @@ RS1034 |  | Prefer 'IsKind' for checking syntax kinds |
 RS1035 |  | Do not use APIs banned for analyzers |
 RS1036 |  | Specify analyzer banned API enforcement setting |
 RS1037 |  | Add "CompilationEnd" custom tag to compilation end diagnostic descriptor |
-RS1038 | <https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1038.md> | Compiler extensions should be implemented in assemblies with compiler-provided references |
 RS1039 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
 RS1040 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
-RS1041 | <https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1041.md> | Compiler extensions should be implemented in assemblies targeting netstandard2.0 |
 RS1042 |  | Implementations of this interface are not allowed |
 RS1043 |  | Do not use file types for implementing analyzers, generators, and code fixers |
-RS2000 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Add analyzer diagnostic IDs to analyzer release |
-RS2001 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release |
-RS2002 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Do not add removed analyzer diagnostic IDs to unshipped analyzer release |
-RS2003 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file |
-RS2004 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers |
-RS2005 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Remove duplicate entries for diagnostic ID in the same analyzer release |
-RS2006 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Remove duplicate entries for diagnostic ID between analyzer releases |
-RS2007 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Invalid entry in analyzer release file |
-RS2008 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md> | Enable analyzer release tracking |

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/RulesMissingDocumentation.md
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/RulesMissingDocumentation.md
@@ -2,6 +2,4 @@
 
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
-RS0030 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md> | Do not use banned APIs |
-RS0031 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md> | The list of banned symbols contains a duplicate |
 RS0035 |  | External access to internal symbols outside the restricted namespace(s) is prohibited |

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/RulesMissingDocumentation.md
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/RulesMissingDocumentation.md
@@ -2,22 +2,3 @@
 
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
-RS0016 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Add public types and members to the declared API |
-RS0017 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Remove deleted types and members from the declared API |
-RS0022 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Constructor make noninheritable base class inheritable |
-RS0024 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | The contents of the public API files are invalid |
-RS0025 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Do not duplicate symbols in public API files |
-RS0036 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Annotate nullability of public types and members in the declared API |
-RS0037 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Enable tracking of nullability of reference types in the declared API |
-RS0041 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Public members should not use oblivious types |
-RS0048 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Missing shipped or unshipped public API file |
-RS0050 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | API is marked as removed but it exists in source code |
-RS0051 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Add internal types and members to the declared API |
-RS0052 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Remove deleted types and members from the declared internal API |
-RS0053 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | The contents of the internal API files are invalid |
-RS0054 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Do not duplicate symbols in internal API files |
-RS0055 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Annotate nullability of internal types and members in the declared API |
-RS0056 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Enable tracking of nullability of reference types in the declared API |
-RS0057 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Internal members should not use oblivious types |
-RS0058 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Missing shipped or unshipped internal API file |
-RS0061 | <https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md> | Constructor make noninheritable base class inheritable |


### PR DESCRIPTION
Transitive pinning is breaking source-build in SDK insertions. See https://github.com/dotnet/sdk/pull/48088


Changes to MissingRulesDocumentation are automated.