### PR TITLE
Move MiscellaneousFilesWorkspace construction to background thread

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -31,7 +31,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     private readonly IThreadingContext _threadingContext;
     private readonly IVsService<IVsTextManager> _textManagerService;
     private readonly OpenTextBufferProvider _openTextBufferProvider;
-    private readonly IMetadataAsSourceFileService _fileTrackingMetadataAsSourceService;
+    private readonly Lazy<IMetadataAsSourceFileService> _fileTrackingMetadataAsSourceService;
 
     private readonly ConcurrentDictionary<Guid, LanguageInformation> _languageInformationByLanguageGuid = [];
 
@@ -47,7 +47,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     /// </summary>
     private readonly Dictionary<string, (ProjectId projectId, SourceTextContainer textContainer)> _monikersToProjectIdAndContainer = [];
 
-    private readonly ImmutableArray<MetadataReference> _metadataReferences;
+    private readonly Lazy<ImmutableArray<MetadataReference>> _metadataReferences;
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -55,16 +55,16 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
         IThreadingContext threadingContext,
         IVsService<SVsTextManager, IVsTextManager> textManagerService,
         OpenTextBufferProvider openTextBufferProvider,
-        IMetadataAsSourceFileService fileTrackingMetadataAsSourceService,
-        VisualStudioWorkspace visualStudioWorkspace)
-        : base(visualStudioWorkspace.Services.HostServices, WorkspaceKind.MiscellaneousFiles)
+        Lazy<IMetadataAsSourceFileService> fileTrackingMetadataAsSourceService,
+        Composition.ExportProvider exportProvider)
+        : base(VisualStudioMefHostServices.Create(exportProvider), WorkspaceKind.MiscellaneousFiles)
     {
         _threadingContext = threadingContext;
         _textManagerService = textManagerService;
         _openTextBufferProvider = openTextBufferProvider;
         _fileTrackingMetadataAsSourceService = fileTrackingMetadataAsSourceService;
 
-        _metadataReferences = [.. CreateMetadataReferences()];
+        _metadataReferences = new(() => [.. CreateMetadataReferences()]);
 
         _openTextBufferProvider.AddListener(this);
     }
@@ -122,6 +122,10 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
 
     private IEnumerable<MetadataReference> CreateMetadataReferences()
     {
+        // VisualStudioMetadataReferenceManager construction requires the main thread
+        // TODO: Determine if main thread affinity can be removed: https://github.com/dotnet/roslyn/issues/77791
+        _threadingContext.ThrowIfNotOnUIThread();
+
         var manager = this.Services.GetService<VisualStudioMetadataReferenceManager>();
         var searchPaths = VisualStudioMetadataReferenceManager.GetReferencePaths();
 
@@ -261,7 +265,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     {
         _threadingContext.ThrowIfNotOnUIThread();
 
-        if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer.AsTextContainer(), out var _))
+        if (_fileTrackingMetadataAsSourceService.Value.TryAddDocumentToWorkspace(moniker, textBuffer.AsTextContainer(), out var _))
         {
             // We already added it, so we will keep it excluded from the misc files workspace
             return;
@@ -282,6 +286,10 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     /// </summary>
     private ProjectInfo CreateProjectInfoForDocument(string filePath)
     {
+        // Potential calculation of _metadataReferences requires being on the main thread
+        // TODO: Determine if main thread affinity can be removed: https://github.com/dotnet/roslyn/issues/77791
+        _threadingContext.ThrowIfNotOnUIThread();
+
         // This should always succeed since we only got here if we already confirmed the moniker is acceptable
         var languageInformation = TryGetLanguageInformation(filePath);
         Contract.ThrowIfNull(languageInformation);
@@ -289,13 +297,13 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
         var checksumAlgorithm = SourceHashAlgorithms.Default;
         var fileLoader = new WorkspaceFileTextLoader(Services.SolutionServices, filePath, defaultEncoding: null);
         return MiscellaneousFileUtilities.CreateMiscellaneousProjectInfoForDocument(
-            this, filePath, fileLoader, languageInformation, checksumAlgorithm, Services.SolutionServices, _metadataReferences);
+            this, filePath, fileLoader, languageInformation, checksumAlgorithm, Services.SolutionServices, _metadataReferences.Value);
     }
 
     private void DetachFromDocument(string moniker)
     {
         _threadingContext.ThrowIfNotOnUIThread();
-        if (_fileTrackingMetadataAsSourceService.TryRemoveDocumentFromWorkspace(moniker))
+        if (_fileTrackingMetadataAsSourceService.Value.TryRemoveDocumentFromWorkspace(moniker))
         {
             return;
         }

--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -286,10 +286,6 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     /// </summary>
     private ProjectInfo CreateProjectInfoForDocument(string filePath)
     {
-        // Potential calculation of _metadataReferences requires being on the main thread
-        // TODO: Determine if main thread affinity can be removed: https://github.com/dotnet/roslyn/issues/77791
-        _threadingContext.ThrowIfNotOnUIThread();
-
         // This should always succeed since we only got here if we already confirmed the moniker is acceptable
         var languageInformation = TryGetLanguageInformation(filePath);
         Contract.ThrowIfNull(languageInformation);

--- a/src/VisualStudio/Core/Def/ProjectSystem/OpenTextBufferProvider.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/OpenTextBufferProvider.cs
@@ -38,7 +38,7 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
     /// A simple object for asserting when we're on the UI thread.
     /// </summary>
     private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
-    private readonly IVsRunningDocumentTable4 _runningDocumentTable;
+    private readonly Lazy<IVsRunningDocumentTable4> _runningDocumentTable;
 
     private ImmutableArray<IOpenTextBufferEventListener> _listeners = [];
 
@@ -60,17 +60,25 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
         _threadingContext = threadingContext;
         _editorAdaptersFactoryService = editorAdaptersFactoryService;
 
-        // The running document table since 16.0 has limited operations that can be done in a free threaded manner, specifically fetching the service and advising events.
-        // This is specifically guaranteed by the shell that those limited operations are safe and do not cause RPCs, and it's important we don't try to fetch the service
-        // via a helper that will "helpfully" try to jump to the UI thread.
-        var runningDocumentTable = (IVsRunningDocumentTable)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
-        _runningDocumentTable = (IVsRunningDocumentTable4)runningDocumentTable;
-        runningDocumentTable.AdviseRunningDocTableEvents(this, out _runningDocumentTableEventsCookie);
+        _runningDocumentTable = new(() =>
+        {
+            /* NOTE: REMOVE ONCE https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441480 IS FIXED */
+            _threadingContext.ThrowIfNotOnUIThread();
+
+            // The running document table since 18.0 has limited operations that can be done in a free threaded manner, specifically fetching the service and advising events.
+            // This is specifically guaranteed by the shell that those limited operations are safe and do not cause RPCs, and it's important we don't try to fetch the service
+            // via a helper that will "helpfully" try to jump to the UI thread.
+            var runningDocumentTable = (IVsRunningDocumentTable)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
+            runningDocumentTable.AdviseRunningDocTableEvents(this, out _runningDocumentTableEventsCookie);
+
+            return (IVsRunningDocumentTable4)runningDocumentTable;
+        });
 
         // We also need to check for any documents that might have been open before we subscribed. That we do have to do on the UI thread.
         var listener = listenerProvider.GetListener(FeatureAttribute.Workspace);
         var asyncToken = listener.BeginAsyncOperation(nameof(CheckForExistingOpenDocumentsAsync));
-        CheckForExistingOpenDocumentsAsync(threadingContext).CompletesAsyncOperation(asyncToken);
+
+        CheckForExistingOpenDocumentsAsync().CompletesAsyncOperation(asyncToken);
     }
 
     private void RaiseEventForEachListener(Action<IOpenTextBufferEventListener> action)
@@ -91,9 +99,27 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
         }
     }
 
-    private async Task CheckForExistingOpenDocumentsAsync(IThreadingContext threadingContext)
+    private async Task CheckForExistingOpenDocumentsAsync()
     {
-        await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+        _threadingContext.ThrowIfNotOnBackgroundThread();
+
+        /* 
+         * NOTE: UNCOMMENT ONCE https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441480 IS FIXED
+         *       AND REMOVE THE THREAD CHECK FROM THE INITIALIZATION OF _runningDocumentTable
+
+         // Yield the thread, so the caller can proceed immediately.
+         await Task.Yield();
+
+         // Ensure we obtain the RDT before transitioning to the main thread
+         _ = _runningDocumentTable.Value;
+
+         */
+
+        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+        /* NOTE: REMOVE ONCE https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441480 IS FIXED */
+        // Temporarily ensure we obtain the RDT from the main thread
+        _ = _runningDocumentTable.Value;
 
         foreach (var (filePath, textBuffer, hierarchy) in EnumerateDocumentSet())
         {
@@ -118,9 +144,9 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
         if (dwReadLocksRemaining + dwEditLocksRemaining == 0)
         {
             _threadingContext.ThrowIfNotOnUIThread();
-            if (_runningDocumentTable.IsDocumentInitialized(docCookie))
+            if (_runningDocumentTable.Value.IsDocumentInitialized(docCookie))
             {
-                var moniker = _runningDocumentTable.GetDocumentMoniker(docCookie);
+                var moniker = _runningDocumentTable.Value.GetDocumentMoniker(docCookie);
                 _monikerToTextBufferMap = _monikerToTextBufferMap.Remove(moniker);
 
                 RaiseEventForEachListener(l => l.OnCloseDocument(moniker));
@@ -132,9 +158,9 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
 
     public int OnAfterSave(uint docCookie)
     {
-        if (_runningDocumentTable.IsDocumentInitialized(docCookie))
+        if (_runningDocumentTable.Value.IsDocumentInitialized(docCookie))
         {
-            var moniker = _runningDocumentTable.GetDocumentMoniker(docCookie);
+            var moniker = _runningDocumentTable.Value.GetDocumentMoniker(docCookie);
             RaiseEventForEachListener(l => l.OnSaveDocument(moniker));
         }
 
@@ -150,7 +176,7 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
         if ((grfAttribs & (uint)__VSRDTATTRIB.RDTA_MkDocument) != 0)
         {
             _threadingContext.ThrowIfNotOnUIThread();
-            if (_runningDocumentTable.IsDocumentInitialized(docCookie))
+            if (_runningDocumentTable.Value.IsDocumentInitialized(docCookie))
             {
                 // We should already have a text buffer for this one
                 if (_monikerToTextBufferMap.TryGetValue(pszMkDocumentOld, out var textBuffer))
@@ -181,10 +207,10 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
         if ((grfAttribs & ((uint)__VSRDTATTRIB.RDTA_DocDataReloaded | (uint)__VSRDTATTRIB3.RDTA_DocumentInitialized)) != 0)
         {
             _threadingContext.ThrowIfNotOnUIThread();
-            if (_runningDocumentTable.IsDocumentInitialized(docCookie) && TryGetMoniker(docCookie, out var moniker) && TryGetBufferFromRunningDocumentTable(docCookie, out var buffer))
+            if (_runningDocumentTable.Value.IsDocumentInitialized(docCookie) && TryGetMoniker(docCookie, out var moniker) && TryGetBufferFromRunningDocumentTable(docCookie, out var buffer))
             {
                 _monikerToTextBufferMap = _monikerToTextBufferMap.Add(moniker, buffer);
-                _runningDocumentTable.GetDocumentHierarchyItem(docCookie, out var hierarchy, out _);
+                _runningDocumentTable.Value.GetDocumentHierarchyItem(docCookie, out var hierarchy, out _);
 
                 RaiseEventForEachListener(l => l.OnOpenDocument(moniker, buffer, hierarchy));
             }
@@ -193,9 +219,9 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
         if ((grfAttribs & (uint)__VSRDTATTRIB.RDTA_Hierarchy) != 0)
         {
             _threadingContext.ThrowIfNotOnUIThread();
-            if (_runningDocumentTable.IsDocumentInitialized(docCookie) && TryGetMoniker(docCookie, out var moniker))
+            if (_runningDocumentTable.Value.IsDocumentInitialized(docCookie) && TryGetMoniker(docCookie, out var moniker))
             {
-                _runningDocumentTable.GetDocumentHierarchyItem(docCookie, out var hierarchy, out _);
+                _runningDocumentTable.Value.GetDocumentHierarchyItem(docCookie, out var hierarchy, out _);
 
                 RaiseEventForEachListener(l => l.OnRefreshDocumentContext(moniker, hierarchy));
             }
@@ -207,13 +233,13 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
     public int OnBeforeDocumentWindowShow(uint docCookie, int fFirstShow, IVsWindowFrame pFrame)
     {
         // Doc data reloaded is not triggered for the underlying aspx.cs file when changes are made to the aspx file, so catch it here.
-        if (fFirstShow != 0 && _runningDocumentTable.IsDocumentInitialized(docCookie) && TryGetMoniker(docCookie, out var moniker))
+        if (fFirstShow != 0 && _runningDocumentTable.Value.IsDocumentInitialized(docCookie) && TryGetMoniker(docCookie, out var moniker))
         {
             // If we hadn't already raised an event for this, do it now
             if (!_monikerToTextBufferMap.ContainsKey(moniker) && TryGetBufferFromRunningDocumentTable(docCookie, out var buffer))
             {
                 _monikerToTextBufferMap = _monikerToTextBufferMap.Add(moniker, buffer);
-                _runningDocumentTable.GetDocumentHierarchyItem(docCookie, out var hierarchy, out _);
+                _runningDocumentTable.Value.GetDocumentHierarchyItem(docCookie, out var hierarchy, out _);
 
                 RaiseEventForEachListener(l => l.OnOpenDocument(moniker, buffer, hierarchy));
             }
@@ -256,13 +282,13 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
     {
         _threadingContext.ThrowIfNotOnUIThread();
 
-        if (!_runningDocumentTable.IsFileOpen(filePath))
+        if (!_runningDocumentTable.Value.IsFileOpen(filePath))
         {
             return null;
         }
 
-        var cookie = _runningDocumentTable.GetDocumentCookie(filePath);
-        _runningDocumentTable.GetDocumentHierarchyItem(cookie, out var hierarchy, out _);
+        var cookie = _runningDocumentTable.Value.GetDocumentCookie(filePath);
+        _runningDocumentTable.Value.GetDocumentHierarchyItem(cookie, out var hierarchy, out _);
         return hierarchy;
     }
 
@@ -278,7 +304,7 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
         {
             if (TryGetMoniker(cookie, out var moniker) && TryGetBufferFromRunningDocumentTable(cookie, out var buffer))
             {
-                _runningDocumentTable.GetDocumentHierarchyItem(cookie, out var hierarchy, out _);
+                _runningDocumentTable.Value.GetDocumentHierarchyItem(cookie, out var hierarchy, out _);
                 documents.Add((moniker, buffer, hierarchy));
             }
         }
@@ -288,9 +314,9 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
 
     private IEnumerable<uint> GetInitializedRunningDocumentTableCookies()
     {
-        foreach (var cookie in _runningDocumentTable.GetRunningDocuments())
+        foreach (var cookie in _runningDocumentTable.Value.GetRunningDocuments())
         {
-            if (_runningDocumentTable.IsDocumentInitialized(cookie))
+            if (_runningDocumentTable.Value.IsDocumentInitialized(cookie))
             {
                 yield return cookie;
             }
@@ -299,14 +325,14 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
 
     private bool TryGetMoniker(uint docCookie, out string moniker)
     {
-        moniker = _runningDocumentTable.GetDocumentMoniker(docCookie);
+        moniker = _runningDocumentTable.Value.GetDocumentMoniker(docCookie);
         return !string.IsNullOrEmpty(moniker);
     }
 
     private bool TryGetBufferFromRunningDocumentTable(uint docCookie, [NotNullWhen(true)] out ITextBuffer? textBuffer)
     {
         _threadingContext.ThrowIfNotOnUIThread();
-        return _runningDocumentTable.TryGetBuffer(_editorAdaptersFactoryService, docCookie, out textBuffer);
+        return _runningDocumentTable.Value.TryGetBuffer(_editorAdaptersFactoryService, docCookie, out textBuffer);
     }
 
     public void Dispose()

--- a/src/VisualStudio/Core/Def/ProjectSystem/OpenTextBufferProvider.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/OpenTextBufferProvider.cs
@@ -101,8 +101,6 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
 
     private async Task CheckForExistingOpenDocumentsAsync()
     {
-        _threadingContext.ThrowIfNotOnBackgroundThread();
-
         /* 
          * NOTE: UNCOMMENT ONCE https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441480 IS FIXED
          *       AND REMOVE THE THREAD CHECK FROM THE INITIALIZATION OF _runningDocumentTable


### PR DESCRIPTION
This PR restores behavior introduced in https://github.com/dotnet/roslyn/pull/77768 that were reverted in PR https://github.com/dotnet/roslyn/pull/77983.
The revert occurred as it was flagged for causing ddrit regressions in some of the WinformsVS64.Designer tests. I was unable to reproduce this scenario locally,
but the RPS tests are able to reliably hit this issue.

Digging into it a bit indicated that creating the OpenTextBufferProvider on a bg thread somehow a thread affinity that caused
microsoft.visualstudio.shell.design.ni!DocData.CreateNativeDocData's call to msenv!CEditorManager::RegisterInvisibleEditor's to require an RPC main->bg thread switch.
This breaks the assumptions of RegisterInvisibleEditor and weird things start happening. Jason helped track down the likely culprit, and logged 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441480 to track that work.

This PR works around that issue by obtaining the RDT while on the main thread. I've logged https://github.com/dotnet/roslyn/issues/78050 to track the Roslyn cleanup
necessary once obtaining the rdt can be done from a background thread.

Compare by commit:

Commit 1:
Restore changes from PR https://github.com/dotnet/roslyn/pull/77768 that were reverted in PR https://github.com/dotnet/roslyn/pull/77983

Commit 2:
    a) Ensure OpenTextBufferProvider._runningDocumentTable is initialized on the main thread.
    b) Added comments about https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441480 and created a tracking bug for us to clean this up once it's fixed (https://github.com/dotnet/roslyn/issues/78050)