### PR TITLE
Move test helpers to NetLatest

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1007,7 +1007,7 @@ namespace System.Diagnostics.CodeAnalysis
                 options,
                 parseOptions,
                 emitOptions,
-                TargetFramework.StandardAndCSharp,
+                TargetFramework.NetLatest,
                 verify);
 
         internal CompilationVerifier CompileAndVerify(
@@ -1026,7 +1026,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            TargetFramework targetFramework = TargetFramework.Standard,
+            TargetFramework targetFramework = TargetFramework.NetLatest,
             Verification verify = default)
         {
             options = options ?? (expectedOutput != null ? TestOptions.ReleaseExe : CheckForTopLevelStatements(source.GetSyntaxTrees(parseOptions)));
@@ -1147,7 +1147,7 @@ namespace System.Diagnostics.CodeAnalysis
         public static CSharpCompilation CreateCompilationWithIL(
             CSharpTestSource source,
             string ilSource,
-            TargetFramework targetFramework = TargetFramework.Standard,
+            TargetFramework targetFramework = TargetFramework.NetLatest,
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
@@ -1249,7 +1249,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             string assemblyName = "",
-            string sourceFileName = "") => CreateCompilation(source, references, options, parseOptions, TargetFramework.StandardAndCSharp, assemblyName, sourceFileName);
+            string sourceFileName = "") => CreateCompilation(source, references, options, parseOptions, TargetFramework.NetLatest, assemblyName, sourceFileName);
 
         public static CSharpCompilation CreateCompilationWithMscorlib40AndDocumentationComments(
             CSharpTestSource source,
@@ -1296,7 +1296,7 @@ namespace System.Diagnostics.CodeAnalysis
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
-            TargetFramework targetFramework = TargetFramework.Standard,
+            TargetFramework targetFramework = TargetFramework.NetLatest,
             string assemblyName = "",
             string sourceFileName = "",
             bool skipUsesIsNullable = false)
@@ -1524,7 +1524,7 @@ namespace System.Diagnostics.CodeAnalysis
             return createCompilationLambda();
         }
 
-        public CompilationVerifier CompileWithCustomILSource(string cSharpSource, string ilSource, Action<CSharpCompilation> compilationVerifier = null, bool importInternals = true, string expectedOutput = null, TargetFramework targetFramework = TargetFramework.Standard)
+        public CompilationVerifier CompileWithCustomILSource(string cSharpSource, string ilSource, Action<CSharpCompilation> compilationVerifier = null, bool importInternals = true, string expectedOutput = null, TargetFramework targetFramework = TargetFramework.NetLatest)
         {
             var compilationOptions = (expectedOutput != null) ? TestOptions.ReleaseExe : TestOptions.ReleaseDll;
 


### PR DESCRIPTION
Using `NetLatest` means that our tests use `net472` reference assemblies when running on .NET Framework and latest .NET Core reference assemblies when running on .NET Core. This is advantageous in a few areas:

1. This is much closer to how our customers operate
2. It mean that as we move the _latest_ definition in our unit test infra our tests move forward automatically

This change moves a number of our core helpers from `Standard`, which is `netstandard2.0` on .NET Core, to `NetLatest`. This should significantly expand our coverage against modern .NET reference assemblies