### PR TITLE
Add Workflow to Tag Issues Missing Area Labels

### DIFF
--- a/.github/workflows/labeler-missing-area-label.yml
+++ b/.github/workflows/labeler-missing-area-label.yml
@@ -1,0 +1,63 @@
+name: "Spot Issues Missing Area Labels"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * *' # Runs daily at 13:00 UTC
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  check-area-labels:
+    name: "Check Issues Missing Area Labels"
+    runs-on: ubuntu-latest
+
+    if: github.repository == 'dotnet/roslyn' # Skip forks
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Tag Issues Missing Area Labels
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const AREA_LABEL_PREFIX = 'Area-';
+            const NEEDS_AREA_LABEL = 'needs_area_label';
+
+            // Fetch open issues in the repo
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              }
+            );
+
+            for (const issue of issues) {
+              // Skip pull requests
+              if (issue.pull_request) continue;
+
+              const labels = issue.labels.map(label => label.name);
+              const hasUntriaged = labels.includes('untriaged');
+              const hasAreaLabel = labels.some(name => name.startsWith(AREA_LABEL_PREFIX));
+              const hasNeedsAreaLabel = labels.includes(NEEDS_AREA_LABEL);
+              const hasAssignee = issue.assignee !== null;
+
+              // If issue needs an Area label
+              if (hasUntriaged && !hasAreaLabel && !hasNeedsAreaLabel && !hasAssignee) {
+                console.log(`Adding '${NEEDS_AREA_LABEL}' to issue #${issue.number}`);
+
+                // Add the needs_area_label
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: [NEEDS_AREA_LABEL],
+                });
+              }
+            }


### PR DESCRIPTION
This PR introduces a scheduled and manually-triggerable GitHub Actions workflow to identify and tag open issues that are missing an Area-* label in the dotnet/roslyn repository.

## ✅ Key Features:
* Runs daily at 13:00 UTC and can be manually triggered.

* Filters open issues that:

  * Have the untriaged label

  * Do not have any Area-* label

  * Do not already have the `needs_area_label` tag

  * Do not have any assignee

* Adds the label `needs_area_label` to such issues

* Skips pull requests

* Skips workflows running on forks (restricted to dotnet/roslyn)

