### PR TITLE
Ensure FindSourceDefinitionAsync works in frozen compilation cases

### DIFF
--- a/src/Analyzers/Core/CodeFixes/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -90,17 +90,17 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
         {
             if (_service.IsConstructorInitializerGeneration(_document, node, cancellationToken))
             {
-                if (!TryInitializeConstructorInitializerGeneration(node, cancellationToken))
+                if (!(await TryInitializeConstructorInitializerGenerationAsync(node, cancellationToken).ConfigureAwait(false)))
                     return false;
             }
             else if (_service.IsSimpleNameGeneration(_document, node, cancellationToken))
             {
-                if (!TryInitializeSimpleNameGeneration(node, cancellationToken))
+                if (!(await TryInitializeSimpleNameGenerationAsync(node, cancellationToken).ConfigureAwait(false)))
                     return false;
             }
             else if (_service.IsImplicitObjectCreation(_document, node, cancellationToken))
             {
-                if (!TryInitializeImplicitObjectCreation(node, cancellationToken))
+                if (!(await TryInitializeImplicitObjectCreationAsync(node, cancellationToken).ConfigureAwait(false)))
                     return false;
             }
             else
@@ -296,7 +296,7 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
                 .RemoveUnnamedErrorTypes(compilation);
         }
 
-        private bool TryInitializeConstructorInitializerGeneration(
+        private async ValueTask<bool> TryInitializeConstructorInitializerGenerationAsync(
             SyntaxNode constructorInitializer, CancellationToken cancellationToken)
         {
             if (_service.TryInitializeConstructorInitializerGeneration(
@@ -309,13 +309,13 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
 
                 var semanticInfo = _document.SemanticModel.GetSymbolInfo(constructorInitializer, cancellationToken);
                 if (semanticInfo.Symbol == null)
-                    return TryDetermineTypeToGenerateIn(typeToGenerateIn, cancellationToken);
+                    return await TryDetermineTypeToGenerateInAsync(typeToGenerateIn, cancellationToken).ConfigureAwait(false);
             }
 
             return false;
         }
 
-        private bool TryInitializeImplicitObjectCreation(SyntaxNode implicitObjectCreation, CancellationToken cancellationToken)
+        private async ValueTask<bool> TryInitializeImplicitObjectCreationAsync(SyntaxNode implicitObjectCreation, CancellationToken cancellationToken)
         {
             if (_service.TryInitializeImplicitObjectCreation(
                     _document, implicitObjectCreation, cancellationToken,
@@ -326,13 +326,13 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
 
                 var semanticInfo = _document.SemanticModel.GetSymbolInfo(implicitObjectCreation, cancellationToken);
                 if (semanticInfo.Symbol == null)
-                    return TryDetermineTypeToGenerateIn(typeToGenerateIn, cancellationToken);
+                    return await TryDetermineTypeToGenerateInAsync(typeToGenerateIn, cancellationToken).ConfigureAwait(false);
             }
 
             return false;
         }
 
-        private bool TryInitializeSimpleNameGeneration(
+        private async ValueTask<bool> TryInitializeSimpleNameGenerationAsync(
             SyntaxNode simpleName,
             CancellationToken cancellationToken)
         {
@@ -359,7 +359,7 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return TryDetermineTypeToGenerateIn(typeToGenerateIn, cancellationToken);
+            return await TryDetermineTypeToGenerateInAsync(typeToGenerateIn, cancellationToken).ConfigureAwait(false);
         }
 
         private static bool IsValidAttributeParameterType(ITypeSymbol type)
@@ -397,10 +397,10 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
             }
         }
 
-        private bool TryDetermineTypeToGenerateIn(
+        private async ValueTask<bool> TryDetermineTypeToGenerateInAsync(
             INamedTypeSymbol original, CancellationToken cancellationToken)
         {
-            var definition = SymbolFinderInternal.FindSourceDefinition(original, _document.Project.Solution, cancellationToken);
+            var definition = await SymbolFinderInternal.FindSourceDefinitionAsync(original, _document.Project.Solution, cancellationToken).ConfigureAwait(false);
             TypeToGenerateIn = definition as INamedTypeSymbol;
 
             return TypeToGenerateIn?.TypeKind is (TypeKind?)TypeKind.Class or (TypeKind?)TypeKind.Struct;

--- a/src/Analyzers/Core/CodeFixes/GenerateEnumMember/AbstractGenerateEnumMemberService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateEnumMember/AbstractGenerateEnumMemberService.State.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -23,17 +24,17 @@ internal abstract partial class AbstractGenerateEnumMemberService<TService, TSim
         public TSimpleNameSyntax SimpleName { get; private set; } = null!;
         public TExpressionSyntax SimpleNameOrMemberAccessExpression { get; private set; } = null!;
 
-        public static State? Generate(
+        public static async Task<State?> GenerateAsync(
             TService service,
             SemanticDocument document,
             SyntaxNode node,
             CancellationToken cancellationToken)
         {
             var state = new State();
-            return state.TryInitialize(service, document, node, cancellationToken) ? state : null;
+            return await state.TryInitializeAsync(service, document, node, cancellationToken).ConfigureAwait(false) ? state : null;
         }
 
-        private bool TryInitialize(
+        private async ValueTask<bool> TryInitializeAsync(
             TService service,
             SemanticDocument document,
             SyntaxNode node,
@@ -63,7 +64,7 @@ internal abstract partial class AbstractGenerateEnumMemberService<TService, TSim
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            var sourceType = SymbolFinderInternal.FindSourceDefinition(TypeToGenerateIn, document.Project.Solution, cancellationToken) as INamedTypeSymbol;
+            var sourceType = (await SymbolFinderInternal.FindSourceDefinitionAsync(TypeToGenerateIn, document.Project.Solution, cancellationToken).ConfigureAwait(false)) as INamedTypeSymbol;
             if (!ValidateTypeToGenerateIn(sourceType, true, EnumType))
                 return false;
 

--- a/src/Analyzers/Core/CodeFixes/GenerateEnumMember/AbstractGenerateEnumMemberService.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateEnumMember/AbstractGenerateEnumMemberService.cs
@@ -27,7 +27,7 @@ internal abstract partial class AbstractGenerateEnumMemberService<TService, TSim
         using (Logger.LogBlock(FunctionId.Refactoring_GenerateMember_GenerateEnumMember, cancellationToken))
         {
             var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            var state = State.Generate((TService)this, semanticDocument, node, cancellationToken);
+            var state = await State.GenerateAsync((TService)this, semanticDocument, node, cancellationToken).ConfigureAwait(false);
             if (state == null)
             {
                 return [];

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
@@ -58,7 +58,7 @@ internal abstract partial class AbstractGenerateParameterizedMemberService<TServ
         protected async Task<bool> TryFinishInitializingStateAsync(TService service, SemanticDocument document, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            TypeToGenerateIn = SymbolFinderInternal.FindSourceDefinition(TypeToGenerateIn, document.Project.Solution, cancellationToken) as INamedTypeSymbol;
+            TypeToGenerateIn = await SymbolFinderInternal.FindSourceDefinitionAsync(TypeToGenerateIn, document.Project.Solution, cancellationToken).ConfigureAwait(false) as INamedTypeSymbol;
             if (TypeToGenerateIn.IsErrorType())
             {
                 return false;

--- a/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.cs
@@ -38,7 +38,7 @@ internal abstract partial class AbstractGenerateVariableService<TService, TSimpl
         {
             var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            var state = State.Generate((TService)this, semanticDocument, node, cancellationToken);
+            var state = await State.GenerateAsync((TService)this, semanticDocument, node, cancellationToken).ConfigureAwait(false);
             if (state == null)
                 return [];
 

--- a/src/Analyzers/Core/CodeFixes/UnsealClass/AbstractUnsealClassCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UnsealClass/AbstractUnsealClassCodeFixProvider.cs
@@ -39,8 +39,8 @@ internal abstract class AbstractUnsealClassCodeFixProvider : CodeFixProvider
         if (semanticModel.GetSymbolInfo(node, cancellationToken).Symbol is INamedTypeSymbol type &&
             type.TypeKind == TypeKind.Class && type.IsSealed && !type.IsStatic)
         {
-            var definition = SymbolFinderInternal.FindSourceDefinition(
-                type, document.Project.Solution, cancellationToken);
+            var definition = await SymbolFinderInternal.FindSourceDefinitionAsync(
+                type, document.Project.Solution, cancellationToken).ConfigureAwait(false);
             if (definition is not null && definition.DeclaringSyntaxReferences.Length > 0)
             {
                 var title = string.Format(TitleFormat, type.Name);

--- a/src/EditorFeatures/Core.Wpf/Peek/PeekableItemFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/Peek/PeekableItemFactory.cs
@@ -59,8 +59,8 @@ internal sealed class PeekableItemFactory : IPeekableItemFactory
             throw new ArgumentNullException(nameof(peekResultFactory));
 
         var solution = project.Solution;
-        symbol = SymbolFinder.FindSourceDefinition(symbol, solution, cancellationToken) ?? symbol;
-        symbol = GoToDefinitionFeatureHelpers.TryGetPreferredSymbol(solution, symbol, cancellationToken);
+        symbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false) ?? symbol;
+        symbol = await GoToDefinitionFeatureHelpers.TryGetPreferredSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false);
         if (symbol is null)
             return [];
 

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -197,7 +197,7 @@ internal sealed partial class RenameTrackingTaggerProvider
                         // This is a reference from a nameof expression. Allow the rename but set the RenameOverloads option
                         ForceRenameOverloads = true;
 
-                        return DetermineIfRenamableSymbols(renameSymbolInfo.Symbols, document);
+                        return await DetermineIfRenamableSymbolsAsync(renameSymbolInfo.Symbols, document).ConfigureAwait(false);
                     }
                     else
                     {
@@ -208,7 +208,7 @@ internal sealed partial class RenameTrackingTaggerProvider
                             return TriggerIdentifierKind.NotRenamable;
                         }
 
-                        return DetermineIfRenamableSymbol(renameSymbolInfo.Symbols.Single(), document, token);
+                        return await DetermineIfRenamableSymbolAsync(renameSymbolInfo.Symbols.Single(), document, token).ConfigureAwait(false);
                     }
                 }
             }
@@ -216,12 +216,12 @@ internal sealed partial class RenameTrackingTaggerProvider
             return TriggerIdentifierKind.NotRenamable;
         }
 
-        private TriggerIdentifierKind DetermineIfRenamableSymbols(IEnumerable<ISymbol> symbols, Document document)
+        private async ValueTask<TriggerIdentifierKind> DetermineIfRenamableSymbolsAsync(IEnumerable<ISymbol> symbols, Document document)
         {
             foreach (var symbol in symbols)
             {
                 // Get the source symbol if possible
-                var sourceSymbol = SymbolFinder.FindSourceDefinition(symbol, document.Project.Solution, _cancellationToken) ?? symbol;
+                var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
 
                 if (!sourceSymbol.IsFromSource())
                 {
@@ -232,10 +232,10 @@ internal sealed partial class RenameTrackingTaggerProvider
             return TriggerIdentifierKind.RenamableReference;
         }
 
-        private TriggerIdentifierKind DetermineIfRenamableSymbol(ISymbol symbol, Document document, SyntaxToken token)
+        private async ValueTask<TriggerIdentifierKind> DetermineIfRenamableSymbolAsync(ISymbol symbol, Document document, SyntaxToken token)
         {
             // Get the source symbol if possible
-            var sourceSymbol = SymbolFinder.FindSourceDefinition(symbol, document.Project.Solution, _cancellationToken) ?? symbol;
+            var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
 
             if (sourceSymbol is IFieldSymbol { ContainingType.IsTupleType: true, IsImplicitlyDeclared: true })
             {

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -890,7 +890,7 @@ internal sealed class CSharpChangeSignatureService : AbstractChangeSignatureServ
 
             if (convertedType != null)
             {
-                convertedType = SymbolFinder.FindSourceDefinition(convertedType, document.Project.Solution, cancellationToken)
+                convertedType = await SymbolFinder.FindSourceDefinitionAsync(convertedType, document.Project.Solution, cancellationToken).ConfigureAwait(false)
                     ?? convertedType;
             }
 

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -107,7 +107,7 @@ internal abstract class AbstractChangeSignatureService : ILanguageService
             document, position, restrictToDeclarations, cancellationToken).ConfigureAwait(false);
 
         // Cross-language symbols will show as metadata, so map it to source if possible.
-        symbol = SymbolFinder.FindSourceDefinition(symbol, document.Project.Solution, cancellationToken) ?? symbol;
+        symbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, cancellationToken).ConfigureAwait(false) ?? symbol;
         if (symbol == null)
             return new CannotChangeSignatureAnalyzedContext(ChangeSignatureFailureKind.IncorrectKind);
 

--- a/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
+++ b/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
@@ -109,7 +109,7 @@ internal sealed class DelegateInvokeMethodReferenceFinder : AbstractReferenceFin
             var convertedType = (ISymbol?)state.SemanticModel.GetTypeInfo(node, cancellationToken).ConvertedType;
             if (convertedType != null)
             {
-                convertedType = SymbolFinder.FindSourceDefinition(convertedType, state.Solution, cancellationToken) ?? convertedType;
+                convertedType = SymbolFinder.FindSourceDefinitionAsync(convertedType, state.Solution, cancellationToken).WaitAndGetResult_CanCallOnBackground(cancellationToken) ?? convertedType;
             }
 
             if (convertedType == methodSymbol.ContainingType)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
@@ -71,7 +71,7 @@ internal abstract partial class AbstractGenerateTypeService<TService, TSimpleNam
         {
             var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            var state = State.Generate((TService)this, semanticDocument, node, cancellationToken);
+            var state = await State.GenerateAsync((TService)this, semanticDocument, node, cancellationToken).ConfigureAwait(false);
             if (state != null)
             {
                 var actions = GetActions(semanticDocument, node, state, cancellationToken);

--- a/src/Features/Core/Portable/GoToBase/AbstractGoToBaseService.cs
+++ b/src/Features/Core/Portable/GoToBase/AbstractGoToBaseService.cs
@@ -61,8 +61,8 @@ internal abstract class AbstractGoToBaseService : IGoToBaseService
         // If not found but the symbol is from metadata, create it's definition item from metadata and add to the context.
         foreach (var baseSymbol in bases)
         {
-            var sourceDefinition = SymbolFinder.FindSourceDefinition(
-               baseSymbol, solution, cancellationToken);
+            var sourceDefinition = await SymbolFinder.FindSourceDefinitionAsync(
+               baseSymbol, solution, cancellationToken).ConfigureAwait(false);
             if (sourceDefinition != null)
             {
                 var definitionItem = await sourceDefinition.ToClassifiedDefinitionItemAsync(

--- a/src/Features/Core/Portable/GoToDefinition/GoToDefinitionFeatureHelpers.cs
+++ b/src/Features/Core/Portable/GoToDefinition/GoToDefinitionFeatureHelpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.GoToDefinition;
 
 internal static class GoToDefinitionFeatureHelpers
 {
-    public static ISymbol? TryGetPreferredSymbol(
+    public static async ValueTask<ISymbol?> TryGetPreferredSymbolAsync(
         Solution solution, ISymbol? symbol, CancellationToken cancellationToken)
     {
         if (symbol is null)
@@ -43,7 +43,7 @@ internal static class GoToDefinitionFeatureHelpers
                 symbol = alias.Target;
         }
 
-        var definition = SymbolFinder.FindSourceDefinition(symbol, solution, cancellationToken);
+        var definition = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
 
         symbol = definition ?? symbol;
@@ -66,7 +66,7 @@ internal static class GoToDefinitionFeatureHelpers
         bool thirdPartyNavigationAllowed,
         CancellationToken cancellationToken)
     {
-        symbol = TryGetPreferredSymbol(solution, symbol, cancellationToken);
+        symbol = await TryGetPreferredSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false);
         if (symbol is null)
             return [];
 

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -314,25 +314,25 @@ internal abstract partial class AbstractInheritanceMarginService
         {
             if (memberSymbol.TypeKind == TypeKind.Interface)
             {
-                var item = CreateInheritanceMemberItemForInterface(
+                var item = await CreateInheritanceMemberItemForInterfaceAsync(
                     solution,
                     memberSymbol,
                     lineNumber,
                     baseSymbols: baseSymbols.CastArray<ISymbol>(),
                     derivedTypesSymbols: derivedSymbols.CastArray<ISymbol>(),
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
                 builder.AddIfNotNull(item);
             }
             else
             {
                 Debug.Assert(memberSymbol.TypeKind is TypeKind.Class or TypeKind.Struct);
-                var item = CreateInheritanceItemForClassAndStructure(
+                var item = await CreateInheritanceItemForClassAndStructureAsync(
                     solution,
                     memberSymbol,
                     lineNumber,
                     baseSymbols: baseSymbols.CastArray<ISymbol>(),
                     derivedTypesSymbols: derivedSymbols.CastArray<ISymbol>(),
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
                 builder.AddIfNotNull(item);
             }
         }
@@ -357,12 +357,12 @@ internal abstract partial class AbstractInheritanceMarginService
 
             if (implementingSymbols.Any())
             {
-                var item = CreateInheritanceMemberItemForInterfaceMember(
+                var item = await CreateInheritanceMemberItemForInterfaceMemberAsync(
                     solution,
                     memberSymbol,
                     lineNumber,
                     implementingMembers: implementingSymbols,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
                 builder.AddIfNotNull(item);
             }
         }
@@ -384,19 +384,19 @@ internal abstract partial class AbstractInheritanceMarginService
 
             if (overridingSymbols.Any() || overriddenSymbols.Any() || implementedSymbols.Any())
             {
-                var item = CreateInheritanceMemberItemForClassOrStructMember(solution,
+                var item = await CreateInheritanceMemberItemForClassOrStructMemberAsync(solution,
                     memberSymbol,
                     lineNumber,
                     implementedMembers: implementedSymbols,
                     overridingMembers: overridingSymbols,
                     overriddenMembers: overriddenSymbols,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
                 builder.AddIfNotNull(item);
             }
         }
     }
 
-    private static InheritanceMarginItem? CreateInheritanceMemberItemForInterface(
+    private static async ValueTask<InheritanceMarginItem?> CreateInheritanceMemberItemForInterfaceAsync(
         Solution solution,
         INamedTypeSymbol interfaceSymbol,
         int lineNumber,
@@ -404,23 +404,25 @@ internal abstract partial class AbstractInheritanceMarginService
         ImmutableArray<ISymbol> derivedTypesSymbols,
         CancellationToken cancellationToken)
     {
-        var baseSymbolItems = baseSymbols
+        var baseSymbolItems = await baseSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 InheritanceRelationship.InheritedInterface,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
-        var derivedTypeItems = derivedTypesSymbols
+        var derivedTypeItems = await derivedTypesSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 InheritanceRelationship.ImplementingType,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
         var nonNullBaseSymbolItems = GetNonNullTargetItems(baseSymbolItems);
         var nonNullDerivedTypeItems = GetNonNullTargetItems(derivedTypeItems);
@@ -433,21 +435,22 @@ internal abstract partial class AbstractInheritanceMarginService
             nonNullBaseSymbolItems.Concat(nonNullDerivedTypeItems));
     }
 
-    private static InheritanceMarginItem? CreateInheritanceMemberItemForInterfaceMember(
+    private static async ValueTask<InheritanceMarginItem?> CreateInheritanceMemberItemForInterfaceMemberAsync(
         Solution solution,
         ISymbol memberSymbol,
         int lineNumber,
         ImmutableArray<ISymbol> implementingMembers,
         CancellationToken cancellationToken)
     {
-        var implementedMemberItems = implementingMembers
+        var implementedMemberItems = await implementingMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 InheritanceRelationship.ImplementingMember,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
         var nonNullImplementedMemberItems = GetNonNullTargetItems(implementedMemberItems);
         return InheritanceMarginItem.CreateOrdered(
@@ -458,7 +461,7 @@ internal abstract partial class AbstractInheritanceMarginService
             nonNullImplementedMemberItems);
     }
 
-    private static InheritanceMarginItem? CreateInheritanceItemForClassAndStructure(
+    private static async ValueTask<InheritanceMarginItem?> CreateInheritanceItemForClassAndStructureAsync(
         Solution solution,
         INamedTypeSymbol memberSymbol,
         int lineNumber,
@@ -468,23 +471,25 @@ internal abstract partial class AbstractInheritanceMarginService
     {
         // If the target is an interface, it would be shown as 'Inherited interface',
         // and if it is an class/struct, it whould be shown as 'Base Type'
-        var baseSymbolItems = baseSymbols
+        var baseSymbolItems = await baseSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 symbol.IsInterfaceType() ? InheritanceRelationship.ImplementedInterface : InheritanceRelationship.BaseType,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
-        var derivedTypeItems = derivedTypesSymbols
+        var derivedTypeItems = await derivedTypesSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 InheritanceRelationship.DerivedType,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
         var nonNullBaseSymbolItems = GetNonNullTargetItems(baseSymbolItems);
         var nonNullDerivedTypeItems = GetNonNullTargetItems(derivedTypeItems);
@@ -497,7 +502,7 @@ internal abstract partial class AbstractInheritanceMarginService
             nonNullBaseSymbolItems.Concat(nonNullDerivedTypeItems));
     }
 
-    private static InheritanceMarginItem? CreateInheritanceMemberItemForClassOrStructMember(
+    private static async ValueTask<InheritanceMarginItem?> CreateInheritanceMemberItemForClassOrStructMemberAsync(
         Solution solution,
         ISymbol memberSymbol,
         int lineNumber,
@@ -506,32 +511,35 @@ internal abstract partial class AbstractInheritanceMarginService
         ImmutableArray<ISymbol> overriddenMembers,
         CancellationToken cancellationToken)
     {
-        var implementedMemberItems = implementedMembers
+        var implementedMemberItems = await implementedMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 InheritanceRelationship.ImplementedMember,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
-        var overriddenMemberItems = overriddenMembers
+        var overriddenMemberItems = await overriddenMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 InheritanceRelationship.OverriddenMember,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
-        var overridingMemberItems = overridingMembers
+        var overridingMemberItems = await overridingMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArray(static (symbol, tuple) => CreateInheritanceItem(
-                tuple.solution,
+            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+                solution,
                 symbol,
                 InheritanceRelationship.OverridingMember,
-                tuple.cancellationToken), (solution, cancellationToken));
+                cancellationToken), solution, cancellationToken)
+            .ConfigureAwait(false);
 
         var nonNullImplementedMemberItems = GetNonNullTargetItems(implementedMemberItems);
         var nonNullOverriddenMemberItems = GetNonNullTargetItems(overriddenMemberItems);
@@ -545,13 +553,13 @@ internal abstract partial class AbstractInheritanceMarginService
             nonNullImplementedMemberItems.Concat(nonNullOverriddenMemberItems, nonNullOverridingMemberItems));
     }
 
-    private static InheritanceTargetItem? CreateInheritanceItem(
+    private static async ValueTask<InheritanceTargetItem?> CreateInheritanceItemAsync(
         Solution solution,
         ISymbol targetSymbol,
         InheritanceRelationship inheritanceRelationship,
         CancellationToken cancellationToken)
     {
-        var symbolInSource = SymbolFinder.FindSourceDefinition(targetSymbol, solution, cancellationToken);
+        var symbolInSource = await SymbolFinder.FindSourceDefinitionAsync(targetSymbol, solution, cancellationToken).ConfigureAwait(false);
         targetSymbol = symbolInSource ?? targetSymbol;
 
         // Right now the targets are not shown in a classified way.

--- a/src/Features/Core/Portable/Navigation/AbstractNavigableItemsService.cs
+++ b/src/Features/Core/Portable/Navigation/AbstractNavigableItemsService.cs
@@ -48,8 +48,8 @@ internal abstract class AbstractNavigableItemsService : INavigableItemsService
 
             var solution = project.Solution;
 
-            symbol = SymbolFinder.FindSourceDefinition(symbol, solution, cancellationToken) ?? symbol;
-            symbol = GoToDefinitionFeatureHelpers.TryGetPreferredSymbol(solution, symbol, cancellationToken);
+            symbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false) ?? symbol;
+            symbol = await GoToDefinitionFeatureHelpers.TryGetPreferredSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false);
 
             if (symbol is null or IErrorTypeSymbol)
                 return null;
@@ -61,8 +61,8 @@ internal abstract class AbstractNavigableItemsService : INavigableItemsService
                 if (typeSymbol is null)
                     return null;
 
-                typeSymbol = SymbolFinder.FindSourceDefinition(typeSymbol, solution, cancellationToken) ?? typeSymbol;
-                typeSymbol = GoToDefinitionFeatureHelpers.TryGetPreferredSymbol(solution, typeSymbol, cancellationToken);
+                typeSymbol = await SymbolFinder.FindSourceDefinitionAsync(typeSymbol, solution, cancellationToken).ConfigureAwait(false) ?? typeSymbol;
+                typeSymbol = await GoToDefinitionFeatureHelpers.TryGetPreferredSymbolAsync(solution, typeSymbol, cancellationToken).ConfigureAwait(false);
 
                 if (typeSymbol is null or IErrorTypeSymbol)
                     return null;

--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -702,7 +702,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
                     End If
 
                     If convertedType IsNot Nothing Then
-                        convertedType = If(SymbolFinder.FindSourceDefinition(convertedType, document.Project.Solution, cancellationToken), convertedType)
+                        convertedType = If(Await SymbolFinder.FindSourceDefinitionAsync(convertedType, document.Project.Solution, cancellationToken).ConfigureAwait(False), convertedType)
                     End If
 
                     If Equals(convertedType, symbol.ContainingType) Then
@@ -721,7 +721,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
                         End If
 
                         If nodeType IsNot Nothing Then
-                            nodeType = If(SymbolFinder.FindSourceDefinition(nodeType, document.Project.Solution, cancellationToken), nodeType)
+                            nodeType = If(Await SymbolFinder.FindSourceDefinitionAsync(nodeType, document.Project.Solution, cancellationToken).ConfigureAwait(False), nodeType)
                         End If
 
                         If Equals(nodeType, symbol.ContainingType) Then

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
             End If
 
             ' Target type may be in other project so we need to find its source definition
-            Dim sourceDefinition = SymbolFinder.FindSourceDefinition(targetType, document.Project.Solution, cancellationToken)
+            Dim sourceDefinition = Await SymbolFinder.FindSourceDefinitionAsync(targetType, document.Project.Solution, cancellationToken).ConfigureAwait(False)
 
             targetType = TryCast(sourceDefinition, INamedTypeSymbol)
 
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                 Return Nothing
             End If
 
-            Dim targetType = TryCast(SymbolFinder.FindSourceDefinition(semanticModel.GetSymbolInfo(node.Left, cancellationToken).Symbol, document.Project.Solution, cancellationToken), INamedTypeSymbol)
+            Dim targetType = TryCast(Await SymbolFinder.FindSourceDefinitionAsync(semanticModel.GetSymbolInfo(node.Left, cancellationToken).Symbol, document.Project.Solution, cancellationToken).ConfigureAwait(False), INamedTypeSymbol)
             If targetType Is Nothing OrElse (targetType.TypeKind <> TypeKind.Interface AndAlso targetType.TypeKind <> TypeKind.Class) Then
                 Return Nothing
             End If
@@ -347,11 +347,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                     Return Nothing
                 End If
 
-                targetType = TryCast(SymbolFinder.FindSourceDefinition(withEventsProperty.Type, document.Project.Solution, cancellationToken), INamedTypeSymbol)
+                targetType = TryCast(Await SymbolFinder.FindSourceDefinitionAsync(withEventsProperty.Type, document.Project.Solution, cancellationToken).ConfigureAwait(False), INamedTypeSymbol)
 
             End If
 
-            targetType = TryCast(SymbolFinder.FindSourceDefinition(targetType, document.Project.Solution, cancellationToken), INamedTypeSymbol)
+            targetType = TryCast(Await SymbolFinder.FindSourceDefinitionAsync(targetType, document.Project.Solution, cancellationToken).ConfigureAwait(False), INamedTypeSymbol)
             If targetType Is Nothing OrElse
                 Not (targetType.TypeKind = TypeKind.Class OrElse targetType.TypeKind = TypeKind.Interface) OrElse
                 targetType.IsAnonymousType Then

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -210,7 +210,7 @@ internal sealed partial class GraphBuilder
         // We may need to look up source code within this solution
         if (preferredLocation == null && symbol.Locations.Any(static loc => loc.IsInMetadata))
         {
-            var newSymbol = SymbolFinder.FindSourceDefinition(symbol, contextProject.Solution, cancellationToken);
+            var newSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, contextProject.Solution, cancellationToken).ConfigureAwait(false);
             if (newSymbol != null)
                 preferredLocation = newSymbol.Locations.Where(loc => loc.IsInSource).FirstOrDefault();
         }

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -358,7 +358,9 @@ internal sealed class CSharpRenameConflictLanguageService() : AbstractRenameRewr
                         symbol = symbol.ContainingSymbol;
                     }
 
-                    var sourceDefinition = SymbolFinder.FindSourceDefinition(symbol, _solution, _cancellationToken);
+                    // We cannot make this containing method async since it's being used in a rewriter. FindSourceDefinitionAsync will only yield in cross-language cases
+                    // when the compilation is not already available, so this is expected to not really cause any significant blocking.
+                    var sourceDefinition = SymbolFinder.FindSourceDefinitionAsync(symbol, _solution, _cancellationToken).WaitAndGetResult_CanCallOnBackground(_cancellationToken);
                     symbol = sourceDefinition ?? symbol;
 
                     if (symbol is INamedTypeSymbol namedTypeSymbol)

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -923,34 +923,6 @@ internal sealed class CSharpRenameConflictLanguageService() : AbstractRenameRewr
         }
     }
 
-    private static async Task<ISymbol?> GetVBPropertyFromAccessorOrAnOverrideAsync(ISymbol symbol, Solution solution, CancellationToken cancellationToken)
-    {
-        try
-        {
-            if (symbol.IsPropertyAccessor())
-            {
-                var property = ((IMethodSymbol)symbol).AssociatedSymbol!;
-
-                return property.Language == LanguageNames.VisualBasic ? property : null;
-            }
-
-            if (symbol.IsOverride && symbol.GetOverriddenMember() != null)
-            {
-                var originalSourceSymbol = SymbolFinder.FindSourceDefinition(symbol.GetOverriddenMember(), solution, cancellationToken);
-                if (originalSourceSymbol != null)
-                {
-                    return await GetVBPropertyFromAccessorOrAnOverrideAsync(originalSourceSymbol, solution, cancellationToken).ConfigureAwait(false);
-                }
-            }
-
-            return null;
-        }
-        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
-        {
-            throw ExceptionUtilities.Unreachable();
-        }
-    }
-
     private static void AddSymbolSourceSpans(
         ArrayBuilder<Location> conflicts, IEnumerable<ISymbol> symbols,
         IDictionary<Location, Location> reverseMappedLocations)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
@@ -65,7 +65,7 @@ internal sealed partial class FindReferencesSearchEngine
             var options = engine._options;
 
             // Start by mapping the initial symbol to the appropriate source symbol in originating project if possible.
-            var searchSymbols = MapToAppropriateSymbols(solution, symbols, cancellationToken);
+            var searchSymbols = await MapToAppropriateSymbolsAsync(solution, symbols, cancellationToken).ConfigureAwait(false);
 
             // If the caller doesn't want any cascading then just return an appropriate set that will just point at
             // only the search symbol and won't cascade to any related symbols, linked symbols, or inheritance
@@ -89,17 +89,17 @@ internal sealed partial class FindReferencesSearchEngine
                 : new BidirectionalSymbolSet(engine, initialSymbols, upSymbols, includeImplementationsThroughDerivedTypes);
         }
 
-        private static MetadataUnifyingSymbolHashSet MapToAppropriateSymbols(
+        private static async ValueTask<MetadataUnifyingSymbolHashSet> MapToAppropriateSymbolsAsync(
             Solution solution, MetadataUnifyingSymbolHashSet symbols, CancellationToken cancellationToken)
         {
             var result = new MetadataUnifyingSymbolHashSet();
             foreach (var symbol in symbols)
-                result.AddIfNotNull(TryMapToAppropriateSymbol(solution, symbol, cancellationToken));
+                result.AddIfNotNull(await TryMapToAppropriateSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false));
 
             return result;
         }
 
-        private static ISymbol? TryMapToAppropriateSymbol(
+        private static async ValueTask<ISymbol?> TryMapToAppropriateSymbolAsync(
             Solution solution, ISymbol symbol, CancellationToken cancellationToken)
         {
             // Never search for an alias.  Always search for it's target.  Note: if the caller was
@@ -132,7 +132,7 @@ internal sealed partial class FindReferencesSearchEngine
             // source definition as the 'truth' of a symbol versus seeing it projected into dependent cross language
             // projects as a metadata symbol.  If there is no source symbol, then continue to just use the metadata
             // symbol as the one to be looking for.
-            var sourceSymbol = SymbolFinder.FindSourceDefinition(searchSymbol, solution, cancellationToken);
+            var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(searchSymbol, solution, cancellationToken).ConfigureAwait(false);
             return sourceSymbol ?? searchSymbol;
         }
 
@@ -209,7 +209,7 @@ internal sealed partial class FindReferencesSearchEngine
 
             async Task<ISymbol?> TryMapAndAddLinkedSymbolsAsync(ISymbol symbol)
             {
-                var mapped = TryMapToAppropriateSymbol(solution, symbol, cancellationToken);
+                var mapped = await TryMapToAppropriateSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false);
                 if (mapped is null)
                     return null;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -137,10 +137,7 @@ public static partial class SymbolFinder
     /// Returns null if no such symbol can be found in the specified solution.
     /// </summary>
     public static Task<ISymbol?> FindSourceDefinitionAsync(ISymbol? symbol, Solution solution, CancellationToken cancellationToken = default)
-        => Task.FromResult(SymbolFinderInternal.FindSourceDefinition(symbol, solution, cancellationToken));
-
-    internal static ISymbol? FindSourceDefinition(ISymbol? symbol, Solution solution, CancellationToken cancellationToken)
-        => SymbolFinderInternal.FindSourceDefinition(symbol, solution, cancellationToken);
+        => SymbolFinderInternal.FindSourceDefinitionAsync(symbol, solution, cancellationToken).AsTask();
 
     /// <summary>
     /// Finds symbols in the given compilation that are similar to the specified symbol.

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Callers.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Callers.cs
@@ -38,7 +38,7 @@ public static partial class SymbolFinder
             throw new System.ArgumentNullException(nameof(solution));
 
         symbol = symbol.OriginalDefinition;
-        var foundSymbol = FindSourceDefinition(symbol, solution, cancellationToken);
+        var foundSymbol = await FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
         symbol = foundSymbol ?? symbol;
 
         var references = await FindCallReferencesAsync(solution, symbol, documents, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
@@ -51,19 +51,19 @@ public static partial class SymbolFinder
 
         // First try finding exact overrides.  If that fails to find anything, look for overrides that loosely
         // match due to errors.
-        FindOverrides(allowLooseMatch: false);
+        await FindOverridesAsync(allowLooseMatch: false).ConfigureAwait(false);
         if (results.Count == 0)
-            FindOverrides(allowLooseMatch: true);
+            await FindOverridesAsync(allowLooseMatch: true).ConfigureAwait(false);
 
         return results.ToImmutableAndClear();
 
-        void FindOverrides(bool allowLooseMatch)
+        async ValueTask FindOverridesAsync(bool allowLooseMatch)
         {
             foreach (var type in derivedTypes)
             {
                 foreach (var m in type.GetMembers(symbol.Name))
                 {
-                    var sourceMember = FindSourceDefinition(m, solution, cancellationToken);
+                    var sourceMember = await FindSourceDefinitionAsync(m, solution, cancellationToken).ConfigureAwait(false);
                     var bestMember = sourceMember ?? m;
 
                     if (IsOverride(solution, bestMember, symbol, allowLooseMatch))
@@ -166,7 +166,7 @@ public static partial class SymbolFinder
                             {
                                 foreach (var interfaceMember in interfaceType.GetMembers(symbol.Name))
                                 {
-                                    var sourceMethod = FindSourceDefinition(interfaceMember, solution, cancellationToken);
+                                    var sourceMethod = await FindSourceDefinitionAsync(interfaceMember, solution, cancellationToken).ConfigureAwait(false);
                                     var bestMethod = sourceMethod ?? interfaceMember;
 
                                     var implementations = type.FindImplementationsForInterfaceMember(bestMethod, solution, cancellationToken);
@@ -373,7 +373,7 @@ public static partial class SymbolFinder
             var implementations = t.FindImplementationsForInterfaceMember(symbol, solution, cancellationToken);
             foreach (var implementation in implementations)
             {
-                var sourceDef = FindSourceDefinition(implementation, solution, cancellationToken);
+                var sourceDef = await FindSourceDefinitionAsync(implementation, solution, cancellationToken).ConfigureAwait(false);
                 var bestDef = sourceDef ?? implementation;
                 if (IsAccessible(bestDef))
                     results.Add(bestDef.OriginalDefinition);

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -534,11 +534,12 @@ internal static partial class ConflictResolver
 
                         hasConflict = true;
 
-                        var newLocations = newReferencedSymbols
-                            .Select(symbol => GetSymbolLocation(solution, symbol, _cancellationToken))
+                        var newLocations = (await newReferencedSymbols
+                            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => GetSymbolLocationAsync(solution, symbol, cancellationToken), solution, _cancellationToken).ConfigureAwait(false))
                             .WhereNotNull()
                             .Where(loc => loc.IsInSource)
                             .ToArray();
+
                         foreach (var originalReference in conflictAnnotation.RenameDeclarationLocationReferences.Where(loc => loc.IsSourceLocation))
                         {
                             var adjustedStartPosition = conflictResolution.GetAdjustedTokenStartingPosition(originalReference.TextSpan.Start, originalReference.DocumentId);
@@ -579,7 +580,7 @@ internal static partial class ConflictResolver
                             break;
                         }
 
-                        var newLocation = GetSymbolLocation(solution, symbol, _cancellationToken);
+                        var newLocation = await GetSymbolLocationAsync(solution, symbol, _cancellationToken).ConfigureAwait(false);
                         if (newLocation != null && conflictAnnotation.RenameDeclarationLocationReferences[symbolIndex].IsSourceLocation)
                         {
                             // location was in source before, but not after rename

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -359,12 +359,18 @@ internal static partial class ConflictResolver
 
                 if (overriddenSymbol != null)
                 {
-                    overriddenSymbol = SymbolFinder.FindSourceDefinition(overriddenSymbol, solution, cancellationToken);
+                    // Unfortunately we cannot easily make CreateDeclarationLocationAnnotations async, as it's used in the rewriter that is rewriting trees.
+                    // The asynchrony in GetSymbolLocationAsync comes from SymbolFinder.FindSourceDefinitionAsync() which will only be async in the cross-language case, and only once
+                    // when the compilation wasn't already available.
+                    overriddenSymbol = SymbolFinder.FindSourceDefinitionAsync(overriddenSymbol, solution, cancellationToken).WaitAndGetResult_CanCallOnBackground(cancellationToken);
                     overriddenFromMetadata = overriddenSymbol == null || overriddenSymbol.Locations.All(loc => loc.IsInMetadata);
                 }
             }
 
-            var location = GetSymbolLocation(solution, symbol, cancellationToken);
+            // Unfortunately we cannot easily make CreateDeclarationLocationAnnotations async, as it's used in the rewriter that is rewriting trees.
+            // The asynchrony in GetSymbolLocationAsync comes from SymbolFinder.FindSourceDefinitionAsync() which will only be async in the cross-language case, and only once
+            // when the compilation wasn't already available.
+            var location = GetSymbolLocationAsync(solution, symbol, cancellationToken).AsTask().WaitAndGetResult_CanCallOnBackground(cancellationToken);
             if (location != null && location.IsInSource)
             {
                 renameDeclarationLocations[symbolIndex] = new RenameDeclarationLocationReference(solution.GetDocumentId(location.SourceTree), location.SourceSpan, overriddenFromMetadata, locations.Length);
@@ -397,11 +403,11 @@ internal static partial class ConflictResolver
     /// <summary>
     /// Gives the First Location for a given Symbol by ordering the locations using DocumentId first and Location starting position second
     /// </summary>
-    private static Location? GetSymbolLocation(Solution solution, ISymbol symbol, CancellationToken cancellationToken)
+    private static async ValueTask<Location?> GetSymbolLocationAsync(Solution solution, ISymbol symbol, CancellationToken cancellationToken)
     {
         var locations = symbol.Locations;
 
-        var originalsourcesymbol = SymbolFinder.FindSourceDefinition(symbol, solution, cancellationToken);
+        var originalsourcesymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
         if (originalsourcesymbol != null)
             locations = originalsourcesymbol.Locations;
 

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -215,8 +215,8 @@ internal static class RenameUtilities
 
         if (symbol.IsOverride && symbol.GetOverriddenMember() != null)
         {
-            var originalSourceSymbol = SymbolFinder.FindSourceDefinition(
-                symbol.GetOverriddenMember(), solution, cancellationToken);
+            var originalSourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(
+                symbol.GetOverriddenMember(), solution, cancellationToken).ConfigureAwait(false);
 
             if (originalSourceSymbol != null)
                 return await TryGetPropertyFromAccessorOrAnOverrideAsync(originalSourceSymbol, solution, cancellationToken).ConfigureAwait(false);
@@ -319,8 +319,8 @@ internal static class RenameUtilities
         Contract.ThrowIfNull(solution);
 
         // Make sure we're on the original source definition if we can be
-        var foundSymbol = SymbolFinder.FindSourceDefinition(
-            symbol, solution, cancellationToken);
+        var foundSymbol = await SymbolFinder.FindSourceDefinitionAsync(
+            symbol, solution, cancellationToken).ConfigureAwait(false);
 
         var bestSymbol = foundSymbol ?? symbol;
         symbol = bestSymbol;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -77,7 +77,8 @@ internal static partial class SyntaxGeneratorExtensions
         {
             // Call accessors directly if C# overriding VB
             if (document.Project.Language == LanguageNames.CSharp
-                && SymbolFinder.FindSourceDefinition(overriddenProperty, document.Project.Solution, cancellationToken) is { Language: LanguageNames.VisualBasic })
+                && (await SymbolFinder.FindSourceDefinitionAsync(overriddenProperty, document.Project.Solution, cancellationToken).ConfigureAwait(false))
+                        is { Language: LanguageNames.VisualBasic })
             {
                 var getName = overriddenProperty.GetMethod?.Name;
                 var setName = overriddenProperty.SetMethod?.Name;


### PR DESCRIPTION
(This is the main branch version of https://github.com/dotnet/roslyn/pull/78164)

FindSourceDefinitionAsync was assuming that in the cross-language case, if you have a symbol from another project, that the compilation must always be available for that project -- for example, that calling TryGetCompilation on the project must always work. That's not the case if we're not generating skeleton references all the time. The fix to make that method work reliably again is simply to call GetCompilationAsync(). This results in a cascade of making more things async though: although our public entrypoint for FindSourceDefinitionAsync was Task-returning, it wasn't async and called into a non-async helper. So this removes those internal helpers and makes everything async again.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2443981
Fixes https://developercommunity.visualstudio.com/t/Go-to-definition-stopped-working-after-u/10796494