### PR TITLE
Move assembly versions back to 4.14.0.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,8 @@
     Roslyn version
   -->
   <PropertyGroup>
-    <MajorVersion>5</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>14</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>


### PR DESCRIPTION
Need to keep the .NET 10 SDK functional in VS 17.14 which means ensuring that the compiler version is 4.14 for a bit longer.