### PR TITLE
Update ICSharpCode.Decompiler to 9.1.0.7988

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -231,7 +231,7 @@
     <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3.net45" Version="$(SqliteVersion)" />
 
     <PackageVersion Include="Humanizer.Core" Version="$(HumanizerVersion)" />
-    <PackageVersion Include="ICSharpCode.Decompiler" Version="8.2.0.7535" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Elfie" Version="1.0.0" />
 
     <!--

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource;
 [UseExportProvider]
 public abstract partial class AbstractMetadataAsSourceTests : IAsyncLifetime
 {
-    protected static readonly string ICSharpCodeDecompilerVersion = "8.2.0.7535";
+    protected static readonly string ICSharpCodeDecompilerVersion = "9.1.0.7988";
 
     public virtual Task InitializeAsync()
     {

--- a/src/LanguageServer/Protocol/Features/DecompiledSource/AssemblyResolver.cs
+++ b/src/LanguageServer/Protocol/Features/DecompiledSource/AssemblyResolver.cs
@@ -49,12 +49,12 @@ internal sealed class AssemblyResolver : IAssemblyResolver
         }
     }
 
-    public Task<PEFile> ResolveAsync(IAssemblyReference name)
+    public Task<MetadataFile> ResolveAsync(IAssemblyReference name)
     {
         return Task.FromResult(Resolve(name));
     }
 
-    public Task<PEFile> ResolveModuleAsync(PEFile mainModule, string moduleName)
+    public Task<MetadataFile> ResolveModuleAsync(MetadataFile mainModule, string moduleName)
     {
         return Task.FromResult(ResolveModule(mainModule, moduleName));
     }
@@ -70,7 +70,7 @@ internal sealed class AssemblyResolver : IAssemblyResolver
         return null;
     }
 
-    public PEFile Resolve(IAssemblyReference name)
+    public MetadataFile Resolve(IAssemblyReference name)
     {
         Log("------------------");
         Log(FeaturesResources.Resolve_0, name.FullName);
@@ -147,7 +147,7 @@ internal sealed class AssemblyResolver : IAssemblyResolver
         }
     }
 
-    public PEFile ResolveModule(PEFile mainModule, string moduleName)
+    public MetadataFile ResolveModule(MetadataFile mainModule, string moduleName)
     {
         Log("-------------");
         Log(FeaturesResources.Resolve_module_0_of_1, moduleName, mainModule.FullName);


### PR DESCRIPTION
@dibarbet referring to https://github.com/dotnet/roslyn/pull/71837#issuecomment-2617967531
![image](https://github.com/user-attachments/assets/a4a965d7-794a-40b7-8b9c-b3d989d7f952)

There were no surprises in https://github.com/icsharpcode/ILSpy/releases/tag/v9.0, and we released https://github.com/icsharpcode/ILSpy/releases/tag/v9.1 with a couple more fixes. Now is a good time to update to the 9 series of the decompiler.