### PR TITLE
Fix MEF composition for Razor

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/Testing/RazorTestLanguageServerFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Testing/RazorTestLanguageServerFactory.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     [Shared]
     [Export(typeof(RazorTestLanguageServerFactory))]
     [Export(typeof(AbstractRazorLanguageServerFactoryWrapper))]
+    [PartNotDiscoverable]
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     [method: ImportingConstructor]
     internal class RazorTestLanguageServerFactory(ILanguageServerFactory languageServerFactory) : AbstractRazorLanguageServerFactoryWrapper

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteExportProviderBuilder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteExportProviderBuilder.cs
@@ -24,7 +24,7 @@ internal sealed class RemoteExportProviderBuilder : ExportProviderBuilder
         MefHostServices.DefaultAssemblyNames
             .Add("Microsoft.CodeAnalysis.ExternalAccess.AspNetCore")
             .Add("Microsoft.CodeAnalysis.Remote.ServiceHub")
-            .Add("Microsoft.CodeAnalysis.ExternalAccess.Razor")
+            .Add("Microsoft.CodeAnalysis.ExternalAccess.Razor.Features")
             .Add("Microsoft.CodeAnalysis.Remote.Workspaces")
             .Add("Microsoft.CodeAnalysis.ExternalAccess.Extensions");
 


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/78122 broke Razor tests, because we now have to initialize the export provider builder first.
Initializing the export provider builder broke Razor tests, because I had an old copy of the EA dll laying around
Fixing the name of the EA dll broke Razor tests, because of a MEF composition error with the RazorTestLanguageServerFactory
And thats how we got here.