### PR TITLE
Small allocation improvement in AbstractRecommendationService.GetRecommendedSymbolsInContext

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -107,7 +107,7 @@ internal sealed class CrefCompletionProvider() : AbstractCrefCompletionProvider
             parentNode, cancellationToken).ConfigureAwait(false);
 
         var symbols = GetSymbols(token, semanticModel, cancellationToken)
-            .FilterToVisibleAndBrowsableSymbols(options.MemberDisplayOptions.HideAdvancedMembers, semanticModel.Compilation);
+            .FilterToVisibleAndBrowsableSymbols(options.MemberDisplayOptions.HideAdvancedMembers, semanticModel.Compilation, inclusionFilter: static s => true);
 
         return (token, semanticModel, symbols);
     }

--- a/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
@@ -91,7 +91,7 @@ internal sealed partial class AttributeSignatureHelpProvider : AbstractCSharpSig
 
         var accessibleConstructors = attributeType.InstanceConstructors
                                                   .WhereAsArray(c => c.IsAccessibleWithin(within))
-                                                  .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation)
+                                                  .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation, inclusionFilter: static s => true)
                                                   .Sort(semanticModel, attribute.SpanStart);
 
         if (!accessibleConstructors.Any())

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -96,7 +96,7 @@ internal sealed class ElementAccessExpressionSignatureHelpProvider : AbstractCSh
             return null;
         }
 
-        accessibleIndexers = accessibleIndexers.FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation)
+        accessibleIndexers = accessibleIndexers.FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation, inclusionFilter: static s => true)
                                                .Sort(semanticModel, expression.SpanStart);
 
         var structuralTypeDisplayService = document.GetRequiredLanguageService<IStructuralTypeDisplayService>();

--- a/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
@@ -119,7 +119,7 @@ internal partial class GenericNameSignatureHelpProvider : AbstractCSharpSignatur
         var accessibleSymbols =
             symbols.WhereAsArray(s => s.GetArity() > 0)
                    .WhereAsArray(s => s is INamedTypeSymbol or IMethodSymbol)
-                   .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation)
+                   .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation, inclusionFilter: static s => true)
                    .Sort(semanticModel, genericIdentifier.SpanStart);
 
         if (!accessibleSymbols.Any())

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
@@ -89,7 +89,7 @@ internal partial class InvocationExpressionSignatureHelpProviderBase : AbstractO
             .GetMemberGroup(invocationExpression.Expression, cancellationToken)
             .OfType<IMethodSymbol>()
             .ToImmutableArray()
-            .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation);
+            .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation, inclusionFilter: static s => true);
         methods = GetAccessibleMethods(invocationExpression, semanticModel, within, methods, cancellationToken);
         methods = methods.Sort(semanticModel, invocationExpression.SpanStart);
 

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.SymbolComputer.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.SymbolComputer.cs
@@ -123,7 +123,7 @@ internal static partial class ExtensionMethodImportCompletionHelper
 
                 var browsableSymbols = symbols
                     .ToImmutable()
-                    .FilterToVisibleAndBrowsableSymbols(hideAdvancedMembers, _originatingSemanticModel.Compilation);
+                    .FilterToVisibleAndBrowsableSymbols(hideAdvancedMembers, _originatingSemanticModel.Compilation, inclusionFilter: static s => true);
 
                 return (browsableSymbols, isPartialResult);
             }

--- a/src/Features/Core/Portable/SignatureHelp/CommonSignatureHelpUtilities.cs
+++ b/src/Features/Core/Portable/SignatureHelp/CommonSignatureHelpUtilities.cs
@@ -172,7 +172,7 @@ internal static class CommonSignatureHelpUtilities
         var addMethods = addSymbols.OfType<IMethodSymbol>()
                                    .Where(m => m.Parameters.Length >= 1)
                                    .ToImmutableArray()
-                                   .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation)
+                                   .FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation, inclusionFilter: static s => true)
                                    .Sort(semanticModel, position);
 
         return addMethods;

--- a/src/Workspaces/CSharp/Portable/ExternalAccess/Pythia/Api/PythiaSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/ExternalAccess/Pythia/Api/PythiaSymbolExtensions.cs
@@ -21,7 +21,7 @@ internal static class PythiaSymbolExtensions
         => Shared.Extensions.SymbolInfoExtensions.GetAnySymbol(info);
 
     public static ImmutableArray<T> FilterToVisibleAndBrowsableSymbols<T>(this ImmutableArray<T> symbols, bool hideAdvancedMembers, Compilation compilation) where T : ISymbol
-        => Shared.Extensions.ISymbolExtensions.FilterToVisibleAndBrowsableSymbols(symbols, hideAdvancedMembers, compilation);
+        => Shared.Extensions.ISymbolExtensions.FilterToVisibleAndBrowsableSymbols(symbols, hideAdvancedMembers, compilation, inclusionFilter: static s => true);
 
     public static bool IsAccessibleWithin(this ISymbol symbol, ISymbol within, ITypeSymbol? throughType = null)
         => Shared.Extensions.ISymbolExtensions.IsAccessibleWithin(symbol, within, throughType);

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -31,12 +29,9 @@ internal abstract partial class AbstractRecommendationService<
         var namedSymbols = result.NamedSymbols;
         var unnamedSymbols = result.UnnamedSymbols;
 
-        namedSymbols = namedSymbols.FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation);
-        unnamedSymbols = unnamedSymbols.FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation);
-
         var shouldIncludeSymbolContext = new ShouldIncludeSymbolContext(syntaxContext, cancellationToken);
-        namedSymbols = namedSymbols.WhereAsArray(shouldIncludeSymbolContext.ShouldIncludeSymbol);
-        unnamedSymbols = unnamedSymbols.WhereAsArray(shouldIncludeSymbolContext.ShouldIncludeSymbol);
+        namedSymbols = namedSymbols.FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation, shouldIncludeSymbolContext.ShouldIncludeSymbol);
+        unnamedSymbols = unnamedSymbols.FilterToVisibleAndBrowsableSymbols(options.HideAdvancedMembers, semanticModel.Compilation, shouldIncludeSymbolContext.ShouldIncludeSymbol);
 
         return new RecommendedSymbols(namedSymbols, unnamedSymbols);
     }
@@ -110,7 +105,7 @@ internal abstract partial class AbstractRecommendationService<
             if (_context.IsAttributeNameContext)
             {
                 return symbol.IsOrContainsAccessibleAttribute(
-                    _context.SemanticModel.GetEnclosingNamedType(_context.LeftToken.SpanStart, _cancellationToken),
+                    _context.SemanticModel.GetEnclosingNamedType(_context.LeftToken.SpanStart, _cancellationToken)!,
                     _context.SemanticModel.Compilation.Assembly,
                     _cancellationToken);
             }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -640,10 +640,11 @@ internal static partial class ISymbolExtensions
     /// This is useful for filtering out symbols that cannot be accessed in a given context due
     /// to the existence of overriding members. Second, remove remaining symbols that are
     /// unsupported (e.g. pointer types in VB) or not editor browsable based on the EditorBrowsable
-    /// attribute.
+    /// attribute. Finally, keep only remaining symbols which the given inclusionFilter indicates
+    /// should be included.
     /// </summary>
     public static ImmutableArray<T> FilterToVisibleAndBrowsableSymbols<T>(
-        this ImmutableArray<T> symbols, bool hideAdvancedMembers, Compilation compilation) where T : ISymbol
+        this ImmutableArray<T> symbols, bool hideAdvancedMembers, Compilation compilation, Func<T, bool> inclusionFilter) where T : ISymbol
     {
         if (symbols.Length == 0)
             return [];
@@ -672,8 +673,9 @@ internal static partial class ISymbolExtensions
             s.IsEditorBrowsable(
                 arg.hideAdvancedMembers,
                 arg.editorBrowsableInfo.Compilation,
-                arg.editorBrowsableInfo),
-            arg: (hideAdvancedMembers, editorBrowsableInfo, overriddenSymbols));
+                arg.editorBrowsableInfo) &&
+            arg.inclusionFilter(s),
+            arg: (hideAdvancedMembers, editorBrowsableInfo, overriddenSymbols, inclusionFilter));
 
         return filteredSymbols;
     }
@@ -681,7 +683,6 @@ internal static partial class ISymbolExtensions
     public static ImmutableArray<T> FilterToVisibleAndBrowsableSymbolsAndNotUnsafeSymbols<T>(
         this ImmutableArray<T> symbols, bool hideAdvancedMembers, Compilation compilation) where T : ISymbol
     {
-        return symbols.FilterToVisibleAndBrowsableSymbols(hideAdvancedMembers, compilation)
-            .WhereAsArray(s => !s.RequiresUnsafeModifier());
+        return symbols.FilterToVisibleAndBrowsableSymbols(hideAdvancedMembers, compilation, static s => !s.RequiresUnsafeModifier());
     }
 }


### PR DESCRIPTION
Reduce allocations in AbstractRecommendationService.GetRecommendedSymbolsInContext by realizing two immutable arrays only once instead of twice. Previously, FilterToVisibleAndBrowsableSymbols returned an IA and then we filtered it and realized it again via a call to WhereAsArray. Instead, modify FilterToVisibleAndBrowsableSymbols to take in a filter that it can use before realizing the array.

This change removes about 50 MB of allocations (~1%) in the C# completion section of the roslyn editing speedometer test

*** Previous allocations  ***
![image](https://github.com/user-attachments/assets/13c0c601-8785-4fca-aaaf-034d937120ed)

*** Allocations with this change ***
![image](https://github.com/user-attachments/assets/5380a4a4-ff33-4d06-8a60-6f9d8775e5dd)