### PR TITLE
Add more telemetry for progression graph query commands to help better understand usage patterns

### DIFF
--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/CallsGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/CallsGraphQuery.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.Schemas;
@@ -18,6 +19,8 @@ internal sealed class CallsGraphQuery : IGraphQuery
 {
     public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
     {
+        using var _ = Logger.LogBlock(FunctionId.GraphQuery_Calls, KeyValueLogMessage.Create(LogType.UserAction), cancellationToken);
+
         var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
 
         foreach (var node in context.InputNodes)

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/ContainsGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/ContainsGraphQuery.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.Schemas;
 
@@ -15,6 +16,8 @@ internal sealed class ContainsGraphQuery : IGraphQuery
 {
     public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
     {
+        using var _ = Logger.LogBlock(FunctionId.GraphQuery_Contains, KeyValueLogMessage.Create(LogType.UserAction), cancellationToken);
+
         var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
         var nodesToProcess = context.InputNodes;
 

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritedByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritedByGraphQuery.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.Schemas;
 
@@ -16,6 +17,8 @@ internal sealed class InheritedByGraphQuery : IGraphQuery
 {
     public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
     {
+        using var _ = Logger.LogBlock(FunctionId.GraphQuery_InheritedBy, KeyValueLogMessage.Create(LogType.UserAction), cancellationToken);
+
         var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
 
         foreach (var node in context.InputNodes)

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritsGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/InheritsGraphQuery.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.Schemas;
 
@@ -16,6 +17,8 @@ internal sealed class InheritsGraphQuery : IGraphQuery
 {
     public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
     {
+        using var _ = Logger.LogBlock(FunctionId.GraphQuery_Inherits, KeyValueLogMessage.Create(LogType.UserAction), cancellationToken);
+
         var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
         var nodesToProcess = context.InputNodes;
 

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/OverriddenByGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/OverriddenByGraphQuery.cs
@@ -5,6 +5,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.GraphModel;
 
@@ -14,6 +15,8 @@ internal sealed class OverriddenByGraphQuery : IGraphQuery
 {
     public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
     {
+        using var _ = Logger.LogBlock(FunctionId.GraphQuery_OverriddenBy, KeyValueLogMessage.Create(LogType.UserAction), cancellationToken);
+
         var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
 
         foreach (var node in context.InputNodes)

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/SearchGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/SearchGraphQuery.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.GraphModel;
@@ -18,6 +19,8 @@ internal sealed partial class SearchGraphQuery(
 {
     public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
     {
+        using var _ = Logger.LogBlock(FunctionId.GraphQuery_Search, KeyValueLogMessage.Create(LogType.UserAction), cancellationToken);
+
         var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
         var callback = new ProgressionNavigateToSearchCallback(solution, context, graphBuilder);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -651,6 +651,13 @@ internal enum FunctionId
     VSCode_Project_Load_Started = 861,
     VSCode_Projects_Load_Completed = 862,
 
+    GraphQuery_Calls = 870,
+    GraphQuery_Contains = 871,
+    GraphQuery_InheritedBy = 872,
+    GraphQuery_Inherits = 873,
+    GraphQuery_OverriddenBy = 874,
+    GraphQuery_Search = 875,
+
     // 900-999 for items that don't fit into other categories.
     Workspace_EventsImmediate = 900,
     ChecksumUpdater_SynchronizeTextChangesStatus = 901,


### PR DESCRIPTION
This will help us understand better which commands are being used and the efforts we should expend to continue supporting certain commands if we move from the progression APIs to IAttachedCollectionSourceProvider.