### PR TITLE
*** WIP: Reduce allocations in CachingDictionary.CreateFullyPopulatedMap

### DIFF
--- a/src/Compilers/Core/Portable/Collections/CachingDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/CachingDictionary.cs
@@ -232,8 +232,13 @@ namespace Microsoft.CodeAnalysis.Collections
             {
                 foreach (var key in allKeys)
                 {
-                    // Copy non-empty values from the existing map
-                    ImmutableArray<TElement> elements = existingMap.GetOrAdd(key, _getElementsOfKey);
+                    // Copy non-empty values from the existing map. Otherwise, use _getElementsOfKey
+                    // to get the calculated value and don't bother to update existingMap.
+                    if (!existingMap.TryGetValue(key, out ImmutableArray<TElement> elements))
+                    {
+                        elements = _getElementsOfKey(key);
+                    }
+
                     Debug.Assert(elements != s_emptySentinel);
                     fullyPopulatedMap.Add(key, elements);
                 }


### PR DESCRIPTION
Created in draft mode and will not escalate out until I get back a test insertion with speedometer data to justify this change.

If that occurs, then I will update this PR to contain before / after allocation information to justify this change.