### PR TITLE
Add BuildHost APIs for loading an in-memory project

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -105,33 +105,6 @@ internal sealed class ProjectBuildManager
         }
     }
 
-    public (MSB.Evaluation.Project? project, DiagnosticLog log) LoadProject(string path, Stream readStream)
-    {
-        var log = new DiagnosticLog();
-        try
-        {
-            var projectCollection = new MSB.Evaluation.ProjectCollection(
-                AllGlobalProperties,
-                _msbuildLogger != null ? [_msbuildLogger] : ImmutableArray<MSB.Framework.ILogger>.Empty,
-                MSB.Evaluation.ToolsetDefinitionLocations.Default);
-            try
-            {
-                return LoadProjectCore(path, readStream, projectCollection, log);
-            }
-            finally
-            {
-                // unload project so collection will release global strings
-                projectCollection.UnloadAllProjects();
-            }
-        }
-        catch (Exception e)
-        {
-            log.Add(e, path);
-            return (project: null, log);
-        }
-    }
-
-    // easy-out is done. we have a stream that gives raw xml. go forth
     private static (MSB.Evaluation.Project? project, DiagnosticLog log) LoadProjectCore(
         string path, Stream readStream, MSB.Evaluation.ProjectCollection? projectCollection, DiagnosticLog log)
     {
@@ -190,6 +163,32 @@ internal sealed class ProjectBuildManager
                 // unload project so collection will release global strings
                 projectCollection.UnloadAllProjects();
             }
+        }
+    }
+
+    public (MSB.Evaluation.Project? project, DiagnosticLog log) LoadProject(string path, Stream readStream)
+    {
+        var log = new DiagnosticLog();
+        try
+        {
+            var projectCollection = new MSB.Evaluation.ProjectCollection(
+                AllGlobalProperties,
+                _msbuildLogger != null ? [_msbuildLogger] : ImmutableArray<MSB.Framework.ILogger>.Empty,
+                MSB.Evaluation.ToolsetDefinitionLocations.Default);
+            try
+            {
+                return LoadProjectCore(path, readStream, projectCollection, log);
+            }
+            finally
+            {
+                // unload project so collection will release global strings
+                projectCollection.UnloadAllProjects();
+            }
+        }
+        catch (Exception e)
+        {
+            log.Add(e, path);
+            return (project: null, log);
         }
     }
 

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,6 +96,47 @@ internal sealed class ProjectBuildManager
 
             using var stream = FileUtilities.OpenAsyncRead(path);
             using var readStream = await SerializableBytes.CreateReadableStreamAsync(stream, cancellationToken).ConfigureAwait(false);
+            return LoadProjectCore(path, readStream, projectCollection, log);
+        }
+        catch (Exception e)
+        {
+            log.Add(e, path);
+            return (project: null, log);
+        }
+    }
+
+    public (MSB.Evaluation.Project? project, DiagnosticLog log) LoadProject(string path, Stream readStream)
+    {
+        var log = new DiagnosticLog();
+        try
+        {
+            var projectCollection = new MSB.Evaluation.ProjectCollection(
+                AllGlobalProperties,
+                _msbuildLogger != null ? [_msbuildLogger] : ImmutableArray<MSB.Framework.ILogger>.Empty,
+                MSB.Evaluation.ToolsetDefinitionLocations.Default);
+            try
+            {
+                return LoadProjectCore(path, readStream, projectCollection, log);
+            }
+            finally
+            {
+                // unload project so collection will release global strings
+                projectCollection.UnloadAllProjects();
+            }
+        }
+        catch (Exception e)
+        {
+            log.Add(e, path);
+            return (project: null, log);
+        }
+    }
+
+    // easy-out is done. we have a stream that gives raw xml. go forth
+    private static (MSB.Evaluation.Project? project, DiagnosticLog log) LoadProjectCore(
+        string path, Stream readStream, MSB.Evaluation.ProjectCollection? projectCollection, DiagnosticLog log)
+    {
+        try
+        {
             using var xmlReader = XmlReader.Create(readStream, s_xmlReaderSettings);
             var xml = MSB.Construction.ProjectRootElement.Create(xmlReader, projectCollection);
 

--- a/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
@@ -196,6 +196,9 @@ internal sealed class BuildHost : IBuildHost
         return _server.AddTarget(projectFile);
     }
 
+    // When using the Mono runtime, the MSBuild types used in this method must be available
+    // to the JIT during compilation of the method, so they have to be loaded by the caller;
+    // therefore this method must not be inlined.
     [MethodImpl(MethodImplOptions.NoInlining)]
     private int LoadProjectCore(string projectFilePath, string projectContent, string languageName)
     {
@@ -208,8 +211,8 @@ internal sealed class BuildHost : IBuildHost
             _ => throw ExceptionUtilities.UnexpectedValue(languageName)
         };
 
-        _logger.LogInformation($"Loading {projectFilePath}");
-        var projectFile = projectLoader.LoadProjectFile(projectFilePath, projectContent, _buildManager);
+        _logger.LogInformation($"Loading an in-memory project with the path {projectFilePath}");
+        var projectFile = projectLoader.LoadProject(projectFilePath, projectContent, _buildManager);
         return _server.AddTarget(projectFile);
     }
 

--- a/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
@@ -167,6 +167,15 @@ internal sealed class BuildHost : IBuildHost
         return LoadProjectFileCoreAsync(projectFilePath, languageName, cancellationToken);
     }
 
+    /// <summary>
+    /// Returns the target ID of the <see cref="ProjectFile"/> object created for this.
+    /// </summary>
+    public int LoadProject(string projectFilePath, string projectContent, string languageName)
+    {
+        EnsureMSBuildLoaded(projectFilePath);
+        return LoadProjectCore(projectFilePath, projectContent, languageName);
+    }
+
     // When using the Mono runtime, the MSBuild types used in this method must be available
     // to the JIT during compilation of the method, so they have to be loaded by the caller;
     // therefore this method must not be inlined.
@@ -184,6 +193,23 @@ internal sealed class BuildHost : IBuildHost
 
         _logger.LogInformation($"Loading {projectFilePath}");
         var projectFile = await projectLoader.LoadProjectFileAsync(projectFilePath, _buildManager, cancellationToken).ConfigureAwait(false);
+        return _server.AddTarget(projectFile);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private int LoadProjectCore(string projectFilePath, string projectContent, string languageName)
+    {
+        CreateBuildManager();
+
+        ProjectFileLoader projectLoader = languageName switch
+        {
+            LanguageNames.CSharp => new CSharpProjectFileLoader(),
+            LanguageNames.VisualBasic => new VisualBasicProjectFileLoader(),
+            _ => throw ExceptionUtilities.UnexpectedValue(languageName)
+        };
+
+        _logger.LogInformation($"Loading {projectFilePath}");
+        var projectFile = projectLoader.LoadProjectFile(projectFilePath, projectContent, _buildManager);
         return _server.AddTarget(projectFile);
     }
 

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFileLoader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFileLoader.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MSB = Microsoft.Build;
@@ -24,6 +26,20 @@ internal abstract class ProjectFileLoader
 
         // load project file async
         var (project, log) = await buildManager.LoadProjectAsync(path, cancellationToken).ConfigureAwait(false);
+
+        return this.CreateProjectFile(project, buildManager, log);
+    }
+
+    public ProjectFile LoadProjectFile(string path, string projectContent, ProjectBuildManager buildManager)
+    {
+        if (path == null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        // load project file
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(projectContent));
+        var (project, log) = buildManager.LoadProject(path, stream);
 
         return this.CreateProjectFile(project, buildManager, log);
     }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFileLoader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFileLoader.cs
@@ -30,14 +30,19 @@ internal abstract class ProjectFileLoader
         return this.CreateProjectFile(project, buildManager, log);
     }
 
-    public ProjectFile LoadProjectFile(string path, string projectContent, ProjectBuildManager buildManager)
+    public ProjectFile LoadProject(string path, string projectContent, ProjectBuildManager buildManager)
     {
         if (path == null)
         {
             throw new ArgumentNullException(nameof(path));
         }
 
-        // load project file
+        // We expect MSBuild to consume this stream with a utf-8 encoding.
+        // This is because we expect the stream we create to not include a BOM nor an an encoding declaration a la `<?xml encoding="..."?>`.
+        // In this scenario, the XML standard requires XML processors to consume the document with a UTF-8 encoding.
+        // https://www.w3.org/TR/xml/#d0e4623
+        // Theoretically we could also enforce that 'projectContent' does not contain an encoding declaration with non-UTF-8 encoding.
+        // But it seems like a very unlikely scenario to actually get into--this is not something people generally put on real project files.
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(projectContent));
         var (project, log) = buildManager.LoadProject(path, stream);
 

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/Contracts/IBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/Contracts/IBuildHost.cs
@@ -16,6 +16,7 @@ internal interface IBuildHost
     bool HasUsableMSBuild(string projectOrSolutionFilePath);
     ImmutableArray<(string ProjectPath, string ProjectGuid)> GetProjectsInSolution(string solutionFilePath);
     Task<int> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken);
+    int LoadProject(string projectFilePath, string projectContent, string languageName);
     Task<string?> TryGetProjectOutputPathAsync(string projectFilePath, CancellationToken cancellationToken);
     Task ShutdownAsync();
 }

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/Contracts/IBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/Contracts/IBuildHost.cs
@@ -16,7 +16,12 @@ internal interface IBuildHost
     bool HasUsableMSBuild(string projectOrSolutionFilePath);
     ImmutableArray<(string ProjectPath, string ProjectGuid)> GetProjectsInSolution(string solutionFilePath);
     Task<int> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken);
+
+    /// <summary>Permits loading a project file which only exists in-memory, for example, for file-based program scenarios.</summary>
+    /// <param name="projectFilePath">A path to a project file which may or may not exist on disk. Note that an extension that is known by MSBuild, such as .csproj or .vbproj, should be used here.</param>
+    /// <param name="projectContent">The project file XML content.</param>
     int LoadProject(string projectFilePath, string projectContent, string languageName);
+
     Task<string?> TryGetProjectOutputPathAsync(string projectFilePath, CancellationToken cancellationToken);
     Task ShutdownAsync();
 }

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
@@ -34,7 +34,7 @@ internal sealed class RemoteBuildHost
     }
 
     /// <summary>Permits loading a project file which only exists in-memory, for example, for file-based program scenarios.</summary>
-    /// <param name="projectFilePath">A path to a project file which may or may not exist on disk.</param>
+    /// <param name="projectFilePath">A path to a project file which may or may not exist on disk. Note that an extension that is known by MSBuild, such as .csproj or .vbproj, should be used here.</param>
     /// <param name="projectContent">The project file XML content.</param>
     public async Task<RemoteProjectFile> LoadProjectAsync(string projectFilePath, string projectContent, string languageName, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
@@ -33,6 +33,9 @@ internal sealed class RemoteBuildHost
         return new RemoteProjectFile(_client, remoteProjectFileTargetObject);
     }
 
+    /// <summary>Permits loading a project file which only exists in-memory, for example, for file-based program scenarios.</summary>
+    /// <param name="projectFilePath">A path to a project file which may or may not exist on disk.</param>
+    /// <param name="projectContent">The project file XML content.</param>
     public async Task<RemoteProjectFile> LoadProjectAsync(string projectFilePath, string projectContent, string languageName, CancellationToken cancellationToken)
     {
         var remoteProjectFileTargetObject = await _client.InvokeAsync<int>(BuildHostTargetObject, nameof(IBuildHost.LoadProject), parameters: [projectFilePath, projectContent, languageName], cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
@@ -33,6 +33,13 @@ internal sealed class RemoteBuildHost
         return new RemoteProjectFile(_client, remoteProjectFileTargetObject);
     }
 
+    public async Task<RemoteProjectFile> LoadProjectAsync(string projectFilePath, string projectContent, string languageName, CancellationToken cancellationToken)
+    {
+        var remoteProjectFileTargetObject = await _client.InvokeAsync<int>(BuildHostTargetObject, nameof(IBuildHost.LoadProject), parameters: [projectFilePath, projectContent, languageName], cancellationToken).ConfigureAwait(false);
+
+        return new RemoteProjectFile(_client, remoteProjectFileTargetObject);
+    }
+
     public Task<string?> TryGetProjectOutputPathAsync(string projectFilePath, CancellationToken cancellationToken)
         => _client.InvokeNullableAsync<string>(BuildHostTargetObject, nameof(IBuildHost.TryGetProjectOutputPathAsync), parameters: [projectFilePath], cancellationToken);
 

--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -105,16 +105,16 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
 
         var projectFilePath = GetSolutionFileName("Project.csproj");
         var content = File.ReadAllText(projectFilePath);
+        File.Delete(projectFilePath);
         var projectDir = Path.GetDirectoryName(projectFilePath);
 
         await using var buildHostProcessManager = new BuildHostProcessManager(ImmutableDictionary<string, string>.Empty);
 
-        var buildHost = await buildHostProcessManager.GetBuildHostWithFallbackAsync(projectFilePath, CancellationToken.None);
+        var buildHost = await buildHostProcessManager.GetBuildHostAsync(BuildHostProcessManager.BuildHostProcessKind.NetCore, CancellationToken.None);
         var projectFile = await buildHost.LoadProjectAsync(projectFilePath, content, LanguageNames.CSharp, CancellationToken.None);
         var projectFileInfo = (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
 
         Assert.Equal(Path.Combine(projectDir, "bin", "Debug", "netcoreapp3.1", "Project.dll"), projectFileInfo.OutputFilePath);
-        Assert.Null(projectFileInfo.GeneratedFilesOutputDirectory);
     }
 
     [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]

--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -6,8 +6,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -92,6 +94,27 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
         var semanticModel = await document.GetSemanticModelAsync();
         var diagnostics = semanticModel.GetDiagnostics();
         Assert.Empty(diagnostics);
+    }
+
+    [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]
+    [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+    [Trait(Traits.Feature, Traits.Features.NetCore)]
+    public async Task TestOpenInMemoryProject_NetCoreApp()
+    {
+        CreateFiles(GetNetCoreAppFiles());
+
+        var projectFilePath = GetSolutionFileName("Project.csproj");
+        var content = File.ReadAllText(projectFilePath);
+        var projectDir = Path.GetDirectoryName(projectFilePath);
+
+        await using var buildHostProcessManager = new BuildHostProcessManager(ImmutableDictionary<string, string>.Empty);
+
+        var buildHost = await buildHostProcessManager.GetBuildHostWithFallbackAsync(projectFilePath, CancellationToken.None);
+        var projectFile = await buildHost.LoadProjectAsync(projectFilePath, content, LanguageNames.CSharp, CancellationToken.None);
+        var projectFileInfo = (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
+
+        Assert.Equal(Path.Combine(projectDir, "bin", "Debug", "netcoreapp3.1", "Project.dll"), projectFileInfo.OutputFilePath);
+        Assert.Null(projectFileInfo.GeneratedFilesOutputDirectory);
     }
 
     [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]

--- a/src/Workspaces/MSBuild/Test/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuild/Test/VisualStudioMSBuildWorkspaceTests.cs
@@ -3124,35 +3124,6 @@ class C { }";
     }
 
     [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
-    public async Task TestOpenProjectContent_CommandLineArgsHaveNoErrors()
-    {
-        CreateFiles(GetSimpleCSharpSolutionFiles());
-
-        using var workspace = CreateMSBuildWorkspace();
-
-        var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
-
-        await using var buildHostProcessManager = new BuildHostProcessManager(ImmutableDictionary<string, string>.Empty);
-
-        var buildHost = await buildHostProcessManager.GetBuildHostWithFallbackAsync(projectFilePath, CancellationToken.None);
-        var projectFile = await buildHost.LoadProjectFileAsync(projectFilePath, LanguageNames.CSharp, CancellationToken.None);
-        var projectFileInfo = (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
-
-        var commandLineParser = workspace.Services
-            .GetLanguageServices(LanguageNames.CSharp)
-            .GetRequiredService<ICommandLineParserService>();
-
-        var projectDirectory = Path.GetDirectoryName(projectFilePath);
-        var commandLineArgs = commandLineParser.Parse(
-            arguments: projectFileInfo.CommandLineArgs,
-            baseDirectory: projectDirectory,
-            isInteractive: false,
-            sdkDirectory: System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory());
-
-        Assert.Empty(commandLineArgs.Errors);
-    }
-
-    [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
     [WorkItem("https://github.com/dotnet/roslyn/issues/29122")]
     public async Task TestOpenSolution_ProjectReferencesWithUnconventionalOutputPaths()
     {


### PR DESCRIPTION
Part of dotnet/sdk#48176
Related to #78208 

We need to be able to create a project (XML) in memory and run a design time build on it. Adding these APIs is a prerequisite for us doing that.