### PR TITLE
Disable transitive pinning from the RoslynAnalyzer targets

### DIFF
--- a/src/RoslynAnalyzers/Directory.Build.props
+++ b/src/RoslynAnalyzers/Directory.Build.props
@@ -8,12 +8,6 @@
 
     <!-- Set 'NoDefaultExcludes' to ensure that we can package .editorconfig files into our analyzer NuGet packages -->
     <NoDefaultExcludes>true</NoDefaultExcludes>
-
-    <!--
-      Disabled TransitivePinning to workaround source-build issues in SDK insertions.
-      A proper fix is being tracked by https://github.com/dotnet/roslyn/issues/78036
-    -->
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!--

--- a/src/RoslynAnalyzers/Directory.Build.targets
+++ b/src/RoslynAnalyzers/Directory.Build.targets
@@ -17,6 +17,12 @@
       Release tables use borders and need https://github.com/dotnet/roslyn-analyzers/pull/7466 to be valid.
     -->
     <NoWarn>$(NoWarn);RS2007</NoWarn>
+
+    <!--
+      Disabled TransitivePinning to workaround source-build issues in SDK insertions.
+      A proper fix is being tracked by https://github.com/dotnet/roslyn/issues/78036
+    -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!-- Add License and Third Party Notices files into each VSIX. -->


### PR DESCRIPTION
Directory.Packages.props is imported after Directory.Build.props. Moving the disablement to the targets file.