### PR TITLE
Handle textDocument/didChange notifications that don't pass across the range

### DIFF
--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -502,12 +502,13 @@ public abstract partial class AbstractLanguageServerProtocolTests
         Uri documentUri,
         ImmutableArray<(LSP.Range? Range, string Text)> changes)
     {
-        var changeEvents = new List<LSP.SumType<LSP.TextDocumentContentChangeEvent, LSP.TextDocumentContentChangeFullReplacementEvent>>(changes.Length);
-        foreach (var (range, text) in changes)
+        var changeEvents = new LSP.SumType<LSP.TextDocumentContentChangeEvent, LSP.TextDocumentContentChangeFullReplacementEvent>[changes.Length];
+        for (var i = 0; i < changes.Length; i++)
         {
-            changeEvents.Add(range != null
+            var (range, text) = changes[i];
+            changeEvents[i] = range != null
                 ? new LSP.TextDocumentContentChangeEvent { Text = text, Range = range }
-                : new LSP.TextDocumentContentChangeFullReplacementEvent { Text = text });
+                : new LSP.TextDocumentContentChangeFullReplacementEvent { Text = text };
         }
 
         return new LSP.DidChangeTextDocumentParams()
@@ -516,7 +517,7 @@ public abstract partial class AbstractLanguageServerProtocolTests
             {
                 Uri = documentUri
             },
-            ContentChanges = [.. changeEvents]
+            ContentChanges = changeEvents
         };
     }
 

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -37,7 +38,7 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
         return SpecializedTasks.Default<object>();
     }
 
-    internal static bool AreChangesInReverseOrder(TextDocumentContentChangeEvent[] contentChanges)
+    internal static bool AreChangesInReverseOrder(ImmutableArray<TextDocumentContentChangeEvent> contentChanges)
     {
         for (var i = 1; i < contentChanges.Length; i++)
         {
@@ -53,8 +54,14 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
         return true;
     }
 
-    private static SourceText GetUpdatedSourceText(TextDocumentContentChangeEvent[] contentChanges, SourceText text)
+    private static SourceText GetUpdatedSourceText(SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeFullReplacementEvent>[] contentChanges, SourceText text)
     {
+        (var remainingContentChanges, text) = GetUpdatedSouorceTextAndChangesAfterFullTextReplacementHandled(contentChanges, text);
+
+        // No range-based changes to apply.
+        if (remainingContentChanges.IsEmpty)
+            return text;
+
         // Per the LSP spec, each text change builds upon the previous, so we don't need to translate any text
         // positions between changes. See
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#didChangeTextDocumentParams
@@ -63,20 +70,41 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
         // If the host sends us changes in a way such that no earlier change can affect the position of a later change,
         // then we can merge the changes into a single TextChange, allowing creation of only a single new
         // source text.
-        if (AreChangesInReverseOrder(contentChanges))
+        if (AreChangesInReverseOrder(remainingContentChanges))
         {
             // The changes were in reverse document order, so we can merge them into a single operation on the source text.
             // Note that the WithChanges implementation works more efficiently with it's input in forward document order.
-            var newChanges = contentChanges.Reverse().SelectAsArray(change => ProtocolConversions.ContentChangeEventToTextChange(change, text));
+            var newChanges = remainingContentChanges.Reverse().SelectAsArray(change => ProtocolConversions.ContentChangeEventToTextChange(change, text));
             text = text.WithChanges(newChanges);
         }
         else
         {
             // The host didn't send us the items ordered, so we'll apply each one independently.
-            foreach (var change in contentChanges)
+            foreach (var change in remainingContentChanges)
                 text = text.WithChanges(ProtocolConversions.ContentChangeEventToTextChange(change, text));
         }
 
         return text;
+    }
+
+    private static (ImmutableArray<TextDocumentContentChangeEvent>, SourceText) GetUpdatedSouorceTextAndChangesAfterFullTextReplacementHandled(SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeFullReplacementEvent>[] contentChanges, SourceText text)
+    {
+        // Per the LSP spec, each content change can be either a TextDocumentContentChangeEvent or TextDocumentContentChangeFullReplacementEvent.
+        // The former is a range-based change while the latter is a full text replacement. If a TextDocumentContentChangeFullReplacementEvent is found,
+        // then make a full text replacement for that and return all subsequent changes as remaining range-based changes.
+        var lastFullTextChangeEventIndex = contentChanges.Length - 1;
+        for (; lastFullTextChangeEventIndex >= 0; lastFullTextChangeEventIndex--)
+        {
+            var change = contentChanges[lastFullTextChangeEventIndex];
+            if (change.Value is TextDocumentContentChangeFullReplacementEvent onlyTextEvent)
+            {
+                // Found a full text replacement. Create the new text and stop processing.
+                text = text.WithChanges([new TextChange(new TextSpan(0, text.Length), onlyTextEvent.Text)]);
+                break;
+            }
+        }
+
+        var remainingContentChanges = contentChanges.Skip(lastFullTextChangeEventIndex + 1).SelectAsArray(c => c.First);
+        return (remainingContentChanges, text);
     }
 }

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
@@ -56,7 +56,7 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
 
     private static SourceText GetUpdatedSourceText(SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeFullReplacementEvent>[] contentChanges, SourceText text)
     {
-        (var remainingContentChanges, text) = GetUpdatedSouorceTextAndChangesAfterFullTextReplacementHandled(contentChanges, text);
+        (var remainingContentChanges, text) = GetUpdatedSourceTextAndChangesAfterFullTextReplacementHandled(contentChanges, text);
 
         // No range-based changes to apply.
         if (remainingContentChanges.IsEmpty)
@@ -87,7 +87,7 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
         return text;
     }
 
-    private static (ImmutableArray<TextDocumentContentChangeEvent>, SourceText) GetUpdatedSouorceTextAndChangesAfterFullTextReplacementHandled(SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeFullReplacementEvent>[] contentChanges, SourceText text)
+    private static (ImmutableArray<TextDocumentContentChangeEvent>, SourceText) GetUpdatedSourceTextAndChangesAfterFullTextReplacementHandled(SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeFullReplacementEvent>[] contentChanges, SourceText text)
     {
         // Per the LSP spec, each content change can be either a TextDocumentContentChangeEvent or TextDocumentContentChangeFullReplacementEvent.
         // The former is a range-based change while the latter is a full text replacement. If a TextDocumentContentChangeFullReplacementEvent is found,

--- a/src/LanguageServer/Protocol/Protocol/DidChangeTextDocumentParams.cs
+++ b/src/LanguageServer/Protocol/Protocol/DidChangeTextDocumentParams.cs
@@ -45,7 +45,7 @@ internal sealed class DidChangeTextDocumentParams : ITextDocumentParams
     /// </summary>
     [JsonPropertyName("contentChanges")]
     [JsonRequired]
-    public TextDocumentContentChangeEvent[] ContentChanges
+    public SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeOnlyTextEvent>[] ContentChanges
     {
         get;
         set;

--- a/src/LanguageServer/Protocol/Protocol/DidChangeTextDocumentParams.cs
+++ b/src/LanguageServer/Protocol/Protocol/DidChangeTextDocumentParams.cs
@@ -45,7 +45,7 @@ internal sealed class DidChangeTextDocumentParams : ITextDocumentParams
     /// </summary>
     [JsonPropertyName("contentChanges")]
     [JsonRequired]
-    public SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeOnlyTextEvent>[] ContentChanges
+    public SumType<TextDocumentContentChangeEvent, TextDocumentContentChangeFullReplacementEvent>[] ContentChanges
     {
         get;
         set;

--- a/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangeEvent.cs
+++ b/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangeEvent.cs
@@ -18,6 +18,7 @@ internal sealed class TextDocumentContentChangeEvent
     /// Gets or sets the range of the text that was changed.
     /// </summary>
     [JsonPropertyName("range")]
+    [JsonRequired]
     public Range Range
     {
         get;
@@ -39,6 +40,7 @@ internal sealed class TextDocumentContentChangeEvent
     /// Gets or sets the new text of the range/document.
     /// </summary>
     [JsonPropertyName("text")]
+    [JsonRequired]
     public string Text
     {
         get;

--- a/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangeFullReplacementEvent.cs
+++ b/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangeFullReplacementEvent.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.LanguageServer.Protocol;
+
+using System.Text.Json.Serialization;
+
+internal sealed class TextDocumentContentChangeFullReplacementEvent
+{
+    /// <summary>
+    /// Gets or sets the new text of the document.
+    /// </summary>
+    [JsonPropertyName("text")]
+    [JsonRequired]
+    public string Text
+    {
+        get;
+        set;
+    }
+}

--- a/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
@@ -448,6 +448,40 @@ public sealed partial class DocumentChangesTests : AbstractLanguageServerProtoco
         }
     }
 
+    [Theory, CombinatorialData]
+    public async Task DidChange_MultipleRequestsIncludingTextOnly(bool mutatingLspWorkspace)
+    {
+        var source =
+            """
+            {|type:|}
+            """;
+        var expected =
+            """
+            /* test */
+            """;
+
+        var (testLspServer, locationTyped, _) = await GetTestLspServerAndLocationAsync(source, mutatingLspWorkspace);
+
+        await using (testLspServer)
+        {
+            await DidOpen(testLspServer, locationTyped.Uri);
+
+            var changes = new (int? line, int? column, string text)[]
+            {
+                (0, 0, "// hi"),
+                (null, null, "/*  */"),
+                (0, 3, "test"),
+            };
+
+            await DidChange(testLspServer, locationTyped.Uri, changes);
+
+            var document = testLspServer.GetTrackedTexts().FirstOrDefault();
+
+            AssertEx.NotNull(document);
+            Assert.Equal(expected, document.ToString());
+        }
+    }
+
     private async Task<(TestLspServer, LSP.Location, string)> GetTestLspServerAndLocationAsync(string source, bool mutatingLspWorkspace)
     {
         var testLspServer = await CreateTestLspServerAsync(source, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
@@ -459,7 +493,7 @@ public sealed partial class DocumentChangesTests : AbstractLanguageServerProtoco
 
     private static Task DidOpen(TestLspServer testLspServer, Uri uri) => testLspServer.OpenDocumentAsync(uri);
 
-    private static async Task DidChange(TestLspServer testLspServer, Uri uri, params (int line, int column, string text)[] changes)
+    private static async Task DidChange(TestLspServer testLspServer, Uri uri, params (int? line, int? column, string text)[] changes)
         => await testLspServer.InsertTextAsync(uri, changes);
 
     private static async Task DidClose(TestLspServer testLspServer, Uri uri) => await testLspServer.CloseDocumentAsync(uri);


### PR DESCRIPTION
Per the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentContentChangeEvent), these notifications can either send over a range/text or can pass over just the text, implying a full document change. Roslyn did not previously support the latter.

Fixes https://github.com/dotnet/roslyn/issues/77002