### PR TITLE
Add back EA.Razor for servicing branches

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -78,6 +78,7 @@
       "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.AspNetCore": "vs-impl",
+      "Microsoft.CodeAnalysis.ExternalAccess.Razor": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.Razor.EditorFeatures": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.Razor.Features": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler": "vs-impl",


### PR DESCRIPTION
publishdata is pulled from main always.  this needs to be present even though the package no longer exists for servicing branches