### PR TITLE
Fix razor analyzer loading

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/HostDiagnosticAnalyzerProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/HostDiagnosticAnalyzerProvider.cs
@@ -8,44 +8,17 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
-internal sealed class HostDiagnosticAnalyzerProvider : IHostDiagnosticAnalyzerProvider
+
+internal sealed class HostDiagnosticAnalyzerProvider(string? razorSourceGenerator) : IHostDiagnosticAnalyzerProvider
 {
+    public ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions() => [];
 
-    private readonly ImmutableArray<(AnalyzerFileReference reference, string extensionId)> _analyzerReferences;
-
-    public HostDiagnosticAnalyzerProvider(string? razorSourceGenerator)
+    public ImmutableArray<(string path, string extensionId)> GetRazorReferencesInExtensions()
     {
-        if (razorSourceGenerator == null || !File.Exists(razorSourceGenerator))
+        if (razorSourceGenerator is not null)
         {
-            _analyzerReferences = [];
+            return [(razorSourceGenerator, ProjectSystemProject.RazorVsixExtensionId)];
         }
-        else
-        {
-            _analyzerReferences = [(
-                new AnalyzerFileReference(razorSourceGenerator, new SimpleAnalyzerAssemblyLoader()),
-                ProjectSystemProject.RazorVsixExtensionId
-            )];
-        }
-    }
-
-    public ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions()
-    {
-        return _analyzerReferences;
-    }
-
-    private sealed class SimpleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
-    {
-        public void AddDependencyLocation(string fullPath)
-        {
-            // This method is used to add a path that should be probed for analyzer dependencies.
-            // In this simple implementation, we do nothing.
-        }
-
-        public Assembly LoadFromPath(string fullPath)
-        {
-            // This method is used to load an analyzer assembly from the specified path.
-            // In this simple implementation, we use Assembly.LoadFrom to load the assembly.
-            return Assembly.LoadFrom(fullPath);
-        }
+        return [];
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/HostDiagnosticAnalyzerProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/HostDiagnosticAnalyzerProvider.cs
@@ -13,7 +13,7 @@ internal sealed class HostDiagnosticAnalyzerProvider(string? razorSourceGenerato
 {
     public ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions() => [];
 
-    public ImmutableArray<(string path, string extensionId)> GetRazorReferencesInExtensions()
+    public ImmutableArray<(string path, string extensionId)> GetRazorAssembliesInExtensions()
     {
         if (razorSourceGenerator is not null)
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/HostDiagnosticAnalyzerProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/HostDiagnosticAnalyzerProvider.cs
@@ -15,7 +15,7 @@ internal sealed class HostDiagnosticAnalyzerProvider(string? razorSourceGenerato
 
     public ImmutableArray<(string path, string extensionId)> GetRazorAssembliesInExtensions()
     {
-        if (razorSourceGenerator is not null)
+        if (File.Exists(razorSourceGenerator))
         {
             return [(razorSourceGenerator, ProjectSystemProject.RazorVsixExtensionId)];
         }

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
@@ -50,7 +50,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
     public ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions()
         => _lazyAnalyzerReferences.Value;
 
-    public ImmutableArray<(string path, string extensionId)> GetRazorReferencesInExtensions()
+    public ImmutableArray<(string path, string extensionId)> GetRazorAssembliesInExtensions()
         => _lazyRazorReferences.Value;
 
     private ImmutableArray<(string path, string extensionId)> GetExtensionContent(string contentTypeName)

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
@@ -22,6 +22,8 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
 {
     private const string AnalyzerContentTypeName = "Microsoft.VisualStudio.Analyzer";
 
+    private const string RazorContentTypeName = "Microsoft.VisualStudio.RazorAssembly";
+
     /// <summary>
     /// Loader for VSIX-based analyzers.
     /// </summary>
@@ -31,6 +33,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
     private readonly Type _typeIExtensionContent;
 
     private readonly Lazy<ImmutableArray<(AnalyzerFileReference reference, string extensionId)>> _lazyAnalyzerReferences;
+    private readonly Lazy<ImmutableArray<(string path, string extensionId)>> _lazyRazorReferences;
 
     // internal for testing
     internal VisualStudioDiagnosticAnalyzerProvider(object extensionManager, Type typeIExtensionContent)
@@ -40,24 +43,28 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
 
         _extensionManager = extensionManager;
         _typeIExtensionContent = typeIExtensionContent;
-        _lazyAnalyzerReferences = new Lazy<ImmutableArray<(AnalyzerFileReference, string)>>(GetAnalyzerReferencesImpl);
+        _lazyAnalyzerReferences = new Lazy<ImmutableArray<(AnalyzerFileReference, string)>>(() => GetExtensionContent(AnalyzerContentTypeName).SelectAsArray(c => (new AnalyzerFileReference(c.path, AnalyzerAssemblyLoader), c.extensionId)));
+        _lazyRazorReferences = new Lazy<ImmutableArray<(string, string)>>(() => GetExtensionContent(RazorContentTypeName));
     }
 
     public ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions()
         => _lazyAnalyzerReferences.Value;
 
-    private ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesImpl()
+    public ImmutableArray<(string path, string extensionId)> GetRazorReferencesInExtensions()
+        => _lazyRazorReferences.Value;
+
+    private ImmutableArray<(string path, string extensionId)> GetExtensionContent(string contentTypeName)
     {
         try
         {
             // dynamic is weird. it can't see internal type with public interface even if callee is
             // implementation of the public interface in internal type. so we can't use dynamic here
-            var _ = PooledDictionary<AnalyzerFileReference, string>.GetInstance(out var analyzePaths);
+            var _ = PooledDictionary<string, string>.GetInstance(out var analyzePaths);
 
-            // var enabledExtensions = extensionManager.GetEnabledExtensions(AnalyzerContentTypeName);
+            // var enabledExtensions = extensionManager.GetEnabledExtensions(contentTypeName);
             var extensionManagerType = _extensionManager.GetType();
             var extensionManager_GetEnabledExtensionsMethod = extensionManagerType.GetRuntimeMethod("GetEnabledExtensions", [typeof(string)]);
-            var enabledExtensions = (IEnumerable<object>)extensionManager_GetEnabledExtensionsMethod.Invoke(_extensionManager, [AnalyzerContentTypeName]);
+            var enabledExtensions = (IEnumerable<object>)extensionManager_GetEnabledExtensionsMethod.Invoke(_extensionManager, [contentTypeName]);
 
             foreach (var extension in enabledExtensions)
             {
@@ -73,7 +80,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
 
                 foreach (var content in extension_Content)
                 {
-                    if (!ShouldInclude(content))
+                    if (!ShouldInclude(content, contentTypeName))
                     {
                         continue;
                     }
@@ -85,7 +92,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
                         continue;
                     }
 
-                    analyzePaths.Add(new AnalyzerFileReference(assemblyPath, AnalyzerAssemblyLoader), identifier);
+                    analyzePaths.Add(assemblyPath, identifier);
                 }
             }
 
@@ -94,7 +101,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
             GC.KeepAlive(enabledExtensions);
 
             // Order for deterministic result.
-            return analyzePaths.OrderBy((x, y) => string.CompareOrdinal(x.Key.FullPath, y.Key.FullPath)).SelectAsArray(entry => (entry.Key, entry.Value));
+            return analyzePaths.OrderBy((x, y) => string.CompareOrdinal(x.Key, y.Key)).SelectAsArray(entry => (entry.Key, entry.Value));
         }
         catch (TargetInvocationException ex) when (ex.InnerException is InvalidOperationException)
         {
@@ -108,13 +115,13 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
         }
     }
 
-    private static bool ShouldInclude(object content)
+    private static bool ShouldInclude(object content, string contentTypeName)
     {
         // var content_ContentTypeName = content.ContentTypeName;
         var contentType = content.GetType();
         var contentType_ContentTypeNameProperty = contentType.GetRuntimeProperty("ContentTypeName");
         var content_ContentTypeName = contentType_ContentTypeNameProperty.GetValue(content) as string;
 
-        return string.Equals(content_ContentTypeName, AnalyzerContentTypeName, StringComparison.InvariantCultureIgnoreCase);
+        return string.Equals(content_ContentTypeName, contentTypeName, StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
@@ -22,7 +22,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider : IHostDiag
 {
     private const string AnalyzerContentTypeName = "Microsoft.VisualStudio.Analyzer";
 
-    private const string RazorContentTypeName = "Microsoft.VisualStudio.RazorAssembly";
+    internal const string RazorContentTypeName = "Microsoft.VisualStudio.RazorAssembly";
 
     /// <summary>
     /// Loader for VSIX-based analyzers.

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticAnalyzerProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticAnalyzerProviderTests.vb
@@ -60,5 +60,21 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.Equal("TestAnalyzer", analyzers(0).ToString)
             End Using
         End Sub
+
+        <Fact>
+        Public Sub GetRazorReferencesInExtensions()
+            Dim extensionManager = New VisualStudioDiagnosticAnalyzerProvider(
+                New MockExtensionManager({({"razorPath1", "razorPath2"}, "RazorVsix")}, contentType:="Microsoft.VisualStudio.RazorAssembly"),
+                GetType(MockExtensionManager.MockContent))
+
+            Dim references = extensionManager.GetRazorReferencesInExtensions()
+
+            AssertEx.SetEqual(
+            {
+                Path.Combine(TempRoot.Root, "InstallPath\razorPath1"),
+                Path.Combine(TempRoot.Root, "InstallPath\razorPath2")
+            },
+            references.Select(Function(pathAndId) pathAndId.path))
+        End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticAnalyzerProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticAnalyzerProviderTests.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 New MockExtensionManager({({"razorPath1", "razorPath2"}, "RazorVsix")}, contentType:="Microsoft.VisualStudio.RazorAssembly"),
                 GetType(MockExtensionManager.MockContent))
 
-            Dim references = extensionManager.GetRazorReferencesInExtensions()
+            Dim references = extensionManager.GetRazorAssembliesInExtensions()
 
             AssertEx.SetEqual(
             {

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -102,7 +102,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         Public Async Function RazorSourceGenerator_FromVsix() As Task
             Using environment = New TestEnvironment()
                 Dim providerFactory = DirectCast(environment.ExportProvider.GetExportedValue(Of IVisualStudioDiagnosticAnalyzerProviderFactory), MockVisualStudioDiagnosticAnalyzerProviderFactory)
-                providerFactory.ContentTypeName = "Microsoft.VisualStudio.RazorAssembly"
+                providerFactory.ContentTypeName = VisualStudioDiagnosticAnalyzerProvider.RazorContentTypeName
                 providerFactory.Extensions =
                 {
                     ({
@@ -185,7 +185,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         Public Async Function RazorSourceGenerator_FromSdk() As Task
             Using environment = New TestEnvironment()
                 Dim providerFactory = DirectCast(environment.ExportProvider.GetExportedValue(Of IVisualStudioDiagnosticAnalyzerProviderFactory), MockVisualStudioDiagnosticAnalyzerProviderFactory)
-                providerFactory.ContentTypeName = "Microsoft.VisualStudio.RazorAssembly"
+                providerFactory.ContentTypeName = VisualStudioDiagnosticAnalyzerProvider.RazorContentTypeName
                 providerFactory.Extensions =
                 {
                      ({

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -102,6 +102,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         Public Async Function RazorSourceGenerator_FromVsix() As Task
             Using environment = New TestEnvironment()
                 Dim providerFactory = DirectCast(environment.ExportProvider.GetExportedValue(Of IVisualStudioDiagnosticAnalyzerProviderFactory), MockVisualStudioDiagnosticAnalyzerProviderFactory)
+                providerFactory.ContentTypeName = "Microsoft.VisualStudio.RazorAssembly"
                 providerFactory.Extensions =
                 {
                     ({
@@ -184,6 +185,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         Public Async Function RazorSourceGenerator_FromSdk() As Task
             Using environment = New TestEnvironment()
                 Dim providerFactory = DirectCast(environment.ExportProvider.GetExportedValue(Of IVisualStudioDiagnosticAnalyzerProviderFactory), MockVisualStudioDiagnosticAnalyzerProviderFactory)
+                providerFactory.ContentTypeName = "Microsoft.VisualStudio.RazorAssembly"
                 providerFactory.Extensions =
                 {
                      ({

--- a/src/VisualStudio/TestUtilities2/MockVisualStudioDiagnosticAnalyzerProviderFactory.vb
+++ b/src/VisualStudio/TestUtilities2/MockVisualStudioDiagnosticAnalyzerProviderFactory.vb
@@ -15,13 +15,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         Public Property Extensions As (Paths As String(), Id As String)() = Array.Empty(Of (Paths As String(), Id As String))()
 
+        Public Property ContentTypeName As String = "Microsoft.VisualStudio.Analyzer"
+
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
         End Sub
 
         Public Function GetOrCreateProviderAsync(cancellationToken As CancellationToken) As Task(Of VisualStudioDiagnosticAnalyzerProvider) Implements IVisualStudioDiagnosticAnalyzerProviderFactory.GetOrCreateProviderAsync
-            Return Task.FromResult(New VisualStudioDiagnosticAnalyzerProvider(New MockExtensionManager(Extensions), GetType(MockExtensionManager.MockContent)))
+            Return Task.FromResult(New VisualStudioDiagnosticAnalyzerProvider(New MockExtensionManager(Extensions, ContentTypeName), GetType(MockExtensionManager.MockContent)))
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IHostDiagnosticAnalyzerProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IHostDiagnosticAnalyzerProvider.cs
@@ -15,5 +15,8 @@ internal interface IHostDiagnosticAnalyzerProvider
 {
     ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions();
 
-    ImmutableArray<(string path, string extensionId)> GetRazorReferencesInExtensions();
+    /// <summary>
+    /// Gets the path to any assemblies that represent the closure of razor compiler.
+    /// </summary>
+    ImmutableArray<(string path, string extensionId)> GetRazorAssembliesInExtensions();
 }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IHostDiagnosticAnalyzerProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IHostDiagnosticAnalyzerProvider.cs
@@ -14,4 +14,6 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 internal interface IHostDiagnosticAnalyzerProvider
 {
     ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions();
+
+    ImmutableArray<(string path, string extensionId)> GetRazorReferencesInExtensions();
 }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1190,9 +1190,9 @@ internal sealed partial class ProjectSystemProject
 
     private OneOrMany<string> GetMappedRazorSourceGenerator(string fullPath)
     {
-        var vsixRazorAnalyzers = _hostInfo.HostDiagnosticAnalyzerProvider.GetAnalyzerReferencesInExtensions().SelectAsArray(
+        var vsixRazorAnalyzers = _hostInfo.HostDiagnosticAnalyzerProvider.GetRazorReferencesInExtensions().SelectAsArray(
             predicate: item => item.extensionId == RazorVsixExtensionId,
-            selector: item => item.reference.FullPath);
+            selector: item => item.path);
 
         if (!vsixRazorAnalyzers.IsEmpty)
         {

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1190,7 +1190,7 @@ internal sealed partial class ProjectSystemProject
 
     private OneOrMany<string> GetMappedRazorSourceGenerator(string fullPath)
     {
-        var vsixRazorAnalyzers = _hostInfo.HostDiagnosticAnalyzerProvider.GetRazorReferencesInExtensions().SelectAsArray(
+        var vsixRazorAnalyzers = _hostInfo.HostDiagnosticAnalyzerProvider.GetRazorAssembliesInExtensions().SelectAsArray(
             predicate: item => item.extensionId == RazorVsixExtensionId,
             selector: item => item.path);
 


### PR DESCRIPTION
Today Razor lists the compiler/source generator as a VSIX analyzer. Roslyn uses this information to find the location of the razor compiler assembly so that it can redirect the SDK copy to the copy shipped in the Razor VSIX.

Previously this was ok, as the assemblies only contained a source generator, not any analyzers, so listing them as VSIX analyzers was essentially a NOP. As of https://github.com/dotnet/razor/pull/11601 however, the assemblies now contain a diagnostic suppressor. Because it's listed as a VSIX analyzer, VS now loads the suppressor in all scenarios, even if razor isn't involved.


This change (along with the matching razor one here https://github.com/dotnet/razor/pull/11731) instead reads razor via a custom asset type. The logic is basically the same but means that the compiler will no longer be listed as a VSIX analyzer, and so the suppressor won't be loaded in scenarios where razor isn't involved.

I don't love making yet more custom Razor stuff, but there is a bigger change here to come, where we can actually remove the razor redirection logic from Roslyn altogether (including the new `GetRazorReferencesInExtensions` call added here), so hopefully this is only a temporary state of affairs.