### PR TITLE
Fix async hoisted type substituted local

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -505,11 +505,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             fields.Add(field);
         }
 
-        private BoundExpression HoistRefInitialization(SynthesizedLocal local, BoundAssignmentOperator node)
+        private BoundExpression HoistRefInitialization(LocalSymbol local, BoundAssignmentOperator node)
         {
+            Debug.Assert(local is SynthesizedLocal or TypeSubstitutedLocalSymbol);
             Debug.Assert(local.SynthesizedKind == SynthesizedLocalKind.Spill ||
                          (local.SynthesizedKind == SynthesizedLocalKind.ForEachArray && local.Type.HasInlineArrayAttribute(out _) && local.Type.TryGetInlineArrayElementField() is object));
-            Debug.Assert(local.SyntaxOpt != null);
+            Debug.Assert(local is SynthesizedLocal sl ? sl.SyntaxOpt != null : true);
 #pragma warning disable format
             Debug.Assert(local.SynthesizedKind switch
                          {
@@ -856,7 +857,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // We have an assignment to a variable that has not yet been assigned a proxy.
             // So we assign the proxy before translating the assignment.
-            return HoistRefInitialization((SynthesizedLocal)leftLocal, node);
+            return HoistRefInitialization(leftLocal, node);
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #76999

Support TypeSubstitutedLocalSymbol's in MethodToStateMachineRewriter.HoistRefInitialization