### PR TITLE
Report warning when changing file that is only included in stale projects

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -169,6 +169,7 @@ internal static class EditAndContinueDiagnosticDescriptors
         AddGeneralDiagnostic(EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee, nameof(FeaturesResources.DocumentIsOutOfSyncWithDebuggee), DiagnosticSeverity.Warning);
         AddGeneralDiagnostic(EditAndContinueErrorCode.UnableToReadSourceFileOrPdb, nameof(FeaturesResources.UnableToReadSourceFileOrPdb));
         AddGeneralDiagnostic(EditAndContinueErrorCode.AddingTypeRuntimeCapabilityRequired, nameof(FeaturesResources.ChangesRequiredSynthesizedType));
+        AddGeneralDiagnostic(EditAndContinueErrorCode.UpdatingDocumentInStaleProject, nameof(FeaturesResources.Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit), DiagnosticSeverity.Warning);
 
         s_descriptors = builder.ToImmutable();
     }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueErrorCode.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueErrorCode.cs
@@ -13,4 +13,5 @@ internal enum EditAndContinueErrorCode
     DocumentIsOutOfSyncWithDebuggee = 5,
     UnableToReadSourceFileOrPdb = 6,
     AddingTypeRuntimeCapabilityRequired = 7,
+    UpdatingDocumentInStaleProject = 8,
 }

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -831,6 +831,26 @@ internal sealed class EditSession
             // After all projects have been analyzed "true" value indicates changed document that is only included in stale projects.
             var changedDocumentsStaleness = new Dictionary<string, bool>(SolutionState.FilePathComparer);
 
+            void UpdateChangedDocumentsStaleness(bool isStale)
+            {
+                foreach (var changedDocument in changedOrAddedDocuments)
+                {
+                    var path = changedDocument.FilePath;
+
+                    // Only documents that support EnC (have paths) are added to the list.
+                    Contract.ThrowIfNull(path);
+
+                    if (isStale)
+                    {
+                        _ = changedDocumentsStaleness.TryAdd(path, true);
+                    }
+                    else
+                    {
+                        changedDocumentsStaleness[path] = false;
+                    }
+                }
+            }
+
             Diagnostic? syntaxError = null;
 
             var oldSolution = DebuggingSession.LastCommittedSolution;
@@ -1168,26 +1188,6 @@ internal sealed class EditSession
                                 var newDocument = await newProject.GetDocumentAsync(changedDocumentAnalysis.DocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                                 await fileLog.WriteDocumentChangeAsync(oldDocument, newDocument, updateId, generation, cancellationToken).ConfigureAwait(false);
                             }
-                        }
-                    }
-                }
-
-                void UpdateChangedDocumentsStaleness(bool isStale)
-                {
-                    foreach (var changedDocument in changedOrAddedDocuments)
-                    {
-                        var path = changedDocument.FilePath;
-
-                        // Only documents that support EnC (have paths) are added to the list.
-                        Contract.ThrowIfNull(path);
-
-                        if (isStale)
-                        {
-                            _ = changedDocumentsStaleness.TryAdd(path, true);
-                        }
-                        else
-                        {
-                            changedDocumentsStaleness[path] = false;
                         }
                     }
                 }

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -354,7 +354,7 @@ internal sealed class EditSession
         foreach (var documentId in newProject.State.DocumentStates.GetChangedStateIds(oldProject.State.DocumentStates, ignoreUnchangedContent: true))
         {
             var document = newProject.GetRequiredDocument(documentId);
-            if (document.State.Attributes.DesignTimeOnly)
+            if (!document.State.SupportsEditAndContinue())
             {
                 continue;
             }
@@ -375,7 +375,7 @@ internal sealed class EditSession
         foreach (var documentId in newProject.State.DocumentStates.GetAddedStateIds(oldProject.State.DocumentStates))
         {
             var document = newProject.GetRequiredDocument(documentId);
-            if (document.State.Attributes.DesignTimeOnly)
+            if (!document.State.SupportsEditAndContinue())
             {
                 continue;
             }
@@ -827,6 +827,10 @@ internal sealed class EditSession
             using var _5 = ArrayBuilder<Document>.GetInstance(out var changedOrAddedDocuments);
             using var _6 = ArrayBuilder<(DocumentId, ImmutableArray<RudeEditDiagnostic>)>.GetInstance(out var documentsWithRudeEdits);
             using var _7 = ArrayBuilder<ProjectId>.GetInstance(out var projectsToStale);
+
+            // After all projects have been analyzed "true" value indicates changed document that is only included in stale projects.
+            var changedDocumentsStaleness = new Dictionary<string, bool>(SolutionState.FilePathComparer);
+
             Diagnostic? syntaxError = null;
 
             var oldSolution = DebuggingSession.LastCommittedSolution;
@@ -860,13 +864,6 @@ internal sealed class EditSession
                     continue;
                 }
 
-                // We don't track document changes in stale projects until they are rebuilt (removed from stale set).
-                if (oldSolution.IsStaleProject(newProject.Id))
-                {
-                    Log.Write($"EnC state of {newProject.Name} '{newProject.FilePath}' queried: project is stale");
-                    continue;
-                }
-
                 await PopulateChangedAndAddedDocumentsAsync(Log, oldProject, newProject, changedOrAddedDocuments, diagnostics, cancellationToken).ConfigureAwait(false);
                 if (changedOrAddedDocuments.IsEmpty)
                 {
@@ -874,6 +871,16 @@ internal sealed class EditSession
                 }
 
                 Log.Write($"Found {changedOrAddedDocuments.Count} potentially changed document(s) in project {newProject.Name} '{newProject.FilePath}'");
+
+                var isStaleProject = oldSolution.IsStaleProject(newProject.Id);
+
+                // We don't consider document changes in stale projects until they are rebuilt (removed from stale set).
+                if (isStaleProject)
+                {
+                    Log.Write($"EnC state of {newProject.Name} '{newProject.FilePath}' queried: project is stale");
+                    UpdateChangedDocumentsStaleness(isStale: true);
+                    continue;
+                }
 
                 var (mvid, mvidReadError) = await DebuggingSession.GetProjectModuleIdAsync(newProject, cancellationToken).ConfigureAwait(false);
                 if (mvidReadError != null)
@@ -891,8 +898,11 @@ internal sealed class EditSession
                 if (mvid == Guid.Empty)
                 {
                     Log.Write($"Changes not applied to {newProject.Name} '{newProject.FilePath}': project not built");
+                    UpdateChangedDocumentsStaleness(isStale: true);
                     continue;
                 }
+
+                UpdateChangedDocumentsStaleness(isStale: false);
 
                 // Ensure that all changed documents are in-sync. Once a document is in-sync it can't get out-of-sync.
                 // Therefore, results of further computations based on base snapshots of changed documents can't be invalidated by
@@ -931,7 +941,10 @@ internal sealed class EditSession
                     // The project is considered stale as long as it has at least one document that is out-of-sync.
                     // Treat the project the same as if it hasn't been built. We won't produce delta for it until it gets rebuilt.
                     Log.Write($"Changes not applied to {newProject.Name} '{newProject.FilePath}': binaries not up-to-date");
+
                     projectsToStale.Add(newProject.Id);
+                    UpdateChangedDocumentsStaleness(isStale: true);
+
                     continue;
                 }
 
@@ -1156,6 +1169,42 @@ internal sealed class EditSession
                                 await fileLog.WriteDocumentChangeAsync(oldDocument, newDocument, updateId, generation, cancellationToken).ConfigureAwait(false);
                             }
                         }
+                    }
+                }
+
+                void UpdateChangedDocumentsStaleness(bool isStale)
+                {
+                    foreach (var changedDocument in changedOrAddedDocuments)
+                    {
+                        var path = changedDocument.FilePath;
+
+                        // Only documents that support EnC (have paths) are added to the list.
+                        Contract.ThrowIfNull(path);
+
+                        if (isStale)
+                        {
+                            _ = changedDocumentsStaleness.TryAdd(path, true);
+                        }
+                        else
+                        {
+                            changedDocumentsStaleness[path] = false;
+                        }
+                    }
+                }
+            }
+
+            // Report stale document updates.
+            // We report a warning when a changed/added document is only included in (linked to) stale projects.
+
+            foreach (var (documentPath, isStale) in changedDocumentsStaleness)
+            {
+                if (isStale)
+                {
+                    foreach (var documentId in solution.GetDocumentIdsWithFilePath(documentPath))
+                    {
+                        var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.UpdatingDocumentInStaleProject);
+                        var diagnostic = Diagnostic.Create(descriptor, Location.Create(documentPath, textSpan: default, lineSpan: default), [documentPath]);
+                        diagnostics.Add(new ProjectDiagnostics(documentId.ProjectId, [diagnostic]));
                     }
                 }
             }

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -902,8 +902,6 @@ internal sealed class EditSession
                     continue;
                 }
 
-                UpdateChangedDocumentsStaleness(isStale: false);
-
                 // Ensure that all changed documents are in-sync. Once a document is in-sync it can't get out-of-sync.
                 // Therefore, results of further computations based on base snapshots of changed documents can't be invalidated by
                 // incoming events updating the content of out-of-sync documents.
@@ -947,6 +945,8 @@ internal sealed class EditSession
 
                     continue;
                 }
+
+                UpdateChangedDocumentsStaleness(isStale: false);
 
                 foreach (var changedDocumentAnalysis in changedDocumentAnalyses)
                 {

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -98,7 +98,13 @@ internal readonly struct EmitSolutionUpdateResults
     public required Solution? Solution { get; init; }
 
     public required ModuleUpdates ModuleUpdates { get; init; }
+
+    /// <summary>
+    /// Reported diagnostics, other than rude edits, per project.
+    /// May contain multiple entries for the same project.
+    /// </summary>
     public required ImmutableArray<ProjectDiagnostics> Diagnostics { get; init; }
+
     public required ImmutableArray<ProjectDiagnostics> RudeEdits { get; init; }
     public required Diagnostic? SyntaxError { get; init; }
 

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -2681,6 +2681,9 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="ChangesRequiredSynthesizedType" xml:space="preserve">
     <value>One or more changes result in a new type being created by the compiler, which requires restarting the application because it is not supported by the runtime</value>
   </data>
+  <data name="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit" xml:space="preserve">
+    <value>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</value>
+  </data>
   <data name="Miscellaneous_Files" xml:space="preserve">
     <value>Miscellaneous Files</value>
   </data>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -440,6 +440,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Změna pseudovlastního atributu {0} u {1} vyžaduje restartování aplikace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">Změna nadřazeného oboru názvů {0} z {1} na {2} vyžaduje restartování aplikace.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -440,6 +440,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Das Ändern des pseudobenutzerdefinierten Attributs „{0}“ von {1} erfordert einen Neustart der Anwendung.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">Um den enthaltenden Namespace von "{0}" von "{1}" in "{2}" zu ändern, muss die Anwendung neu gestartet werden</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -440,6 +440,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Para cambiar el atributo pseudo-personalizado "{0}" de {1} se requiere reiniciar la aplicación</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">Para cambiar el espacio de nombres contenedor de '{0}' de '{1}' a '{2}' es necesario reiniciar la aplicación</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -440,6 +440,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">La modification de l’attribut pseudo-personnalisé « {0} » de {1} requiert le redémarrage de l’application</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">La modification de l’espace de noms conteneur de '{0}' de '{1}' en '{2}' nécessite le redémarrage de l’application</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -440,6 +440,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Se si modifica l'attributo pseudo-personalizzato '{0}' di {1}, è necessario riavviare l'applicazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">Per modificare lo spazio dei nomi contenitore di '{0}' da '{1}' a '{2}' è necessario riavviare l'applicazione</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -440,6 +440,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">{0} の擬似カスタム属性 '{1}' を変更するには、アプリケーションを再起動する必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">'{0}' の包含名前空間を '{1}' から '{2}' に変更するには、アプリケーションを再起動する必要があります</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -440,6 +440,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">{1}의 허위 사용자 지정 특성 '{0}'을(를) 변경하려면 애플리케이션을 다시 시작해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">'{0}'의 포함 네임스페이스를 '{1}'에서 '{2}'(으)로 변경하려면 애플리케이션을 다시 시작해야 합니다.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -440,6 +440,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Zmiana atrybutu pseudoniestandardowego elementu „{0}” z {1} wymaga ponownego uruchomienia aplikacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">Zmiana zawierającej przestrzeni nazw „{0}” z „{1}” na „{2}” wymaga ponownego uruchomienia aplikacji</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -440,6 +440,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Alterar o atributo pseudo-personalizado '{0}' de {1} requer o reinício do aplicativo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">Alterar o namespace que o contém '{0}' de '{1}' para '{2}' requer a reinicialização do aplicativo</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -440,6 +440,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Для изменения псевдонастраиваемого атрибута "{0}" для {1} требуется перезапустить приложение.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">Чтобы изменить содержащее пространство имен "{0}" с "{1}" на "{2}", необходимо перезапустить приложение</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -440,6 +440,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">{1} öğesinin '{0}' sahte özel özniteliğinin değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">'{1}' olan '{0}' kapsayan ad alanının '{2}' olarak değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -440,6 +440,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">更改 {1} 的伪自定义属性“{0}”需要重启应用程序</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">将 '{0}' 的包含命名空间从 '{1}' 更改为'{2}' 需要重新启动应用程序</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -440,6 +440,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">變更 {1} 的虛擬自訂屬性 '{0}' 需要重新啟動應用程式</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit">
+        <source>Changing source file '{0}' in a stale project has no effect until the project is rebuit.</source>
+        <target state="new">Changing source file '{0}' in a stale project has no effect until the project is rebuit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
         <target state="translated">將包含的命名空間 '{0}' 從 '{1}' 變更為 '{2}' 需要重新啟動應用程式</target>

--- a/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -187,7 +187,10 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
         Assert.Equal(ModuleUpdateStatus.None, updates.Status);
         Assert.Empty(updates.Updates);
-        Assert.Empty(emitDiagnostics);
+        AssertEx.Equal(
+        [
+            $"proj.csproj: (0,0)-(0,0): Warning ENC1008: {string.Format(FeaturesResources.Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit, document1.FilePath)}"
+        ], InspectDiagnostics(emitDiagnostics));
 
         EndDebuggingSession(debuggingSession);
     }
@@ -2356,7 +2359,10 @@ class G
         sourceFile.WriteAllText(source1, Encoding.UTF8);
 
         (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
-        Assert.Empty(emitDiagnostics);
+        AssertEx.Equal(
+        [
+            $"test.csproj: (0,0)-(0,0): Warning ENC1008: {string.Format(FeaturesResources.Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit, sourceFile.Path)}"
+        ], InspectDiagnostics(emitDiagnostics));
 
         // the content actually hasn't changed:
         Assert.Equal(ModuleUpdateStatus.None, updates.Status);

--- a/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -3478,6 +3478,60 @@ class C { int Y => 1; }
     }
 
     [Fact]
+    public async Task MultiTargeted_AllTargetsStale()
+    {
+        var dir = Temp.CreateDirectory();
+
+        var source0 = "class A { void M() { System.Console.WriteLine(0); } }";
+        var source1 = "class A { void M() { System.Console.WriteLine(1); } }";
+        var source2 = "class A { void M() { System.Console.WriteLine(2); } }";
+
+        // Create two projects with a shared (linked) document.
+
+        using var _ = CreateWorkspace(out var solution, out var service);
+
+        var sourcePath = dir.CreateFile("Lib.cs").WriteAllText(source1, Encoding.UTF8).Path;
+
+        var documentA = solution.AddTestProject("A").WithAssemblyName("A").
+            AddMetadataReferences(TargetFrameworkUtil.GetReferences(TargetFramework.NetStandard20)).
+            AddDocument("Lib.cs", source1, filePath: sourcePath);
+
+        var documentB = documentA.Project.Solution.AddTestProject("B").WithAssemblyName("A").
+            AddMetadataReferences(TargetFrameworkUtil.GetReferences(TargetFramework.Net90)).
+            AddDocument("Lib.cs", source1, filePath: sourcePath);
+
+        solution = documentB.Project.Solution;
+        var projectAId = documentA.Project.Id;
+        var projectBId = documentB.Project.Id;
+
+        // target A is built with stale source:
+        var mvidA = EmitAndLoadLibraryToDebuggee(projectAId, source0, sourceFilePath: sourcePath, assemblyName: "A", targetFramework: TargetFramework.NetStandard20);
+
+        // target B is built with stale source:
+        var mvidB = EmitAndLoadLibraryToDebuggee(projectBId, source0, sourceFilePath: sourcePath, assemblyName: "A", targetFramework: TargetFramework.Net90);
+
+        // force document checksum validation:
+        var debuggingSession = await StartDebuggingSessionAsync(service, solution, initialState: CommittedSolution.DocumentState.None);
+
+        EnterBreakState(debuggingSession);
+
+        // update source file in the editor:
+        var text2 = CreateText(source2);
+        solution = solution.WithDocumentText(documentA.Id, text2).WithDocumentText(documentB.Id, text2);
+
+        // no updates
+        var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+        Assert.Equal(ModuleUpdateStatus.None, updates.Status);
+        AssertEx.Equal(
+        [
+            $"A.csproj: (0,0)-(0,0): Warning ENC1008: {string.Format(FeaturesResources.Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit, sourcePath)}",
+            $"B.csproj: (0,0)-(0,0): Warning ENC1008: {string.Format(FeaturesResources.Changing_source_file_0_in_a_stale_project_has_no_effect_until_the_project_is_rebuit, sourcePath)}"
+        ], InspectDiagnostics(emitDiagnostics));
+
+        EndDebuggingSession(debuggingSession);
+    }
+
+    [Fact]
     public async Task ValidSignificantChange_BaselineCreationFailed_NoStream()
     {
         using var _ = CreateWorkspace(out var solution, out var service);

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -225,7 +225,7 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase, IDisposable
         ActiveStatementSpanProvider? activeStatementSpanProvider = null)
     {
         var result = await session.EmitSolutionUpdateAsync(solution, runningProjects: [], activeStatementSpanProvider ?? s_noActiveSpans, CancellationToken.None);
-        return (result.ModuleUpdates, result.Diagnostics.ToDiagnosticData(solution));
+        return (result.ModuleUpdates, result.Diagnostics.OrderBy(d => d.ProjectId.DebugName).ToImmutableArray().ToDiagnosticData(solution));
     }
 
     internal static IEnumerable<string> InspectDiagnostics(ImmutableArray<DiagnosticData> actual)


### PR DESCRIPTION
In https://github.com/dotnet/roslyn/pull/78166 we detect projects with stale output binaries and ignore changes made to them.
The change fixed scenarios where only subset of targets of a multi-targeted project is built.

This change reports a warning if changed document is only included in projects that are stale. In that case the change won't have impact on the running app.