### PR TITLE
Ensure new Razor features project gets codebase

### DIFF
--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -79,6 +79,12 @@
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <PkgDefEntry>BindingRedirect</PkgDefEntry>
     </ProjectReference>
+    <ProjectReference Include="..\..\Tools\ExternalAccess\Razor\Features\Microsoft.CodeAnalysis.ExternalAccess.Razor.Features.csproj">
+      <Name>Microsoft.CodeAnalysis.ExternalAccess.Razor</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
+      <PkgDefEntry>BindingRedirect</PkgDefEntry>
+    </ProjectReference>
     <ProjectReference Include="..\..\Tools\ExternalAccess\Razor\EditorFeatures\Microsoft.CodeAnalysis.ExternalAccess.Razor.EditorFeatures.csproj">
       <Name>Microsoft.CodeAnalysis.ExternalAccess.Razor</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>


### PR DESCRIPTION
Should fix ngen issues like
```
04/11/2025 18:20:23.284 [5832]: 1>    Compiling assembly C:\VisualStudio\Common7\IDE\CommonExtensions\Microsoft\RazorLanguageServices\Microsoft.VisualStudio.LanguageServices.Razor.dll (CLR v4.0.30319) ...
04/11/2025 18:20:23.419 [5832]: 1>Warning: System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.CodeAnalysis.ExternalAccess.Razor.Features, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified. while resolving 0x200001f - Microsoft.VisualStudio.LanguageServices.Razor.LanguageClient.Cohost.CohostOnAutoInsertEndpoint.
```

seen in https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/627582