### PR TITLE
Fix VS xaml lsp shutdown

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLifeCycleManager.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLifeCycleManager.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Editor.Xaml;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.ServerLifetime;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer;
+
+[ExportLspServiceFactory(typeof(LspServiceLifeCycleManager), StringConstants.XamlLspLanguagesContract), Shared]
+internal class XamlLifeCycleManager : LspServiceLifeCycleManager.LspLifeCycleManagerFactory
+{
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public XamlLifeCycleManager(LspWorkspaceRegistrationService lspWorkspaceRegistrationService) : base(lspWorkspaceRegistrationService)
+    {
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLifeCycleManager.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLifeCycleManager.cs
@@ -12,11 +12,6 @@ using Microsoft.CodeAnalysis.LanguageServer.Handler.ServerLifetime;
 namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer;
 
 [ExportLspServiceFactory(typeof(LspServiceLifeCycleManager), StringConstants.XamlLspLanguagesContract), Shared]
-internal class XamlLifeCycleManager : LspServiceLifeCycleManager.LspLifeCycleManagerFactory
-{
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public XamlLifeCycleManager(LspWorkspaceRegistrationService lspWorkspaceRegistrationService) : base(lspWorkspaceRegistrationService)
-    {
-    }
-}
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class XamlLifeCycleManager(LspWorkspaceRegistrationService lspWorkspaceRegistrationService) : LspServiceLifeCycleManager.LspLifeCycleManagerFactory(lspWorkspaceRegistrationService);


### PR DESCRIPTION
was refactored in the extensions work, and we missed adding an export for the VS xaml server

resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2456006