### PR TITLE
Reduce allocations in NamespaceSymbol.GetExtensionContainers

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -305,15 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (member is NamedTypeSymbol type)
                 {
-                    if (!type.IsReferenceType || !type.IsStatic || type.IsGenericType || !type.MightContainExtensionMethods) continue;
-
-                    foreach (var nestedType in type.GetTypeMembersUnordered())
-                    {
-                        if (nestedType.IsExtension)
-                        {
-                            extensions.Add(nestedType);
-                        }
-                    }
+                    AddExtensionContainersForType(type, extensions);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (member is NamedTypeSymbol type)
                 {
-                    AddExtensionContainersForType(type, extensions);
+                    AddExtensionContainersInType(type, extensions);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -231,6 +231,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _cachedLookup[name];
         }
 
+        internal sealed override void AddTypeMembersUnordered(ArrayBuilder<NamedTypeSymbol> builder)
+        {
+            foreach (var member in GetMembersUnordered())
+            {
+                if (member is NamedTypeSymbol typeMember)
+                    builder.Add(typeMember);
+            }
+        }
+
         internal sealed override ImmutableArray<NamedTypeSymbol> GetTypeMembersUnordered()
         {
             return ImmutableArray.CreateRange<NamedTypeSymbol>(GetMembersUnordered().OfType<NamedTypeSymbol>());

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
@@ -145,6 +145,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// Adds all members of this symbol that are types. The members may not be in a particular order, and the order
+        /// may not be stable from call-to-call.
+        /// </summary>
+        internal virtual void AddTypeMembersUnordered(ArrayBuilder<NamedTypeSymbol> builder)
+        {
+            // Default implemntation isn't optimized, and just uses ImmutableArray version for simplicity
+            builder.AddRange(GetTypeMembersUnordered());
+        }
+
+        /// <summary>
         /// Get all the members of this symbol that are types.
         /// </summary>
         /// <returns>An ImmutableArray containing all the types that are members of this symbol. If this symbol has no type members,

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
@@ -145,16 +145,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Adds all members of this symbol that are types. The members may not be in a particular order, and the order
-        /// may not be stable from call-to-call.
-        /// </summary>
-        internal virtual void AddTypeMembersUnordered(ArrayBuilder<NamedTypeSymbol> builder)
-        {
-            // Default implemntation isn't optimized, and just uses ImmutableArray version for simplicity
-            builder.AddRange(GetTypeMembersUnordered());
-        }
-
-        /// <summary>
         /// Get all the members of this symbol that are types.
         /// </summary>
         /// <returns>An ImmutableArray containing all the types that are members of this symbol. If this symbol has no type members,

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -355,26 +355,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal void GetExtensionContainers(ArrayBuilder<NamedTypeSymbol> extensions)
+        internal virtual void GetExtensionContainers(ArrayBuilder<NamedTypeSymbol> extensions)
         {
-            var builder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
-            this.AddTypeMembersUnordered(builder);
-            foreach (var type in builder)
+            foreach (var type in this.GetTypeMembersUnordered())
             {
                 if (!type.IsReferenceType || !type.IsStatic || type.IsGenericType || !type.MightContainExtensionMethods) continue;
 
-                var nestedBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
-                type.AddTypeMembersUnordered(nestedBuilder);
-                foreach (var nestedType in nestedBuilder)
+                foreach (var nestedType in type.GetTypeMembersUnordered())
                 {
                     if (nestedType.IsExtension)
                     {
                         extensions.Add(nestedType);
                     }
                 }
-                nestedBuilder.Free();
             }
-            builder.Free();
         }
 
         internal string QualifiedName

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -359,11 +359,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             foreach (var type in this.GetTypeMembersUnordered())
             {
-                AddExtensionContainersForType(type, extensions);
+                AddExtensionContainersInType(type, extensions);
             }
         }
 
-        protected void AddExtensionContainersForType(NamedTypeSymbol type, ArrayBuilder<NamedTypeSymbol> extensions)
+        protected void AddExtensionContainersInType(NamedTypeSymbol type, ArrayBuilder<NamedTypeSymbol> extensions)
         {
             if (!type.IsReferenceType || !type.IsStatic || type.IsGenericType || !type.MightContainExtensionMethods) return;
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -359,14 +359,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             foreach (var type in this.GetTypeMembersUnordered())
             {
-                if (!type.IsReferenceType || !type.IsStatic || type.IsGenericType || !type.MightContainExtensionMethods) continue;
+                AddExtensionContainersForType(type, extensions);
+            }
+        }
 
-                foreach (var nestedType in type.GetTypeMembersUnordered())
+        protected void AddExtensionContainersForType(NamedTypeSymbol type, ArrayBuilder<NamedTypeSymbol> extensions)
+        {
+            if (!type.IsReferenceType || !type.IsStatic || type.IsGenericType || !type.MightContainExtensionMethods) return;
+
+            foreach (var nestedType in type.GetTypeMembersUnordered())
+            {
+                if (nestedType.IsExtension)
                 {
-                    if (nestedType.IsExtension)
-                    {
-                        extensions.Add(nestedType);
-                    }
+                    extensions.Add(nestedType);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -357,18 +357,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal void GetExtensionContainers(ArrayBuilder<NamedTypeSymbol> extensions)
         {
-            foreach (var type in this.GetTypeMembersUnordered())
+            var builder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+            this.AddTypeMembersUnordered(builder);
+            foreach (var type in builder)
             {
                 if (!type.IsReferenceType || !type.IsStatic || type.IsGenericType || !type.MightContainExtensionMethods) continue;
 
-                foreach (var nestedType in type.GetTypeMembersUnordered())
+                var nestedBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+                type.AddTypeMembersUnordered(nestedBuilder);
+                foreach (var nestedType in nestedBuilder)
                 {
                     if (nestedType.IsExtension)
                     {
                         extensions.Add(nestedType);
                     }
                 }
+                nestedBuilder.Free();
             }
+            builder.Free();
         }
 
         internal string QualifiedName

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -365,6 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected void AddExtensionContainersInType(NamedTypeSymbol type, ArrayBuilder<NamedTypeSymbol> extensions)
         {
+            // Consider whether IsClassType could be used instead. Tracked by https://github.com/dotnet/roslyn/issues/78275
             if (!type.IsReferenceType || !type.IsStatic || type.IsGenericType || !type.MightContainExtensionMethods) return;
 
             foreach (var nestedType in type.GetTypeMembersUnordered())


### PR DESCRIPTION
Reduce allocations from executing NamespaceSymbol.GetExtensionContainers. This method accounts for 48% of allocations in our CodeAnalysis process during completion in our C# editing speedometer test. The changes in this PR reduce that to about 4.5%

The change here is to add an override of NamespaceSymbol.GetExtensionContainers to MergedNamespaceSymbol. Specifically, the base class implementation of GetExtensionContainers calls GetTypeMembersUnordered, which is inefficient when in a MergedNamespaceSymbol instance as it does a Linq OfType call and allocates an IA from that. Instead, the new override can just enumerate over the result of GetMembersUnordered directly, and do the check before calling into shared code with the base implementation.

*** Previous allocations during completion section of C# editing speedometer test ***
![image](https://github.com/user-attachments/assets/5fd1136a-2c2a-4229-bf6e-a87a9047a8f9)

*** New allocations in NamespaceSymbol.GetTypeMembersUnordered ***
![image](https://github.com/user-attachments/assets/d6a1f780-3621-4582-9e74-555837829fb4)

*** New allocations in MergedNamespaceSymbol.GetTypeMembersUnordered ***
![image](https://github.com/user-attachments/assets/b95a0ff2-2a83-4a22-bb01-4c704fab36e7)
