### PR TITLE
Create a NuGet package for Microsoft.VisualStudio.LanguageServices.Xaml

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -95,6 +95,7 @@
       "Microsoft.VisualStudio.LanguageServices.LiveShare": "vs-impl",
       "Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient": "vs-impl",
       "Microsoft.VisualStudio.LanguageServices.ExternalAccess.Copilot": "vs-impl",
+      "Microsoft.VisualStudio.LanguageServices.Xaml": "vs-impl",
       "Microsoft.CommonLanguageServerProtocol.Framework": "vs-impl",
       "Microsoft.CommonLanguageServerProtocol.Framework.Binary": "vs-impl",
       "Microsoft.CodeAnalysis.Analyzers": "arcade",

--- a/src/VisualStudio/Xaml/Impl/Microsoft.VisualStudio.LanguageServices.Xaml.csproj
+++ b/src/VisualStudio/Xaml/Impl/Microsoft.VisualStudio.LanguageServices.Xaml.csproj
@@ -8,6 +8,11 @@
     <TargetFramework>net472</TargetFramework>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+
+    <IsPackable>true</IsPackable>
+    <PackageDescription>
+      .NET Compiler Platform ("Roslyn") support for building the XAML Language Service.
+    </PackageDescription>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />


### PR DESCRIPTION
This is to replace the current consumption in the VS repo that is consuming this project out of VS.ExternalAPIs.Roslyn.