### PR TITLE
Switch Project data structures from ImmutableDictionary => Dictionary and lock

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis;
 [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
 public partial class Project
 {
-    private readonly object _gate = new object();
+    private readonly object _gate = new();
 
     // Only access these dictionaries when holding _gate
     private Dictionary<DocumentId, Document?>? _idToDocumentMap;
@@ -339,7 +339,7 @@ public partial class Project
             return null;
 
         // Quick check first: if we already have created a SourceGeneratedDocument wrapper, we're good
-        if (_idToSourceGeneratedDocumentMap.TryGetValue(documentId, out var sourceGeneratedDocument))
+        if (_idToSourceGeneratedDocumentMap != null && _idToSourceGeneratedDocumentMap.TryGetValue(documentId, out var sourceGeneratedDocument))
             return sourceGeneratedDocument;
 
         // We'll have to run generators if we haven't already and now try to find it.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -258,8 +258,8 @@ public partial class Project
     {
         if (idMap == null)
         {
-            // First call assigns a new dictionary. Any other simultaneous requests will get the same
-            // dictionary, and the normal locking rules will apply at that point.
+            // First call assigns a new dictionary. Any other simultaneous requests will not assign the
+            // dictionary they created to idMap. At that point, normal locking rules apply.
             Interlocked.CompareExchange(ref idMap, new Dictionary<DocumentId, TDocument>(), null);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -27,9 +27,7 @@ namespace Microsoft.CodeAnalysis;
 /// </summary>
 public partial class Solution
 {
-    private readonly object _gate = new();
-
-    // Values for all these are created on demand. Only access when holding _gate.
+    // Values for all these are created on demand. Only access when holding the dictionary as a lock.
     private readonly Dictionary<ProjectId, Project> _projectIdToProjectMap = [];
 
     /// <summary>
@@ -152,7 +150,7 @@ public partial class Solution
     {
         if (this.ContainsProject(projectId))
         {
-            lock (_gate)
+            lock (_projectIdToProjectMap)
             {
                 return _projectIdToProjectMap.GetOrAdd(projectId, s_createProjectFunction, this);
             }


### PR DESCRIPTION
Solution/Project classes keep several immutable dictionaries for mapping (Document/Project)Id to various data. ImmutableDictionaries are a fine (but slow) data structure when data between versions is to be shared, but none of the values in these ImmutableDictionaries persist between solution/project transformations. In fact, the only operation performed on these dictionaries is GetOrAdd calls. As immutable dictionaries are quite poor performing wrt lookups/adds, I thought I would try out two approaches to see if they showed improvements:

1) Switch to ConcurrentDictionary (see https://github.com/dotnet/roslyn/pull/78285).
2) Switch to simple Dictionaries guarded by locks (this PR)

I created test insertions for each of these PRs to gather speedometer numbers, particularly during the solution load of the c# editing speedometer test. The measurements below are from GC Heap Allocs and CPU samples for those tests under (Solution/Project).GetDocument calls 

1) ConcurrentDictionary change test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/631277
2) Dictionary/lock test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/631278

*** Baseline ***
Alloc: 120 MB (1.0%)
CPU:  560 ms (0.3%)

*** Concurrent Dictionary ***
Alloc: 59 MB
CPU: 258 ms (0.1%)

*** Dictionary with lock ***
Alloc: 28 MB
CPU: 172 ms (< 0.1%)

So, it looks like the best performing of the bunch is this PR, which uses simple dictionaries and locks, thus why I'm elevating this PR out of draft mode. The ConcurrentDictionary PR is interesting as the code changes are simple and do give a nice perf improvement.