### PR TITLE
Do not return metadata names for document symbols

### DIFF
--- a/src/Features/CSharp/Portable/NavigationBar/CSharpNavigationBarItemService.cs
+++ b/src/Features/CSharp/Portable/NavigationBar/CSharpNavigationBarItemService.cs
@@ -28,7 +28,10 @@ internal sealed class CSharpNavigationBarItemService() : AbstractNavigationBarIt
     private static readonly SymbolDisplayFormat s_typeFormat =
         SymbolDisplayFormat.CSharpErrorMessageFormat.AddGenericsOptions(SymbolDisplayGenericsOptions.IncludeVariance);
 
-    private static readonly SymbolDisplayFormat s_memberFormat =
+    private static readonly SymbolDisplayFormat s_memberNameFormat =
+        new(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly);
+
+    private static readonly SymbolDisplayFormat s_memberDetailsFormat =
         new(genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             memberOptions: SymbolDisplayMemberOptions.IncludeParameters |
                            SymbolDisplayMemberOptions.IncludeExplicitInterface,
@@ -186,8 +189,8 @@ internal sealed class CSharpNavigationBarItemService() : AbstractNavigationBarIt
             return null;
 
         return new SymbolItem(
-            member.Name,
-            member.ToDisplayString(s_memberFormat),
+            member.ToDisplayString(s_memberNameFormat),
+            member.ToDisplayString(s_memberDetailsFormat),
             member.GetGlyph(),
             member.IsObsolete(),
             location.Value);

--- a/src/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,12 +22,22 @@ public sealed class DocumentSymbolsTests : AbstractLanguageServerProtocolTests
     public async Task TestGetDocumentSymbolsAsync(bool mutatingLspWorkspace)
     {
         var markup =
-@"{|class:class {|classSelection:A|}
-{
-    {|method:void {|methodSelection:M|}()
-    {
-    }|}
-}|}";
+            """
+            namespace Test;
+
+            {|class:class {|classSelection:A|}
+            {
+                {|constructor:public {|constructorSelection:A|}()
+                {
+                }|}
+
+                {|method:void {|methodSelection:M|}()
+                {
+                }|}
+
+                {|operator:static A {|operatorSelection:operator +|}(A a1, A a2) => a1;|}
+            }|}
+            """;
         var clientCapabilities = new LSP.ClientCapabilities()
         {
             TextDocument = new LSP.TextDocumentClientCapabilities()
@@ -41,11 +49,12 @@ public sealed class DocumentSymbolsTests : AbstractLanguageServerProtocolTests
             }
         };
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, clientCapabilities);
-        var expected = new LSP.DocumentSymbol[]
-        {
-            CreateDocumentSymbol(LSP.SymbolKind.Class, "A", "A", testLspServer.GetLocations("class").Single(), testLspServer.GetLocations("classSelection").Single())
-        };
-        CreateDocumentSymbol(LSP.SymbolKind.Method, "M", "M()", testLspServer.GetLocations("method").Single(), testLspServer.GetLocations("methodSelection").Single(), expected.First());
+        var classSymbol = CreateDocumentSymbol(LSP.SymbolKind.Class, "A", "Test.A", testLspServer.GetLocations("class").Single(), testLspServer.GetLocations("classSelection").Single());
+        var constructorSymbol = CreateDocumentSymbol(LSP.SymbolKind.Method, "A", "A()", testLspServer.GetLocations("constructor").Single(), testLspServer.GetLocations("constructorSelection").Single(), classSymbol);
+        var methodSymbol = CreateDocumentSymbol(LSP.SymbolKind.Method, "M", "M()", testLspServer.GetLocations("method").Single(), testLspServer.GetLocations("methodSelection").Single(), classSymbol);
+        var operatorSymbol = CreateDocumentSymbol(LSP.SymbolKind.Operator, "operator +", "operator +(A a1, A a2)", testLspServer.GetLocations("operator").Single(), testLspServer.GetLocations("operatorSelection").Single(), classSymbol);
+
+        LSP.DocumentSymbol[] expected = [classSymbol];
 
         var results = await RunGetDocumentSymbolsAsync<LSP.DocumentSymbol[]>(testLspServer);
         Assert.Equal(expected.Length, results.Length);
@@ -59,18 +68,29 @@ public sealed class DocumentSymbolsTests : AbstractLanguageServerProtocolTests
     public async Task TestGetDocumentSymbolsAsync_WithoutHierarchicalSupport(bool mutatingLspWorkspace)
     {
         var markup =
-@"class {|class:A|}
-{
-    void {|method:M|}()
-    {
-    }
-}";
+            """
+            namespace Test;
+
+            class {|class:A|}
+            {
+                public {|constructor:A|}()
+                {
+                }
+
+                void {|method:M|}()
+                {
+                }
+
+                static A operator {|operator:+|}(A a1, A a2) => a1;
+            }
+            """;
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
-        var expected = new LSP.SymbolInformation[]
-        {
-            CreateSymbolInformation(LSP.SymbolKind.Class, "A", testLspServer.GetLocations("class").Single(), Glyph.ClassInternal),
-            CreateSymbolInformation(LSP.SymbolKind.Method, "M()", testLspServer.GetLocations("method").Single(), Glyph.MethodPrivate, "A")
-        };
+        LSP.SymbolInformation[] expected = [
+            CreateSymbolInformation(LSP.SymbolKind.Class, "Test.A", testLspServer.GetLocations("class").Single(), Glyph.ClassInternal),
+            CreateSymbolInformation(LSP.SymbolKind.Method, "A()", testLspServer.GetLocations("constructor").Single(), Glyph.MethodPublic, "Test.A"),
+            CreateSymbolInformation(LSP.SymbolKind.Method, "M()", testLspServer.GetLocations("method").Single(), Glyph.MethodPrivate, "Test.A"),
+            CreateSymbolInformation(LSP.SymbolKind.Operator, "operator +(A a1, A a2)", testLspServer.GetLocations("operator").Single(), Glyph.Operator, "Test.A"),
+        ];
 
         var results = await RunGetDocumentSymbolsAsync<LSP.SymbolInformation[]>(testLspServer);
         AssertJsonEquals(expected, results);
@@ -82,13 +102,15 @@ public sealed class DocumentSymbolsTests : AbstractLanguageServerProtocolTests
     public async Task TestGetDocumentSymbolsAsync__WithLocals(bool mutatingLspWorkspace)
     {
         var markup =
-@"class A
-{
-    void Method()
-    {
-        int i = 1;
-    }
-}";
+            """
+            class A
+            {
+                void Method()
+                {
+                    int i = 1;
+                }
+            }
+            """;
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
         var results = await RunGetDocumentSymbolsAsync<LSP.SymbolInformation[]>(testLspServer).ConfigureAwait(false);
         Assert.Equal(3, results.Length);
@@ -98,10 +120,11 @@ public sealed class DocumentSymbolsTests : AbstractLanguageServerProtocolTests
     public async Task TestGetDocumentSymbolsAsync_EmptyName(bool mutatingLspWorkspace)
     {
         var markup =
-@"namepsace NamespaceA
-{
-    public class
-";
+            """
+            namepsace NamespaceA
+            {
+                public class
+            """;
 
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
         var results = await RunGetDocumentSymbolsAsync<LSP.SymbolInformation[]>(testLspServer).ConfigureAwait(false);
@@ -114,10 +137,11 @@ public sealed class DocumentSymbolsTests : AbstractLanguageServerProtocolTests
     public async Task TestGetDocumentSymbolsAsync_EmptyNameWithHierarchicalSupport(bool mutatingLspWorkspace)
     {
         var markup =
-@"namepsace NamespaceA
-{
-    public class
-";
+            """
+            namepsace NamespaceA
+            {
+                public class
+            """;
         var clientCapabilities = new LSP.ClientCapabilities()
         {
             TextDocument = new LSP.TextDocumentClientCapabilities()
@@ -163,6 +187,7 @@ public sealed class DocumentSymbolsTests : AbstractLanguageServerProtocolTests
     {
         Assert.Equal(expected.Kind, actual.Kind);
         Assert.Equal(expected.Name, actual.Name);
+        Assert.Equal(expected.Detail, actual.Detail);
         Assert.Equal(expected.Range, actual.Range);
         Assert.Equal(expected.Children.Length, actual.Children.Length);
         for (var i = 0; i < actual.Children.Length; i++)


### PR DESCRIPTION
For EditorFeatures NavigationBar and non-hierarchy LSP DocumentSymbols we do not use the SymbolItem.Name and instead return SymbolItem.Text which is the symbol formatted as member name with parameters. The hierarchy DocumentSymbols did return the SymbolItem.Name which could contain values such as `.ctor`. The NavBarItemService is updated to construct SymbolItems with the symbol formatted as a simple member name instead.

Resolves #78072