### PR TITLE
Dictionary expressions: extend support for key-value pairs to non-dictionary collections of `KeyValuePair<K, V>`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1133,12 +1133,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 LookupResultKind.Empty,
                                 symbols: [],
                                 childBoundNodes: [],
-                                elementType) { WasCompilerGenerated = true } :
+                                elementType)
+                            { WasCompilerGenerated = true } :
                             new BoundObjectCreationExpression(
                                 keyValuePairSyntax,
                                 keyValuePairConstructor.AsMember((NamedTypeSymbol)elementType),
                                 key,
-                                value) { WasCompilerGenerated = true };
+                                value)
+                            { WasCompilerGenerated = true };
                         return binder.BindCollectionInitializerElementAddMethod(
                             keyValuePairSyntax,
                             [keyValuePair],

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1111,7 +1111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         convertedElement = BindCollectionExpressionSpreadElement(
                             (SpreadElementSyntax)spreadElement.Syntax,
                             spreadElement,
-                            implicitReceiver!, // PROTOTYPE: We don't always need an implicit receiver here, and in fact it can be null.
+                            implicitReceiver,
                             static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
                             {
                                 // PROTOTYPE: This implementation is almost identical to the BoundExpression case above. The code should be shared.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1127,20 +1127,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                             keyType.Equals(key.Type, TypeCompareKind.AllIgnoreOptions) &&
                             valueType.Equals(value.Type, TypeCompareKind.AllIgnoreOptions));
 #endif
-                        BoundExpression keyValuePair = (keyValuePairConstructor is null) ?
-                            new BoundBadExpression(
+                        if (keyValuePairConstructor is null)
+                        {
+                            return new BoundBadExpression(
                                 keyValuePairSyntax,
                                 LookupResultKind.Empty,
                                 symbols: [],
-                                childBoundNodes: [],
+                                childBoundNodes: [key, value],
                                 elementType)
-                            { WasCompilerGenerated = true } :
-                            new BoundObjectCreationExpression(
-                                keyValuePairSyntax,
-                                keyValuePairConstructor.AsMember((NamedTypeSymbol)elementType),
-                                key,
-                                value)
                             { WasCompilerGenerated = true };
+                        }
+                        var keyValuePair = new BoundObjectCreationExpression(
+                            keyValuePairSyntax,
+                            keyValuePairConstructor.AsMember((NamedTypeSymbol)elementType),
+                            key,
+                            value)
+                        { WasCompilerGenerated = true };
                         return binder.BindCollectionInitializerElementAddMethod(
                             keyValuePairSyntax,
                             [keyValuePair],

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1171,7 +1171,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
                             {
                                 var keyValuePairSyntax = (KeyValuePairElementSyntax)keyValuePairElement.Syntax;
-                                var keyValuePairConstructor = (MethodSymbol?)GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairSyntax); // PROTOTYPE: Test missing constructor.
+                                var keyValuePairConstructor = (MethodSymbol?)GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairSyntax);
                                 var key = CreateConversion(keyValuePairElement.Key, keyConversion, elementKeyType, diagnostics);
                                 var value = CreateConversion(keyValuePairElement.Value, valueConversion, elementValueType, diagnostics);
                                 if (collectionInitializerAddMethodBinder is { })

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1070,7 +1070,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     builder.Add(convertedElement);
                 }
             }
-            else if (elementType is { } && ConversionsBase.TryGetCollectionKeyValuePairTypes(Compilation, collectionTypeKind, elementType) is (var elementKeyType, var elementValueType))
+            else if (elementType is { } && ConversionsBase.TryGetCollectionKeyValuePairTypes(Compilation, elementType) is (var elementKeyType, var elementValueType))
             {
                 var elementConversions = conversion.UnderlyingConversions;
 
@@ -2198,7 +2198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // Compare with similar loop in Conversions.GetCollectionExpressionConversion().
-                var keyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(Compilation, collectionTypeKind, elementType);
+                var keyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(Compilation, elementType);
                 var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 foreach (var element in elements)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1021,11 +1021,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol targetType,
             Conversion conversion,
             CollectionExpressionTypeKind collectionTypeKind,
-            TypeSymbol? elementType,
+            TypeSymbol elementType,
             BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
             MethodSymbol? setMethod,
             BindingDiagnosticBag diagnostics)
         {
+            Debug.Assert(elementType is { });
+
             var syntax = node.Syntax;
             var elements = node.Elements;
             var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
@@ -1042,6 +1044,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         case BoundCollectionExpressionWithElement:
                             continue;
                         case BoundCollectionExpressionSpreadElement spreadElement:
+                            // PROTOTYPE: Test with KeyValuePair<,> variance conversion.
                             convertedElement = BindCollectionExpressionSpreadElement(
                                 (SpreadElementSyntax)spreadElement.Syntax,
                                 spreadElement,
@@ -1058,6 +1061,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 diagnostics);
                             break;
                         case BoundExpression expressionElement:
+                            // PROTOTYPE: Test with KeyValuePair<,> variance conversion.
                             convertedElement = BindCollectionInitializerElementAddMethod(
                                 element.Syntax,
                                 [expressionElement],
@@ -1072,11 +1076,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     builder.Add(convertedElement);
                 }
             }
-            else if (elementType is { } && ConversionsBase.TryGetCollectionKeyValuePairTypes(Compilation, elementType) is (var elementKeyType, var elementValueType))
+            else if (ConversionsBase.TryGetCollectionKeyValuePairTypes(Compilation, elementType) is (var elementKeyType, var elementValueType))
             {
                 var elementConversions = conversion.UnderlyingConversions;
 
-                Debug.Assert(elementType is { });
                 Debug.Assert(elementConversions.All(c => c.Exists));
 
                 int conversionIndex = 0;
@@ -1174,8 +1177,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 var elementConversions = conversion.UnderlyingConversions;
-
-                Debug.Assert(elementType is { });
                 Debug.Assert(elementConversions.All(c => c.Exists));
 
                 int conversionIndex = 0;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 setMethod,
                 wasTargetTyped: true,
                 node,
-                ConvertCollectionExpressionElements(node, targetType, conversion, collectionTypeKind, elementType, implicitReceiver, setMethod, diagnostics),
+                ConvertCollectionExpressionElements(node, targetType, conversion, collectionTypeKind, elementType, implicitReceiver, diagnostics),
                 targetType)
             { WasCompilerGenerated = node.IsParamsArrayOrCollection, IsParamsArrayOrCollection = node.IsParamsArrayOrCollection };
         }
@@ -1023,7 +1023,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             CollectionExpressionTypeKind collectionTypeKind,
             TypeSymbol elementType,
             BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
-            MethodSymbol? setMethod,
             BindingDiagnosticBag diagnostics)
         {
             Debug.Assert(elementType is { });

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6604,8 +6604,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundCollectionExpressionSpreadElement BindCollectionExpressionSpreadElement<TArg>(
             SpreadElementSyntax syntax,
             BoundCollectionExpressionSpreadElement element,
-            BoundObjectOrCollectionValuePlaceholder implicitReceiver,
-            Func<Binder, ExpressionSyntax, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
+            BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
+            Func<Binder, ExpressionSyntax, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder?, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
             TArg arg,
             BindingDiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6623,10 +6623,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert(enumeratorInfo.ElementType is { }); // ElementType is set always, even for IEnumerable.
-            // We should use .WithSuppression(syntax.Expression.IsSuppressed) here, as in ConvertCollectionExpressionElements.bindSpreadElement(),
-            // but currently we're not reporting nullable warnings for spread elements generated through this method, so this is not observable.
-            // See https://github.com/dotnet/roslyn/issues/68786 and CollectionExpressionTests.Nullable_Spread_04.
-            var itemPlaceholder = new BoundValuePlaceholder(syntax, enumeratorInfo.ElementType);
+            var itemPlaceholder = new BoundValuePlaceholder(syntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
+            itemPlaceholder = (BoundValuePlaceholder)itemPlaceholder.WithSuppression(element.Expression.IsSuppressed);
             var item = bindItem(
                 this,
                 syntax.Expression,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -253,6 +253,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 var valueConversion = ClassifyImplicitConversionFromType(itemValueType, valueType, ref useSiteInfo);
                                 if (keyConversion.Exists && valueConversion.Exists)
                                 {
+                                    // If key and value conversions are both identity, GetCollectionExpressionSpreadElementConversion()
+                                    // should have returned an identity conversion.
+                                    Debug.Assert(!keyConversion.IsIdentity || !valueConversion.IsIdentity);
                                     return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
                                 }
                             }
@@ -287,6 +290,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var valueConversion = ClassifyImplicitConversionFromType(elementValueType, valueType, ref useSiteInfo);
                             if (keyConversion.Exists && valueConversion.Exists)
                             {
+                                // If key and value conversions are both identity, ClassifyImplicitConversionFromExpression()
+                                // should have returned an identity conversion for the entire expression.
+                                Debug.Assert(!keyConversion.IsIdentity || !valueConversion.IsIdentity);
                                 return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
                             }
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            var elementKeyValueTypes = TryGetCollectionKeyValuePairTypes(Compilation, collectionTypeKind, elementType);
+            var elementKeyValueTypes = TryGetCollectionKeyValuePairTypes(Compilation, elementType);
             var builder = ArrayBuilder<Conversion>.GetInstance(elements.Length);
             foreach (var element in elements)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1771,17 +1771,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static (TypeSymbol Key, TypeSymbol Value)? TryGetCollectionKeyValuePairTypes(
             CSharpCompilation compilation,
-            CollectionExpressionTypeKind collectionTypeKind,
             TypeSymbol elementType)
         {
-            // https://github.com/dotnet/roslyn/issues/77871: Should apply to any collection of KeyValuePair<,>, not just dictionaries.
-            if (collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer or CollectionExpressionTypeKind.DictionaryInterface)
+            if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureDictionaryExpressions) &&
+                IsKeyValuePairType(compilation, elementType, out var keyType, out var valueType))
             {
-                if (IsKeyValuePairType(compilation, elementType, out var keyType, out var valueType))
-                {
-                    return (keyType, valueType);
-                }
-                Debug.Assert(false);
+                return (keyType, valueType);
             }
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -692,7 +692,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         MakeSpreadElementTypeInferences(spread, targetElementType, ref useSiteInfo);
                         break;
                     case BoundKeyValuePairElement keyValuePairElement:
-                    case BoundKeyValuePairExpressionElement keyValuePairExpressionElement:
+                    case BoundKeyValuePairConversion keyValuePairConversion:
                         // https://github.com/dotnet/roslyn/issues/77873: Handle input type inference for key:value elements.
                         break;
                     default:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1921,6 +1921,8 @@
     <Field Name="CollectionCreation" Type="BoundExpression?" Null="allow" SkipInVisitor="true"/>
     <!-- Placeholder for collection builder elements span. -->
     <Field Name="CollectionBuilderSpanPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
+    <!-- Indexer setter, if any. -->
+    <Field Name="IndexerSetMethod" Type="MethodSymbol?" Null="allow"/>
     <!-- Indicates whether the collection expression was successfully target-typed (it is inside a conversion) -->
     <Field Name="WasTargetTyped" Type="bool" />
     <Field Name="UnconvertedCollectionExpression" Type="BoundUnconvertedCollectionExpression" Null="disallow" SkipInVisitor="true"/>
@@ -1951,22 +1953,22 @@
     <Field Name="Key" Type="BoundExpression"/>
     <!-- Value expression. -->
     <Field Name="Value" Type="BoundExpression"/>
-    <!-- Placeholder for Key in assignment. -->
-    <Field Name="KeyPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
-    <!-- Placeholder for Value in assignment. -->
-    <Field Name="ValuePlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
-    <!-- Indexer assignment of key:value pair to containing dictionary. -->
-    <Field Name="IndexerAssignment" Type="BoundExpression?" SkipInVisitor="true" Null="allow"/>
   </Node>
 
-  <!-- An expression element of KeyValuePair&lt;,&gt; type in a collection expression where the target type is a collection of KeyValuePair&lt;,&gt;. -->
-  <Node Name="BoundKeyValuePairExpressionElement" Base="BoundNode">
+  <!-- A KeyValuePair&lt;,&gt; with key and value conversions. -->
+  <Node Name="BoundKeyValuePairConversion" Base="BoundExpression">
+    <!-- Non-null type is required for this node kind -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <!-- Expression. -->
     <Field Name="Expression" Type="BoundExpression"/>
-    <!-- Placeholder for Expression in assignment. -->
-    <Field Name="ExpressionPlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
-    <!-- Indexer assignment of Key and Value properties of Expression to containing dictionary. -->
-    <Field Name="IndexerAssignment" Type="BoundExpression" SkipInVisitor="true"/>
+    <!-- Placeholder for Expression.Key in KeyConversion. -->
+    <Field Name="KeyPlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
+    <!-- Placeholder for Expression.Value in ValueConversion. -->
+    <Field Name="ValuePlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
+    <!-- Key conversion. -->
+    <Field Name="KeyConversion" Type="BoundExpression" SkipInVisitor="true"/>
+    <!-- Value conversion. -->
+    <Field Name="ValueConversion" Type="BoundExpression" SkipInVisitor="true"/>
   </Node>
 
   <!-- Unconverted collection expression arguments. -->

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2120,7 +2120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitKeyValuePairExpressionElement(BoundKeyValuePairExpressionElement node)
+        public override BoundNode VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
         {
             VisitRvalue(node.Expression);
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3874,8 +3874,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         VisitRvalue(keyValuePair.Value);
                         // https://github.com/dotnet/roslyn/issues/77875: Check nullability from conversions of key and value.
                         break;
-                    case BoundKeyValuePairExpressionElement keyValuePairExpressionElement:
-                        VisitRvalue(keyValuePairExpressionElement.Expression);
+                    case BoundKeyValuePairConversion keyValuePairConversion:
+                        VisitRvalue(keyValuePairConversion);
                         // https://github.com/dotnet/roslyn/issues/77875: Check nullability from conversions of key and value.
                         break;
                     default:
@@ -3998,6 +3998,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(node.EnumeratorInfoOpt is null);
             }
 
+            return null;
+        }
+
+        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
+        {
+            VisitRvalue(node.Expression);
+            SetUnknownResultNullability(node);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -1430,7 +1430,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(key.Type is { });
             Debug.Assert(value.Type is { });
 
-            // PROTOTYPE: Test missing KeyValuePair<K, V> constructor. Should only be reported when using k:v or a KVP conversion.
             var constructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor));
             var type = constructor.ContainingType.Construct(key.Type, value.Type);
             constructor = constructor.AsMember(type);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -1398,7 +1398,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             localsBuilder.Add(exprTemp);
             sideEffects.Add(assignmentToTemp);
 
-            // PROTOTYPE: Test with element that has side effects.
             AddPlaceholderReplacement(keyValuePairConversion.KeyPlaceholder, GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key));
             rewrittenKeyConversion = VisitExpression(keyValuePairConversion.KeyConversion);
             RemovePlaceholderReplacement(keyValuePairConversion.KeyPlaceholder);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -1278,6 +1278,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // dictionary[(TKey)element.Key] = (TValue)element.Value;
                         assignItemFromKeyValuePairConversion(keyValuePairConversion, dictionaryTemp, setMethod, localsBuilder, sideEffects);
                         break;
+                    case BoundExpression expressionElement:
+                        // dictionary[element.Key] = element.Value;
+                        assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                        break;
                     case BoundCollectionExpressionSpreadElement spreadElement:
                         {
                             var rewrittenExpression = VisitExpression(spreadElement.Expression);
@@ -1310,10 +1314,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 });
                             sideEffects.Add(rewrittenElement);
                         }
-                        break;
-                    case BoundExpression expressionElement:
-                        // dictionary[element.Key] = element.Value;
-                        assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
                         break;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(element);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -706,7 +706,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node is { Elements: [BoundCollectionExpressionSpreadElement { Expression: { } spreadExpression } spreadElement] }
                 && spreadElement.IteratorBody is BoundExpressionStatement expressionStatement)
             {
-                var spreadElementHasIdentityConversion = expressionStatement.Expression is not BoundConversion;
+                var spreadElementHasIdentityConversion = expressionStatement.Expression is not (BoundConversion or BoundKeyValuePairConversion);
                 var spreadTypeOriginalDefinition = spreadExpression.Type!.OriginalDefinition;
 
                 if (spreadElementHasIdentityConversion
@@ -1508,8 +1508,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         rewrittenExpression,
                         iteratorBody =>
                         {
-                            // PROTOTYPE: Are we testing this with BoundKeyValuePairConversion?
-                            var rewrittenValue = VisitExpression(((BoundExpressionStatement)iteratorBody).Expression);
+                            var rewrittenValue = RewriteNonSpreadElement(((BoundExpressionStatement)iteratorBody).Expression);
                             var builder = ArrayBuilder<BoundExpression>.GetInstance();
                             addElement(builder, rewrittenReceiver, rewrittenValue, false);
                             var statements = builder.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -1451,6 +1451,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(key.Type is { });
             Debug.Assert(value.Type is { });
 
+            // PROTOTYPE: Test missing KeyValuePair<K, V> constructor. Should only be reported when using k:v or a KVP conversion.
             var constructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor));
             var type = constructor.ContainingType.Construct(key.Type, value.Type);
             constructor = constructor.AsMember(type);

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1282,7 +1282,7 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isImplicit = element.WasCompilerGenerated;
             var elementType = element.EnumeratorInfoOpt?.ElementType.GetPublicSymbol();
             // https://github.com/dotnet/roslyn/issues/77872: For key-value pairs, we probably need a pair of conversions rather a single conversion.
-            var elementConversion = iteratorItem is BoundKeyValuePairConversion ?
+            var elementConversion = iteratorItem is BoundKeyValuePairConversion or BoundConversion { Operand: BoundKeyValuePairConversion } ?
                 Conversion.Identity :
                 BoundNode.GetConversion(iteratorItem, element.ElementPlaceholder);
             return new SpreadOperation(

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.TypeOrValueExpression:
                 case BoundKind.KeyValuePairElement: // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
                 case BoundKind.CollectionExpressionWithElement: // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
-                case BoundKind.KeyValuePairExpressionElement: // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
+                case BoundKind.KeyValuePairConversion: // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
                     ConstantValue? constantValue = (boundNode as BoundExpression)?.ConstantValueOpt;
                     bool isImplicit = boundNode.WasCompilerGenerated;
 
@@ -1267,7 +1267,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 BoundCollectionExpressionWithElement withElement => Create(withElement),
                 BoundCollectionExpressionSpreadElement spreadElement => CreateBoundCollectionExpressionSpreadElement(expr, spreadElement),
                 BoundKeyValuePairElement keyValuePairElement => Create(keyValuePairElement),
-                BoundKeyValuePairExpressionElement keyValuePairExpressionElement => Create(keyValuePairExpressionElement),
+                BoundKeyValuePairConversion keyValuePairConversion => Create(keyValuePairConversion),
                 _ => Create(Binder.GetUnderlyingCollectionExpressionElement(expr, (BoundExpression)element, throwOnErrors: false))
             };
         }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1282,7 +1282,7 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isImplicit = element.WasCompilerGenerated;
             var elementType = element.EnumeratorInfoOpt?.ElementType.GetPublicSymbol();
             // https://github.com/dotnet/roslyn/issues/77872: For key-value pairs, we probably need a pair of conversions rather a single conversion.
-            var elementConversion = (expr.CollectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer or CollectionExpressionTypeKind.DictionaryInterface) ?
+            var elementConversion = iteratorItem is BoundKeyValuePairConversion ?
                 Conversion.Identity :
                 BoundNode.GetConversion(iteratorItem, element.ElementPlaceholder);
             return new SpreadOperation(

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -4531,15 +4531,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 """;
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (9,31): warning CS8601: Possible null reference assignment.
+                // (9,29): warning CS8601: Possible null reference assignment.
                 //         object[] ab = [..a, ..b]; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b").WithLocation(9, 31),
-                // (10,26): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..b").WithLocation(9, 29),
+                // (10,24): warning CS8601: Possible null reference assignment.
                 //         object[] bb = [..b, ..b]; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b").WithLocation(10, 26),
-                // (10,31): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..b").WithLocation(10, 24),
+                // (10,29): warning CS8601: Possible null reference assignment.
                 //         object[] bb = [..b, ..b]; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b").WithLocation(10, 31));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..b").WithLocation(10, 29));
         }
 
         [Fact]
@@ -4562,15 +4562,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 """;
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (10,44): warning CS8619: Nullability of reference types in value of type 'IEnumerable<string?>' doesn't match target type 'IEnumerable<object>'.
+                // (10,42): warning CS8619: Nullability of reference types in value of type 'IEnumerable<string?>' doesn't match target type 'IEnumerable<object>'.
                 //         IEnumerable<object>[] ab = [..a, ..b]; // 1
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b").WithArguments("System.Collections.Generic.IEnumerable<string?>", "System.Collections.Generic.IEnumerable<object>").WithLocation(10, 44),
-                // (11,39): warning CS8619: Nullability of reference types in value of type 'IEnumerable<string?>' doesn't match target type 'IEnumerable<object>'.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "..b").WithArguments("System.Collections.Generic.IEnumerable<string?>", "System.Collections.Generic.IEnumerable<object>").WithLocation(10, 42),
+                // (11,37): warning CS8619: Nullability of reference types in value of type 'IEnumerable<string?>' doesn't match target type 'IEnumerable<object>'.
                 //         IEnumerable<object>[] bb = [..b, ..b]; // 2
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b").WithArguments("System.Collections.Generic.IEnumerable<string?>", "System.Collections.Generic.IEnumerable<object>").WithLocation(11, 39),
-                // (11,44): warning CS8619: Nullability of reference types in value of type 'IEnumerable<string?>' doesn't match target type 'IEnumerable<object>'.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "..b").WithArguments("System.Collections.Generic.IEnumerable<string?>", "System.Collections.Generic.IEnumerable<object>").WithLocation(11, 37),
+                // (11,42): warning CS8619: Nullability of reference types in value of type 'IEnumerable<string?>' doesn't match target type 'IEnumerable<object>'.
                 //         IEnumerable<object>[] bb = [..b, ..b]; // 2
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b").WithArguments("System.Collections.Generic.IEnumerable<string?>", "System.Collections.Generic.IEnumerable<object>").WithLocation(11, 44));
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "..b").WithArguments("System.Collections.Generic.IEnumerable<string?>", "System.Collections.Generic.IEnumerable<object>").WithLocation(11, 42));
         }
 
         [Fact]
@@ -14233,9 +14233,9 @@ namespace System
                 }
                 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (5,21): warning CS8601: Possible null reference assignment.
+                // (5,19): warning CS8601: Possible null reference assignment.
                 //     object[] b = [..a];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "a").WithLocation(5, 21));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..a").WithLocation(5, 19));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75560")]
@@ -14278,9 +14278,9 @@ namespace System
                 bool m() => throw null!;
                 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (6,22): warning CS8601: Possible null reference assignment.
+                // (6,19): warning CS8601: Possible null reference assignment.
                 //     object[] b = [..(m() ? a1 : a2)];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "m() ? a1 : a2").WithLocation(6, 22));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..(m() ? a1 : a2)").WithLocation(6, 19));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75560")]
@@ -43474,12 +43474,12 @@ class Program
                 // (11,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object x = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(11, 20),
-                // (13,25): warning CS8601: Possible null reference assignment.
+                // (13,23): warning CS8601: Possible null reference assignment.
                 //         object[] z = [..y];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(13, 25),
-                // (14,16): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..y").WithLocation(13, 23),
+                // (14,14): warning CS8601: Possible null reference assignment.
                 //         z = [..y];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(14, 16));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..y").WithLocation(14, 14));
         }
 
         [Fact]
@@ -43501,9 +43501,9 @@ class Program
                 """;
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (8,37): warning CS8601: Possible null reference assignment.
+                // (8,35): warning CS8601: Possible null reference assignment.
                 //         IEnumerable<object> y1 = [..x1];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(8, 37));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..x1").WithLocation(8, 35));
         }
 
         [Fact]
@@ -43579,9 +43579,9 @@ class Program
                 // (14,14): warning CS8601: Possible null reference assignment.
                 //         z = [x, ..F(x)];
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x").WithLocation(14, 14),
-                // (14,19): warning CS8601: Possible null reference assignment.
+                // (14,17): warning CS8601: Possible null reference assignment.
                 //         z = [x, ..F(x)];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "F(x)").WithLocation(14, 19),
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "..F(x)").WithLocation(14, 17),
                 // (16,26): warning CS8604: Possible null reference argument for parameter 'x' in 'IEnumerable<string> Program.F<string>(string x)'.
                 //         z = [..F<string>(x)];
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("x", "IEnumerable<string> Program.F<string>(string x)").WithLocation(16, 26));

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
@@ -2997,7 +2997,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             else
             {
-                var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
+                var verifier = CompileAndVerify(
+                    comp,
+                    verify: Verification.Skipped,
+                    expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
                 verifier.VerifyDiagnostics();
             }
         }
@@ -3097,7 +3100,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             else
             {
-                var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
+                var verifier = CompileAndVerify(
+                    comp,
+                    verify: Verification.Skipped,
+                    expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
                 verifier.VerifyDiagnostics();
             }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
@@ -1380,79 +1380,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyEmitDiagnostics();
 
             comp = CreateCompilation(source);
-            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_KeyValuePair_KV);
-            comp.VerifyEmitDiagnostics(
-                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
-                // d = [];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(3, 5),
-                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
-                // d = [];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(3, 5),
-                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(4, 5),
-                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(4, 5),
-                // (4,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"1:""one""").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(4, 6));
-
-            comp = CreateCompilation(source);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
             comp.VerifyEmitDiagnostics(
-                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
-                // d = [];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(3, 5),
-                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(4, 5),
-                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
                 // d = [new KeyValuePair<int, string>(2, "two")];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 5),
-                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
                 // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 5));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 9));
 
             comp = CreateCompilation(source);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
             comp.VerifyEmitDiagnostics(
-                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
-                // d = [];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(3, 5),
-                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(4, 5),
-                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
                 // d = [new KeyValuePair<int, string>(2, "two")];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 5),
-                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
                 // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 5));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 9));
 
             comp = CreateCompilation(source);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
-            if (typeName.Contains("<int, string>"))
-            {
-                // PROTOTYPE: Should we really require KeyValuePair<,>..ctor() here?
-                comp.VerifyEmitDiagnostics(
-                    // (4,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
-                    // d = [1:"one"];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"1:""one""").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(4, 6));
-            }
-            else
-            {
-                comp.VerifyEmitDiagnostics(
-                    // (4,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
-                    // d = [1:"one"];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"1:""one""").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(4, 6),
-                    // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
-                    // d = [new KeyValuePair<int, string>(2, "two")];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(5, 6),
-                    // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
-                    // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(6, 9));
-            }
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -1484,65 +1433,65 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyEmitDiagnostics();
 
             comp = CreateCompilation(sourceB, references: [refA]);
-            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_KeyValuePair_KV);
-            comp.VerifyEmitDiagnostics(
-                // (4,5): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[1:""one""]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(4, 5),
-                // (4,6): error CS9500: Collection expression type 'MyDictionary<int, string>' does not support key-value pair elements.
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"1:""one""").WithArguments("MyDictionary<int, string>").WithLocation(4, 6),
-                // (5,5): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
-                // d = [new KeyValuePair<int, string>(2, "two")];
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(5, 5),
-                // (6,5): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
-                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(6, 5));
-
-            comp = CreateCompilation(sourceB, references: [refA]);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
             comp.VerifyEmitDiagnostics(
-                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
-                // d = [];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(3, 5),
-                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(4, 5),
-                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
                 // d = [new KeyValuePair<int, string>(2, "two")];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 5),
-                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
                 // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 5));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 9));
 
             comp = CreateCompilation(sourceB, references: [refA]);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
             comp.VerifyEmitDiagnostics(
-                // (3,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
-                // d = [];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(3, 5),
-                // (4,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(4, 5),
-                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
                 // d = [new KeyValuePair<int, string>(2, "two")];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 5),
-                // (6,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
                 // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[.. new KeyValuePair<int, string>[] { new(3, ""three"") }]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 5));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 9));
 
             comp = CreateCompilation(sourceB, references: [refA]);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
-            comp.VerifyEmitDiagnostics(
-                // (4,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
-                // d = [1:"one"];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"1:""one""").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(4, 6));
+            comp.VerifyEmitDiagnostics();
         }
 
         [Theory]
-        [InlineData("KeyValuePair<int?, object>[]")]
-        [InlineData("List<KeyValuePair<int?, object>>")]
-        public void KeyValuePair_MissingMember_NonDictionary(string typeName)
+        [CombinatorialData]
+        public void KeyValuePair_MissingMember_NonDictionary_01(
+            [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues("KeyValuePair<int, string>[]", "List<KeyValuePair<int, string>>")] string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                {{typeName}} d;
+                d = [];
+                d = [new KeyValuePair<int, string>(2, "two")];
+                d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                """;
+
+            var parseOptions = TestOptions.Regular.WithLanguageVersion(languageVersion);
+            var comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePair_MissingMember_NonDictionary_02(
+            [CombinatorialValues("KeyValuePair<int?, object>[]", "List<KeyValuePair<int?, object>>")] string typeName)
         {
             string source = $$"""
                 using System.Collections.Generic;
@@ -1559,16 +1508,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp = CreateCompilation(source);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
             comp.VerifyEmitDiagnostics(
-                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
                 // d = [new KeyValuePair<int, string>(2, "two")];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 5));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 9));
 
             comp = CreateCompilation(source);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
             comp.VerifyEmitDiagnostics(
-                // (5,5): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
                 // d = [new KeyValuePair<int, string>(2, "two")];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[new KeyValuePair<int, string>(2, ""two"")]").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 5));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 9));
 
             comp = CreateCompilation(source);
             comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
@@ -2776,7 +2731,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 [sourceA, s_collectionExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            // PROTOTYPE: Support KeyValuePair<,> variance with params?
+            // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#support-keyvaluepair-variance-with-params: Support KeyValuePair<,> variance with params?
             comp.VerifyEmitDiagnostics(
                 // (9,40): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
                 //         /*<bind>*/Params<int?, object>(x)/*</bind>*/;
@@ -3128,7 +3083,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 references: [refA],
                 targetFramework: TargetFramework.Net80);
-            // PROTOTYPE: Support KeyValuePair<,> variance with params?
+            // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#support-keyvaluepair-variance-with-params: Support KeyValuePair<,> variance with params?
             comp.VerifyEmitDiagnostics(
                 // (9,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
                 //         Params<int?, object>(x);

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
@@ -2221,10 +2221,69 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 if (typeName == "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>")
                 {
                     verifier.VerifyIL("Program.Spread1", """
-                        ...
+                        {
+                          // Code size       12 (0xc)
+                          .maxstack  1
+                          IL_0000:  ldarg.0
+                          IL_0001:  call       "System.Collections.Generic.KeyValuePair<int, string>[] System.Linq.Enumerable.ToArray<System.Collections.Generic.KeyValuePair<int, string>>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                          IL_0006:  newobj     "<>z__ReadOnlyArray<System.Collections.Generic.KeyValuePair<int, string>>..ctor(System.Collections.Generic.KeyValuePair<int, string>[])"
+                          IL_000b:  ret
+                        }
                         """);
                     verifier.VerifyIL("Program.Spread2", """
-                        ...
+                        {
+                          // Code size       82 (0x52)
+                          .maxstack  4
+                          .locals init (int V_0,
+                                        System.Collections.Generic.KeyValuePair<int?, object>[] V_1,
+                                        System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                        int V_3,
+                                        System.Collections.Generic.KeyValuePair<int, string> V_4,
+                                        System.Collections.Generic.KeyValuePair<int, string> V_5)
+                          IL_0000:  ldarg.0
+                          IL_0001:  ldc.i4.0
+                          IL_0002:  stloc.0
+                          IL_0003:  dup
+                          IL_0004:  ldlen
+                          IL_0005:  conv.i4
+                          IL_0006:  newarr     "System.Collections.Generic.KeyValuePair<int?, object>"
+                          IL_000b:  stloc.1
+                          IL_000c:  stloc.2
+                          IL_000d:  ldc.i4.0
+                          IL_000e:  stloc.3
+                          IL_000f:  br.s       IL_0045
+                          IL_0011:  ldloc.2
+                          IL_0012:  ldloc.3
+                          IL_0013:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                          IL_0018:  stloc.s    V_4
+                          IL_001a:  ldloc.1
+                          IL_001b:  ldloc.0
+                          IL_001c:  ldloc.s    V_4
+                          IL_001e:  stloc.s    V_5
+                          IL_0020:  ldloca.s   V_5
+                          IL_0022:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                          IL_0027:  newobj     "int?..ctor(int)"
+                          IL_002c:  ldloca.s   V_5
+                          IL_002e:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                          IL_0033:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                          IL_0038:  stelem     "System.Collections.Generic.KeyValuePair<int?, object>"
+                          IL_003d:  ldloc.0
+                          IL_003e:  ldc.i4.1
+                          IL_003f:  add
+                          IL_0040:  stloc.0
+                          IL_0041:  ldloc.3
+                          IL_0042:  ldc.i4.1
+                          IL_0043:  add
+                          IL_0044:  stloc.3
+                          IL_0045:  ldloc.3
+                          IL_0046:  ldloc.2
+                          IL_0047:  ldlen
+                          IL_0048:  conv.i4
+                          IL_0049:  blt.s      IL_0011
+                          IL_004b:  ldloc.1
+                          IL_004c:  newobj     "<>z__ReadOnlyArray<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>[])"
+                          IL_0051:  ret
+                        }
                         """);
                 }
             }
@@ -2248,8 +2307,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                       ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null) (Syntax: '..s')
                         Operand:
                           IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) (Syntax: 's')
-                        ElementConversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                          (NoConversion)
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
                 """);
         }
 
@@ -2281,6 +2340,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var verifier = CompileAndVerify(
                 [source, s_collectionExtensions],
                 targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
                 expectedOutput: IncludeExpectedOutput("[[3, three]], "));
             verifier.VerifyDiagnostics();
             string expectedIL = typeName switch
@@ -2336,13 +2396,170 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     }
                     """,
                 "System.Collections.Generic.KeyValuePair<K, V>[]" => """
-                    ...
+                    {
+                      // Code size       92 (0x5c)
+                      .maxstack  4
+                      .locals init (int V_0,
+                                    System.Collections.Generic.KeyValuePair<KBase, VBase>[] V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_5)
+                      IL_0000:  ldarg.0
+                      IL_0001:  ldc.i4.0
+                      IL_0002:  stloc.0
+                      IL_0003:  dup
+                      IL_0004:  ldlen
+                      IL_0005:  conv.i4
+                      IL_0006:  newarr     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_000b:  stloc.1
+                      IL_000c:  stloc.2
+                      IL_000d:  ldc.i4.0
+                      IL_000e:  stloc.3
+                      IL_000f:  br.s       IL_0054
+                      IL_0011:  ldloc.2
+                      IL_0012:  ldloc.3
+                      IL_0013:  ldelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0018:  stloc.s    V_4
+                      IL_001a:  ldloc.1
+                      IL_001b:  ldloc.0
+                      IL_001c:  ldloc.s    V_4
+                      IL_001e:  stloc.s    V_5
+                      IL_0020:  ldloca.s   V_5
+                      IL_0022:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0027:  box        "K"
+                      IL_002c:  unbox.any  "KBase"
+                      IL_0031:  ldloca.s   V_5
+                      IL_0033:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0038:  box        "V"
+                      IL_003d:  unbox.any  "VBase"
+                      IL_0042:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                      IL_0047:  stelem     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_004c:  ldloc.0
+                      IL_004d:  ldc.i4.1
+                      IL_004e:  add
+                      IL_004f:  stloc.0
+                      IL_0050:  ldloc.3
+                      IL_0051:  ldc.i4.1
+                      IL_0052:  add
+                      IL_0053:  stloc.3
+                      IL_0054:  ldloc.3
+                      IL_0055:  ldloc.2
+                      IL_0056:  ldlen
+                      IL_0057:  conv.i4
+                      IL_0058:  blt.s      IL_0011
+                      IL_005a:  ldloc.1
+                      IL_005b:  ret
+                    }
                     """,
                 "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>" => """
-                    ...
+                    {
+                      // Code size      111 (0x6f)
+                      .maxstack  4
+                      .locals init (int V_0,
+                                    System.Collections.Generic.KeyValuePair<KBase, VBase>[] V_1,
+                                    System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator V_2,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4)
+                      IL_0000:  ldarg.0
+                      IL_0001:  ldc.i4.0
+                      IL_0002:  stloc.0
+                      IL_0003:  dup
+                      IL_0004:  callvirt   "int System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Count.get"
+                      IL_0009:  newarr     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_000e:  stloc.1
+                      IL_000f:  callvirt   "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_0014:  stloc.2
+                      .try
+                      {
+                        IL_0015:  br.s       IL_0054
+                        IL_0017:  ldloca.s   V_2
+                        IL_0019:  call       "System.Collections.Generic.KeyValuePair<K, V> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.Current.get"
+                        IL_001e:  stloc.3
+                        IL_001f:  ldloc.1
+                        IL_0020:  ldloc.0
+                        IL_0021:  ldloc.3
+                        IL_0022:  stloc.s    V_4
+                        IL_0024:  ldloca.s   V_4
+                        IL_0026:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                        IL_002b:  box        "K"
+                        IL_0030:  unbox.any  "KBase"
+                        IL_0035:  ldloca.s   V_4
+                        IL_0037:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                        IL_003c:  box        "V"
+                        IL_0041:  unbox.any  "VBase"
+                        IL_0046:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                        IL_004b:  stelem     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                        IL_0050:  ldloc.0
+                        IL_0051:  ldc.i4.1
+                        IL_0052:  add
+                        IL_0053:  stloc.0
+                        IL_0054:  ldloca.s   V_2
+                        IL_0056:  call       "bool System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.MoveNext()"
+                        IL_005b:  brtrue.s   IL_0017
+                        IL_005d:  leave.s    IL_006d
+                      }
+                      finally
+                      {
+                        IL_005f:  ldloca.s   V_2
+                        IL_0061:  constrained. "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator"
+                        IL_0067:  callvirt   "void System.IDisposable.Dispose()"
+                        IL_006c:  endfinally
+                      }
+                      IL_006d:  ldloc.1
+                      IL_006e:  ret
+                    }
                     """,
                 "System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>" => """
-                    ...
+                    {
+                      // Code size      106 (0x6a)
+                      .maxstack  4
+                      .locals init (System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>> V_0,
+                                    int V_1,
+                                    System.Collections.Generic.KeyValuePair<KBase, VBase>[] V_2,
+                                    System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_5)
+                      IL_0000:  ldarg.0
+                      IL_0001:  stloc.0
+                      IL_0002:  ldc.i4.0
+                      IL_0003:  stloc.1
+                      IL_0004:  ldloca.s   V_0
+                      IL_0006:  call       "int System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Length.get"
+                      IL_000b:  newarr     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_0010:  stloc.2
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  call       "System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_0018:  stloc.3
+                      IL_0019:  br.s       IL_005f
+                      IL_001b:  ldloca.s   V_3
+                      IL_001d:  call       "ref readonly System.Collections.Generic.KeyValuePair<K, V> System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.Current.get"
+                      IL_0022:  ldobj      "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0027:  stloc.s    V_4
+                      IL_0029:  ldloc.2
+                      IL_002a:  ldloc.1
+                      IL_002b:  ldloc.s    V_4
+                      IL_002d:  stloc.s    V_5
+                      IL_002f:  ldloca.s   V_5
+                      IL_0031:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0036:  box        "K"
+                      IL_003b:  unbox.any  "KBase"
+                      IL_0040:  ldloca.s   V_5
+                      IL_0042:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0047:  box        "V"
+                      IL_004c:  unbox.any  "VBase"
+                      IL_0051:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                      IL_0056:  stelem     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_005b:  ldloc.1
+                      IL_005c:  ldc.i4.1
+                      IL_005d:  add
+                      IL_005e:  stloc.1
+                      IL_005f:  ldloca.s   V_3
+                      IL_0061:  call       "bool System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.MoveNext()"
+                      IL_0066:  brtrue.s   IL_001b
+                      IL_0068:  ldloc.2
+                      IL_0069:  ret
+                    }
                     """,
                 _ => throw ExceptionUtilities.UnexpectedValue(typeName),
             };
@@ -2379,21 +2596,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 [sourceA, s_collectionExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13)
-            {
-                comp.VerifyEmitDiagnostics(
-                    // (9,40): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
-                    //         /*<bind>*/Params<int?, object>(x)/*</bind>*/;
-                    Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(9, 40));
-            }
-            else
-            {
-                var verifier = CompileAndVerify(comp, expectedOutput: "[[2, two]], [[2, two]], [[2, two]], ");
-                verifier.VerifyDiagnostics();
-                verifier.VerifyIL("Program.Main", """
-                    ...
-                    """);
-            }
+            // PROTOTYPE: Support KeyValuePair<,> variance with params?
+            comp.VerifyEmitDiagnostics(
+                // (9,40): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         /*<bind>*/Params<int?, object>(x)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(9, 40));
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2610,7 +2817,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             else
             {
-                var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[1:one, 2:two, 3:three], "));
+                var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
                 verifier.VerifyDiagnostics();
             }
         }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
@@ -1838,7 +1838,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Theory]
         [CombinatorialData]
-        public void KeyValuePairConversions_09(
+        public void KeyValuePairConversions_KeyValueElement(
             [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             [CombinatorialValues(
                 "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
@@ -1848,20 +1848,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string typeName1 = typeName.Replace("K, V", "int, string");
             string typeName2 = typeName.Replace("K, V", "int?, object");
             string source = $$"""
-                using System.Collections.Generic;
                 class Program
                 {
                     static void Main()
                     {
                         int k = 1;
                         string v = "one";
-                        {{typeName1}} c1;
-                        c1 = [k:v];
-                        c1.Report();
-                        {{typeName2}} c2;
-                        c2 = /*<bind>*/[k:v]/*</bind>*/;
-                        c2.Report();
+                        KeyValue1(k, v).Report();
+                        KeyValue2(k, v).Report();
                     }
+                    static {{typeName1}} KeyValue1(int k, string v) =>
+                        [k:v];
+                    static {{typeName2}} KeyValue2(int k, string v) =>
+                        /*<bind>*/[k:v]/*</bind>*/;
                 }
                 """;
             var comp = CreateCompilation(
@@ -1871,23 +1870,49 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             if (languageVersion == LanguageVersion.CSharp12)
             {
                 comp.VerifyEmitDiagnostics(
-                    // (9,15): error CS9300: Collection expression type 'IEnumerable<KeyValuePair<int, string>>' does not support key-value pair elements.
-                    //         c1 = [k:v];
-                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments(typeName1).WithLocation(9, 15),
-                    // (9,16): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    //         c1 = [k:v];
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(9, 16),
-                    // (12,25): error CS9300: Collection expression type 'IEnumerable<KeyValuePair<int?, object>>' does not support key-value pair elements.
-                    //         c2 = /*<bind>*/[k:v]/*</bind>*/;
-                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments(typeName2).WithLocation(12, 25),
-                    // (12,26): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    //         c2 = /*<bind>*/[k:v]/*</bind>*/;
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(12, 26));
+                    // (11,10): error CS9500: Collection expression type 'IEnumerable<KeyValuePair<int, string>>' does not support key-value pair elements.
+                    //         [k:v];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments(typeName1).WithLocation(11, 10),
+                    // (11,11): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         [k:v];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(11, 11),
+                    // (13,20): error CS9500: Collection expression type 'IEnumerable<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         /*<bind>*/[k:v]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments(typeName2).WithLocation(13, 20),
+                    // (13,21): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         /*<bind>*/[k:v]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(13, 21));
             }
             else
             {
-                var verifier = CompileAndVerify(comp, expectedOutput: "[1:one], [1:one], ");
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[1, one]], [[1, one]],");
                 verifier.VerifyDiagnostics();
+                if (typeName == "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>")
+                {
+                    verifier.VerifyIL("Program.KeyValue1", """
+                    {
+                      // Code size       13 (0xd)
+                      .maxstack  2
+                      IL_0000:  ldarg.0
+                      IL_0001:  ldarg.1
+                      IL_0002:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0007:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int, string>>..ctor(System.Collections.Generic.KeyValuePair<int, string>)"
+                      IL_000c:  ret
+                    }
+                    """);
+                    verifier.VerifyIL("Program.KeyValue2", """
+                    {
+                      // Code size       18 (0x12)
+                      .maxstack  2
+                      IL_0000:  ldarg.0
+                      IL_0001:  newobj     "int?..ctor(int)"
+                      IL_0006:  ldarg.1
+                      IL_0007:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_000c:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_0011:  ret
+                    }
+                    """);
+                }
             }
 
             var tree = comp.SyntaxTrees[0];
@@ -1895,24 +1920,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var element = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().Last();
             var typeInfo = model.GetTypeInfo(element.KeyExpression);
             Assert.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
-            Assert.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/77872: Should be System.Nullable<System.Int32>.
+            Assert.Equal((languageVersion == LanguageVersion.CSharp12) ? "System.Int32" : "System.Int32?", typeInfo.ConvertedType.ToTestDisplayString());
             typeInfo = model.GetTypeInfo(element.ValueExpression);
             Assert.Equal("System.String", typeInfo.Type.ToTestDisplayString());
-            Assert.Equal("System.String", typeInfo.ConvertedType.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/77872: Should be System.Object.
+            Assert.Equal((languageVersion == LanguageVersion.CSharp12) ? "System.String" : "System.Object", typeInfo.ConvertedType.ToTestDisplayString());
 
             string collectionTypeName = typeName.Replace("K, V", "System.Int32?, System.Object");
             // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                (languageVersion == LanguageVersion.CSharp12) ?
                 $$"""
                 ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}, IsInvalid) (Syntax: '[k:v]')
                   Elements(1):
                       IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'k:v')
+                """ :
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}) (Syntax: '[k:v]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
                 """);
         }
 
         [Theory]
         [CombinatorialData]
-        public void KeyValuePairConversions_10(
+        public void KeyValuePairConversions_ExpressionElement(
             [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             [CombinatorialValues(
                 "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
@@ -1928,14 +1959,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     static void Main()
                     {
                         var x = new KeyValuePair<int, string>(2, "two");
-                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
-                        {{typeName1}} c1;
-                        c1 = [x, ..y];
-                        c1.Report();
-                        {{typeName2}} c2;
-                        c2 = /*<bind>*/[x, ..y]/*</bind>*/;
-                        c2.Report();
+                        Expression1(x).Report();
+                        Expression2(x).Report();
                     }
+                    static {{typeName1}} Expression1(KeyValuePair<int, string> e) =>
+                        [e];
+                    static {{typeName2}} Expression2(KeyValuePair<int, string> e) =>
+                        /*<bind>*/[e]/*</bind>*/;
                 }
                 """;
             var comp = CreateCompilation(
@@ -1945,17 +1975,43 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             if (languageVersion == LanguageVersion.CSharp12)
             {
                 comp.VerifyEmitDiagnostics(
-                    // (12,25): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
-                    //         c2 = /*<bind>*/[x, ..y]/*</bind>*/;
-                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(12, 25),
-                    // (12,30): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
-                    //         c2 = /*<bind>*/[x, ..y]/*</bind>*/;
-                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "y").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(12, 30));
+                    // (13,20): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         /*<bind>*/[e]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(13, 20));
             }
             else
             {
-                var verifier = CompileAndVerify(comp, expectedOutput: "[2:two, 3:three], [2:two, 3:three], ");
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[2, two]], [[2, two]], ");
                 verifier.VerifyDiagnostics();
+                if (typeName == "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>")
+                {
+                    verifier.VerifyIL("Program.Expression1", """
+                        {
+                          // Code size        7 (0x7)
+                          .maxstack  1
+                          IL_0000:  ldarg.0
+                          IL_0001:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int, string>>..ctor(System.Collections.Generic.KeyValuePair<int, string>)"
+                          IL_0006:  ret
+                        }
+                        """);
+                    verifier.VerifyIL("Program.Expression2", """
+                        {
+                          // Code size       32 (0x20)
+                          .maxstack  2
+                          .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                          IL_0000:  ldarg.0
+                          IL_0001:  stloc.0
+                          IL_0002:  ldloca.s   V_0
+                          IL_0004:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                          IL_0009:  newobj     "int?..ctor(int)"
+                          IL_000e:  ldloca.s   V_0
+                          IL_0010:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                          IL_0015:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                          IL_001a:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>)"
+                          IL_001f:  ret
+                        }
+                        """);
+                }
             }
 
             var tree = comp.SyntaxTrees[0];
@@ -1964,18 +2020,96 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // https://github.com/dotnet/roslyn/issues/77872: Implement GetTypeInfo() support.
             var typeInfo = model.GetTypeInfo(element.Expression);
             Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
-            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal((languageVersion == LanguageVersion.CSharp12) ? "System.Collections.Generic.KeyValuePair<System.Int32, System.String>" : "System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>", typeInfo.ConvertedType.ToTestDisplayString());
 
             string collectionTypeName = typeName.Replace("K, V", "System.Int32?, System.Object");
             // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                (languageVersion == LanguageVersion.CSharp12) ?
                 $$"""
-                ICollectionExpressionOperation (2 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}, IsInvalid) (Syntax: '[x, ..y]')
-                  Elements(2):
-                      ILocalReferenceOperation: x (OperationKind.LocalReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>, IsInvalid) (Syntax: 'x')
-                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null, IsInvalid) (Syntax: '..y')
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}, IsInvalid) (Syntax: '[e]')
+                  Elements(1):
+                      IParameterReferenceOperation: e (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>, IsInvalid) (Syntax: 'e')
+                """ :
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}) (Syntax: '[e]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>) (Syntax: 'e')
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_SpreadElement(
+            [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(
+                "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.Collections.Generic.KeyValuePair<K, V>[]",
+                "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>")] string typeName)
+        {
+            string typeName1 = typeName.Replace("K, V", "int, string");
+            string typeName2 = typeName.Replace("K, V", "int?, object");
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        Spread1(y).Report();
+                        Spread2(y).Report();
+                    }
+                    static {{typeName1}} Spread1(KeyValuePair<int, string>[] s) =>
+                        [..s];
+                    static {{typeName2}} Spread2(KeyValuePair<int, string>[] s) =>
+                        /*<bind>*/[..s]/*</bind>*/;
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp12)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (13,22): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         /*<bind>*/[..s]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(13, 22));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[3, three]], [[3, three]], ");
+                verifier.VerifyDiagnostics();
+                if (typeName == "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>")
+                {
+                    verifier.VerifyIL("Program.Spread1", """
+                        ...
+                        """);
+                    verifier.VerifyIL("Program.Spread2", """
+                        ...
+                        """);
+                }
+            }
+
+            string collectionTypeName = typeName.Replace("K, V", "System.Int32?, System.Object");
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                (languageVersion == LanguageVersion.CSharp12) ?
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}, IsInvalid) (Syntax: '[..s]')
+                  Elements(1):
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null, IsInvalid) (Syntax: '..s')
                         Operand:
-                          ILocalReferenceOperation: y (OperationKind.LocalReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[], IsInvalid) (Syntax: 'y')
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[], IsInvalid) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (NoConversion)
+                """ :
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}) (Syntax: '[..s]')
+                  Elements(1):
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) (Syntax: 's')
                         ElementConversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                           (NoConversion)
                 """);
@@ -1983,7 +2117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Theory]
         [CombinatorialData]
-        public void KeyValuePairConversions_11(
+        public void KeyValuePairConversions_Params(
             [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             [CombinatorialValues(
                 "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
@@ -2022,6 +2156,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 var verifier = CompileAndVerify(comp, expectedOutput: "[[2, two]], [[2, two]], [[2, two]], ");
                 verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Main", """
+                    ...
+                    """);
             }
 
             var tree = comp.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/DictionaryExpressionTests.cs
@@ -723,7 +723,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ICollectionExpressionOperation (3 elements, ConstructMethod: {{constructMethod}}) (OperationKind.CollectionExpression, Type: System.Collections.Generic.{{typeName}}<K, V>) (Syntax: '[k:v, e, ..s]')
                   Elements(3):
                       IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
-                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'e')
+                      IParameterReferenceOperation: e (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<K, V>) (Syntax: 'e')
                       ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<K, V>) (OperationKind.Spread, Type: null) (Syntax: '..s')
                         Operand:
                           IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>) (Syntax: 's')

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -720,6 +720,7 @@ namespace Microsoft.CodeAnalysis
 
         System_Collections_Generic_Dictionary_KV__ctor,
         System_Collections_Generic_Dictionary_KV__set_Item,
+        System_Collections_Generic_KeyValuePair_KV__ctor,
         System_Collections_Generic_KeyValuePair_KV__get_Key,
         System_Collections_Generic_KeyValuePair_KV__get_Value,
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -5214,6 +5214,15 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.GenericTypeParameter, 0,
                     (byte)SignatureTypeCode.GenericTypeParameter, 1,
 
+                // System_Collections_Generic_KeyValuePair_KV__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_KeyValuePair_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+
                 // System_Collections_Generic_KeyValuePair_KV__get_Key
                 (byte)MemberFlags.PropertyGet,                                                                              // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_KeyValuePair_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
@@ -5855,6 +5864,7 @@ namespace Microsoft.CodeAnalysis
                 "GetString",                                // System_Text_Encoding__GetString
                 ".ctor",                                    // System_Collections_Generic_Dictionary_KV__ctor,
                 "set_Item",                                 // System_Collections_Generic_Dictionary_KV__set_Item
+                ".ctor",                                    // System_Collections_Generic_KeyValuePair_KV__ctor,
                 "get_Key",                                  // System_Collections_Generic_KeyValuePair_KV__get_Key
                 "get_Value",                                // System_Collections_Generic_KeyValuePair_KV__get_Value
             };


### PR DESCRIPTION
Support `k:v` elements, and support variance conversions for expression and spread elements with `KeyValuePair<,>` type, in non-dictionary collections of `KeyValuePair<K, V>`.

Fixes #77871.

Relates to test plan https://github.com/dotnet/roslyn/issues/76310