### PR TITLE
Convert SyntaxNode.GetText users to instead retrieve the source text from the document

### DIFF
--- a/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
@@ -62,7 +62,7 @@ internal abstract class AbstractFormattingCodeFixProvider : SyntaxEditorBasedCod
     private async Task<Document> FixOneAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
     {
         var root = await context.Document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var text = root.GetText();
+        var text = await context.Document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
         // The span to format is the full line(s) containing the diagnostic
         var diagnosticSpan = diagnostic.Location.SourceSpan;

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicEditorNavigationBarItemService_CodeGeneration.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicEditorNavigationBarItemService_CodeGeneration.vb
@@ -31,7 +31,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Dim formattingOptions = Await document.GetLineFormattingOptionsAsync(cancellationToken).ConfigureAwait(False)
             Dim indentSize = formattingOptions.IndentationSize
 
-            Dim navigationPoint = NavigationPointHelpers.GetNavigationPoint(generatedTree.GetText(text.Encoding), indentSize, generatedNode)
+            Dim generatedText = Await newDocument.GetValueTextAsync(cancellationToken).ConfigureAwait(False)
+            Dim navigationPoint = NavigationPointHelpers.GetNavigationPoint(generatedText, indentSize, generatedNode)
 
             ' switch back to ui thread to actually perform the application and navigation
             Await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -253,7 +253,7 @@ internal abstract class AbstractInternalsVisibleToCompletionProvider : LSPComple
         var token = root.FindToken(result.Start);
         if (syntaxFacts.IsStringLiteral(token) || syntaxFacts.IsVerbatimStringLiteral(token))
         {
-            var text = root.GetText();
+            var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
             // Expand selection in both directions until a double quote or any line break character is reached
             static bool IsWordCharacter(char ch) => !(ch == '"' || TextUtilities.IsAnyLineBreakCharacter(ch));


### PR DESCRIPTION
Remove some of the SyntaxNode.GetText callers that were calling this on a root node, and instead switch them over to use Document.GetValueTextAsync instead. Each SyntaxNode.GetText call builds up a new SourceText from scratch. Instead, if Document.GetValueTextAsync is used, there is the potential for sharing the sourcetext with other document consumers.

This shows up as about a 50MB allocation improvement in VS under AbstractMemberInsertingCompletionProvider.RemoveDestinationNodeAsync in the override completion commit scenario in the C# editing speedometer.