### PR TITLE
Disable source index temporarily to unblock signed builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -101,7 +101,7 @@ variables:
 
   - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
     - name: enableSourceIndex
-      value: true
+      value: false
   - name: VSCodeOptimizationDataRoot
     value: $(Pipeline.Workspace)/profilingInputs/merged mibc
 


### PR DESCRIPTION
hitting auth issues uploading the index, making this draft PR in case we can't figure out the auth issues soon.

https://dnceng.visualstudio.com/internal/_build/results?buildId=2693946&view=results