### PR TITLE
CSharp Completion Context - Add overriden member context

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -9,7 +9,7 @@
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</PackageTags>
     <ThirdPartyNoticesFilePath>$(MSBuildThisFileDirectory)..\..\src\NuGet\ThirdPartyNotices.rtf</ThirdPartyNoticesFilePath>
 
-    <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix>Exp</VSSDKTargetPlatformRegRootSuffix>
 
     <!-- Workaround for old Microsoft.VisualStudio.Progression.* packages -->
     <NoWarn>$(NoWarn);VSIXCompatibility1001</NoWarn>

--- a/src/Features/ExternalAccess/Copilot/ContextProviders/ICopilotOverrideImplementationService.cs
+++ b/src/Features/ExternalAccess/Copilot/ContextProviders/ICopilotOverrideImplementationService.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Copilot.ContextProviders;
+internal interface ICopilotOverrideImplementationService : ILanguageService
+{
+    Task<ImmutableArray<ISymbol>> GetPotentialOverridesAsync(Document document, int position, CancellationToken cancellationToken);
+
+    Task FindOverrideImplementationsAsync(Document document, ISymbol member, Func<Document, TextSpan, CancellationToken, ValueTask> reporter, CancellationToken cancellationToken);
+}

--- a/src/Features/ExternalAccess/Copilot/Internal/ContextProviders/CSharpCopilotOverrideImplementationService.cs
+++ b/src/Features/ExternalAccess/Copilot/Internal/ContextProviders/CSharpCopilotOverrideImplementationService.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.ExternalAccess.Copilot.ContextProviders;
+using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Copilot.Internal.ContextProviders;
+
+[ExportLanguageService(typeof(ICopilotOverrideImplementationService), language: LanguageNames.CSharp), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class CSharpCopilotOverrideImplementationService() : ICopilotOverrideImplementationService
+{
+    /// <summary>
+    /// Provider that returns default classification options.  Classification is not relevant to this use case, so the values don't matter.
+    /// </summary>
+    private class DefaultClassificationOptionsProvider : OptionsProvider<ClassificationOptions>
+    {
+        public static OptionsProvider<ClassificationOptions> Instance { get; } = new DefaultClassificationOptionsProvider();
+        public ValueTask<ClassificationOptions> GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+        {
+            return new ValueTask<ClassificationOptions>(ClassificationOptions.Default);
+        }
+    }
+
+    private class CopilotOverrideImplementationFindUsagesContext(Func<Document, TextSpan, CancellationToken, ValueTask> reporter) : FindUsagesContext
+    {
+        public override async ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken)
+        {
+            // For each source span in the definition, write it to the channel
+            foreach (var sourceSpan in definition.SourceSpans)
+            {
+                await reporter(sourceSpan.Document, sourceSpan.SourceSpan, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async Task FindOverrideImplementationsAsync(Document document, ISymbol member, Func<Document, TextSpan, CancellationToken, ValueTask> reporter, CancellationToken cancellationToken)
+    {
+        var context = new CopilotOverrideImplementationFindUsagesContext(reporter);
+        await AbstractFindUsagesService.FindImplementationsAsync(context, member, document.Project, DefaultClassificationOptionsProvider.Instance, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<ImmutableArray<ISymbol>> GetPotentialOverridesAsync(Document document, int position, CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var containingType = semanticModel.GetEnclosingSymbol<INamedTypeSymbol>(position, cancellationToken);
+        if (containingType == null)
+        {
+            return [];
+        }
+
+        var overrideableMembers = containingType.GetOverridableMembers(cancellationToken);
+        return overrideableMembers;
+    }
+}

--- a/src/Features/ExternalAccess/Copilot/Internal/ContextProviders/CSharpCopilotOverrideImplementationService.cs
+++ b/src/Features/ExternalAccess/Copilot/Internal/ContextProviders/CSharpCopilotOverrideImplementationService.cs
@@ -61,7 +61,7 @@ internal class CSharpCopilotOverrideImplementationService() : ICopilotOverrideIm
             return [];
         }
 
-        var overrideableMembers = containingType.GetOverridableMembers(cancellationToken);
-        return overrideableMembers;
+        var overridableMembers = containingType.GetOverridableMembers(cancellationToken);
+        return overridableMembers;
     }
 }

--- a/src/Features/ExternalAccess/Copilot/InternalAPI.Unshipped.txt
+++ b/src/Features/ExternalAccess/Copilot/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.CodeMapper.ICSharpCopilotMapCodeService
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.CodeMapper.ICSharpCopilotMapCodeService.MapCodeAsync(Microsoft.CodeAnalysis.Document! document, System.Collections.Immutable.ImmutableArray<string!> contents, System.Collections.Immutable.ImmutableArray<(Microsoft.CodeAnalysis.Document! document, Microsoft.CodeAnalysis.Text.TextSpan textSpan)> prioritizedFocusLocations, System.Collections.Generic.Dictionary<string!, object!>! options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Text.TextChange>?>!
+Microsoft.CodeAnalysis.ExternalAccess.Copilot.ContextProviders.ICopilotOverrideImplementationService
+Microsoft.CodeAnalysis.ExternalAccess.Copilot.ContextProviders.ICopilotOverrideImplementationService.FindOverrideImplementationsAsync(Microsoft.CodeAnalysis.Document! document, Microsoft.CodeAnalysis.ISymbol! member, System.Func<Microsoft.CodeAnalysis.Document!, Microsoft.CodeAnalysis.Text.TextSpan, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! reporter, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.CodeAnalysis.ExternalAccess.Copilot.ContextProviders.ICopilotOverrideImplementationService.GetPotentialOverridesAsync(Microsoft.CodeAnalysis.Document! document, int position, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISymbol!>>!
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.CopilotChecksumWrapper
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.CopilotChecksumWrapper.Equals(Microsoft.CodeAnalysis.ExternalAccess.Copilot.CopilotChecksumWrapper? other) -> bool
 Microsoft.CodeAnalysis.ExternalAccess.Copilot.CopilotDocumentationCommentProposalWrapper


### PR DESCRIPTION
Determines if an override is typed, tries to find examples from other types overriding the same member.
Conversations side change: https://devdiv.visualstudio.com/DevDiv/_git/VisualStudio.Conversations/pullrequest/627001