### PR TITLE
Remove unused reference

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -145,7 +145,6 @@
     <PackageVersion Include="NuGet.ProjectModel" Version="6.8.0-rc.112" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="9.0.0-preview.25064.4" />
 
     <!--
       Analyzers

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -132,7 +132,6 @@
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" />
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="System.CommandLine" />
 


### PR DESCRIPTION
This is no longer used, which is fantastic! Less EA to worry about, fewer dual insertions, the whole 9 meters. However, it turns out it still happily restores and gets packaged in the LanguageServer for VS Code. Now that razor is on 10.x the 9.x version load will cause an exception when loading. It will eventually find the right version because it's packaged next to the source generator in the rzls package, but the exception is both alarming to users and slows things down. Let's fix that.

Fixes https://github.com/dotnet/vscode-csharp/issues/8193
