### PR TITLE
Edit & Continue support for field access in auto-properties

### DIFF
--- a/src/Features/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -2200,6 +2200,52 @@ class C
     }
 
     [Fact]
+    public void Property_Update_ExpressionBodyToAutoProp_FieldAccess()
+    {
+        var src1 = @"
+class C
+{
+    public int P => <AS:0>1</AS:0>;
+}
+";
+        var src2 = @"
+class C
+{
+    public int P => <AS:0>field</AS:0>;
+}
+";
+        var edits = GetTopEdits(src1, src2);
+        var active = GetActiveStatements(src1, src2);
+
+        edits.VerifySemanticDiagnostics(
+            active,
+            capabilities: EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+    }
+
+    [Fact]
+    public void Property_Update_Accessor_ExpressionBodyToAutoProp_FieldAccess()
+    {
+        var src1 = @"
+class C
+{
+    public int P { get => <AS:0>1</AS:0>; }
+}
+";
+        var src2 = @"
+class C
+{
+    public int P { get => <AS:0>field</AS:0>; }
+}
+";
+        var edits = GetTopEdits(src1, src2);
+        var active = GetActiveStatements(src1, src2);
+
+        edits.VerifySemanticDiagnostics(
+            active,
+            capabilities: EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+    }
+
+    [Fact]
     public void Property_Auto_Record_ReplacingNonPrimaryWithPrimary_Getter()
     {
         var src1 = @"

--- a/src/Features/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestVerifier.cs
+++ b/src/Features/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestVerifier.cs
@@ -17,6 +17,7 @@ internal sealed class CSharpEditAndContinueTestVerifier(Action<SyntaxNode>? faul
     public override string ProjectFileExtension => ".csproj";
     public override TreeComparer<SyntaxNode> TopSyntaxComparer => SyntaxComparer.TopLevel;
     public override string? TryGetResource(string keyword) => EditingTestBase.TryGetResource(keyword);
+    public override ParseOptions ParseOptions => CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
 
     public override ImmutableArray<SyntaxNode> GetDeclarators(ISymbol method)
     {

--- a/src/Features/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/Features/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -134,7 +134,7 @@ using System.Runtime.CompilerServices;
     private static SyntaxTree ParseSource(string markedSource, int documentIndex = 0)
         => SyntaxFactory.ParseSyntaxTree(
             SourceMarkers.Clear(markedSource),
-            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12),
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview),
             path: GetDocumentFilePath(documentIndex));
 
     internal static EditScriptDescription GetTopEdits(string methodBody1, string methodBody2, MethodKind kind)

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -4217,8 +4217,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         else if (oldSymbol is IMethodSymbol oldMethod && newSymbol is IMethodSymbol newMethod)
         {
             // Changing property accessor to auto-property accessor adds a field:
-            if (oldMethod is { MethodKind: MethodKind.PropertyGet, AssociatedSymbol: IPropertySymbol oldProperty } && !oldProperty.IsAutoProperty() &&
-                newMethod is { MethodKind: MethodKind.PropertyGet, AssociatedSymbol: IPropertySymbol newProperty } && newProperty.IsAutoProperty() &&
+            if (oldMethod is { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet, AssociatedSymbol: IPropertySymbol oldProperty } && !oldProperty.IsAutoProperty() &&
+                newMethod is { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet, AssociatedSymbol: IPropertySymbol newProperty } && newProperty.IsAutoProperty() &&
                 !capabilities.Grant(GetRequiredAddFieldCapabilities(newMethod)))
             {
                 rudeEdit = RudeEditKind.InsertNotSupportedByRuntime;

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestVerifier.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestVerifier.cs
@@ -9,17 +9,17 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
+using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.EditAndContinue.AbstractEditAndContinueAnalyzer;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 
@@ -58,6 +58,7 @@ internal abstract class EditAndContinueTestVerifier
     public abstract string ProjectFileExtension { get; }
     public abstract TreeComparer<SyntaxNode> TopSyntaxComparer { get; }
     public abstract string? TryGetResource(string keyword);
+    public abstract ParseOptions ParseOptions { get; }
 
     internal static AbstractEditAndContinueAnalyzer CreateAnalyzer(Action<SyntaxNode>? faultInjector, string languageName)
     {
@@ -463,7 +464,8 @@ internal abstract class EditAndContinueTestVerifier
                 language: LanguageName,
                 compilationOutputInfo: default,
                 filePath: Path.Combine(TempRoot.Root, "project" + ProjectFileExtension),
-                checksumAlgorithm: SourceHashAlgorithms.Default));
+                checksumAlgorithm: SourceHashAlgorithms.Default),
+            parseOptions: ParseOptions);
 
         oldProject = workspace.AddProject(projectInfo).WithMetadataReferences(TargetFrameworkUtil.GetReferences(targetFramework));
         foreach (var editScript in editScripts)

--- a/src/Features/VisualBasicTest/EditAndContinue/Helpers/VisualBasicEditAndContinueTestVerifier.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/Helpers/VisualBasicEditAndContinueTestVerifier.vb
@@ -44,6 +44,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EditAndContinue
         Public Overrides Function TryGetResource(keyword As String) As String
             Return EditingTestBase.TryGetResource(keyword)
         End Function
+
+        Public Overrides ReadOnly Property ParseOptions As ParseOptions
+            Get
+                Return VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest)
+            End Get
+        End Property
     End Class
 End Namespace
 


### PR DESCRIPTION
Fixes #77951

Field access in auto-properties mostly already worked in EnC.

- Update the EnC unit testing infrastructure to always run C# tests with the "preview" language version and VB tests with the "latest" language version.
- Add unit test coverage
- Fix small issue in the `AbstractEditAndContinueAnalyzer` to allow auto-properties to be detected from a set accessor.

cc @tmat 