### PR TITLE
Use output parent directory to reduce guardian scan

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -204,16 +204,6 @@ extends:
             usePat: false
             retentionDays: 90
 
-          # Publishes setup VSIXes to a drop.
-          # Note: The insertion tool looks for the display name of this task in the logs.
-          - output: microBuildVstsDrop
-            displayName: Upload VSTS Drop
-            condition: succeeded()
-            dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-            dropName: $(VisualStudio.DropName)
-            accessToken: $(_DevDivDropAccessToken)
-            dropRetentionDays: 90
-
           # Publish insertion packages to CoreXT store.
           - output: nuget
             displayName: 'Publish CoreXT Packages'
@@ -223,6 +213,16 @@ extends:
             allowPackageConflicts: true
             nuGetFeedType: external
             publishFeedCredentials: 'DevDiv - VS package feed'
+
+          # Publishes setup VSIXes to a drop.
+          # Note: The insertion tool looks for the display name of this task in the logs.
+          - output: microBuildVstsDrop
+            displayName: Upload VSTS Drop
+            condition: succeeded()
+            dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+            dropName: $(VisualStudio.DropName)
+            accessToken: $(_DevDivDropAccessToken)
+            dropRetentionDays: 90
 
         steps:
         - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true


### PR DESCRIPTION
`outputParentDirectory` tells guardian that all the outputs come from the same place, so scanning only needs to happen once.  This applies to output items that are all the same `pipelineArtifact` type and grouped together.

After (no interceding guardian steps):
![image](https://github.com/user-attachments/assets/576034d7-841c-4001-98ec-59c966a9b709)

https://dnceng.visualstudio.com/internal/_build/results?buildId=2683644&view=results
