### PR TITLE
Support empty root namespaces in ResxSourceGenerator

### DIFF
--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp5/Resources.Designer.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp5/Resources.Designer.cs
@@ -9,13 +9,13 @@ namespace TestProject
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager s_resourceManager;
-        internal static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
-        internal static global::System.Globalization.CultureInfo Culture { get; set; }
+        public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        public static global::System.Globalization.CultureInfo Culture { get; set; }
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string GetResourceString(string resourceKey, string defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;
         /// <summary>value</summary>
-        internal static string @Name => GetResourceString("Name");
+        public static string @Name => GetResourceString("Name");
 
     }
 }

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync/Resources.Designer.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync/Resources.Designer.cs
@@ -4,18 +4,17 @@
 using System.Reflection;
 
 
-namespace 
-{
-    internal static partial class Resources
-    {
-        private static global::System.Resources.ResourceManager? s_resourceManager;
-        public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
-        public static global::System.Globalization.CultureInfo? Culture { get; set; }
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
-        internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;
-        /// <summary>value</summary>
-        public static string @Name => GetResourceString("Name")!;
 
-    }
+internal static partial class Resources
+{
+    private static global::System.Resources.ResourceManager? s_resourceManager;
+    public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+    public static global::System.Globalization.CultureInfo? Culture { get; set; }
+    [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
+    internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;
+    /// <summary>value</summary>
+    public static string @Name => GetResourceString("Name")!;
+
 }
+

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync/Resources.Designer.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync/Resources.Designer.cs
@@ -9,13 +9,13 @@ namespace
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
-        internal static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
-        internal static global::System.Globalization.CultureInfo? Culture { get; set; }
+        public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        public static global::System.Globalization.CultureInfo? Culture { get; set; }
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;
         /// <summary>value</summary>
-        internal static string @Name => GetResourceString("Name")!;
+        public static string @Name => GetResourceString("Name")!;
 
     }
 }

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync/Resources.Designer.vb
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync/Resources.Designer.vb
@@ -3,31 +3,31 @@
 Imports System.Reflection
 
 
-Namespace Global.
-    Friend Partial Class Resources
-        Private Sub New
-        End Sub
-        
-        Private Shared s_resourceManager As Global.System.Resources.ResourceManager
-        Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
-            Get
-                If s_resourceManager Is Nothing Then
-                    s_resourceManager = New Global.System.Resources.ResourceManager(GetType(Resources))
-                End If
-                Return s_resourceManager
-            End Get
-        End Property
-        Public Shared Property Culture As Global.System.Globalization.CultureInfo
-        <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
-        Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
-            Return ResourceManager.GetString(resourceKey, Culture)
-        End Function
-        ''' <summary>value</summary>
-        Public Shared ReadOnly Property [Name] As String
-          Get
-            Return GetResourceString("Name")
-          End Get
-        End Property
 
-    End Class
-End Namespace
+Friend Partial Class Resources
+    Private Sub New
+    End Sub
+    
+    Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+    Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
+        Get
+            If s_resourceManager Is Nothing Then
+                s_resourceManager = New Global.System.Resources.ResourceManager(GetType(Resources))
+            End If
+            Return s_resourceManager
+        End Get
+    End Property
+    Public Shared Property Culture As Global.System.Globalization.CultureInfo
+    <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
+    Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
+        Return ResourceManager.GetString(resourceKey, Culture)
+    End Function
+    ''' <summary>value</summary>
+    Public Shared ReadOnly Property [Name] As String
+      Get
+        Return GetResourceString("Name")
+      End Get
+    End Property
+
+End Class
+

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync/Resources.Designer.vb
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync/Resources.Designer.vb
@@ -9,7 +9,7 @@ Namespace Global.
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
-        Friend Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
+        Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
                     s_resourceManager = New Global.System.Resources.ResourceManager(GetType(Resources))
@@ -17,13 +17,13 @@ Namespace Global.
                 Return s_resourceManager
             End Get
         End Property
-        Friend Shared Property Culture As Global.System.Globalization.CultureInfo
+        Public Shared Property Culture As Global.System.Globalization.CultureInfo
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)
         End Function
         ''' <summary>value</summary>
-        Friend Shared ReadOnly Property [Name] As String
+        Public Shared ReadOnly Property [Name] As String
           Get
             Return GetResourceString("Name")
           End Get

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/ResxGeneratorTests.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/ResxGeneratorTests.cs
@@ -245,7 +245,7 @@ build_metadata.AdditionalFiles.GenerateSource = false
         }
 
         [Theory]
-        [InlineData("", Skip = "Empty root namespaces are not supported")]
+        [InlineData("")]
         [InlineData("NS")]
         [InlineData("NS1.NS2")]
         public async Task SingleString_RootNamespaceCSharpAsync(string rootNamespace)
@@ -275,7 +275,7 @@ build_property.RootNamespace = {rootNamespace}
         }
 
         [Theory]
-        [InlineData("", Skip = "Empty root namespaces are not supported")]
+        [InlineData("")]
         [InlineData("NS")]
         [InlineData("NS1.NS2")]
         public async Task SingleString_RootNamespaceVisualBasicAsync(string rootNamespace)

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                         new ResourceInformation(
                             CompilationInformation: compilationInfo,
                             ResourceFile: resourceFile,
-                            ResourceName: string.Join(".", rootNamespace, resourceName),
+                            ResourceName: string.IsNullOrEmpty(rootNamespace) ? resourceName : string.Join(".", rootNamespace, resourceName),
                             ResourceHintName: resourceHintName,
                             ResourceClassName: resourceClassName,
                             OmitGetResourceString: omitGetResourceString,


### PR DESCRIPTION
Fixes dotnet/roslyn-analyzers#7626