### PR TITLE
EnC: Track stale projects

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -259,7 +259,7 @@ public sealed class EditAndContinueLanguageServiceTests : EditAndContinueWorkspa
         Assert.True(workspace.SetCurrentSolution(_ => solution, WorkspaceChangeKind.SolutionAdded));
         solution = workspace.CurrentSolution;
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(projectId, source1, sourceFilePath: sourceFile.Path);
 
         // hydrate document text and overwrite file content:
         var document1 = solution.GetRequiredDocument(documentId);

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -262,7 +262,9 @@ public sealed class EditAndContinueLanguageServiceTests : EditAndContinueWorkspa
         var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
 
         // hydrate document text and overwrite file content:
-        var document1 = await solution.GetDocument(documentId).GetTextAsync();
+        var document1 = solution.GetRequiredDocument(documentId);
+        _ = await document1.GetTextAsync(CancellationToken.None);
+
         File.WriteAllText(sourceFile.Path, source2, Encoding.UTF8);
 
         await languageService.StartSessionAsync(CancellationToken.None);
@@ -282,7 +284,7 @@ public sealed class EditAndContinueLanguageServiceTests : EditAndContinueWorkspa
 
         // check committed document status:
         var debuggingSession = service.GetTestAccessor().GetActiveDebuggingSessions().Single();
-        var (document, state) = await debuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(documentId, currentDocument: null, CancellationToken.None);
+        var (document, state) = await debuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(document1, CancellationToken.None);
         var text = await document.GetTextAsync();
         Assert.Equal(CommittedSolution.DocumentState.MatchesBuildOutput, state);
         Assert.Equal(source1, (await document.GetTextAsync(CancellationToken.None)).ToString());

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -137,12 +137,11 @@ internal sealed class CommittedSolution
     /// 
     /// The result is cached and the next lookup uses the cached value, including failures unless <paramref name="reloadOutOfSyncDocument"/> is true.
     /// </summary>
-    public async Task<(Document? Document, DocumentState State)> GetDocumentAndStateAsync(DocumentId documentId, Document? currentDocument, CancellationToken cancellationToken, bool reloadOutOfSyncDocument = false)
+    public async Task<(Document? Document, DocumentState State)> GetDocumentAndStateAsync(Document currentDocument, CancellationToken cancellationToken, bool reloadOutOfSyncDocument = false)
     {
-        Contract.ThrowIfFalse(currentDocument == null || documentId == currentDocument.Id);
-
         Solution solution;
         var documentState = DocumentState.None;
+        var documentId = currentDocument.Id;
 
         lock (_guard)
         {

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -461,7 +461,7 @@ internal sealed class CommittedSolution
             _solution = solution;
             _staleProjects.AddRange(projectsToStale);
             _staleProjects.RemoveRange(projectsToUnstale);
-            _documentState.Remove(static (documentId, _, projectsToUnstale) => projectsToUnstale.Contains(documentId.ProjectId), projectsToUnstale);
+            _documentState.RemoveAll(static (documentId, _, projectsToUnstale) => projectsToUnstale.Contains(documentId.ProjectId), projectsToUnstale);
         }
     }
 

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -305,7 +305,7 @@ internal sealed class CommittedSolution
         }
     }
 
-    private async ValueTask<(Optional<SourceText?> matchingSourceText, bool? hasDocument)> TryGetMatchingSourceTextAsync(Document document, SourceText sourceText, Document? currentDocument, CancellationToken cancellationToken)
+    private async ValueTask<(Optional<SourceText?> matchingSourceText, bool? hasDocument)> TryGetMatchingSourceTextAsync(Document document, SourceText sourceText, Document currentDocument, CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(document.FilePath);
 

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -142,7 +142,12 @@ internal sealed class CommittedSolution
         => _solution.GetRequiredProject(id);
 
     public bool IsStaleProject(ProjectId id)
-        => _staleProjects.Contains(id);
+    {
+        lock (_guard)
+        {
+            return _staleProjects.Contains(id);
+        }
+    }
 
     public ImmutableArray<DocumentId> GetDocumentIdsWithFilePath(string path)
         => _solution.GetDocumentIdsWithFilePath(path);

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -62,7 +62,7 @@ internal sealed class DebuggingSession : IDisposable
     /// 
     /// For example, in the following scenario:
     /// 
-    ///   A shared library Lib is references by two executable projects A and B and Lib.dll is copied to their respective output directories and the following events occur:
+    ///   A shared library Lib is referenced by two executable projects A and B and Lib.dll is copied to their respective output directories and the following events occur:
     ///   1) A is launched, modules A.exe and Lib.dll [1] are loaded.
     ///   2) Change is made to Lib.cs and applied.
     ///   3) B is launched, which builds new version of Lib.dll [2], and modules B.exe and Lib.dll [2] are loaded.

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -46,15 +46,32 @@ internal sealed class DebuggingSession : IDisposable
     internal readonly TraceLog AnalysisLog;
 
     /// <summary>
-    /// The current baseline for given project id.
-    /// The baseline is updated when changes are committed at the end of edit session.
-    /// The backing module readers of initial baselines need to be kept alive -- store them in
-    /// <see cref="_initialBaselineModuleReaders"/> and dispose them at the end of the debugging session.
+    /// Current baselines for given project id.
+    /// The baselines are updated when changes are committed at the end of edit session.
     /// </summary>
     /// <remarks>
+    /// The backing module readers of initial baselines need to be kept alive -- store them in
+    /// <see cref="_initialBaselineModuleReaders"/> and dispose them at the end of the debugging session.
+    /// 
     /// The baseline of each updated project is linked to its initial baseline that reads from the on-disk metadata and PDB.
     /// Therefore once an initial baseline is created it needs to be kept alive till the end of the debugging session,
     /// even when it's replaced in <see cref="_projectBaselines"/> by a newer baseline.
+    /// 
+    /// One project may have multiple baselines. Deltas emitted for the project when source changes are applied are based 
+    /// on the same source changes for all the baselines, however they differ in the baseline they are chained to (MVID and relative tokens).
+    /// 
+    /// For example, in the following scenario:
+    /// 
+    ///   A shared library Lib is references by two executable projects A and B and Lib.dll is copied to their respective output directories and the following events occur:
+    ///   1) A is launched, modules A.exe and Lib.dll [1] are loaded.
+    ///   2) Change is made to Lib.cs and applied.
+    ///   3) B is launched, which builds new version of Lib.dll [2], and modules B.exe and Lib.dll [2] are loaded.
+    ///   4) Another change is made to Lib.cs and applied.
+    ///     
+    ///   At this point we have two baselines for Lib: Lib.dll [1] and Lib.dll [2], each have different MVID.
+    ///   We need to emit 2 deltas for the change in step 4:
+    ///   - one that chains to the first delta applied to Lib.dll, which itself chains to the baseline of Lib.dll [1].
+    ///   - one that chains to the baseline Lib.dll [2]
     /// </remarks>
     private readonly Dictionary<ProjectId, ImmutableList<ProjectBaseline>> _projectBaselines = [];
     private readonly Dictionary<Guid, (IDisposable metadata, IDisposable pdb)> _initialBaselineModuleReaders = [];
@@ -518,6 +535,7 @@ internal sealed class DebuggingSession : IDisposable
                 // based on whether the updates will be applied successfully or not.
                 StorePendingUpdate(new PendingSolutionUpdate(
                     solution,
+                    solutionUpdate.ProjectsToStale,
                     solutionUpdate.ProjectBaselines,
                     solutionUpdate.ModuleUpdates.Updates,
                     solutionUpdate.NonRemappableRegions));
@@ -529,8 +547,8 @@ internal sealed class DebuggingSession : IDisposable
                 Contract.ThrowIfFalse(solutionUpdate.NonRemappableRegions.IsEmpty);
 
                 // No significant changes have been made.
-                // Commit the solution to apply any changes in comments that do not generate updates.
-                LastCommittedSolution.CommitSolution(solution);
+                // Commit the solution to apply any insignificant changes that do not generate updates.
+                LastCommittedSolution.CommitChanges(solution, projectsToStale: solutionUpdate.ProjectsToStale, projectsToUnstale: []);
                 break;
         }
 
@@ -587,7 +605,7 @@ internal sealed class DebuggingSession : IDisposable
             if (newNonRemappableRegions.IsEmpty)
                 newNonRemappableRegions = null;
 
-            LastCommittedSolution.CommitSolution(pendingSolutionUpdate.Solution);
+            LastCommittedSolution.CommitChanges(pendingSolutionUpdate.Solution, projectsToStale: pendingSolutionUpdate.ProjectsToStale, projectsToUnstale: []);
         }
 
         // update baselines:
@@ -618,7 +636,7 @@ internal sealed class DebuggingSession : IDisposable
         // Make sure the solution snapshot has all source-generated documents up-to-date.
         solution = solution.WithUpToDateSourceGeneratorDocuments(solution.ProjectIds);
 
-        LastCommittedSolution.CommitSolution(solution);
+        LastCommittedSolution.CommitChanges(solution, projectsToStale: [], projectsToUnstale: rebuiltProjects);
 
         // Wait for all operations on baseline to finish before we dispose the readers.
         _baselineAccessLock.EnterWriteLock();

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -455,7 +455,7 @@ internal sealed class DebuggingSession : IDisposable
                 return [];
             }
 
-            var (oldDocument, oldDocumentState) = await LastCommittedSolution.GetDocumentAndStateAsync(document.Id, document, cancellationToken).ConfigureAwait(false);
+            var (oldDocument, oldDocumentState) = await LastCommittedSolution.GetDocumentAndStateAsync(document, cancellationToken).ConfigureAwait(false);
             if (oldDocumentState is CommittedSolution.DocumentState.OutOfSync or
                 CommittedSolution.DocumentState.Indeterminate or
                 CommittedSolution.DocumentState.DesignTimeOnly)
@@ -726,7 +726,7 @@ internal sealed class DebuggingSession : IDisposable
 
                     var newDocument = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
 
-                    var (oldDocument, _) = await LastCommittedSolution.GetDocumentAndStateAsync(newDocument.Id, newDocument, cancellationToken).ConfigureAwait(false);
+                    var (oldDocument, _) = await LastCommittedSolution.GetDocumentAndStateAsync(newDocument, cancellationToken).ConfigureAwait(false);
                     if (oldDocument == null)
                     {
                         // Document is out-of-sync, can't reason about its content with respect to the binaries loaded in the debuggee.
@@ -857,7 +857,7 @@ internal sealed class DebuggingSession : IDisposable
             {
                 var newUnmappedDocument = await newSolution.GetRequiredDocumentAsync(unmappedDocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
 
-                var (oldUnmappedDocument, _) = await LastCommittedSolution.GetDocumentAndStateAsync(newUnmappedDocument.Id, newUnmappedDocument, cancellationToken).ConfigureAwait(false);
+                var (oldUnmappedDocument, _) = await LastCommittedSolution.GetDocumentAndStateAsync(newUnmappedDocument, cancellationToken).ConfigureAwait(false);
                 if (oldUnmappedDocument == null)
                 {
                     // document out-of-date

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -166,7 +166,7 @@ internal static class EditAndContinueDiagnosticDescriptors
         AddGeneralDiagnostic(EditAndContinueErrorCode.ErrorReadingFile, nameof(FeaturesResources.ErrorReadingFile));
         AddGeneralDiagnostic(EditAndContinueErrorCode.CannotApplyChangesUnexpectedError, nameof(FeaturesResources.CannotApplyChangesUnexpectedError));
         AddGeneralDiagnostic(EditAndContinueErrorCode.ChangesDisallowedWhileStoppedAtException, nameof(FeaturesResources.ChangesDisallowedWhileStoppedAtException));
-        AddGeneralDiagnostic(EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee, nameof(FeaturesResources.DocumentIsOutOfSyncWithDebuggee));
+        AddGeneralDiagnostic(EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee, nameof(FeaturesResources.DocumentIsOutOfSyncWithDebuggee), DiagnosticSeverity.Warning);
         AddGeneralDiagnostic(EditAndContinueErrorCode.UnableToReadSourceFileOrPdb, nameof(FeaturesResources.UnableToReadSourceFileOrPdb));
         AddGeneralDiagnostic(EditAndContinueErrorCode.AddingTypeRuntimeCapabilityRequired, nameof(FeaturesResources.ChangesRequiredSynthesizedType));
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -542,7 +542,7 @@ internal sealed class EditSession
 
         foreach (var newDocument in changedOrAddedDocuments)
         {
-            var (oldDocument, oldDocumentState) = await DebuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(newDocument.Id, newDocument, cancellationToken, reloadOutOfSyncDocument: true).ConfigureAwait(false);
+            var (oldDocument, oldDocumentState) = await DebuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(newDocument, cancellationToken, reloadOutOfSyncDocument: true).ConfigureAwait(false);
             switch (oldDocumentState)
             {
                 case CommittedSolution.DocumentState.DesignTimeOnly:

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -532,13 +532,14 @@ internal sealed class EditSession
         }
     }
 
-    private async Task<(ImmutableArray<DocumentAnalysisResults> results, ImmutableArray<Diagnostic> diagnostics)> AnalyzeDocumentsAsync(
+    private async Task<(ImmutableArray<DocumentAnalysisResults> results, ImmutableArray<Diagnostic> diagnostics, bool hasOutOfSyncDocument)> AnalyzeDocumentsAsync(
         ArrayBuilder<Document> changedOrAddedDocuments,
         ActiveStatementSpanProvider newDocumentActiveStatementSpanProvider,
         CancellationToken cancellationToken)
     {
         using var _1 = ArrayBuilder<Diagnostic>.GetInstance(out var documentDiagnostics);
         using var _2 = ArrayBuilder<(Document? oldDocument, Document newDocument)>.GetInstance(out var documents);
+        var hasOutOfSyncDocument = false;
 
         foreach (var newDocument in changedOrAddedDocuments)
         {
@@ -549,10 +550,14 @@ internal sealed class EditSession
                     break;
 
                 case CommittedSolution.DocumentState.Indeterminate:
-                case CommittedSolution.DocumentState.OutOfSync:
-                    var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor((oldDocumentState == CommittedSolution.DocumentState.Indeterminate) ?
-                        EditAndContinueErrorCode.UnableToReadSourceFileOrPdb : EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee);
+                    var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.UnableToReadSourceFileOrPdb);
                     documentDiagnostics.Add(Diagnostic.Create(descriptor, Location.Create(newDocument.FilePath!, textSpan: default, lineSpan: default), [newDocument.FilePath]));
+                    break;
+
+                case CommittedSolution.DocumentState.OutOfSync:
+                    // TODO: https://github.com/dotnet/roslyn/issues/78125
+                    // consider reporting EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee warning if project doesn't specify SingleTargetBuildForStartupProjects property
+                    hasOutOfSyncDocument = true;
                     break;
 
                 case CommittedSolution.DocumentState.MatchesBuildOutput:
@@ -568,8 +573,12 @@ internal sealed class EditSession
             }
         }
 
-        var analyses = await Analyses.GetDocumentAnalysesAsync(DebuggingSession.LastCommittedSolution, documents, newDocumentActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
-        return (analyses, documentDiagnostics.ToImmutable());
+        // No need to report rude edits if project has any documents that are out of sync. No deltas will be emitted for such project.
+        var analyses = hasOutOfSyncDocument
+            ? []
+            : await Analyses.GetDocumentAnalysesAsync(DebuggingSession.LastCommittedSolution, documents, newDocumentActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+
+        return (analyses, documentDiagnostics.ToImmutable(), hasOutOfSyncDocument);
     }
 
     private static ProjectAnalysisSummary GetProjectAnalysisSummary(ImmutableArray<DocumentAnalysisResults> documentAnalyses)
@@ -817,6 +826,7 @@ internal sealed class EditSession
             using var _4 = ArrayBuilder<ProjectDiagnostics>.GetInstance(out var diagnostics);
             using var _5 = ArrayBuilder<Document>.GetInstance(out var changedOrAddedDocuments);
             using var _6 = ArrayBuilder<(DocumentId, ImmutableArray<RudeEditDiagnostic>)>.GetInstance(out var documentsWithRudeEdits);
+            using var _7 = ArrayBuilder<ProjectId>.GetInstance(out var projectsToStale);
             Diagnostic? syntaxError = null;
 
             var oldSolution = DebuggingSession.LastCommittedSolution;
@@ -850,6 +860,13 @@ internal sealed class EditSession
                     continue;
                 }
 
+                // We don't track document changes in stale projects until they are rebuilt (removed from stale set).
+                if (oldSolution.IsStaleProject(newProject.Id))
+                {
+                    Log.Write($"EnC state of {newProject.Name} '{newProject.FilePath}' queried: project is stale");
+                    continue;
+                }
+
                 await PopulateChangedAndAddedDocumentsAsync(Log, oldProject, newProject, changedOrAddedDocuments, diagnostics, cancellationToken).ConfigureAwait(false);
                 if (changedOrAddedDocuments.IsEmpty)
                 {
@@ -873,7 +890,7 @@ internal sealed class EditSession
 
                 if (mvid == Guid.Empty)
                 {
-                    Log.Write($"Emitting update of {newProject.Name} '{newProject.FilePath}': project not built");
+                    Log.Write($"Changes not applied to {newProject.Name} '{newProject.FilePath}': project not built");
                     continue;
                 }
 
@@ -892,7 +909,9 @@ internal sealed class EditSession
                 // which change we have not observed yet. Then call-sites of C.M in a changed document observed by the analysis will be seen as C.M(object)
                 // instead of the true C.M(string).
 
-                var (changedDocumentAnalyses, documentDiagnostics) = await AnalyzeDocumentsAsync(changedOrAddedDocuments, solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+                var (changedDocumentAnalyses, documentDiagnostics, hasOutOfSyncChangedDocument) =
+                    await AnalyzeDocumentsAsync(changedOrAddedDocuments, solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+
                 if (documentDiagnostics.Any())
                 {
                     // The diagnostic hasn't been reported by GetDocumentDiagnosticsAsync since out-of-sync documents are likely to be synchronized
@@ -905,6 +924,15 @@ internal sealed class EditSession
                     {
                         blockUpdates = hadDocumentReadError = true;
                     }
+                }
+
+                if (hasOutOfSyncChangedDocument)
+                {
+                    // The project is considered stale as long as it has at least one document that is out-of-sync.
+                    // Treat the project the same as if it hasn't been built. We won't produce delta for it until it gets rebuilt.
+                    Log.Write($"Changes not applied to {newProject.Name} '{newProject.FilePath}': binaries not up-to-date");
+                    projectsToStale.Add(newProject.Id);
+                    continue;
                 }
 
                 foreach (var changedDocumentAnalysis in changedDocumentAnalyses)
@@ -927,7 +955,7 @@ internal sealed class EditSession
                 var projectSummary = GetProjectAnalysisSummary(changedDocumentAnalyses);
                 Log.Write($"Project summary for {newProject.Name} '{newProject.FilePath}': {projectSummary}");
 
-                if (projectSummary == ProjectAnalysisSummary.NoChanges)
+                if (projectSummary is ProjectAnalysisSummary.NoChanges or ProjectAnalysisSummary.ValidInsignificantChanges)
                 {
                     continue;
                 }
@@ -1148,6 +1176,7 @@ internal sealed class EditSession
                     new ModuleUpdates(
                         (deltas.Count > 0) ? ModuleUpdateStatus.Ready : ModuleUpdateStatus.None,
                         deltas.ToImmutable()),
+                    projectsToStale.ToImmutable(),
                     nonRemappableRegions.ToImmutable(),
                     newProjectBaselines.ToImmutable(),
                     diagnostics.ToImmutable(),

--- a/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
@@ -18,10 +18,12 @@ internal abstract class PendingUpdate(
 
 internal sealed class PendingSolutionUpdate(
     Solution solution,
+    ImmutableArray<ProjectId> projectsToStale,
     ImmutableArray<ProjectBaseline> projectBaselines,
     ImmutableArray<ManagedHotReloadUpdate> deltas,
     ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions) : PendingUpdate(projectBaselines, deltas)
 {
     public readonly Solution Solution = solution;
+    public readonly ImmutableArray<ProjectId> ProjectsToStale = projectsToStale;
     public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)> Regions)> NonRemappableRegions = nonRemappableRegions;
 }

--- a/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 internal readonly struct SolutionUpdate(
     ModuleUpdates moduleUpdates,
+    ImmutableArray<ProjectId> projectsToStale,
     ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
     ImmutableArray<ProjectBaseline> projectBaselines,
     ImmutableArray<ProjectDiagnostics> diagnostics,
@@ -18,6 +19,7 @@ internal readonly struct SolutionUpdate(
     Diagnostic? syntaxError)
 {
     public readonly ModuleUpdates ModuleUpdates = moduleUpdates;
+    public readonly ImmutableArray<ProjectId> ProjectsToStale = projectsToStale;
     public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> NonRemappableRegions = nonRemappableRegions;
     public readonly ImmutableArray<ProjectBaseline> ProjectBaselines = projectBaselines;
     public readonly ImmutableArray<ProjectDiagnostics> Diagnostics = diagnostics;
@@ -31,6 +33,7 @@ internal readonly struct SolutionUpdate(
         ModuleUpdateStatus status)
         => new(
             new(status, Updates: []),
+            projectsToStale: [],
             nonRemappableRegions: [],
             projectBaselines: [],
             diagnostics,

--- a/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -69,9 +70,11 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         var sourceTreeB1 = SyntaxFactory.ParseSyntaxTree(SourceText.From(sourceBytesB1, sourceBytesB1.Length, encodingB, SourceHashAlgorithms.Default), TestOptions.Regular, sourceFileB.Path);
         var sourceTreeC1 = SyntaxFactory.ParseSyntaxTree(SourceText.From(sourceBytesC1, sourceBytesC1.Length, encodingC, SourceHashAlgorithm.Sha1), TestOptions.Regular, sourceFileC.Path);
 
+        var projectPId = ProjectId.CreateNewId("P");
+
         // E is not included in the compilation:
         var compilation = CSharpTestBase.CreateCompilation([sourceTreeA1, sourceTreeB1, sourceTreeC1], options: TestOptions.DebugDll, targetFramework: DefaultTargetFramework, assemblyName: "P");
-        EmitLibrary(compilation);
+        EmitLibrary(projectPId, compilation);
 
         // change content of B on disk:
         sourceFileB.WriteAllText(sourceB2, encodingB);
@@ -80,7 +83,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         using var _ = CreateWorkspace(out var solution, out var service, [typeof(NoCompilationLanguageService)]);
 
         solution = solution
-            .AddTestProject("P", LanguageNames.CSharp, out var projectPId).Solution
+            .AddTestProject("P", LanguageNames.CSharp, projectPId).Solution
             .WithProjectChecksumAlgorithm(projectPId, SourceHashAlgorithm.Sha1);
 
         var documentIdA = DocumentId.CreateNewId(projectPId, debugName: "A");
@@ -166,8 +169,6 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(Guid.Empty);
-
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
         // no changes:
@@ -200,7 +201,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         (solution, var document) = AddDefaultTestProject(solution, source);
 
         solution = solution.WithProjectOutputFilePath(document.Project.Id, moduleFile.Path);
-        _mockCompilationOutputsProvider = _ => new CompilationOutputFiles(moduleFile.Path);
+        _mockCompilationOutputs.Add(document.Project.Id, new CompilationOutputFiles(moduleFile.Path));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -309,10 +310,11 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
 
-        var documentInfo = CreateDesignTimeOnlyDocument(document1.Project.Id);
-        solution = solution.WithProjectOutputFilePath(document1.Project.Id, moduleFile.Path).AddDocument(documentInfo);
+        var projectId = document1.Project.Id;
+        var documentInfo = CreateDesignTimeOnlyDocument(projectId);
+        solution = solution.WithProjectOutputFilePath(projectId, moduleFile.Path).AddDocument(documentInfo);
 
-        _mockCompilationOutputsProvider = _ => new CompilationOutputFiles(moduleFile.Path);
+        _mockCompilationOutputs.Add(projectId, new CompilationOutputFiles(moduleFile.Path));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -409,7 +411,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         }
 
         // only compile actual source document, not design-time-only document:
-        var moduleId = EmitLibrary(source, sourceFilePath: sourceFilePath);
+        var moduleId = EmitLibrary(projectId, source, sourceFilePath: sourceFilePath);
 
         if (!delayLoad)
         {
@@ -498,7 +500,8 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         using var _w = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, source1);
 
-        _mockCompilationOutputsProvider = _ => new CompilationOutputFiles(moduleFile.Path);
+        var projectId = document1.Project.Id;
+        _mockCompilationOutputs.Add(projectId, new CompilationOutputFiles(moduleFile.Path));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -521,7 +524,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         AssertEx.Equal([$"proj.csproj: (0,0)-(0,0): Error ENC1001: {string.Format(FeaturesResources.ErrorReadingFile, moduleFile.Path, expectedErrorMessage)}"], InspectDiagnostics(emitDiagnostics));
 
         // correct the error:
-        EmitLibrary(source2);
+        EmitLibrary(projectId, source2);
 
         var (updates2, emitDiagnostics2) = await EmitSolutionUpdateAsync(debuggingSession, solution);
         Assert.Equal(ModuleUpdateStatus.Ready, updates2.Status);
@@ -572,9 +575,9 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         var project = document1.Project;
         solution = project.Solution;
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(project.Id, source1, sourceFilePath: sourceFile.Path);
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(moduleId)
+        _mockCompilationOutputs[project.Id] = new MockCompilationOutputs(moduleId)
         {
             OpenPdbStreamImpl = () =>
             {
@@ -625,7 +628,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         var project = document1.Project;
         solution = project.Solution;
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path, checksumAlgorithm: SourceHashAlgorithms.Default);
+        var moduleId = EmitAndLoadLibraryToDebuggee(project.Id, source1, sourceFilePath: sourceFile.Path, checksumAlgorithm: SourceHashAlgorithms.Default);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution, initialState: CommittedSolution.DocumentState.None);
         EnterBreakState(debuggingSession);
@@ -680,12 +683,11 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
             AddMetadataReferences(TargetFrameworkUtil.GetReferences(TargetFramework.Mscorlib40)).
             AddDocument("test.cs", CreateText(sourceA), filePath: sourceFileA.Path);
 
-        solution = documentA.Project.Solution;
+        var project = documentA.Project;
+        solution = project.Solution;
 
         // Source B will be added while debugging.
-        EmitAndLoadLibraryToDebuggee(sourceA, sourceFilePath: sourceFileA.Path);
-
-        var project = documentA.Project;
+        EmitAndLoadLibraryToDebuggee(project.Id, sourceA, sourceFilePath: sourceFileA.Path);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -767,7 +769,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         solution = project.Solution;
 
         // compile with source1:
-        var moduleId = EmitLibrary(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitLibrary(project.Id, source1, sourceFilePath: sourceFile.Path);
         LoadLibraryToDebuggee(moduleId, new ManagedHotReloadAvailability(ManagedHotReloadAvailabilityStatus.NotAllowedForRuntime, "*message*"));
 
         // update the file with source1 before session starts:
@@ -813,7 +815,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source1, generator);
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(moduleId);
+        _mockCompilationOutputs.Add(document.Project.Id, new MockCompilationOutputs(moduleId));
 
         LoadLibraryToDebuggee(moduleId, new ManagedHotReloadAvailability(ManagedHotReloadAvailabilityStatus.NotAllowedForRuntime, "*message*"));
 
@@ -863,7 +865,7 @@ class C1
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source1, generator);
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(moduleId);
+        _mockCompilationOutputs.Add(document.Project.Id, new MockCompilationOutputs(moduleId));
 
         LoadLibraryToDebuggee(moduleId, new ManagedHotReloadAvailability(ManagedHotReloadAvailabilityStatus.NotAllowedForRuntime, "*message*"));
 
@@ -923,7 +925,7 @@ class C1
             AddDocument(documentId, "test.cs", SourceText.From(source1, encoding, SourceHashAlgorithm.Sha1), filePath: sourceFile.Path);
 
         // use different checksum alg to trigger PdbMatchingSourceTextProvider call:
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path, encoding: encoding, checksumAlgorithm: SourceHashAlgorithm.Sha256);
+        var moduleId = EmitAndLoadLibraryToDebuggee(projectId, source1, sourceFilePath: sourceFile.Path, encoding: encoding, checksumAlgorithm: SourceHashAlgorithm.Sha256);
 
         var sourceTextProviderCalled = false;
         var sourceTextProvider = new MockPdbMatchingSourceTextProvider()
@@ -962,7 +964,7 @@ class C1
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source1);
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(moduleId);
+        _mockCompilationOutputs.Add(document.Project.Id, new MockCompilationOutputs(moduleId));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -1024,10 +1026,10 @@ class C1
         var source1 = "class C { void M() { System.Console.WriteLine(1); } }";
         var source2 = "class C { void M() { System.Console.WriteLine(2); } }";
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1);
-
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source1);
+
+        var moduleId = EmitAndLoadLibraryToDebuggee(document.Project.Id, source1);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -1142,7 +1144,7 @@ class C { int Y => 2; }
         solution = project.Solution;
 
         // compile with source0:
-        var moduleId = EmitAndLoadLibraryToDebuggee(source0, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(project.Id, source0, sourceFilePath: sourceFile.Path);
 
         // update the file with source1 before session starts:
         sourceFile.WriteAllText(source1, Encoding.UTF8);
@@ -1247,7 +1249,7 @@ class C { int Y => 2; }
         var project = document1.Project;
         solution = project.Solution;
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(project.Id, source1, sourceFilePath: sourceFile.Path);
 
         // do not initialize the document state - we will detect the state based on the PDB content.
         var debuggingSession = await StartDebuggingSessionAsync(service, solution, initialState: CommittedSolution.DocumentState.None);
@@ -1290,7 +1292,7 @@ class C { int Y => 2; }
         var project = document1.Project;
         solution = project.Solution;
 
-        var moduleId = EmitLibrary(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitLibrary(project.Id, source1, sourceFilePath: sourceFile.Path);
 
         // do not initialize the document state - we will detect the state based on the PDB content.
         var debuggingSession = await StartDebuggingSessionAsync(service, solution, initialState: CommittedSolution.DocumentState.None);
@@ -1346,7 +1348,7 @@ class C { int Y => 2; }
 
         var documentId = document.Id;
         var projectId = document.Project.Id;
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(projectId, source1, sourceFilePath: sourceFile.Path);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -1394,7 +1396,7 @@ class C { int Y => 2; }
 
         // restart:
         _debuggerService.LoadedModules.Remove(moduleId);
-        moduleId = EmitAndLoadLibraryToDebuggee(source3, sourceFilePath: sourceFile.Path);
+        moduleId = EmitAndLoadLibraryToDebuggee(projectId, source3, sourceFilePath: sourceFile.Path);
         debuggingSession.UpdateBaselines(solution, result.ProjectsToRebuild);
 
         if (validChangeBeforeRudeEdit)
@@ -1448,7 +1450,7 @@ class C { int Y => 2; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(moduleId);
+        _mockCompilationOutputs.Add(document.Project.Id, new MockCompilationOutputs(moduleId));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -1488,7 +1490,7 @@ class C { int Y => 2; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, sourceV1);
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(sourceV1);
+        var moduleId = EmitAndLoadLibraryToDebuggee(document.Project.Id, sourceV1);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -1863,8 +1865,11 @@ class C { int Y => 2; }
         solution = AddDefaultTestProject(solution, [sourceA1]);
         var documentA1 = solution.Projects.Single().Documents.Single();
 
-        var mvidA = EmitAndLoadLibraryToDebuggee(sourceA1, sourceFilePath: sourceFileA.Path, assemblyName: "A");
-        var mvidB = EmitAndLoadLibraryToDebuggee(sourceB1, sourceFilePath: sourceFileB.Path, assemblyName: "B");
+        var projectAId = documentA1.Project.Id;
+        var projectBId = ProjectId.CreateNewId("B");
+
+        var mvidA = EmitAndLoadLibraryToDebuggee(projectAId, sourceA1, sourceFilePath: sourceFileA.Path, assemblyName: "A");
+        var mvidB = EmitAndLoadLibraryToDebuggee(projectBId, sourceB1, sourceFilePath: sourceFileB.Path, assemblyName: "B");
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -1889,7 +1894,7 @@ class C { int Y => 2; }
         // add project that matches assembly B and update the document:
 
         var documentB2 = solution.
-            AddTestProject("B").
+            AddTestProject("B", projectBId).
             AddTestDocument(sourceB2, path: sourceFileB.Path);
 
         solution = documentB2.Project.Solution;
@@ -1943,7 +1948,7 @@ class C { int Y => 2; }
         solution = AddDefaultTestProject(solution, [source1]);
         var documentId = solution.Projects.Single().Documents.Single().Id;
 
-        EmitAndLoadLibraryToDebuggee(source1);
+        EmitAndLoadLibraryToDebuggee(documentId.ProjectId, source1);
 
         // attached to processes that allow updating custom attributes:
         _debuggerService.GetCapabilitiesImpl = () => ["Baseline", "ChangeCustomAttributes"];
@@ -2055,7 +2060,7 @@ class G
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1, generator);
 
-        var moduleId = EmitLibrary(sourceV1, generatorProject: document1.Project);
+        var moduleId = EmitLibrary(document1.Project.Id, sourceV1, generatorProject: document1.Project);
         LoadLibraryToDebuggee(moduleId);
 
         // attached to processes that doesn't allow creating new types
@@ -2091,7 +2096,7 @@ class G
         solution = solution.WithProjectParseOptions(project.Id, new CSharpParseOptions(LanguageVersion.CSharp10));
         var documentId = solution.Projects.Single().Documents.Single().Id;
 
-        EmitAndLoadLibraryToDebuggee(source1);
+        EmitAndLoadLibraryToDebuggee(project.Id, source1);
 
         // attached to processes that doesn't allow creating new types
         _debuggerService.GetCapabilitiesImpl = () => ["Baseline"];
@@ -2125,7 +2130,7 @@ class G
         using var _ = CreateWorkspace(out var solution, out var service);
 
         (solution, var document) = AddDefaultTestProject(solution, sourceV1);
-        EmitAndLoadLibraryToDebuggee(sourceV1);
+        EmitAndLoadLibraryToDebuggee(document.Project.Id, sourceV1);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -2216,7 +2221,7 @@ class G
             }
         };
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(documentId.ProjectId, source1, sourceFilePath: sourceFile.Path);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution, initialState: CommittedSolution.DocumentState.None, sourceTextProvider);
 
@@ -2294,7 +2299,7 @@ class G
         var project = document2.Project;
         solution = project.Solution;
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(project.Id, source1, sourceFilePath: sourceFile.Path);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution, initialState: CommittedSolution.DocumentState.None);
 
@@ -2358,7 +2363,7 @@ class G
 
         solution = project.Solution;
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source1, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitAndLoadLibraryToDebuggee(project.Id, source1, sourceFilePath: sourceFile.Path);
 
         _debuggerService.IsEditAndContinueAvailable = _ => new ManagedHotReloadAvailability(ManagedHotReloadAvailabilityStatus.Attach, localizedMessage: "*attached*");
 
@@ -2421,7 +2426,7 @@ class G
         var project = document1.Project;
         solution = project.Solution;
 
-        var moduleId = EmitLibrary(sourceOnDisk, sourceFilePath: sourceFile.Path);
+        var moduleId = EmitLibrary(project.Id, sourceOnDisk, sourceFilePath: sourceFile.Path);
 
         if (!delayLoad)
         {
@@ -2464,7 +2469,7 @@ class G
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1);
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(sourceV1);
+        var moduleId = EmitAndLoadLibraryToDebuggee(document1.Project.Id, sourceV1);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -2600,7 +2605,7 @@ class G
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1);
 
-        _mockCompilationOutputsProvider = _ => new CompilationOutputFiles(moduleFile.Path, pdbFile.Path);
+        _mockCompilationOutputs.Add(document1.Project.Id, new CompilationOutputFiles(moduleFile.Path, pdbFile.Path));
 
         // set up an active statement in the first method, so that we can test preservation of local signature.
         var activeStatements = ImmutableArray.Create(new ManagedActiveStatementDebugInfo(
@@ -2721,7 +2726,7 @@ partial class E { int B = 2; public E(int a, int b) { A = a; B = new System.Func
         solution = AddDefaultTestProject(solution, [sourceA1, sourceB1]);
         var project = solution.Projects.Single();
 
-        LoadLibraryToDebuggee(EmitLibrary([(sourceA1, "test1.cs"), (sourceB1, "test2.cs")]));
+        LoadLibraryToDebuggee(EmitLibrary(project.Id, [(sourceA1, "test1.cs"), (sourceB1, "test2.cs")]));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -2775,7 +2780,7 @@ class C { int Y => 2; }
 
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1, generator);
 
-        var moduleId = EmitLibrary(sourceV1, generatorProject: document1.Project);
+        var moduleId = EmitLibrary(document1.Project.Id, sourceV1, generatorProject: document1.Project);
         LoadLibraryToDebuggee(moduleId);
 
         // Trigger initial source generation before debugging session starts.
@@ -2832,7 +2837,7 @@ class C { int Y => 2; }
 
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1, generator);
 
-        var moduleId = EmitLibrary(sourceV1, generatorProject: document1.Project);
+        var moduleId = EmitLibrary(document1.Project.Id, sourceV1, generatorProject: document1.Project);
         LoadLibraryToDebuggee(moduleId);
 
         // Trigger initial source generation before debugging session starts.
@@ -2902,7 +2907,7 @@ class G
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1, generator);
 
-        var moduleId = EmitLibrary(sourceV1, generatorProject: document1.Project);
+        var moduleId = EmitLibrary(document1.Project.Id, sourceV1, generatorProject: document1.Project);
         LoadLibraryToDebuggee(moduleId);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -2950,7 +2955,7 @@ partial class C { int X = 1; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1, generator);
 
-        var moduleId = EmitLibrary(sourceV1, generatorProject: document1.Project);
+        var moduleId = EmitLibrary(document1.Project.Id, sourceV1, generatorProject: document1.Project);
         LoadLibraryToDebuggee(moduleId);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -2997,7 +3002,7 @@ class C { int Y => 1; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source, generator, additionalFileText: additionalSourceV1);
 
-        var moduleId = EmitLibrary(source, generatorProject: document.Project, additionalFileText: additionalSourceV1);
+        var moduleId = EmitLibrary(document.Project.Id, source, generatorProject: document.Project, additionalFileText: additionalSourceV1);
         LoadLibraryToDebuggee(moduleId);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -3041,7 +3046,7 @@ class C { int Y => 1; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source, generator, analyzerConfig: configV1);
 
-        var moduleId = EmitLibrary(source, generatorProject: document.Project, analyzerOptions: configV1);
+        var moduleId = EmitLibrary(document.Project.Id, source, generatorProject: document.Project, analyzerOptions: configV1);
         LoadLibraryToDebuggee(moduleId);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -3083,7 +3088,7 @@ class C { int Y => 1; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, source1, generator);
 
-        var moduleId = EmitLibrary(source1, generatorProject: document1.Project);
+        var moduleId = EmitLibrary(document1.Project.Id, source1, generatorProject: document1.Project);
         LoadLibraryToDebuggee(moduleId);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -3120,7 +3125,7 @@ class C { int Y => 1; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, sourceV1);
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(sourceV1);
+        var moduleId = EmitAndLoadLibraryToDebuggee(document1.Project.Id, sourceV1);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -3161,7 +3166,7 @@ class C { int Y => 1; }
         solution = solution.WithProjectParseOptions(project.Id, new CSharpParseOptions(LanguageVersion.CSharp10));
         var documentId = solution.Projects.Single().Documents.Single().Id;
 
-        EmitAndLoadLibraryToDebuggee(source1);
+        EmitAndLoadLibraryToDebuggee(project.Id, source1);
 
         // attached to processes that doesn't allow creating new types
         _debuggerService.GetCapabilitiesImpl = () => ["Baseline"];
@@ -3224,10 +3229,8 @@ class C { int Y => 1; }
 
         solution = projectB.Solution;
 
-        _mockCompilationOutputsProvider = project =>
-            (project.Id == projectA.Id) ? new CompilationOutputFiles(moduleFileA.Path, pdbFileA.Path) :
-            (project.Id == projectB.Id) ? new CompilationOutputFiles(moduleFileB.Path, pdbFileB.Path) :
-            throw ExceptionUtilities.UnexpectedValue(project);
+        _mockCompilationOutputs.Add(projectA.Id, new CompilationOutputFiles(moduleFileA.Path, pdbFileA.Path));
+        _mockCompilationOutputs.Add(projectB.Id, new CompilationOutputFiles(moduleFileB.Path, pdbFileB.Path));
 
         // only module A is loaded
         LoadLibraryToDebuggee(moduleIdA);
@@ -3342,17 +3345,63 @@ class C { int Y => 1; }
         VerifyReadersDisposed(readers);
     }
 
+    /// <summary>
+    /// Emulates update to Multi-TFM project where only one of the projects has up-to-date binaries.
+    /// This may occur when projects sepecify SingleTargetBuildForStartupProjects msbuild property (e.g. MAUI).
+    /// </summary>
+    [Fact]
+    public async Task MultiTargetedProjects_OnlyOneTargetIsBuilt()
+    {
+        var dir = Temp.CreateDirectory();
+
+        var source1 = "class A { void M() { System.Console.WriteLine(1); } }";
+        var source2 = "class A { void M() { System.Console.WriteLine(2); } }";
+
+        // Create two projects with a shared (linked) document.
+
+        using var _ = CreateWorkspace(out var solution, out var service);
+
+        var sourcePath = dir.CreateFile("Lib.cs").WriteAllText(source1, Encoding.UTF8).Path;
+
+        var documentA = solution.AddTestProject("A").WithAssemblyName("A").
+            AddMetadataReferences(TargetFrameworkUtil.GetReferences(TargetFramework.NetStandard20)).
+            AddDocument("Lib.cs", source1, filePath: sourcePath);
+
+        var documentB = documentA.Project.Solution.AddTestProject("B").WithAssemblyName("A").
+            AddMetadataReferences(TargetFrameworkUtil.GetReferences(TargetFramework.Net90)).
+            AddDocument("Lib.cs", source1, filePath: sourcePath);
+
+        solution = documentB.Project.Solution;
+
+        EmitAndLoadLibraryToDebuggee(documentA.Project.Id, source1, sourceFilePath: sourcePath, assemblyName: "A");
+
+        // force document checksum validation:
+        var debuggingSession = await StartDebuggingSessionAsync(service, solution, initialState: CommittedSolution.DocumentState.None);
+
+        EnterBreakState(debuggingSession);
+
+        // update source file:
+        File.WriteAllText(sourcePath, source2, Encoding.UTF8);
+        var text2 = CreateText(source2);
+        solution = solution.WithDocumentText(documentA.Id, text2);
+        solution = solution.WithDocumentText(documentB.Id, text2);
+
+        var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+        Assert.Equal(ModuleUpdateStatus.Blocked, updates.Status);
+        Assert.Empty(emitDiagnostics);
+    }
+
     [Fact]
     public async Task ValidSignificantChange_BaselineCreationFailed_NoStream()
     {
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document1) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(Guid.NewGuid())
+        _mockCompilationOutputs.Add(document1.Project.Id, new MockCompilationOutputs(Guid.NewGuid())
         {
             OpenPdbStreamImpl = () => null,
             OpenAssemblyStreamImpl = () => null,
-        };
+        });
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -3380,11 +3429,11 @@ class C { int Y => 1; }
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, sourceV1);
 
-        _mockCompilationOutputsProvider = _ => new MockCompilationOutputs(Guid.NewGuid())
+        _mockCompilationOutputs.Add(document.Project.Id, new MockCompilationOutputs(Guid.NewGuid())
         {
             OpenPdbStreamImpl = () => pdbStream,
             OpenAssemblyStreamImpl = () => throw new IOException("*message*"),
-        };
+        });
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -3827,7 +3876,7 @@ class C
 
         var generatedDocument1 = (await solution.Projects.Single().GetSourceGeneratedDocumentsAsync().ConfigureAwait(false)).Single();
 
-        var moduleId = EmitLibrary(source1, generatorProject: document1.Project, additionalFileText: additionalFileSourceV1);
+        var moduleId = EmitLibrary(document1.Project.Id, source1, generatorProject: document1.Project, additionalFileText: additionalFileSourceV1);
         LoadLibraryToDebuggee(moduleId);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -3910,7 +3959,7 @@ class C
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source1);
 
-        var moduleId = EmitLibrary(source1);
+        var moduleId = EmitLibrary(document.Project.Id, source1);
         LoadLibraryToDebuggee(moduleId);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -3991,11 +4040,11 @@ class C
         var markedSourceV3 = Update(markedSourceV2, marker: "2");
         var markedSourceV4 = Update(markedSourceV3, marker: "3");
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(SourceMarkers.Clear(markedSourceV1));
-
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSourceV1));
         var documentId = document.Id;
+
+        var moduleId = EmitAndLoadLibraryToDebuggee(document.Project.Id, SourceMarkers.Clear(markedSourceV1));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -4136,11 +4185,11 @@ class C
     }
 }";
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(SourceMarkers.Clear(markedSource1));
-
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSource1));
         var documentId = document.Id;
+
+        var moduleId = EmitAndLoadLibraryToDebuggee(document.Project.Id, SourceMarkers.Clear(markedSource1));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -4239,11 +4288,12 @@ class C
     {
     }
 }";
-        var moduleId = EmitAndLoadLibraryToDebuggee(SourceMarkers.Clear(markedSource1));
 
         using var _ = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSource1));
         var documentId = document.Id;
+
+        var moduleId = EmitAndLoadLibraryToDebuggee(document.Project.Id, SourceMarkers.Clear(markedSource1));
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -4334,12 +4384,12 @@ class C
             }
             """;
 
-        var moduleId = EmitAndLoadLibraryToDebuggee(source);
-
         using var workspace = CreateWorkspace(out var solution, out var service);
         (solution, var document) = AddDefaultTestProject(solution, source);
         var documentId = document.Id;
         var oldProject = document.Project;
+
+        var moduleId = EmitAndLoadLibraryToDebuggee(document.Project.Id, source);
 
         var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
@@ -4378,7 +4428,6 @@ class C
 
         var dir = Temp.CreateDirectory();
         var sourceFileA = dir.CreateFile("A.cs").WriteAllText(source1, Encoding.UTF8);
-        var moduleId = EmitLibrary(source1, sourceFileA.Path, assemblyName: "Proj");
 
         using var _ = CreateWorkspace(out var solution, out var encService);
 
@@ -4387,6 +4436,8 @@ class C
             WithMetadataReferences(TargetFrameworkUtil.GetReferences(DefaultTargetFramework));
 
         solution = projectP.Solution;
+
+        var moduleId = EmitLibrary(projectP.Id, source1, sourceFileA.Path, assemblyName: "Proj");
 
         var documentIdA = DocumentId.CreateNewId(projectP.Id, debugName: "A");
         solution = solution.AddDocument(DocumentInfo.Create(
@@ -4492,7 +4543,7 @@ class C
         // 
         // The update to the library source also produces delta to be applied to V1 of the library.
 
-        var libMvid1 = EmitAndLoadLibraryToDebuggee(libSource1);
+        var libMvid1 = EmitAndLoadLibraryToDebuggee(oldProject.Id, libSource1);
 
         // lib source is updated:
         solution = solution.WithDocumentText(documentId, CreateText(libSource2));
@@ -4511,7 +4562,7 @@ class C
         CommitSolutionUpdate(debuggingSession);
 
         // B is launched:
-        var libMvid2 = EmitAndLoadLibraryToDebuggee(libSource2);
+        var libMvid2 = EmitAndLoadLibraryToDebuggee(oldProject.Id, libSource2);
 
         // lib source is updated:
         solution = solution.WithDocumentText(documentId, CreateText(libSource3));

--- a/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -941,7 +941,7 @@ class C1
 
         EnterBreakState(debuggingSession);
 
-        var (document, state) = await debuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(documentId, currentDocument: null, CancellationToken.None);
+        var (document, state) = await debuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(solution.GetRequiredDocument(documentId), CancellationToken.None);
         var text = await document.GetTextAsync();
         Assert.Same(encoding, text.Encoding);
         Assert.Equal(CommittedSolution.DocumentState.MatchesBuildOutput, state);
@@ -2318,11 +2318,11 @@ class G
         // undo:
         solution = solution.WithDocumentText(documentId, CreateText(source1));
 
-        var currentDocument = solution.GetDocument(documentId);
+        var currentDocument = solution.GetRequiredDocument(documentId);
 
         // save (note that this call will fail to match the content with the PDB since it uses the content prior to the actual file write)
         // TODO: await debuggingSession.OnSourceFileUpdatedAsync(currentDocument);
-        var (doc, state) = await debuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(documentId, currentDocument, CancellationToken.None);
+        var (doc, state) = await debuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(currentDocument, CancellationToken.None);
         Assert.Null(doc);
         Assert.Equal(CommittedSolution.DocumentState.OutOfSync, state);
         sourceFile.WriteAllText(source1, Encoding.UTF8);

--- a/src/Features/Test/EditAndContinue/UnitTestingHotReloadServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/UnitTestingHotReloadServiceTests.cs
@@ -29,13 +29,14 @@ public sealed class UnitTestingHotReloadServiceTests : EditAndContinueWorkspaceT
 
         var dir = Temp.CreateDirectory();
         var sourceFileA = dir.CreateFile("A.cs").WriteAllText(source1, Encoding.UTF8);
-        var moduleId = EmitLibrary(source1, sourceFileA.Path, assemblyName: "Proj");
 
         using var workspace = CreateWorkspace(out var solution, out var encService);
 
         var projectP = solution.
             AddTestProject("P").
             WithMetadataReferences(TargetFrameworkUtil.GetReferences(DefaultTargetFramework));
+
+        var moduleId = EmitLibrary(projectP.Id, source1, sourceFileA.Path, assemblyName: "Proj");
 
         solution = projectP.Solution;
 

--- a/src/Features/Test/EditAndContinue/WatchHotReloadServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/WatchHotReloadServiceTests.cs
@@ -42,16 +42,16 @@ public sealed class WatchHotReloadServiceTests : EditAndContinueWorkspaceTestBas
 
         var dir = Temp.CreateDirectory();
         var sourceFileA = dir.CreateFile("A.cs").WriteAllText(source1, Encoding.UTF8);
-        var moduleId = EmitLibrary(source1, sourceFileA.Path, assemblyName: "Proj");
 
         using var workspace = CreateWorkspace(out var solution, out var encService);
 
-        var projectId = ProjectId.CreateNewId();
         var projectP = solution.
             AddTestProject("P").
             WithMetadataReferences(TargetFrameworkUtil.GetReferences(DefaultTargetFramework));
 
         solution = projectP.Solution;
+
+        var moduleId = EmitLibrary(projectP.Id, source1, sourceFileA.Path, assemblyName: "Proj");
 
         var documentIdA = DocumentId.CreateNewId(projectP.Id, debugName: "A");
         solution = solution.AddDocument(DocumentInfo.Create(

--- a/src/Features/Test/Microsoft.CodeAnalysis.Features.UnitTests.csproj
+++ b/src/Features/Test/Microsoft.CodeAnalysis.Features.UnitTests.csproj
@@ -15,4 +15,7 @@
     <ProjectReference Include="..\TestUtilities\Microsoft.CodeAnalysis.Features.Test.Utilities.csproj" />
     <ProjectReference Include="..\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Features.vbproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" />
+  </ItemGroup>
 </Project>

--- a/src/Features/TestUtilities/EditAndContinue/Extensions.cs
+++ b/src/Features/TestUtilities/EditAndContinue/Extensions.cs
@@ -51,17 +51,23 @@ internal static class Extensions
             i = eoln + LineSeparator.Length;
         }
     }
-
+#nullable enable
     public static Project AddTestProject(this Solution solution, string projectName, string language = LanguageNames.CSharp)
         => AddTestProject(solution, projectName, language, out _);
+
+    public static Project AddTestProject(this Solution solution, string projectName, ProjectId id)
+        => AddTestProject(solution, projectName, LanguageNames.CSharp, id);
 
     public static Project AddTestProject(this Solution solution, string projectName, out ProjectId id)
         => AddTestProject(solution, projectName, LanguageNames.CSharp, out id);
 
     public static Project AddTestProject(this Solution solution, string projectName, string language, out ProjectId id)
+        => AddTestProject(solution, projectName, language, id = ProjectId.CreateNewId(debugName: projectName));
+
+    public static Project AddTestProject(this Solution solution, string projectName, string language, ProjectId id)
     {
-        var info = CreateProjectInfo(projectName, language);
-        return solution.AddProject(info).GetRequiredProject(id = info.Id);
+        var info = CreateProjectInfo(projectName, id, language);
+        return solution.AddProject(info).GetRequiredProject(id);
     }
 
     public static Document AddTestDocument(this Project project, string source, string path)
@@ -83,9 +89,9 @@ internal static class Extensions
         return BlobContentId.FromHash(Encoding.UTF8.GetBytes(projectName.PadRight(20, '\0'))).Guid;
     }
 
-    public static ProjectInfo CreateProjectInfo(string projectName, string language = LanguageNames.CSharp)
+    public static ProjectInfo CreateProjectInfo(string projectName, ProjectId id, string language = LanguageNames.CSharp)
         => ProjectInfo.Create(
-            ProjectId.CreateNewId(debugName: projectName),
+            id,
             VersionStamp.Create(),
             name: projectName,
             assemblyName: projectName,
@@ -109,5 +115,4 @@ internal static class Extensions
                 assemblyPath: Path.Combine(TempRoot.Root, projectName + ".dll"),
                 generatedFilesOutputDirectory: null))
             .WithTelemetryId(CreateProjectTelemetryId(projectName));
-
 }

--- a/src/Workspaces/CoreTest/UtilityTest/DictionaryExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DictionaryExtensionsTests.cs
@@ -11,15 +11,15 @@ namespace Microsoft.CodeAnalysis.UnitTests;
 public class DictionaryExtensionsTests
 {
     [Fact]
-    public void Remove_Empty()
+    public void RemoveAll_Empty()
     {
         var dictionary = new Dictionary<int, string>();
-        dictionary.Remove((_, _, _) => true, 0);
+        dictionary.RemoveAll((_, _, _) => true, 0);
         Assert.Empty(dictionary);
     }
 
     [Fact]
-    public void Remove_RemovesMatchingEntries()
+    public void RemoveAll_RemovesMatchingEntries()
     {
         var dictionary = new Dictionary<int, string>
         {
@@ -28,7 +28,7 @@ public class DictionaryExtensionsTests
             { 3, "three" }
         };
 
-        dictionary.Remove((key, value, arg) => value.StartsWith(arg), "t");
+        dictionary.RemoveAll((key, value, arg) => value.StartsWith(arg), "t");
 
         Assert.Equal(1, dictionary.Count);
         Assert.True(dictionary.ContainsKey(1));
@@ -37,7 +37,7 @@ public class DictionaryExtensionsTests
     }
 
     [Fact]
-    public void Remove_NoMatching()
+    public void RemoveAll_NoMatching()
     {
         var dictionary = new Dictionary<int, string>
         {
@@ -46,7 +46,7 @@ public class DictionaryExtensionsTests
             { 3, "three" }
         };
 
-        dictionary.Remove((key, value, arg) => value.StartsWith(arg), "z");
+        dictionary.RemoveAll((key, value, arg) => value.StartsWith(arg), "z");
 
         Assert.Equal(3, dictionary.Count);
         Assert.True(dictionary.ContainsKey(1));
@@ -55,7 +55,7 @@ public class DictionaryExtensionsTests
     }
 
     [Fact]
-    public void Remove_AllMatching()
+    public void RemoveAll_AllMatching()
     {
         var dictionary = new Dictionary<int, string>
         {
@@ -64,7 +64,7 @@ public class DictionaryExtensionsTests
             { 3, "test3" }
         };
 
-        dictionary.Remove((key, value, arg) => value.StartsWith(arg), "t");
+        dictionary.RemoveAll((key, value, arg) => value.StartsWith(arg), "t");
 
         Assert.Empty(dictionary);
     }

--- a/src/Workspaces/CoreTest/UtilityTest/DictionaryExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DictionaryExtensionsTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests;
+
+public class DictionaryExtensionsTests
+{
+    [Fact]
+    public void Remove_Empty()
+    {
+        var dictionary = new Dictionary<int, string>();
+        dictionary.Remove((_, _, _) => true, 0);
+        Assert.Empty(dictionary);
+    }
+
+    [Fact]
+    public void Remove_RemovesMatchingEntries()
+    {
+        var dictionary = new Dictionary<int, string>
+        {
+            { 1, "one" },
+            { 2, "two" },
+            { 3, "three" }
+        };
+
+        dictionary.Remove((key, value, arg) => value.StartsWith(arg), "t");
+
+        Assert.Equal(1, dictionary.Count);
+        Assert.True(dictionary.ContainsKey(1));
+        Assert.False(dictionary.ContainsKey(2));
+        Assert.False(dictionary.ContainsKey(3));
+    }
+
+    [Fact]
+    public void Remove_NoMatching()
+    {
+        var dictionary = new Dictionary<int, string>
+        {
+            { 1, "one" },
+            { 2, "two" },
+            { 3, "three" }
+        };
+
+        dictionary.Remove((key, value, arg) => value.StartsWith(arg), "z");
+
+        Assert.Equal(3, dictionary.Count);
+        Assert.True(dictionary.ContainsKey(1));
+        Assert.True(dictionary.ContainsKey(2));
+        Assert.True(dictionary.ContainsKey(3));
+    }
+
+    [Fact]
+    public void Remove_AllMatching()
+    {
+        var dictionary = new Dictionary<int, string>
+        {
+            { 1, "test1" },
+            { 2, "test2" },
+            { 3, "test3" }
+        };
+
+        dictionary.Remove((key, value, arg) => value.StartsWith(arg), "t");
+
+        Assert.Empty(dictionary);
+    }
+}
+

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
@@ -224,4 +224,42 @@ internal static class IDictionaryExtensions
             }
         }
     }
+
+    /// <summary>
+    /// Removes entries from a dictionary based on a specified condition. The condition is defined by a function that
+    /// evaluates each key-value pair.
+    /// </summary>
+    public static void Remove<TKey, TValue, TArg>(this IDictionary<TKey, TValue> dictionary, Func<TKey, TValue, TArg, bool> predicate, TArg arg)
+        where TKey : notnull
+    {
+#if NET
+        // .NET supports removing while enumerating:
+        foreach (var entry in dictionary)
+        {
+            if (predicate(entry.Key, entry.Value, arg))
+            {
+                dictionary.Remove(entry.Key);
+            }
+        }
+#else
+        if (dictionary.IsEmpty())
+        {
+            return;
+        }
+
+        using var _ = ArrayBuilder<TKey>.GetInstance(out var keysToRemove);
+        foreach (var entry in dictionary)
+        {
+            if (predicate(entry.Key, entry.Value, arg))
+            {
+                keysToRemove.Add(entry.Key);
+            }
+        }
+
+        foreach (var key in keysToRemove)
+        {
+            dictionary.Remove(key);
+        }
+#endif
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
@@ -229,7 +229,7 @@ internal static class IDictionaryExtensions
     /// Removes entries from a dictionary based on a specified condition. The condition is defined by a function that
     /// evaluates each key-value pair.
     /// </summary>
-    public static void Remove<TKey, TValue, TArg>(this IDictionary<TKey, TValue> dictionary, Func<TKey, TValue, TArg, bool> predicate, TArg arg)
+    public static void RemoveAll<TKey, TValue, TArg>(this Dictionary<TKey, TValue> dictionary, Func<TKey, TValue, TArg, bool> predicate, TArg arg)
         where TKey : notnull
     {
 #if NET
@@ -242,7 +242,7 @@ internal static class IDictionaryExtensions
             }
         }
 #else
-        if (dictionary.IsEmpty())
+        if (dictionary.Count == 0)
         {
             return;
         }


### PR DESCRIPTION
Fixes Hot Reload in MAUI projects (or any projects that set `SingleTargetBuildForStartupProjects` msbuild property).

These projects only build the target that's being launched. Other targets are left stale. 

EnC analyzer assumed that, unless something went wrong, the binaries of all projects that were built are up to date with the state of the solution. That's not the case in this scenario.
To fix the issue, we track stale projects along with committed solution. The committed solution is used during an edit session as a baseline for emitting module deltas.
Whenever the changes are successfully applied we set the committed solution to the current solution snapshot (of the main workspace).

When a document is changed during edit session we first check if we have a baseline document whose content matches the PDB, so that we can emit precise difference between the baseline and the current content.
If it does not, we consider the entire containing project _stale_. Any changes to a stale project or its documents are ignored until the project gets rebuilt.

The debugger recently added an API that's called whenever a project is rebuilt (`UpdateProjectBaseline`). We remove the project from the stale list and update the status of all its documents in that call.

Fixed issues:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2442521
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2433992
https://github.com/dotnet/maui/issues/27612

Follow up:
- [ ] https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2449700
- [ ] https://github.com/dotnet/roslyn/issues/78125