### PR TITLE
Allocate slightly less in ImmutableArrayExtensions.ConditionallyDeOrder

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -847,7 +847,8 @@ namespace Microsoft.CodeAnalysis
                 var temp = copy[0];
                 copy[0] = copy[last];
                 copy[last] = temp;
-                return copy.AsImmutable();
+
+                return ImmutableCollectionsMarshal.AsImmutableArray(copy);
             }
 #endif
             return array;


### PR DESCRIPTION
This method currently allocates two arrays (once during the ToArray call, the other in the AsImmutable call). This is generally not a problem as this is debug only code, but this method is called very frequently, so I'll change the line to make this method only allocate the array once.