### PR TITLE
Move runtime async method validation into initial binding

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var exprOriginalType = expression.Type!.OriginalDefinition;
                 SpecialMember awaitCall;
-                TypeWithAnnotations? maybeResultType = null;
+                TypeWithAnnotations resultType = default;
                 if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task, diagnostics, expression.Syntax)))
                 {
                     awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask;
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task_T, diagnostics, expression.Syntax)))
                 {
                     awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T;
-                    maybeResultType = ((NamedTypeSymbol)expression.Type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
+                    resultType = ((NamedTypeSymbol)expression.Type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
                 }
                 else if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask, diagnostics, expression.Syntax)))
                 {
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask_T, diagnostics, expression.Syntax)))
                 {
                     awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T;
-                    maybeResultType = ((NamedTypeSymbol)expression.Type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
+                    resultType = ((NamedTypeSymbol)expression.Type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
                 }
                 else
                 {
@@ -341,9 +341,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                Debug.Assert((runtimeAwaitHelper is { Arity: 1 } && maybeResultType is { }) || runtimeAwaitHelper.TypeParameters.Length == 0);
+                Debug.Assert(runtimeAwaitHelper.Arity == (resultType.HasType ? 1 : 0));
 
-                if (maybeResultType is { } resultType)
+                if (resultType.HasType)
                 {
                     runtimeAwaitHelper = runtimeAwaitHelper.Construct([resultType]);
                     ConstraintsHelper.CheckConstraints(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // The expression await t is classified the same way as the expression (t).GetAwaiter().GetResult(). Thus,
             // if the return type of GetResult is void, the await-expression is classified as nothing. If it has a
             // non-void return type T, the await-expression is classified as a value of type T.
-            TypeSymbol awaitExpressionType = info.GetResult?.ReturnType ?? (hasErrors ? CreateErrorType() : Compilation.DynamicType);
+            TypeSymbol awaitExpressionType = (info.GetResult ?? info.RuntimeAsyncAwaitMethod)?.ReturnType ?? (hasErrors ? CreateErrorType() : Compilation.DynamicType);
 
             return new BoundAwaitExpression(node, expression, info, debugInfo: default, awaitExpressionType, hasErrors);
         }
@@ -58,11 +59,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 out PropertySymbol? isCompleted,
                 out MethodSymbol? getResult,
                 getAwaiterGetResultCall: out _,
+                out MethodSymbol? runtimeAsyncAwaitCall,
                 node,
                 diagnostics);
             hasErrors |= hasGetAwaitableErrors;
 
-            return new BoundAwaitableInfo(node, placeholder, isDynamic: isDynamic, getAwaiter, isCompleted, getResult, hasErrors: hasGetAwaitableErrors) { WasCompilerGenerated = true };
+            return new BoundAwaitableInfo(node, placeholder, isDynamic: isDynamic, getAwaiter, isCompleted, getResult, runtimeAsyncAwaitCall, hasErrors: hasGetAwaitableErrors) { WasCompilerGenerated = true };
         }
 
         /// <summary>
@@ -123,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            return GetAwaitableExpressionInfo(expression, getAwaiterGetResultCall: out _,
+            return GetAwaitableExpressionInfo(expression, getAwaiterGetResultCall: out _, runtimeAsyncAwaitCall: out _,
                 node: syntax, diagnostics: BindingDiagnosticBag.Discarded);
         }
 
@@ -242,10 +244,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool GetAwaitableExpressionInfo(
             BoundExpression expression,
             out BoundExpression? getAwaiterGetResultCall,
+            out MethodSymbol? runtimeAsyncAwaitCall,
             SyntaxNode node,
             BindingDiagnosticBag diagnostics)
         {
-            return GetAwaitableExpressionInfo(expression, expression, out _, out _, out _, out _, out getAwaiterGetResultCall, node, diagnostics);
+            return GetAwaitableExpressionInfo(expression, expression, out _, out _, out _, out _, out getAwaiterGetResultCall, out runtimeAsyncAwaitCall, node, diagnostics);
         }
 
         private bool GetAwaitableExpressionInfo(
@@ -256,6 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out PropertySymbol? isCompleted,
             out MethodSymbol? getResult,
             out BoundExpression? getAwaiterGetResultCall,
+            out MethodSymbol? runtimeAsyncAwaitCall,
             SyntaxNode node,
             BindingDiagnosticBag diagnostics)
         {
@@ -266,6 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             isCompleted = null;
             getResult = null;
             getAwaiterGetResultCall = null;
+            runtimeAsyncAwaitCall = null;
 
             if (!ValidateAwaitedExpression(expression, node, diagnostics))
             {
@@ -274,7 +279,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (expression.HasDynamicType())
             {
+                // PROTOTYPE: Handle runtime async here
                 isDynamic = true;
+                return true;
+            }
+
+            var isRuntimeAsyncEnabled = Compilation.IsRuntimeAsyncEnabledIn(this.ContainingMemberOrLambda);
+
+            // When RuntimeAsync is enabled, we first check for whether there is an AsyncHelpers.Await method that can handle the expression.
+            // PROTOTYPE: Do the full algorithm specified in https://github.com/dotnet/roslyn/pull/77957
+
+            if (tryGetRuntimeAwaitHelper(out runtimeAsyncAwaitCall))
+            {
                 return true;
             }
 
@@ -286,7 +302,130 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol awaiterType = getAwaiter.Type!;
             return GetIsCompletedProperty(awaiterType, node, expression.Type!, diagnostics, out isCompleted)
                 && AwaiterImplementsINotifyCompletion(awaiterType, node, diagnostics)
-                && GetGetResultMethod(getAwaiter, node, expression.Type!, diagnostics, out getResult, out getAwaiterGetResultCall);
+                && GetGetResultMethod(getAwaiter, node, expression.Type!, diagnostics, out getResult, out getAwaiterGetResultCall)
+                && (!isRuntimeAsyncEnabled || getRuntimeAwaitAwaiter(awaiterType, out runtimeAsyncAwaitCall));
+
+            bool tryGetRuntimeAwaitHelper(out MethodSymbol? runtimeAwaitHelper)
+            {
+                if (!isRuntimeAsyncEnabled)
+                {
+                    runtimeAwaitHelper = null;
+                    return false;
+                }
+
+                var exprOriginalType = expression.Type!.OriginalDefinition;
+                SpecialMember awaitCall;
+                TypeWithAnnotations? maybeNestedType = null;
+                if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task, diagnostics, expression.Syntax)))
+                {
+                    awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask;
+                }
+                else if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task_T, diagnostics, expression.Syntax)))
+                {
+                    awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T;
+                    maybeNestedType = ((NamedTypeSymbol)expression.Type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
+                }
+                else if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask, diagnostics, expression.Syntax)))
+                {
+                    awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask;
+                }
+                else if (ReferenceEquals(exprOriginalType, GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask_T, diagnostics, expression.Syntax)))
+                {
+                    awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T;
+                    maybeNestedType = ((NamedTypeSymbol)expression.Type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
+                }
+                else
+                {
+                    runtimeAwaitHelper = null;
+                    return false;
+                }
+
+                runtimeAwaitHelper = (MethodSymbol)GetSpecialTypeMember(awaitCall, diagnostics, expression.Syntax);
+
+                if (runtimeAwaitHelper is null)
+                {
+                    return false;
+                }
+
+                if (maybeNestedType is { } nestedType)
+                {
+                    Debug.Assert(runtimeAwaitHelper.TypeParameters.Length == 1);
+                    runtimeAwaitHelper = runtimeAwaitHelper.Construct([nestedType]);
+                    checkMethodGenericConstraints(expression, diagnostics, runtimeAwaitHelper);
+                }
+#if DEBUG
+                else
+                {
+                    Debug.Assert(runtimeAwaitHelper.TypeParameters.Length == 0);
+                }
+#endif
+
+                return true;
+            }
+
+            bool getRuntimeAwaitAwaiter(TypeSymbol awaiterType, out MethodSymbol? runtimeAwaitAwaiterMethod)
+            {
+                // Use site info is discarded because we don't actually do this conversion, we just need to know which generic
+                // method to call.
+                var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+                var useUnsafeAwait = Compilation.Conversions.ClassifyImplicitConversionFromType(
+                    awaiterType,
+                    Compilation.GetSpecialType(InternalSpecialType.System_Runtime_CompilerServices_ICriticalNotifyCompletion),
+                    ref discardedUseSiteInfo).IsImplicit;
+
+                var awaitMethod = (MethodSymbol?)GetSpecialTypeMember(
+                    useUnsafeAwait
+                        ? SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter
+                        : SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter,
+                    diagnostics,
+                    expression.Syntax);
+
+                if (awaitMethod is null)
+                {
+                    runtimeAwaitAwaiterMethod = null;
+                    return false;
+                }
+
+                Debug.Assert(awaitMethod is { Arity: 1 });
+
+                runtimeAwaitAwaiterMethod = awaitMethod.Construct(awaiterType);
+                checkMethodGenericConstraints(expression, diagnostics, runtimeAwaitAwaiterMethod);
+
+                return true;
+            }
+
+            void checkMethodGenericConstraints(BoundExpression expression, BindingDiagnosticBag diagnostics, MethodSymbol method)
+            {
+                var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
+                ArrayBuilder<TypeParameterDiagnosticInfo>? useSiteDiagnosticsBuilder = null;
+                ConstraintsHelper.CheckMethodConstraints(
+                    method,
+                    new ConstraintsHelper.CheckConstraintsArgs(this.Compilation, this.Conversions, includeNullability: false, location: expression.Syntax.Location, diagnostics: null),
+                    diagnosticsBuilder,
+                    nullabilityDiagnosticsBuilderOpt: null,
+                    ref useSiteDiagnosticsBuilder);
+
+                foreach (var pair in diagnosticsBuilder)
+                {
+                    if (pair.UseSiteInfo.DiagnosticInfo is { } diagnosticInfo)
+                    {
+                        diagnostics.Add(diagnosticInfo, expression.Syntax.Location);
+                    }
+                    diagnosticsBuilder.Free();
+                }
+
+                if (useSiteDiagnosticsBuilder is { })
+                {
+                    foreach (var pair in useSiteDiagnosticsBuilder)
+                    {
+                        if (pair.UseSiteInfo.DiagnosticInfo is { } diagnosticInfo)
+                        {
+                            diagnostics.Add(diagnosticInfo, expression.Syntax.Location);
+                        }
+                    }
+                    useSiteDiagnosticsBuilder.Free();
+                }
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     Debug.Assert(runtimeAwaitHelper.TypeParameters.Length == 1);
                     runtimeAwaitHelper = runtimeAwaitHelper.Construct([nestedType]);
-                    checkMethodGenericConstraints(expression, diagnostics, runtimeAwaitHelper);
+                    checkMethodGenericConstraints(runtimeAwaitHelper, diagnostics, expression.Syntax.Location);
                 }
 #if DEBUG
                 else
@@ -389,18 +389,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(awaitMethod is { Arity: 1 });
 
                 runtimeAwaitAwaiterMethod = awaitMethod.Construct(awaiterType);
-                checkMethodGenericConstraints(expression, diagnostics, runtimeAwaitAwaiterMethod);
+                checkMethodGenericConstraints(runtimeAwaitAwaiterMethod, diagnostics, expression.Syntax.Location);
 
                 return true;
             }
 
-            void checkMethodGenericConstraints(BoundExpression expression, BindingDiagnosticBag diagnostics, MethodSymbol method)
+            void checkMethodGenericConstraints(MethodSymbol method, BindingDiagnosticBag diagnostics, Location location)
             {
                 var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
                 ArrayBuilder<TypeParameterDiagnosticInfo>? useSiteDiagnosticsBuilder = null;
                 ConstraintsHelper.CheckMethodConstraints(
                     method,
-                    new ConstraintsHelper.CheckConstraintsArgs(this.Compilation, this.Conversions, includeNullability: false, location: expression.Syntax.Location, diagnostics: null),
+                    new ConstraintsHelper.CheckConstraintsArgs(this.Compilation, this.Conversions, includeNullability: false, location, diagnostics: null),
                     diagnosticsBuilder,
                     nullabilityDiagnosticsBuilderOpt: null,
                     ref useSiteDiagnosticsBuilder);
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (pair.UseSiteInfo.DiagnosticInfo is { } diagnosticInfo)
                     {
-                        diagnostics.Add(diagnosticInfo, expression.Syntax.Location);
+                        diagnostics.Add(diagnosticInfo, location);
                     }
                     diagnosticsBuilder.Free();
                 }
@@ -420,7 +420,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (pair.UseSiteInfo.DiagnosticInfo is { } diagnosticInfo)
                         {
-                            diagnostics.Add(diagnosticInfo, expression.Syntax.Location);
+                            diagnostics.Add(diagnosticInfo, location);
                         }
                     }
                     useSiteDiagnosticsBuilder.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1654,12 +1654,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal NamedTypeSymbol GetSpecialType(SpecialType typeId, BindingDiagnosticBag diagnostics, SyntaxNode node)
+        internal NamedTypeSymbol GetSpecialType(ExtendedSpecialType typeId, BindingDiagnosticBag diagnostics, SyntaxNode node)
         {
             return GetSpecialType(this.Compilation, typeId, node, diagnostics);
         }
 
-        internal static NamedTypeSymbol GetSpecialType(CSharpCompilation compilation, SpecialType typeId, SyntaxNode node, BindingDiagnosticBag diagnostics)
+        internal static NamedTypeSymbol GetSpecialType(CSharpCompilation compilation, ExtendedSpecialType typeId, SyntaxNode node, BindingDiagnosticBag diagnostics)
         {
             NamedTypeSymbol typeSymbol = compilation.GetSpecialType(typeId);
             Debug.Assert((object)typeSymbol != null, "Expect an error type if special type isn't found");
@@ -1667,7 +1667,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return typeSymbol;
         }
 
-        internal static NamedTypeSymbol GetSpecialType(CSharpCompilation compilation, SpecialType typeId, Location location, BindingDiagnosticBag diagnostics)
+        internal static NamedTypeSymbol GetSpecialType(CSharpCompilation compilation, ExtendedSpecialType typeId, Location location, BindingDiagnosticBag diagnostics)
         {
             NamedTypeSymbol typeSymbol = compilation.GetSpecialType(typeId);
             Debug.Assert((object)typeSymbol != null, "Expect an error type if special type isn't found");

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (awaitableTypeOpt is null)
                 {
-                    awaitOpt = new BoundAwaitableInfo(syntax, awaitableInstancePlaceholder: null, isDynamic: true, getAwaiter: null, isCompleted: null, getResult: null) { WasCompilerGenerated = true };
+                    awaitOpt = new BoundAwaitableInfo(syntax, awaitableInstancePlaceholder: null, isDynamic: true, getAwaiter: null, isCompleted: null, getResult: null, runtimeAsyncAwaitMethod: null) { WasCompilerGenerated = true };
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundAwaitableInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundAwaitableInfo.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+partial class BoundAwaitableInfo
+{
+    private partial void Validate()
+    {
+        if (RuntimeAsyncAwaitMethod is not null)
+        {
+            Debug.Assert(RuntimeAsyncAwaitMethod.ContainingType.ExtendedSpecialType == InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers);
+
+            switch (RuntimeAsyncAwaitMethod.Name)
+            {
+                case "Await":
+                    Debug.Assert(GetAwaiter is null);
+                    Debug.Assert(IsCompleted is null);
+                    Debug.Assert(GetResult is null);
+                    break;
+
+                case "AwaitAwaiter":
+                case "UnsafeAwaitAwaiter":
+                    Debug.Assert(GetAwaiter is not null);
+                    Debug.Assert(IsCompleted is not null);
+                    Debug.Assert(GetResult is not null);
+                    break;
+
+                default:
+                    Debug.Fail($"Unexpected RuntimeAsyncAwaitMethod: {RuntimeAsyncAwaitMethod.Name}");
+                    break;
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -693,7 +693,7 @@
     <Field Name="GetAwaiter" Type="BoundExpression?" Null="allow"/>
     <Field Name="IsCompleted" Type="PropertySymbol?" Null="allow"/>
     <Field Name="GetResult" Type="MethodSymbol?" Null="allow"/>
-    <!-- Refers to the runtime async helper we method for awaiting. Either this is an instance of an AsyncHelpers.Await method symbol, and 
+    <!-- Refers to the runtime async helper method we use for awaiting. Either this is an instance of an AsyncHelpers.Await method symbol, and 
          GetAwaiter, IsCompleted, and GetResult are null, or this is AsyncHelpers.AwaitAwaiter/UnsafeAwaitAwaiter, and the other
          fields are not null. -->
     <!-- PROTOTYPE: Look at consumers of this API and see if we can assert that this is null when it should be -->

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -686,16 +686,17 @@
     <Field Name="Expression" Type="BoundExpression"/>
   </Node>
 
-  <Node Name="BoundAwaitableInfo" Base="BoundNode">
+  <Node Name="BoundAwaitableInfo" Base="BoundNode" HasValidate="true">
     <!-- Used to refer to the awaitable expression in GetAwaiter -->
     <Field Name="AwaitableInstancePlaceholder" Type="BoundAwaitableValuePlaceholder?" Null="allow" />
     <Field Name="IsDynamic" Type="bool"/>
     <Field Name="GetAwaiter" Type="BoundExpression?" Null="allow"/>
     <Field Name="IsCompleted" Type="PropertySymbol?" Null="allow"/>
     <Field Name="GetResult" Type="MethodSymbol?" Null="allow"/>
-    <!-- Refers to the runtime async helper we call for awaiting. Either this is an instance of an AsyncHelpers.Await call, and 
+    <!-- Refers to the runtime async helper we method for awaiting. Either this is an instance of an AsyncHelpers.Await method symbol, and 
          GetAwaiter, IsCompleted, and GetResult are null, or this is AsyncHelpers.AwaitAwaiter/UnsafeAwaitAwaiter, and the other
          fields are not null. -->
+    <!-- PROTOTYPE: Look at consumers of this API and see if we can assert that this is null when it should be -->
     <Field Name="RuntimeAsyncAwaitMethod" Type="MethodSymbol?" Null="allow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -693,6 +693,10 @@
     <Field Name="GetAwaiter" Type="BoundExpression?" Null="allow"/>
     <Field Name="IsCompleted" Type="PropertySymbol?" Null="allow"/>
     <Field Name="GetResult" Type="MethodSymbol?" Null="allow"/>
+    <!-- Refers to the runtime async helper we call for awaiting. Either this is an instance of an AsyncHelpers.Await call, and 
+         GetAwaiter, IsCompleted, and GetResult are null, or this is AsyncHelpers.AwaitAwaiter/UnsafeAwaitAwaiter, and the other
+         fields are not null. -->
+    <Field Name="RuntimeAsyncAwaitMethod" Type="MethodSymbol?" Null="allow"/>
   </Node>
 
   <Node Name="BoundAwaitExpression" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2224,13 +2224,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             var syntax = method.ExtractReturnTypeSyntax();
             var dumbInstance = new BoundLiteral(syntax, ConstantValue.Null, namedType);
             var binder = GetBinder(syntax);
-            BoundExpression? result;
-            var success = binder.GetAwaitableExpressionInfo(dumbInstance, out result, out MethodSymbol? runtimeAwaitMethod, syntax, diagnostics);
+            var success = binder.GetAwaitableExpressionInfo(dumbInstance, out BoundExpression? result, out MethodSymbol? runtimeAwaitMethod, syntax, diagnostics);
 
             RoslynDebug.Assert(!namedType.IsDynamic());
+            if (!success)
+            {
+                return false;
+            }
+
             Debug.Assert(result is { Type: not null } || runtimeAwaitMethod is { ReturnType: not null });
             var returnType = result?.Type ?? runtimeAwaitMethod!.ReturnType;
-            return success && (returnType.IsVoidType() || returnType.SpecialType == SpecialType.System_Int32);
+            return returnType.IsVoidType() || returnType.SpecialType == SpecialType.System_Int32;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -331,10 +331,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var methodReturn = method.ReturnType.OriginalDefinition;
-            if (!ReferenceEquals(methodReturn, GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task))
-                && !ReferenceEquals(methodReturn, GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task_T))
-                && !ReferenceEquals(methodReturn, GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask))
-                && !ReferenceEquals(methodReturn, GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask_T)))
+            if (((InternalSpecialType)methodReturn.ExtendedSpecialType) is not (
+                    InternalSpecialType.System_Threading_Tasks_Task or
+                    InternalSpecialType.System_Threading_Tasks_Task_T or
+                    InternalSpecialType.System_Threading_Tasks_ValueTask or
+                    InternalSpecialType.System_Threading_Tasks_ValueTask_T))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2229,8 +2229,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             RoslynDebug.Assert(!namedType.IsDynamic());
             Debug.Assert(result is { Type: not null } || runtimeAwaitMethod is { ReturnType: not null });
-            return success &&
-                ((result?.Type ?? runtimeAwaitMethod!.ReturnType)!.IsVoidType() || result.Type!.SpecialType == SpecialType.System_Int32);
+            var returnType = result?.Type ?? runtimeAwaitMethod!.ReturnType;
+            return success && (returnType.IsVoidType() || returnType.SpecialType == SpecialType.System_Int32);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -2147,7 +2147,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.IsCompleted = isCompleted;
             this.GetResult = getResult;
             this.RuntimeAsyncAwaitMethod = runtimeAsyncAwaitMethod;
+            Validate();
         }
+
+        [Conditional("DEBUG")]
+        private partial void Validate();
 
         public BoundAwaitableValuePlaceholder? AwaitableInstancePlaceholder { get; }
         public bool IsDynamic { get; }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -2138,7 +2138,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundAwaitableInfo : BoundNode
     {
-        public BoundAwaitableInfo(SyntaxNode syntax, BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder, bool isDynamic, BoundExpression? getAwaiter, PropertySymbol? isCompleted, MethodSymbol? getResult, bool hasErrors = false)
+        public BoundAwaitableInfo(SyntaxNode syntax, BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder, bool isDynamic, BoundExpression? getAwaiter, PropertySymbol? isCompleted, MethodSymbol? getResult, MethodSymbol? runtimeAsyncAwaitMethod, bool hasErrors = false)
             : base(BoundKind.AwaitableInfo, syntax, hasErrors || awaitableInstancePlaceholder.HasErrors() || getAwaiter.HasErrors())
         {
             this.AwaitableInstancePlaceholder = awaitableInstancePlaceholder;
@@ -2146,6 +2146,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.GetAwaiter = getAwaiter;
             this.IsCompleted = isCompleted;
             this.GetResult = getResult;
+            this.RuntimeAsyncAwaitMethod = runtimeAsyncAwaitMethod;
         }
 
         public BoundAwaitableValuePlaceholder? AwaitableInstancePlaceholder { get; }
@@ -2153,15 +2154,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression? GetAwaiter { get; }
         public PropertySymbol? IsCompleted { get; }
         public MethodSymbol? GetResult { get; }
+        public MethodSymbol? RuntimeAsyncAwaitMethod { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitAwaitableInfo(this);
 
-        public BoundAwaitableInfo Update(BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder, bool isDynamic, BoundExpression? getAwaiter, PropertySymbol? isCompleted, MethodSymbol? getResult)
+        public BoundAwaitableInfo Update(BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder, bool isDynamic, BoundExpression? getAwaiter, PropertySymbol? isCompleted, MethodSymbol? getResult, MethodSymbol? runtimeAsyncAwaitMethod)
         {
-            if (awaitableInstancePlaceholder != this.AwaitableInstancePlaceholder || isDynamic != this.IsDynamic || getAwaiter != this.GetAwaiter || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(isCompleted, this.IsCompleted) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(getResult, this.GetResult))
+            if (awaitableInstancePlaceholder != this.AwaitableInstancePlaceholder || isDynamic != this.IsDynamic || getAwaiter != this.GetAwaiter || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(isCompleted, this.IsCompleted) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(getResult, this.GetResult) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(runtimeAsyncAwaitMethod, this.RuntimeAsyncAwaitMethod))
             {
-                var result = new BoundAwaitableInfo(this.Syntax, awaitableInstancePlaceholder, isDynamic, getAwaiter, isCompleted, getResult, this.HasErrors);
+                var result = new BoundAwaitableInfo(this.Syntax, awaitableInstancePlaceholder, isDynamic, getAwaiter, isCompleted, getResult, runtimeAsyncAwaitMethod, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -11175,9 +11177,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             PropertySymbol? isCompleted = this.VisitPropertySymbol(node.IsCompleted);
             MethodSymbol? getResult = this.VisitMethodSymbol(node.GetResult);
+            MethodSymbol? runtimeAsyncAwaitMethod = this.VisitMethodSymbol(node.RuntimeAsyncAwaitMethod);
             BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder = (BoundAwaitableValuePlaceholder?)this.Visit(node.AwaitableInstancePlaceholder);
             BoundExpression? getAwaiter = (BoundExpression?)this.Visit(node.GetAwaiter);
-            return node.Update(awaitableInstancePlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult);
+            return node.Update(awaitableInstancePlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult, runtimeAsyncAwaitMethod);
         }
         public override BoundNode? VisitAwaitExpression(BoundAwaitExpression node)
         {
@@ -13133,9 +13136,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             PropertySymbol? isCompleted = GetUpdatedSymbol(node, node.IsCompleted);
             MethodSymbol? getResult = GetUpdatedSymbol(node, node.GetResult);
+            MethodSymbol? runtimeAsyncAwaitMethod = GetUpdatedSymbol(node, node.RuntimeAsyncAwaitMethod);
             BoundAwaitableValuePlaceholder? awaitableInstancePlaceholder = (BoundAwaitableValuePlaceholder?)this.Visit(node.AwaitableInstancePlaceholder);
             BoundExpression? getAwaiter = (BoundExpression?)this.Visit(node.GetAwaiter);
-            return node.Update(awaitableInstancePlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult);
+            return node.Update(awaitableInstancePlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult, runtimeAsyncAwaitMethod);
         }
 
         public override BoundNode? VisitAwaitExpression(BoundAwaitExpression node)
@@ -15622,6 +15626,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("getAwaiter", null, new TreeDumperNode[] { Visit(node.GetAwaiter, null) }),
             new TreeDumperNode("isCompleted", node.IsCompleted, null),
             new TreeDumperNode("getResult", node.GetResult, null),
+            new TreeDumperNode("runtimeAsyncAwaitMethod", node.RuntimeAsyncAwaitMethod, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/RuntimeAsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/RuntimeAsyncRewriter.cs
@@ -125,7 +125,7 @@ internal sealed class RuntimeAsyncRewriter : BoundTreeRewriterWithStackGuard
         // becomes
         // var _tmp = expr.GetAwaiter();
         // if (!_tmp.IsCompleted)
-        //    UnsafeAwaitAwaiterFromRuntimeAsync(_tmp) OR AwaitAwaiterFromRuntimeAsync(_tmp);
+        //    UnsafeAwaitAwaiter(_tmp) OR AwaitAwaiter(_tmp);
         // _tmp.GetResult()
 
         // PROTOTYPE: await dynamic will need runtime checks, see AsyncMethodToStateMachine.GenerateAwaitOnCompletedDynamic
@@ -157,7 +157,7 @@ internal sealed class RuntimeAsyncRewriter : BoundTreeRewriterWithStackGuard
         Debug.Assert(isCompletedMethod is not null);
         var isCompletedCall = _factory.Call(tmp, isCompletedMethod);
 
-        // UnsafeAwaitAwaiterFromRuntimeAsync(_tmp) OR AwaitAwaiterFromRuntimeAsync(_tmp)
+        // UnsafeAwaitAwaiter(_tmp) OR AwaitAwaiter(_tmp)
         var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
         var useUnsafeAwait = _factory.Compilation.Conversions.ClassifyImplicitConversionFromType(
             tmp.Type,
@@ -166,8 +166,8 @@ internal sealed class RuntimeAsyncRewriter : BoundTreeRewriterWithStackGuard
 
         // PROTOTYPE: Make sure that we report an error in initial binding if these are missing
         var awaitMethod = (MethodSymbol?)_compilation.GetSpecialTypeMember(useUnsafeAwait
-            ? SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
-            : SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter);
+            ? SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter
+            : SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter);
 
         Debug.Assert(awaitMethod is { Arity: 1 });
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/RuntimeAsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/RuntimeAsyncRewriter.cs
@@ -41,22 +41,22 @@ internal sealed class RuntimeAsyncRewriter : BoundTreeRewriterWithStackGuard
 
     private NamedTypeSymbol Task
     {
-        get => field ??= _compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+        get => field ??= _compilation.GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task);
     } = null!;
 
     private NamedTypeSymbol TaskT
     {
-        get => field ??= _compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+        get => field ??= _compilation.GetSpecialType(InternalSpecialType.System_Threading_Tasks_Task_T);
     } = null!;
 
     private NamedTypeSymbol ValueTask
     {
-        get => field ??= _compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_ValueTask);
+        get => field ??= _compilation.GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask);
     } = null!;
 
     private NamedTypeSymbol ValueTaskT
     {
-        get => field ??= _compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_ValueTask_T);
+        get => field ??= _compilation.GetSpecialType(InternalSpecialType.System_Threading_Tasks_ValueTask_T);
     } = null!;
 
     [return: NotNullIfNotNull(nameof(node))]
@@ -72,25 +72,25 @@ internal sealed class RuntimeAsyncRewriter : BoundTreeRewriterWithStackGuard
         Debug.Assert(nodeType is not null);
         var originalType = nodeType.OriginalDefinition;
 
-        WellKnownMember awaitCall;
+        SpecialMember awaitCall;
         TypeWithAnnotations? maybeNestedType = null;
 
         if (ReferenceEquals(originalType, Task))
         {
-            awaitCall = WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTask;
+            awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask;
         }
         else if (ReferenceEquals(originalType, TaskT))
         {
-            awaitCall = WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTaskT_T;
+            awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T;
             maybeNestedType = ((NamedTypeSymbol)nodeType).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
         }
         else if (ReferenceEquals(originalType, ValueTask))
         {
-            awaitCall = WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTask;
+            awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask;
         }
         else if (ReferenceEquals(originalType, ValueTaskT))
         {
-            awaitCall = WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTaskT_T;
+            awaitCall = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T;
             maybeNestedType = ((NamedTypeSymbol)nodeType).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
         }
         else
@@ -99,7 +99,7 @@ internal sealed class RuntimeAsyncRewriter : BoundTreeRewriterWithStackGuard
         }
 
         // PROTOTYPE: Make sure that we report an error in initial binding if these are missing
-        var awaitMethod = (MethodSymbol?)_compilation.GetWellKnownTypeMember(awaitCall);
+        var awaitMethod = (MethodSymbol?)_compilation.GetSpecialTypeMember(awaitCall);
         Debug.Assert(awaitMethod is not null);
 
         if (maybeNestedType is { } nestedType)
@@ -165,9 +165,9 @@ internal sealed class RuntimeAsyncRewriter : BoundTreeRewriterWithStackGuard
             ref discardedUseSiteInfo).IsImplicit;
 
         // PROTOTYPE: Make sure that we report an error in initial binding if these are missing
-        var awaitMethod = (MethodSymbol?)_compilation.GetWellKnownTypeMember(useUnsafeAwait
-            ? WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
-            : WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter);
+        var awaitMethod = (MethodSymbol?)_compilation.GetSpecialTypeMember(useUnsafeAwait
+            ? SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+            : SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter);
 
         Debug.Assert(awaitMethod is { Arity: 1 });
 

--- a/src/Compilers/CSharp/Portable/Lowering/ExtensionMethodReferenceRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ExtensionMethodReferenceRewriter.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                              { Name: nameof(VisitUnaryOperator) } => !method.IsExtensionMethod, // Expression tree context. At the moment an operator cannot be an extension method
                              { Name: nameof(VisitUserDefinedConditionalLogicalOperator) } => !method.IsExtensionMethod, // Expression tree context. At the moment an operator cannot be an extension method
                              { Name: nameof(VisitCollectionElementInitializer) } => !method.IsExtensionMethod, // Expression tree context. At the moment an extension method cannot be used in expression tree here.
-                             { Name: nameof(VisitAwaitableInfo) } => method is { Name: "GetResult", IsExtensionMethod: false }, // Cannot be an extension method
+                             { Name: nameof(VisitAwaitableInfo) } => method is { Name: "GetResult" or "Await" or "AwaitAwaiter" or "UnsafeAwaitAwaiter", IsExtensionMethod: false }, // Cannot be an extension method
                              { Name: nameof(VisitMethodSymbolWithExtensionRewrite), DeclaringType: { } declaringType } => declaringType == typeof(ExtensionMethodReferenceRewriter),
                              _ => false
                          });

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -268,10 +268,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var getAwaiter = (BoundExpression?)this.Visit(node.GetAwaiter);
             var isCompleted = VisitPropertySymbol(node.IsCompleted);
             var getResult = VisitMethodSymbol(node.GetResult);
+            var runtimeAsyncAwaitMethod = VisitMethodSymbol(node.RuntimeAsyncAwaitMethod);
 
             _placeholderMap.Remove(awaitablePlaceholder);
 
-            return node.Update(rewrittenPlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult);
+            return node.Update(rewrittenPlaceholder, node.IsDynamic, getAwaiter, isCompleted, getResult, runtimeAsyncAwaitMethod);
         }
 
         public override BoundNode VisitAwaitableValuePlaceholder(BoundAwaitableValuePlaceholder node)

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // Keep in sync with VB's AssemblySymbol.RuntimeSupportsAsyncMethods
         internal bool RuntimeSupportsAsyncMethods
-            => RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__Async)
+            => GetSpecialType(InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers) is { TypeKind: TypeKind.Class, IsStatic: true }
                || _overrideRuntimeSupportsAsyncMethods;
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -497,17 +497,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
 #nullable enable
-        // PROTOTYPE: Remove when we have a runtime with support
-        private bool _overrideRuntimeSupportsAsyncMethods;
-        internal void SetOverrideRuntimeSupportsAsyncMethods()
-        {
-            _overrideRuntimeSupportsAsyncMethods = true;
-        }
-
         // Keep in sync with VB's AssemblySymbol.RuntimeSupportsAsyncMethods
         internal bool RuntimeSupportsAsyncMethods
-            => GetSpecialType(InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers) is { TypeKind: TypeKind.Class, IsStatic: true }
-               || _overrideRuntimeSupportsAsyncMethods;
+            => GetSpecialType(InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers) is { TypeKind: TypeKind.Class, IsStatic: true };
 #nullable disable
 
         protected bool RuntimeSupportsFeature(SpecialMember feature)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 // The diagnostics that would be produced here will already have been captured and returned.
                 // PROTOTYPE: handle the runtime case
-                var success = binder.GetAwaitableExpressionInfo(userMainInvocation, out _getAwaiterGetResultCall!, runtimeAsyncAwaitCall: out _, _userMainReturnTypeSyntax, BindingDiagnosticBag.Discarded);
+                var success = binder.GetAwaitableExpressionInfo(userMainInvocation, out _getAwaiterGetResultCall!, runtimeAsyncAwaitMethod: out _, _userMainReturnTypeSyntax, BindingDiagnosticBag.Discarded);
 
                 Debug.Assert(
                     ReturnType.IsVoidType() ||
@@ -491,7 +491,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var initializeCall = CreateParameterlessCall(syntax, scriptLocal, receiverIsSubjectToCloning: ThreeState.False, initializer);
                 BoundExpression getAwaiterGetResultCall;
                 // PROTOTYPE: handle the runtime case
-                if (!binder.GetAwaitableExpressionInfo(initializeCall, out getAwaiterGetResultCall, runtimeAsyncAwaitCall: out _, syntax, diagnostics))
+                if (!binder.GetAwaitableExpressionInfo(initializeCall, out getAwaiterGetResultCall, runtimeAsyncAwaitMethod: out _, syntax, diagnostics))
                 {
                     return new BoundBlock(
                         syntax: syntax,

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -371,7 +371,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 { WasCompilerGenerated = true };
 
                 // The diagnostics that would be produced here will already have been captured and returned.
-                var success = binder.GetAwaitableExpressionInfo(userMainInvocation, out _getAwaiterGetResultCall!, _userMainReturnTypeSyntax, BindingDiagnosticBag.Discarded);
+                // PROTOTYPE: handle the runtime case
+                var success = binder.GetAwaitableExpressionInfo(userMainInvocation, out _getAwaiterGetResultCall!, runtimeAsyncAwaitCall: out _, _userMainReturnTypeSyntax, BindingDiagnosticBag.Discarded);
 
                 Debug.Assert(
                     ReturnType.IsVoidType() ||
@@ -489,7 +490,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(!initializer.ReturnType.IsDynamic());
                 var initializeCall = CreateParameterlessCall(syntax, scriptLocal, receiverIsSubjectToCloning: ThreeState.False, initializer);
                 BoundExpression getAwaiterGetResultCall;
-                if (!binder.GetAwaitableExpressionInfo(initializeCall, out getAwaiterGetResultCall, syntax, diagnostics))
+                // PROTOTYPE: handle the runtime case
+                if (!binder.GetAwaitableExpressionInfo(initializeCall, out getAwaiterGetResultCall, runtimeAsyncAwaitCall: out _, syntax, diagnostics))
                 {
                     return new BoundBlock(
                         syntax: syntax,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -8442,7 +8442,7 @@ class Test1
             // Runtime async not turned on, so we shouldn't care about the missing member
             comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
             comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask);
-            CompileAndVerify(comp);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -8463,7 +8463,7 @@ class Test1
             // Runtime async not turned on, so we shouldn't care about the missing member
             comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
             comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T);
-            CompileAndVerify(comp);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -8484,7 +8484,7 @@ class Test1
             // Runtime async not turned on, so we shouldn't care about the missing member
             comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
             comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask);
-            CompileAndVerify(comp);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -8505,7 +8505,7 @@ class Test1
             // Runtime async not turned on, so we shouldn't care about the missing member
             comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
             comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T);
-            CompileAndVerify(comp);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -8526,7 +8526,7 @@ class Test1
             // Runtime async not turned on, so we shouldn't care about the missing member
             comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
             comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter);
-            CompileAndVerify(comp);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -8561,7 +8561,7 @@ class Test1
             // Runtime async not turned on, so we shouldn't care about the missing member
             comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
             comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter);
-            CompileAndVerify(comp);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -8438,6 +8438,11 @@ class Test1
                 // await System.Threading.Tasks.Task.CompletedTask;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "System.Threading.Tasks.Task.CompletedTask").WithArguments("System.Runtime.CompilerServices.AsyncHelpers", "Await").WithLocation(1, 7)
             );
+
+            // Runtime async not turned on, so we shouldn't care about the missing member
+            comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
+            comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask);
+            CompileAndVerify(comp);
         }
 
         [Fact]
@@ -8454,6 +8459,11 @@ class Test1
                 // await System.Threading.Tasks.Task.FromResult(0);
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "System.Threading.Tasks.Task.FromResult(0)").WithArguments("System.Runtime.CompilerServices.AsyncHelpers", "Await").WithLocation(1, 7)
             );
+
+            // Runtime async not turned on, so we shouldn't care about the missing member
+            comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
+            comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T);
+            CompileAndVerify(comp);
         }
 
         [Fact]
@@ -8470,6 +8480,11 @@ class Test1
                 // await default(System.Threading.Tasks.ValueTask);
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "default(System.Threading.Tasks.ValueTask)").WithArguments("System.Runtime.CompilerServices.AsyncHelpers", "Await").WithLocation(1, 7)
             );
+
+            // Runtime async not turned on, so we shouldn't care about the missing member
+            comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
+            comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask);
+            CompileAndVerify(comp);
         }
 
         [Fact]
@@ -8486,6 +8501,11 @@ class Test1
                 // await default(System.Threading.Tasks.ValueTask<int>);
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "default(System.Threading.Tasks.ValueTask<int>)").WithArguments("System.Runtime.CompilerServices.AsyncHelpers", "Await").WithLocation(1, 7)
             );
+
+            // Runtime async not turned on, so we shouldn't care about the missing member
+            comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
+            comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T);
+            CompileAndVerify(comp);
         }
 
         [Fact]
@@ -8502,6 +8522,11 @@ class Test1
                 // await System.Threading.Tasks.Task.Yield();
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "System.Threading.Tasks.Task.Yield()").WithArguments("System.Runtime.CompilerServices.AsyncHelpers", "UnsafeAwaitAwaiter").WithLocation(1, 7)
             );
+
+            // Runtime async not turned on, so we shouldn't care about the missing member
+            comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
+            comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter);
+            CompileAndVerify(comp);
         }
 
         [Fact]
@@ -8532,6 +8557,11 @@ class Test1
                 // await new C();
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "new C()").WithArguments("System.Runtime.CompilerServices.AsyncHelpers", "AwaitAwaiter").WithLocation(3, 7)
             );
+
+            // Runtime async not turned on, so we shouldn't care about the missing member
+            comp = CreateRuntimeAsyncCompilation(code, parseOptions: TestOptions.RegularPreview);
+            comp.MakeMemberMissing(SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter);
+            CompileAndVerify(comp);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -7,7 +7,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -45,6 +44,302 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             references = (references != null) ? references.Concat(asyncRefs) : asyncRefs;
 
             return CreateCompilationWithMscorlib461(source, options: options, references: references);
+        }
+
+        private const string RuntimeAsyncCoreLib = """
+            namespace System
+            {
+                public delegate void Action();
+                public delegate void Action<T>(T obj);
+                public delegate void Action<T1, T2>(T1 arg1, T2 arg2);
+                public class ArgumentNullException : Exception
+                {
+                    public ArgumentNullException(string message) : base(message) {}
+                }
+                public class Attribute {}
+                [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+                public sealed class AsyncMethodBuilderAttribute : Attribute
+                {
+                    public AsyncMethodBuilderAttribute(Type builderType) {}
+                    public Type BuilderType => null!;
+                }
+                public class AttributeUsageAttribute : Attribute
+                {
+                    public AttributeUsageAttribute(AttributeTargets targets) {}
+                    public bool AllowMultiple { get; set; }
+                    public bool Inherited { get; set; }
+                }
+                public enum AttributeTargets
+                {
+                    All = 0x1,
+                    Class = 0x2,
+                    Struct = 0x4,
+                    Enum = 0x8,
+                    Interface = 0x10,
+                    Delegate = 0x20,
+                    Method = 0x40,
+                    Property = 0x80,
+                    Field = 0x100,
+                    Event = 0x200,
+                }
+                public struct Boolean {}
+                public static class Console
+                {
+                    public static void Write(object i) {}
+                    public static void Write(int i) {}
+                    public static void WriteLine(string s) {}
+                    public static void WriteLine(int i) {}
+                }
+                public class Delegate {}
+                public class Enum {}
+                public class Exception
+                {
+                    public Exception() {}
+                    public Exception(string message) {}
+                }
+                public delegate TResult Func<TResult>();
+                public delegate TResult Func<T, TResult>(T arg);
+                public struct Int32 {}
+                public struct IntPtr {}
+                public class MulticastDelegate {}
+                public struct Nullable<T>(T t) where T : struct {}
+                public class NullReferenceException : Exception
+                {
+                    public NullReferenceException(string message) : base(message) {}
+                }
+                public class Object {}
+                public class String {}
+                public class Type {}
+                public class ValueType {}
+                public class Void {}
+
+                namespace Threading
+                {
+                    public class AutoResetEvent : EventWaitHandle
+                    {
+                        public AutoResetEvent(bool initialState) {}
+                    }
+                    public class EventWaitHandle
+                    {
+                        public bool Set() => default;
+                        public bool WaitOne() => default;
+                        public bool WaitOne(int millisecondsTimeout) => default;
+                    }
+                    public static class Interlocked
+                    {
+                        public static int Increment(ref int location) => default;
+                    }
+                    public static class Thread
+                    {
+                        public static void Sleep(int millisecondsTimeout) {}
+                    }
+                    namespace Tasks
+                    {
+                        using System.Runtime.CompilerServices;
+                        public class Task
+                        {
+                            public Task() {}
+                            public Task(Action action) {}
+                            
+                            public static Task CompletedTask => null!;
+                            public TaskAwaiter GetAwaiter() => default;
+                            public static TaskFactory Factory => null!;
+                            public void Wait() {}
+                            public bool Wait(int millisecondsTimeout) => false;
+                            public static YieldAwaitable Yield() => default;
+                            public static Task<TResult> FromResult<TResult>(TResult result) => default;
+                            public Task ContinueWith(Action<Task> continuationAction) => default;
+                        }
+                        public class Task<TResult>
+                        {
+                            public Task() {}
+                            public Task(Func<TResult> function) {}
+                            
+                            public TaskAwaiter<TResult> GetAwaiter() => default;
+                            public void Wait() {}
+                            public bool Wait(int millisecondsTimeout) => false;
+                            public TResult Result => default;
+                        }
+                        [AsyncMethodBuilder(typeof(AsyncValueTaskMethodBuilder))]
+                        public struct ValueTask
+                        {
+                            public ValueTaskAwaiter GetAwaiter() => default;
+                            public static ValueTask<TResult> FromResult<TResult>(TResult result) => default;
+                        }
+                        [AsyncMethodBuilder(typeof(AsyncValueTaskMethodBuilder<>))]
+                        public struct ValueTask<TResult>
+                        {
+                            public ValueTask(TResult result) {}
+                            public ValueTaskAwaiter<TResult> GetAwaiter() => default;
+                            public TResult Result => default;
+                        }
+                        public class TaskFactory
+                        {
+                            public TaskFactory() {}
+                            public static TaskFactory Factory => default;
+                            public Task StartNew(Action action) => default;
+                            public Task<TResult> StartNew<TResult>(Func<TResult> function) => default;
+                            public ValueTask StartNew(Func<ValueTask> function) => default;
+                            public ValueTask<TResult> StartNew<TResult>(Func<ValueTask<TResult>> function) => default;
+                        }
+                        public class TaskCompletionSource
+                        {
+                            public TaskCompletionSource() {}
+                            public Task Task => default;
+                            public void SetResult() {}
+                            public void SetCanceled() {}
+                            public void SetException(Exception exception) {}
+                        }
+                        public class TaskCompletionSource<TResult>
+                        {
+                            public TaskCompletionSource() {}
+                            public Task<TResult> Task => default;
+                            public void SetResult(TResult result) {}
+                            public void SetCanceled() {}
+                            public void SetException(Exception exception) {}
+                        }
+                    }
+                }
+
+                namespace Runtime.CompilerServices
+                {
+                    public class AsyncMethodBuilderAttribute : Attribute
+                    {
+                        public AsyncMethodBuilderAttribute(Type builderType) {}
+                    }
+                    public struct AsyncTaskMethodBuilder
+                    {
+                        public static AsyncTaskMethodBuilder Create() => default;
+                        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine {}
+                        public void SetStateMachine(IAsyncStateMachine stateMachine) {}
+                        public void SetException(Exception exception) {}
+                        public void SetResult() {}
+                        public Threading.Tasks.Task Task => default;
+                        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : INotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : ICriticalNotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                    }
+                    public struct AsyncTaskMethodBuilder<T>
+                    {
+                        public static AsyncTaskMethodBuilder<T> Create() => default;
+                        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine {}
+                        public void SetStateMachine(IAsyncStateMachine stateMachine) {}
+                        public void SetException(Exception exception) {}
+                        public void SetResult(T result) {}
+                        public Threading.Tasks.Task<T> Task => default;
+                        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : INotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : ICriticalNotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                    }
+                    public struct AsyncValueTaskMethodBuilder
+                    {
+                        public static AsyncValueTaskMethodBuilder Create() => default;
+                        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine {}
+                        public void SetStateMachine(IAsyncStateMachine stateMachine) {}
+                        public void SetException(Exception exception) {}
+                        public void SetResult() {}
+                        public Threading.Tasks.ValueTask Task => default;
+                        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : INotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : ICriticalNotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                    }
+                    public struct AsyncValueTaskMethodBuilder<T>
+                    {
+                        public static AsyncValueTaskMethodBuilder<T> Create() => default;
+                        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine {}
+                        public void SetStateMachine(IAsyncStateMachine stateMachine) {}
+                        public void SetException(Exception exception) {}
+                        public void SetResult(T result) {}
+                        public Threading.Tasks.ValueTask<T> Task => default;
+                        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : INotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) 
+                            where TAwaiter : ICriticalNotifyCompletion 
+                            where TStateMachine : IAsyncStateMachine {}
+                    }
+                    public class ExtensionAttribute : Attribute {}
+                    public interface IAsyncStateMachine
+                    {
+                        void MoveNext();
+                        void SetStateMachine(IAsyncStateMachine stateMachine);
+                    }
+                    public interface INotifyCompletion
+                    {
+                        void OnCompleted(Action continuation);
+                    }
+                    public interface ICriticalNotifyCompletion : INotifyCompletion
+                    {
+                        void UnsafeOnCompleted(Action continuation);
+                    }
+                    public static class RuntimeFeature
+                    {
+                        public const string NumericIntPtr = nameof(NumericIntPtr);
+                    }
+                    public static class RuntimeHelpers
+                    {
+                        public static void AwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion {}
+                        public static void UnsafeAwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion {}
+                    }
+                    public struct TaskAwaiter : ICriticalNotifyCompletion
+                    {
+                        public void OnCompleted(Action continuation) {}
+                        public void UnsafeOnCompleted(Action continuation) {}
+                        public bool IsCompleted => false;
+                        public void GetResult() {}
+                    }
+                    public struct TaskAwaiter<TResult> : ICriticalNotifyCompletion
+                    {
+                        public void OnCompleted(Action continuation) {}
+                        public void UnsafeOnCompleted(Action continuation) {}
+                        public bool IsCompleted => false;
+                        public TResult GetResult() => default;
+                    }
+                    public struct ValueTaskAwaiter : ICriticalNotifyCompletion
+                    {
+                        public void OnCompleted(Action continuation) {}
+                        public void UnsafeOnCompleted(Action continuation) {}
+                        public bool IsCompleted => false;
+                        public void GetResult() {}
+                    }
+                    public struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion
+                    {
+                        public void OnCompleted(Action continuation) {}
+                        public void UnsafeOnCompleted(Action continuation) {}
+                        public bool IsCompleted => false;
+                        public TResult GetResult() => default;
+                    }
+                    public struct YieldAwaitable
+                    {
+                        public YieldAwaiter GetAwaiter() => default;
+                        public struct YieldAwaiter : ICriticalNotifyCompletion
+                        {
+                            public void UnsafeOnCompleted(Action continuation) {}
+                            public void OnCompleted(Action continuation) {}
+                            public bool IsCompleted => false;
+                            public void GetResult() {}
+                        }
+                    }
+                }
+            }
+            """;
+
+        private static CSharpCompilation CreateRuntimeAsyncCompilation(CSharpTestSource source, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
+        {
+            // PROTOTYPE: Remove this helper and just use .NET 10 when we can
+            var corlib = CreateEmptyCompilation([RuntimeAsyncCoreLib, RuntimeAsyncAwaitHelpers]);
+
+            var compilation = CreateEmptyCompilation(source, references: [.. references ?? [], corlib.EmitToImageReference()], options: options, parseOptions: parseOptions ?? WithRuntimeAsync(TestOptions.RegularPreview));
+            return compilation;
         }
 
         private CompilationVerifier CompileAndVerify(string source, string expectedOutput, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, Verification verify = default)
@@ -179,8 +474,7 @@ class Test
 ";
             CompileAndVerify(source, expectedOutput: expected);
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput(expected, isRuntimeAsync: true), verify: Verification.Fails with
             {
@@ -203,7 +497,7 @@ class Test
                   IL_001e:  dup
                   IL_001f:  stsfld     "System.Action Test.<>c.<>9__1_0"
                   IL_0024:  callvirt   "System.Threading.Tasks.Task System.Threading.Tasks.TaskFactory.StartNew(System.Action)"
-                  IL_0029:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                  IL_0029:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                   IL_002e:  ret
                 }
                 """);
@@ -246,8 +540,7 @@ class Test
 }";
 
             var expected = "42";
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput(expected, isRuntimeAsync: true), verify: Verification.Fails with
             {
@@ -268,7 +561,7 @@ class Test
                   // Code size       11 (0xb)
                   .maxstack  1
                   IL_0000:  call       "System.Threading.Tasks.ValueTask Test.<F>g__Impl|1_0()"
-                  IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)"
+                  IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.ValueTask)"
                   IL_000a:  ret
                 }
                 """);
@@ -308,12 +601,11 @@ O brave new world...
 ";
             CompileAndVerify(source, expectedOutput: expected);
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput(expected, isRuntimeAsync: true), verify: Verification.Fails with
             {
-                ILVerifyMessage = "[F]: Unexpected type on the stack. { Offset = 0x2e, Found = ref 'string', Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<string>' }",
+                ILVerifyMessage = "[F]: Unexpected type on the stack. { Offset = 0x2e, Found = ref 'string', Expected = ref 'System.Threading.Tasks.Task`1<string>' }",
             }, symbolValidator: verify);
             verifier.VerifyDiagnostics();
 
@@ -332,7 +624,7 @@ O brave new world...
                   IL_001e:  dup
                   IL_001f:  stsfld     "System.Func<string> Test.<>c.<>9__0_0"
                   IL_0024:  callvirt   "System.Threading.Tasks.Task<string> System.Threading.Tasks.TaskFactory.StartNew<string>(System.Func<string>)"
-                  IL_0029:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
+                  IL_0029:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
                   IL_002e:  ret
                 }
                 """);
@@ -369,13 +661,12 @@ class Test
     }
 }";
             var expected = @"O brave new world...";
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput(expected, isRuntimeAsync: true), verify: Verification.Fails with
             {
                 ILVerifyMessage = $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xa, Found = ref 'string', Expected = value '[System.Runtime]System.Threading.Tasks.ValueTask`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xa, Found = ref 'string', Expected = value 'System.Threading.Tasks.ValueTask`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
             }, symbolValidator: verify);
@@ -386,7 +677,7 @@ class Test
                   // Code size       11 (0xb)
                   .maxstack  1
                   IL_0000:  call       "System.Threading.Tasks.ValueTask<string> Test.<F>g__Impl|0_0()"
-                  IL_0005:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
+                  IL_0005:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
                   IL_000a:  ret
                 }
                 """);
@@ -427,8 +718,7 @@ class Test
                     }
                 }
                 """;
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var ilVerifyMessage = (useValueTask, useGeneric) switch
             {
@@ -437,7 +727,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (false, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0x29, Found = ref 'string', Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0x29, Found = ref 'string', Expected = ref 'System.Threading.Tasks.Task`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
                 (true, false) => $$"""
@@ -445,7 +735,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (true, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xf, Found = ref 'string', Expected = value '[System.Runtime]System.Threading.Tasks.ValueTask`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xf, Found = ref 'string', Expected = value 'System.Threading.Tasks.ValueTask`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
             };
@@ -464,7 +754,7 @@ class Test
                       .maxstack  1
                       IL_0000:  ldnull
                       IL_0001:  newobj     "System.Threading.Tasks.Task..ctor(System.Action)"
-                      IL_0006:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                      IL_0006:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                       IL_000b:  ret
                     }
                     """,
@@ -482,7 +772,7 @@ class Test
                       IL_0019:  dup
                       IL_001a:  stsfld     "System.Func<string> Test.<>c.<>9__0_0"
                       IL_001f:  newobj     "System.Threading.Tasks.Task<string>..ctor(System.Func<string>)"
-                      IL_0024:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
+                      IL_0024:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
                       IL_0029:  ret
                     }
                     """,
@@ -494,7 +784,7 @@ class Test
                       IL_0000:  ldloca.s   V_0
                       IL_0002:  initobj    "System.Threading.Tasks.ValueTask"
                       IL_0008:  ldloc.0
-                      IL_0009:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)"
+                      IL_0009:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.ValueTask)"
                       IL_000e:  ret
                     }
                     """,
@@ -504,7 +794,7 @@ class Test
                       .maxstack  1
                       IL_0000:  ldstr      "42"
                       IL_0005:  newobj     "System.Threading.Tasks.ValueTask<string>..ctor(string)"
-                      IL_000a:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
+                      IL_000a:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
                       IL_000f:  ret
                     }
                     """,
@@ -567,8 +857,7 @@ class Test
                     }
                 }
                 """;
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var ilVerifyMessage = (useValueTask, useGeneric) switch
             {
@@ -577,7 +866,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x16")}}
                     """,
                 (false, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xb, Found = ref 'string', Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xb, Found = ref 'string', Expected = ref 'System.Threading.Tasks.Task`1<string>' }
                     {{ReturnValueMissing("Main", "0x17")}}
                     """,
                 (true, false) => $$"""
@@ -585,7 +874,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x16")}}
                     """,
                 (true, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0x13, Found = ref 'string', Expected = value '[System.Runtime]System.Threading.Tasks.ValueTask`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0x13, Found = ref 'string', Expected = value 'System.Threading.Tasks.ValueTask`1<string>' }
                     {{ReturnValueMissing("Main", "0x18")}}
                     """,
             };
@@ -604,7 +893,7 @@ class Test
                       .maxstack  1
                       IL_0000:  ldnull
                       IL_0001:  call       "void Test.NoOp()"
-                      IL_0006:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                      IL_0006:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                       IL_000b:  ret
                     }
                     """,
@@ -614,7 +903,7 @@ class Test
                       .maxstack  1
                       IL_0000:  ldnull
                       IL_0001:  call       "void Test.NoOp()"
-                      IL_0006:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
+                      IL_0006:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
                       IL_000b:  ret
                     }
                     """,
@@ -627,7 +916,7 @@ class Test
                       IL_0002:  initobj    "System.Threading.Tasks.ValueTask"
                       IL_0008:  ldloc.0
                       IL_0009:  call       "void Test.NoOp()"
-                      IL_000e:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)"
+                      IL_000e:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.ValueTask)"
                       IL_0013:  ret
                     }
                     """,
@@ -640,7 +929,7 @@ class Test
                       IL_0002:  initobj    "System.Threading.Tasks.ValueTask<string>"
                       IL_0008:  ldloc.0
                       IL_0009:  call       "void Test.NoOp()"
-                      IL_000e:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
+                      IL_000e:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
                       IL_0013:  ret
                     }
                     """,
@@ -692,8 +981,7 @@ class Test
                     }
                 }
                 """;
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var ilVerifyMessage = (useValueTask, useGeneric) switch
             {
@@ -702,7 +990,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x16")}}
                     """,
                 (false, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0x6, Found = ref 'string', Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0x6, Found = ref 'string', Expected = ref 'System.Threading.Tasks.Task`1<string>' }
                     {{ReturnValueMissing("Main", "0x17")}}
                     """,
                 (true, false) => $$"""
@@ -710,7 +998,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x16")}}
                     """,
                 (true, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xe, Found = ref 'string', Expected = value '[System.Runtime]System.Threading.Tasks.ValueTask`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xe, Found = ref 'string', Expected = value 'System.Threading.Tasks.ValueTask`1<string>' }
                     {{ReturnValueMissing("Main", "0x18")}}
                     """,
             };
@@ -728,7 +1016,7 @@ class Test
                       // Code size        7 (0x7)
                       .maxstack  1
                       IL_0000:  ldnull
-                      IL_0001:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                      IL_0001:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                       IL_0006:  ret
                     }
                     """,
@@ -737,7 +1025,7 @@ class Test
                       // Code size        7 (0x7)
                       .maxstack  1
                       IL_0000:  ldnull
-                      IL_0001:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
+                      IL_0001:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
                       IL_0006:  ret
                     }
                     """,
@@ -749,7 +1037,7 @@ class Test
                       IL_0000:  ldloca.s   V_0
                       IL_0002:  initobj    "System.Threading.Tasks.ValueTask"
                       IL_0008:  ldloc.0
-                      IL_0009:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)"
+                      IL_0009:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.ValueTask)"
                       IL_000e:  ret
                     }
                     """,
@@ -761,7 +1049,7 @@ class Test
                       IL_0000:  ldloca.s   V_0
                       IL_0002:  initobj    "System.Threading.Tasks.ValueTask<string>"
                       IL_0008:  ldloc.0
-                      IL_0009:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
+                      IL_0009:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
                       IL_000e:  ret
                     }
                     """,
@@ -806,8 +1094,7 @@ class Test
                     }
                 }
                 """;
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var ilVerifyMessage = (useValueTask, useGeneric) switch
             {
@@ -816,7 +1103,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (false, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0x1e, Found = ref 'string', Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0x1e, Found = ref 'string', Expected = ref 'System.Threading.Tasks.Task`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
                 (true, false) => $$"""
@@ -824,7 +1111,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (true, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0x1e, Found = ref 'string', Expected = value '[System.Runtime]System.Threading.Tasks.ValueTask`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0x1e, Found = ref 'string', Expected = value 'System.Threading.Tasks.ValueTask`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
             };
@@ -846,7 +1133,7 @@ class Test
                       IL_0003:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
                       IL_0008:  br.s       IL_000f
                       IL_000a:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                      IL_000f:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                      IL_000f:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                       IL_0014:  ret
                     }
                     """,
@@ -861,7 +1148,7 @@ class Test
                       IL_000d:  br.s       IL_0019
                       IL_000f:  ldstr      "42"
                       IL_0014:  call       "System.Threading.Tasks.Task<string> System.Threading.Tasks.Task.FromResult<string>(string)"
-                      IL_0019:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
+                      IL_0019:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
                       IL_001e:  ret
                     }
                     """,
@@ -879,7 +1166,7 @@ class Test
                       IL_000e:  ldloca.s   V_0
                       IL_0010:  initobj    "System.Threading.Tasks.ValueTask"
                       IL_0016:  ldloc.0
-                      IL_0017:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)"
+                      IL_0017:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.ValueTask)"
                       IL_001c:  ret
                     }
                     """,
@@ -894,7 +1181,7 @@ class Test
                       IL_000d:  br.s       IL_0019
                       IL_000f:  ldstr      "42"
                       IL_0014:  newobj     "System.Threading.Tasks.ValueTask<string>..ctor(string)"
-                      IL_0019:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
+                      IL_0019:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
                       IL_001e:  ret
                     }
                     """,
@@ -938,8 +1225,7 @@ class Test
                     }
                 }
                 """;
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var ilVerifyMessage = (useValueTask, useGeneric) switch
             {
@@ -948,7 +1234,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (false, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xf, Found = ref 'string', Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xf, Found = ref 'string', Expected = ref 'System.Threading.Tasks.Task`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
                 (true, false) => $$"""
@@ -956,7 +1242,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (true, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xf, Found = ref 'string', Expected = value '[System.Runtime]System.Threading.Tasks.ValueTask`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xf, Found = ref 'string', Expected = value 'System.Threading.Tasks.ValueTask`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
             };
@@ -974,7 +1260,7 @@ class Test
                       // Code size       11 (0xb)
                       .maxstack  1
                       IL_0000:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                      IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                      IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                       IL_000a:  ret
                     }
                     """,
@@ -984,7 +1270,7 @@ class Test
                       .maxstack  1
                       IL_0000:  ldstr      "42"
                       IL_0005:  call       "System.Threading.Tasks.Task<string> System.Threading.Tasks.Task.FromResult<string>(string)"
-                      IL_000a:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
+                      IL_000a:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
                       IL_000f:  ret
                     }
                     """,
@@ -996,7 +1282,7 @@ class Test
                       IL_0000:  ldloca.s   V_0
                       IL_0002:  initobj    "System.Threading.Tasks.ValueTask"
                       IL_0008:  ldloc.0
-                      IL_0009:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)"
+                      IL_0009:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.ValueTask)"
                       IL_000e:  ret
                     }
                     """,
@@ -1006,7 +1292,7 @@ class Test
                       .maxstack  1
                       IL_0000:  ldstr      "42"
                       IL_0005:  newobj     "System.Threading.Tasks.ValueTask<string>..ctor(string)"
-                      IL_000a:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
+                      IL_000a:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
                       IL_000f:  ret
                     }
                     """,
@@ -1052,8 +1338,7 @@ class Test
                     public static {{retType}} Prop => {{baseExpr}};
                 }
                 """;
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var ilVerifyMessage = (useValueTask, useGeneric) switch
             {
@@ -1062,7 +1347,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (false, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xa, Found = ref 'string', Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xa, Found = ref 'string', Expected = ref 'System.Threading.Tasks.Task`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
                 (true, false) => $$"""
@@ -1070,7 +1355,7 @@ class Test
                     {{ReturnValueMissing("Main", "0x11")}}
                     """,
                 (true, true) => $$"""
-                    [F]: Unexpected type on the stack. { Offset = 0xa, Found = ref 'string', Expected = value '[System.Runtime]System.Threading.Tasks.ValueTask`1<string>' }
+                    [F]: Unexpected type on the stack. { Offset = 0xa, Found = ref 'string', Expected = value 'System.Threading.Tasks.ValueTask`1<string>' }
                     {{ReturnValueMissing("Main", "0xf")}}
                     """,
             };
@@ -1088,7 +1373,7 @@ class Test
                       // Code size       11 (0xb)
                       .maxstack  1
                       IL_0000:  call       "System.Threading.Tasks.Task Test.Prop.get"
-                      IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                      IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                       IL_000a:  ret
                     }
                     """,
@@ -1097,7 +1382,7 @@ class Test
                       // Code size       11 (0xb)
                       .maxstack  1
                       IL_0000:  call       "System.Threading.Tasks.Task<string> Test.Prop.get"
-                      IL_0005:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
+                      IL_0005:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.Task<string>)"
                       IL_000a:  ret
                     }
                     """,
@@ -1106,7 +1391,7 @@ class Test
                       // Code size       11 (0xb)
                       .maxstack  1
                       IL_0000:  call       "System.Threading.Tasks.ValueTask Test.Prop.get"
-                      IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)"
+                      IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.ValueTask)"
                       IL_000a:  ret
                     } 
                     """,
@@ -1115,7 +1400,7 @@ class Test
                       // Code size       11 (0xb)
                       .maxstack  1
                       IL_0000:  call       "System.Threading.Tasks.ValueTask<string> Test.Prop.get"
-                      IL_0005:  call       "string System.Runtime.CompilerServices.RuntimeHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
+                      IL_0005:  call       "string System.Runtime.CompilerServices.AsyncHelpers.Await<string>(System.Threading.Tasks.ValueTask<string>)"
                       IL_000a:  ret
                     }
                     """,
@@ -1209,8 +1494,7 @@ class Test
 
             CompileAndVerify(source, "0");
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("0", isRuntimeAsync: true), verify: Verification.FailsPEVerify);
             verifier.VerifyDiagnostics();
@@ -1237,7 +1521,7 @@ class Test
                     IL_0013:  callvirt   "bool MyTaskAwaiter<int>.IsCompleted.get"
                     IL_0018:  brtrue.s   IL_0020
                     IL_001a:  ldloc.1
-                    IL_001b:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.{{(useCritical ? "Unsafe" : "")}}AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter<int>>(MyTaskAwaiter<int>)"
+                    IL_001b:  call       "void System.Runtime.CompilerServices.AsyncHelpers.{{(useCritical ? "Unsafe" : "")}}AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter<int>>(MyTaskAwaiter<int>)"
                     IL_0020:  ldloc.1
                     IL_0021:  callvirt   "int MyTaskAwaiter<int>.GetResult()"
                     IL_0026:  brtrue.s   IL_0034
@@ -3050,8 +3334,7 @@ class Driver
 }";
             CompileAndVerify(source, "0");
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], parseOptions: WithRuntimeAsync(TestOptions.RegularPreview), targetFramework: TargetFramework.NetCoreApp);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("0", isRuntimeAsync: true), verify: Verification.FailsPEVerify);
             verifier.VerifyIL("MyTask.Run", """
@@ -3075,7 +3358,7 @@ class Driver
                     IL_0012:  callvirt   "bool MyTaskAwaiter.IsCompleted.get"
                     IL_0017:  brtrue.s   IL_001f
                     IL_0019:  ldloc.1
-                    IL_001a:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter>(MyTaskAwaiter)"
+                    IL_001a:  call       "void System.Runtime.CompilerServices.AsyncHelpers.AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter>(MyTaskAwaiter)"
                     IL_001f:  ldloc.1
                     IL_0020:  callvirt   "int MyTaskAwaiter.GetResult()"
                     IL_0025:  ldc.i4.s   123
@@ -3177,8 +3460,7 @@ class Driver
 }";
             CompileAndVerify(source, "0");
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], parseOptions: WithRuntimeAsync(TestOptions.RegularPreview), targetFramework: TargetFramework.NetCoreApp);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("0", isRuntimeAsync: true), verify: Verification.FailsPEVerify);
             verifier.VerifyIL("MyTask.Run", """
@@ -3202,7 +3484,7 @@ class Driver
                     IL_0012:  callvirt   "bool MyTaskBaseAwaiter.IsCompleted.get"
                     IL_0017:  brtrue.s   IL_001f
                     IL_0019:  ldloc.1
-                    IL_001a:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter>(MyTaskAwaiter)"
+                    IL_001a:  call       "void System.Runtime.CompilerServices.AsyncHelpers.AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter>(MyTaskAwaiter)"
                     IL_001f:  ldloc.1
                     IL_0020:  callvirt   "int MyTaskBaseAwaiter.GetResult()"
                     IL_0025:  ldc.i4.s   123
@@ -6892,8 +7174,7 @@ class Program
             var expected = "StructAwaitable";
             CompileAndVerify(comp, expectedOutput: expected);
 
-            comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], parseOptions: WithRuntimeAsync(TestOptions.RegularPreview), targetFramework: TargetFramework.NetCoreApp);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            comp = CreateRuntimeAsyncCompilation(source);
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput(expected, isRuntimeAsync: true), verify: Verification.Fails with
             {
                 ILVerifyMessage = ReturnValueMissing("Main", "0x2a")
@@ -6915,7 +7196,7 @@ class Program
                   IL_0016:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
                   IL_001b:  brtrue.s   IL_0023
                   IL_001d:  ldloc.0
-                  IL_001e:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
+                  IL_001e:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
                   IL_0023:  ldloca.s   V_0
                   IL_0025:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
                   IL_002a:  ret
@@ -6956,8 +7237,7 @@ class Program
             var expected = "StructAwaitable";
             CompileAndVerify(comp, expectedOutput: expected);
 
-            comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], parseOptions: WithRuntimeAsync(TestOptions.RegularPreview), targetFramework: TargetFramework.NetCoreApp);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            comp = CreateRuntimeAsyncCompilation(source);
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput(expected, isRuntimeAsync: true), verify: Verification.Fails with
             {
                 ILVerifyMessage = ReturnValueMissing("Main", "0x2f")
@@ -6980,7 +7260,7 @@ class Program
                   IL_001b:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
                   IL_0020:  brtrue.s   IL_0028
                   IL_0022:  ldloc.1
-                  IL_0023:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
+                  IL_0023:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
                   IL_0028:  ldloca.s   V_1
                   IL_002a:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
                   IL_002f:  ret
@@ -7523,8 +7803,7 @@ class Test1
                 await Task.CompletedTask;
                 """;
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
 
             var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>$", "0xa") });
 
@@ -7533,7 +7812,7 @@ class Test1
                   // Code size       11 (0xb)
                   .maxstack  1
                   IL_0000:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                  IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                  IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                   IL_000a:  ret
                 }
                 """);
@@ -7548,8 +7827,7 @@ class Test1
                 await Task.CompletedTask;
                 """;
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
             var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
 
             verifier.VerifyIL("<top-level-statements-entry-point>", """
@@ -7591,8 +7869,7 @@ class Test1
                 parseOptions = parseOptions.WithFeature("runtime-async", "off");
             }
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source, parseOptions: parseOptions);
 
             var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
 
@@ -7642,8 +7919,7 @@ class Test1
                 parseOptions = parseOptions.WithFeature("runtime-async", "off");
             }
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation([source, RuntimeAsyncMethodGenerationAttributeDefinition], parseOptions: parseOptions);
 
             var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("Main", "0xa") });
 
@@ -7652,7 +7928,7 @@ class Test1
                   // Code size       11 (0xb)
                   .maxstack  1
                   IL_0000:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                  IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                  IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                   IL_000a:  ret
                 }
                 """);
@@ -7683,8 +7959,7 @@ class Test1
                 parseOptions = parseOptions.WithFeature("runtime-async", "off");
             }
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation([source, RuntimeAsyncMethodGenerationAttributeDefinition], parseOptions: parseOptions);
 
             var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("Main", "0xa") });
 
@@ -7693,7 +7968,7 @@ class Test1
                   // Code size       11 (0xb)
                   .maxstack  1
                   IL_0000:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                  IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                  IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                   IL_000a:  ret
                 }
                 """);
@@ -7746,8 +8021,7 @@ class Test1
                 parseOptions = parseOptions.WithFeature("runtime-async", "off");
             }
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: parseOptions);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation([source, RuntimeAsyncMethodGenerationAttributeDefinition], parseOptions: parseOptions);
 
             var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("Main", "0x26") });
 
@@ -7756,7 +8030,7 @@ class Test1
                   // Code size       39 (0x27)
                   .maxstack  2
                   IL_0000:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                  IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                  IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                   IL_000a:  ldsfld     "System.Func<System.Threading.Tasks.Task> Program.<>c.<>9__0_0"
                   IL_000f:  brtrue.s   IL_0026
                   IL_0011:  ldsfld     "Program.<>c Program.<>c.<>9"
@@ -7806,8 +8080,7 @@ class Test1
                 }
                 """;
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation([source, RuntimeAsyncMethodGenerationAttributeDefinition]);
 
             var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
 
@@ -7852,8 +8125,7 @@ class Test1
                 }
                 """;
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation([source, RuntimeAsyncMethodGenerationAttributeDefinition]);
 
             var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>g__LocalFunc|0_0", "0xa") });
 
@@ -7884,7 +8156,7 @@ class Test1
                   // Code size       11 (0xb)
                   .maxstack  1
                   IL_0000:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                  IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                  IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                   IL_000a:  ret
                 }
                 """);
@@ -7908,8 +8180,7 @@ class Test1
                 }
                 """;
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers, RuntimeAsyncMethodGenerationAttributeDefinition], targetFramework: TargetFramework.Net90, parseOptions: WithRuntimeAsync(TestOptions.RegularPreview));
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation([source, RuntimeAsyncMethodGenerationAttributeDefinition]);
 
             var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>b__0_0", "0xa") });
 
@@ -7940,7 +8211,7 @@ class Test1
                   // Code size       11 (0xb)
                   .maxstack  1
                   IL_0000:  call       "System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get"
-                  IL_0005:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)"
+                  IL_0005:  call       "void System.Runtime.CompilerServices.AsyncHelpers.Await(System.Threading.Tasks.Task)"
                   IL_000a:  ret
                 }
                 """);
@@ -7978,8 +8249,7 @@ class Test1
                 }
                 """;
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], parseOptions: WithRuntimeAsync(TestOptions.RegularPreview), targetFramework: TargetFramework.NetCoreApp);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("42", isRuntimeAsync: true), verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>$", "0x1f") });
 
             var expectedAwait = notifyType == "INotifyCompletion" ? "AwaitAwaiterFromRuntimeAsync" : "UnsafeAwaitAwaiterFromRuntimeAsync";
@@ -7995,7 +8265,7 @@ class Test1
                   IL_000c:  callvirt   "bool C.Awaiter.IsCompleted.get"
                   IL_0011:  brtrue.s   IL_0019
                   IL_0013:  ldloc.0
-                  IL_0014:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.{{expectedAwait}}<C.Awaiter>(C.Awaiter)"
+                  IL_0014:  call       "void System.Runtime.CompilerServices.AsyncHelpers.{{expectedAwait}}<C.Awaiter>(C.Awaiter)"
                   IL_0019:  ldloc.0
                   IL_001a:  callvirt   "void C.Awaiter.GetResult()"
                   IL_001f:  ret
@@ -8036,8 +8306,7 @@ class Test1
                 }
                 """;
 
-            var comp = CreateCompilation([source, RuntimeAsyncAwaitHelpers], parseOptions: WithRuntimeAsync(TestOptions.RegularPreview), targetFramework: TargetFramework.NetCoreApp);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(source);
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("42", isRuntimeAsync: true), verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>$", "0x24") });
 
             var expectedAwait = notifyType.Contains("Critical") ? "UnsafeAwaitAwaiterFromRuntimeAsync" : "AwaitAwaiterFromRuntimeAsync";
@@ -8053,7 +8322,7 @@ class Test1
                   IL_000c:  callvirt   "bool C.Awaiter.IsCompleted.get"
                   IL_0011:  brtrue.s   IL_0019
                   IL_0013:  ldloc.0
-                  IL_0014:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.{{expectedAwait}}<C.Awaiter>(C.Awaiter)"
+                  IL_0014:  call       "void System.Runtime.CompilerServices.AsyncHelpers.{{expectedAwait}}<C.Awaiter>(C.Awaiter)"
                   IL_0019:  ldloc.0
                   IL_001a:  callvirt   "int C.Awaiter.GetResult()"
                   IL_001f:  call       "void System.Console.WriteLine(int)"
@@ -8096,14 +8365,13 @@ class Test1
                 }
                 """;
 
-            var comp = CreateCompilation([code, RuntimeAsyncAwaitHelpers], parseOptions: WithRuntimeAsync(TestOptions.RegularPreview), targetFramework: TargetFramework.NetCoreApp);
-            comp.Assembly.SetOverrideRuntimeSupportsAsyncMethods();
+            var comp = CreateRuntimeAsyncCompilation(code);
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("55", isRuntimeAsync: true), verify: Verification.Fails with
             {
                 ILVerifyMessage = $$"""
                     {{ReturnValueMissing("Main", "0x11")}}
-                    [Fib]: Unexpected type on the stack. { Offset = 0x30, Found = Int32, Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<int32>' }
-                    [Fib]: Unexpected type on the stack. { Offset = 0x4e, Found = Int32, Expected = ref '[System.Runtime]System.Threading.Tasks.Task`1<int32>' }
+                    [Fib]: Unexpected type on the stack. { Offset = 0x30, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
+                    [Fib]: Unexpected type on the stack. { Offset = 0x4e, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
                     """
             });
             verifier.VerifyIL("C.Fib(int)", """
@@ -8127,7 +8395,7 @@ class Test1
                   IL_001b:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
                   IL_0020:  brtrue.s   IL_0028
                   IL_0022:  ldloc.1
-                  IL_0023:  call       "void System.Runtime.CompilerServices.RuntimeHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter>(System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter)"
+                  IL_0023:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter>(System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter)"
                   IL_0028:  ldloca.s   V_1
                   IL_002a:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
                   IL_002f:  ldc.i4.1
@@ -8136,12 +8404,12 @@ class Test1
                   IL_0032:  ldc.i4.1
                   IL_0033:  sub
                   IL_0034:  call       "System.Threading.Tasks.Task<int> C.Fib(int)"
-                  IL_0039:  call       "int System.Runtime.CompilerServices.RuntimeHelpers.Await<int>(System.Threading.Tasks.Task<int>)"
+                  IL_0039:  call       "int System.Runtime.CompilerServices.AsyncHelpers.Await<int>(System.Threading.Tasks.Task<int>)"
                   IL_003e:  ldarg.0
                   IL_003f:  ldc.i4.2
                   IL_0040:  sub
                   IL_0041:  call       "System.Threading.Tasks.Task<int> C.Fib(int)"
-                  IL_0046:  call       "int System.Runtime.CompilerServices.RuntimeHelpers.Await<int>(System.Threading.Tasks.Task<int>)"
+                  IL_0046:  call       "int System.Runtime.CompilerServices.AsyncHelpers.Await<int>(System.Threading.Tasks.Task<int>)"
                   IL_004b:  stloc.0
                   IL_004c:  ldloc.0
                   IL_004d:  add

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -285,11 +285,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
                     {
                         public const string NumericIntPtr = nameof(NumericIntPtr);
                     }
-                    public static class RuntimeHelpers
-                    {
-                        public static void AwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion {}
-                        public static void UnsafeAwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion {}
-                    }
                     public struct TaskAwaiter : ICriticalNotifyCompletion
                     {
                         public void OnCompleted(Action continuation) {}
@@ -1521,7 +1516,7 @@ class Test
                     IL_0013:  callvirt   "bool MyTaskAwaiter<int>.IsCompleted.get"
                     IL_0018:  brtrue.s   IL_0020
                     IL_001a:  ldloc.1
-                    IL_001b:  call       "void System.Runtime.CompilerServices.AsyncHelpers.{{(useCritical ? "Unsafe" : "")}}AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter<int>>(MyTaskAwaiter<int>)"
+                    IL_001b:  call       "void System.Runtime.CompilerServices.AsyncHelpers.{{(useCritical ? "Unsafe" : "")}}AwaitAwaiter<MyTaskAwaiter<int>>(MyTaskAwaiter<int>)"
                     IL_0020:  ldloc.1
                     IL_0021:  callvirt   "int MyTaskAwaiter<int>.GetResult()"
                     IL_0026:  brtrue.s   IL_0034
@@ -3358,7 +3353,7 @@ class Driver
                     IL_0012:  callvirt   "bool MyTaskAwaiter.IsCompleted.get"
                     IL_0017:  brtrue.s   IL_001f
                     IL_0019:  ldloc.1
-                    IL_001a:  call       "void System.Runtime.CompilerServices.AsyncHelpers.AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter>(MyTaskAwaiter)"
+                    IL_001a:  call       "void System.Runtime.CompilerServices.AsyncHelpers.AwaitAwaiter<MyTaskAwaiter>(MyTaskAwaiter)"
                     IL_001f:  ldloc.1
                     IL_0020:  callvirt   "int MyTaskAwaiter.GetResult()"
                     IL_0025:  ldc.i4.s   123
@@ -3484,7 +3479,7 @@ class Driver
                     IL_0012:  callvirt   "bool MyTaskBaseAwaiter.IsCompleted.get"
                     IL_0017:  brtrue.s   IL_001f
                     IL_0019:  ldloc.1
-                    IL_001a:  call       "void System.Runtime.CompilerServices.AsyncHelpers.AwaitAwaiterFromRuntimeAsync<MyTaskAwaiter>(MyTaskAwaiter)"
+                    IL_001a:  call       "void System.Runtime.CompilerServices.AsyncHelpers.AwaitAwaiter<MyTaskAwaiter>(MyTaskAwaiter)"
                     IL_001f:  ldloc.1
                     IL_0020:  callvirt   "int MyTaskBaseAwaiter.GetResult()"
                     IL_0025:  ldc.i4.s   123
@@ -7196,7 +7191,7 @@ class Program
                   IL_0016:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
                   IL_001b:  brtrue.s   IL_0023
                   IL_001d:  ldloc.0
-                  IL_001e:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
+                  IL_001e:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiter<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
                   IL_0023:  ldloca.s   V_0
                   IL_0025:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
                   IL_002a:  ret
@@ -7260,7 +7255,7 @@ class Program
                   IL_001b:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
                   IL_0020:  brtrue.s   IL_0028
                   IL_0022:  ldloc.1
-                  IL_0023:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
+                  IL_0023:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiter<System.Runtime.CompilerServices.TaskAwaiter>(System.Runtime.CompilerServices.TaskAwaiter)"
                   IL_0028:  ldloca.s   V_1
                   IL_002a:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
                   IL_002f:  ret
@@ -8252,7 +8247,7 @@ class Test1
             var comp = CreateRuntimeAsyncCompilation(source);
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("42", isRuntimeAsync: true), verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>$", "0x1f") });
 
-            var expectedAwait = notifyType == "INotifyCompletion" ? "AwaitAwaiterFromRuntimeAsync" : "UnsafeAwaitAwaiterFromRuntimeAsync";
+            var expectedAwait = notifyType == "INotifyCompletion" ? "AwaitAwaiter" : "UnsafeAwaitAwaiter";
             verifier.VerifyIL("<top-level-statements-entry-point>", $$"""
                 {
                   // Code size       32 (0x20)
@@ -8309,7 +8304,7 @@ class Test1
             var comp = CreateRuntimeAsyncCompilation(source);
             var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("42", isRuntimeAsync: true), verify: Verification.Fails with { ILVerifyMessage = ReturnValueMissing("<Main>$", "0x24") });
 
-            var expectedAwait = notifyType.Contains("Critical") ? "UnsafeAwaitAwaiterFromRuntimeAsync" : "AwaitAwaiterFromRuntimeAsync";
+            var expectedAwait = notifyType.Contains("Critical") ? "UnsafeAwaitAwaiter" : "AwaitAwaiter";
             verifier.VerifyIL("<top-level-statements-entry-point>", $$"""
                 {
                   // Code size       37 (0x25)
@@ -8395,7 +8390,7 @@ class Test1
                   IL_001b:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
                   IL_0020:  brtrue.s   IL_0028
                   IL_0022:  ldloc.1
-                  IL_0023:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter>(System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter)"
+                  IL_0023:  call       "void System.Runtime.CompilerServices.AsyncHelpers.UnsafeAwaitAwaiter<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter>(System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter)"
                   IL_0028:  ldloca.s   V_1
                   IL_002a:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
                   IL_002f:  ldc.i4.1

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
@@ -67,11 +67,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
 
             for (int i = 1; i <= (int)SpecialType.Count; i++)
             {
-                var t = msCorLibRef.GetSpecialType((SpecialType)i);
-                Assert.Equal((SpecialType)i, t.SpecialType);
+                var specialType = (SpecialType)i;
+                var t = msCorLibRef.GetSpecialType(specialType);
+                Assert.Equal(specialType, t.SpecialType);
                 Assert.Equal((ExtendedSpecialType)i, t.ExtendedSpecialType);
                 Assert.Same(msCorLibRef, t.ContainingAssembly);
-                if (knownMissingSpecialTypes.Contains((SpecialType)i))
+                if (knownMissingSpecialTypes.Contains(specialType))
                 {
                     // not present on dotnet core 3.1
                     Assert.Equal(TypeKind.Error, t.TypeKind);
@@ -84,11 +85,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
 
             for (int i = (int)InternalSpecialType.First; i < (int)InternalSpecialType.NextAvailable; i++)
             {
-                var t = msCorLibRef.GetSpecialType((InternalSpecialType)i);
+                var internalSpecialType = (InternalSpecialType)i;
+                var t = msCorLibRef.GetSpecialType(internalSpecialType);
                 Assert.Equal(SpecialType.None, t.SpecialType);
                 Assert.Equal((ExtendedSpecialType)i, t.ExtendedSpecialType);
                 Assert.Same(msCorLibRef, t.ContainingAssembly);
-                if (knownMissingInternalSpecialTypes.Contains((InternalSpecialType)i))
+                if (knownMissingInternalSpecialTypes.Contains(internalSpecialType))
                 {
                     // not present on dotnet core 3.1
                     Assert.Equal(TypeKind.Error, t.TypeKind);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
@@ -55,9 +55,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
 
             MetadataOrSourceAssemblySymbol msCorLibRef = (MetadataOrSourceAssemblySymbol)assemblies[0];
 
-            var knownMissingTypes = new HashSet<int>()
+            var knownMissingSpecialTypes = new HashSet<SpecialType>()
             {
-                (int)SpecialType.System_Runtime_CompilerServices_InlineArrayAttribute
+                SpecialType.System_Runtime_CompilerServices_InlineArrayAttribute,
+            };
+
+            var knownMissingInternalSpecialTypes = new HashSet<InternalSpecialType>()
+            {
+                InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,
             };
 
             for (int i = 1; i <= (int)SpecialType.Count; i++)
@@ -66,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
                 Assert.Equal((SpecialType)i, t.SpecialType);
                 Assert.Equal((ExtendedSpecialType)i, t.ExtendedSpecialType);
                 Assert.Same(msCorLibRef, t.ContainingAssembly);
-                if (knownMissingTypes.Contains(i))
+                if (knownMissingSpecialTypes.Contains((SpecialType)i))
                 {
                     // not present on dotnet core 3.1
                     Assert.Equal(TypeKind.Error, t.TypeKind);
@@ -83,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
                 Assert.Equal(SpecialType.None, t.SpecialType);
                 Assert.Equal((ExtendedSpecialType)i, t.ExtendedSpecialType);
                 Assert.Same(msCorLibRef, t.ContainingAssembly);
-                if (knownMissingTypes.Contains(i))
+                if (knownMissingInternalSpecialTypes.Contains((InternalSpecialType)i))
                 {
                     // not present on dotnet core 3.1
                     Assert.Equal(TypeKind.Error, t.TypeKind);
@@ -128,8 +133,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
                 }
             }
 
-            Assert.Equal((int)SpecialType.Count, count + knownMissingTypes.Count);
-            Assert.Equal(knownMissingTypes.Any(), msCorLibRef.KeepLookingForDeclaredSpecialTypes);
+            Assert.Equal((int)SpecialType.Count, count + knownMissingSpecialTypes.Count);
+            Assert.Equal(knownMissingSpecialTypes.Any(), msCorLibRef.KeepLookingForDeclaredSpecialTypes);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -923,7 +923,7 @@ namespace System
             }
 
             // There were 200 well-known types prior to CSharp7
-            Assert.Equal(200, (int)(WellKnownType.CSharp7Sentinel - WellKnownType.First));
+            Assert.Equal(200, (int)(WellKnownType.CSharp7Sentinel - WellKnownType.First - 1 /* WellKnownTypes.ExtSentinel is before CSharp7Sentinel */));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -568,8 +568,8 @@ namespace System
                     || special == SpecialMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor
                     || special == SpecialMember.System_Runtime_CompilerServices_InlineArrayAttribute__ctor
                     || special == SpecialMember.System_ReadOnlySpan_T__ctor_Reference
-                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
-                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter
                     || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
                     || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
                     || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -568,7 +568,13 @@ namespace System
                     || special == SpecialMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor
                     || special == SpecialMember.System_Runtime_CompilerServices_InlineArrayAttribute__ctor
                     || special == SpecialMember.System_ReadOnlySpan_T__ctor_Reference
-                    || special == SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__Async)
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
+                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
+                    )
                 {
                     Assert.Null(symbol); // Not available
                 }
@@ -1023,12 +1029,6 @@ namespace System
                     case WellKnownMember.System_Runtime_CompilerServices_Unsafe__AsRef_T:
                     case WellKnownMember.System_Runtime_CompilerServices_RequiresLocationAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_ParamCollectionAttribute__ctor:
-                    case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTask:
-                    case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTaskT_T:
-                    case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTask:
-                    case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTaskT_T:
-                    case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter:
-                    case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/CodeAnalysisTest/Symbols/SpecialTypeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Symbols/SpecialTypeTests.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertEx.Equal("System_Runtime_CompilerServices_InlineArrayAttribute", ((ExtendedSpecialType)SpecialType.Count).ToString());
             AssertEx.Equal("System_ReadOnlySpan_T", ((ExtendedSpecialType)InternalSpecialType.First).ToString());
             AssertEx.Equal("System_ReadOnlySpan_T", ((ExtendedSpecialType)InternalSpecialType.System_ReadOnlySpan_T).ToString());
-            AssertEx.Equal("System_Reflection_MethodInfo", ((ExtendedSpecialType)(InternalSpecialType.NextAvailable - 1)).ToString());
-            AssertEx.Equal("52", ((ExtendedSpecialType)InternalSpecialType.NextAvailable).ToString());
+            AssertEx.Equal("System_Runtime_CompilerServices_ICriticalNotifyCompletion", ((ExtendedSpecialType)(InternalSpecialType.NextAvailable - 1)).ToString());
+            AssertEx.Equal("58", ((ExtendedSpecialType)InternalSpecialType.NextAvailable).ToString());
         }
     }
 }

--- a/src/Compilers/Core/Portable/ExtendedSpecialType.cs
+++ b/src/Compilers/Core/Portable/ExtendedSpecialType.cs
@@ -57,6 +57,9 @@ namespace Microsoft.CodeAnalysis
             return _value.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a string representation of the ExtendedSpecialType. This exists only for debugging purposes.
+        /// </summary>
         public override string ToString()
         {
             if (_value > (int)SpecialType.None && _value <= (int)SpecialType.Count)
@@ -64,7 +67,15 @@ namespace Microsoft.CodeAnalysis
                 return ((SpecialType)_value).ToString();
             }
 
-            if (_value >= (int)InternalSpecialType.First && _value < (int)InternalSpecialType.NextAvailable)
+            // When there are overlapping labels for a value in an enum, it is undefined which label is returned.
+            // ReadOnlySpan is the one we care about most from a debugging perspective.
+            Debug.Assert(InternalSpecialType.First == InternalSpecialType.System_ReadOnlySpan_T);
+            if (_value == (int)InternalSpecialType.System_ReadOnlySpan_T)
+            {
+                return nameof(InternalSpecialType.System_ReadOnlySpan_T);
+            }
+
+            if (_value > (int)InternalSpecialType.First && _value < (int)InternalSpecialType.NextAvailable)
             {
                 return ((InternalSpecialType)_value).ToString();
             }

--- a/src/Compilers/Core/Portable/ExtendedSpecialType.cs
+++ b/src/Compilers/Core/Portable/ExtendedSpecialType.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis
         public static explicit operator SpecialType(ExtendedSpecialType value) => value._value < (int)InternalSpecialType.First ? (SpecialType)value._value : SpecialType.None;
 
         public static implicit operator ExtendedSpecialType(InternalSpecialType value) => new ExtendedSpecialType((int)value);
+        public static explicit operator InternalSpecialType(ExtendedSpecialType value) => value._value is < (int)InternalSpecialType.First or >= (int)InternalSpecialType.NextAvailable ? InternalSpecialType.Unknown : (InternalSpecialType)value._value;
 
         public static explicit operator ExtendedSpecialType(int value) => new ExtendedSpecialType(value);
         public static explicit operator int(ExtendedSpecialType value) => value._value;

--- a/src/Compilers/Core/Portable/InternalSpecialType.cs
+++ b/src/Compilers/Core/Portable/InternalSpecialType.cs
@@ -64,6 +64,11 @@ namespace Microsoft.CodeAnalysis
         System_Reflection_MethodInfo,
 
         /// <summary>
+        /// Indicates that the type is <code>System.Runtime.CompilerServices.AsyncHelpers</code> from the COR library.
+        /// </summary>
+        System_Runtime_CompilerServices_AsyncHelpers,
+
+        /// <summary>
         /// This item should be kept last and it doesn't represent any specific type.
         /// </summary>
         NextAvailable

--- a/src/Compilers/Core/Portable/InternalSpecialType.cs
+++ b/src/Compilers/Core/Portable/InternalSpecialType.cs
@@ -113,6 +113,17 @@ namespace Microsoft.CodeAnalysis
         System_Threading_Tasks_ValueTask_T,
 
         /// <summary>
+        /// Indicates that the type is <see cref="System.Runtime.CompilerServices.ICriticalNotifyCompletion"/> from the COR library.
+        /// </summary>
+        /// <remarks>
+        /// Check for this special type cannot be used to find the "canonical" definition of <see cref="System.Runtime.CompilerServices.ICriticalNotifyCompletion"/>
+        /// since it is fully legal for it to come from sources other than the COR library.
+        /// The <see cref="WellKnownType.System_Runtime_CompilerServices_ICriticalNotifyCompletion"/> should be used for that purpose instead.
+        /// This entry mostly exists so that compiler can tell this type apart when resolving other members of the COR library.
+        /// </remarks>
+        System_Runtime_CompilerServices_ICriticalNotifyCompletion,
+
+        /// <summary>
         /// This item should be kept last and it doesn't represent any specific type.
         /// </summary>
         NextAvailable

--- a/src/Compilers/Core/Portable/InternalSpecialType.cs
+++ b/src/Compilers/Core/Portable/InternalSpecialType.cs
@@ -69,6 +69,50 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_AsyncHelpers,
 
         /// <summary>
+        /// Indicates that the type is <see cref="System.Threading.Tasks.Task"/> from the COR library.
+        /// </summary>
+        /// <remarks>
+        /// Check for this special type cannot be used to find the "canonical" definition of <see cref="System.Threading.Tasks.Task"/>
+        /// since it is fully legal for it to come from sources other than the COR library.
+        /// The <see cref="WellKnownType.System_Threading_Tasks_Task"/> should be used for that purpose instead.
+        /// This entry mostly exists so that compiler can tell this type apart when resolving other members of the COR library.
+        /// </remarks>
+        System_Threading_Tasks_Task,
+
+        /// <summary>
+        /// Indicates that the type is <see cref="System.Threading.Tasks.Task{TResult}"/> from the COR library.
+        /// </summary>
+        /// <remarks>
+        /// Check for this special type cannot be used to find the "canonical" definition of <see cref="System.Threading.Tasks.Task{TResult}"/>
+        /// since it is fully legal for it to come from sources other than the COR library.
+        /// The <see cref="WellKnownType.System_Threading_Tasks_Task_T"/> should be used for that purpose instead.
+        /// This entry mostly exists so that compiler can tell this type apart when resolving other members of the COR library.
+        /// </remarks>
+        System_Threading_Tasks_Task_T,
+
+        /// <summary>
+        /// Indicates that the type is <see cref="System.Threading.Tasks.ValueTask"/> from the COR library.
+        /// </summary>
+        /// <remarks>
+        /// Check for this special type cannot be used to find the "canonical" definition of <see cref="System.Threading.Tasks.ValueTask"/>
+        /// since it is fully legal for it to come from sources other than the COR library.
+        /// The <see cref="WellKnownType.System_Threading_Tasks_ValueTask"/> should be used for that purpose instead.
+        /// This entry mostly exists so that compiler can tell this type apart when resolving other members of the COR library.
+        /// </remarks>
+        System_Threading_Tasks_ValueTask,
+
+        /// <summary>
+        /// Indicates that the type is <see cref="System.Threading.Tasks.ValueTask{TResult}"/> from the COR library.
+        /// </summary>
+        /// <remarks>
+        /// Check for this special type cannot be used to find the "canonical" definition of <see cref="System.Threading.Tasks.ValueTask{TResult}"/>
+        /// since it is fully legal for it to come from sources other than the COR library.
+        /// The <see cref="WellKnownType.System_Threading_Tasks_ValueTask_T"/> should be used for that purpose instead.
+        /// This entry mostly exists so that compiler can tell this type apart when resolving other members of the COR library.
+        /// </remarks>
+        System_Threading_Tasks_ValueTask_T,
+
+        /// <summary>
         /// This item should be kept last and it doesn't represent any specific type.
         /// </summary>
         NextAvailable

--- a/src/Compilers/Core/Portable/SpecialMember.cs
+++ b/src/Compilers/Core/Portable/SpecialMember.cs
@@ -195,6 +195,13 @@ namespace Microsoft.CodeAnalysis
 
         System_Type__GetTypeFromHandle,
 
+        System_Runtime_CompilerServices_AsyncHelpers__AwaitTask,
+        System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T,
+        System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask,
+        System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T,
+        System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter,
+        System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter,
+
         Count
     }
 }

--- a/src/Compilers/Core/Portable/SpecialMember.cs
+++ b/src/Compilers/Core/Portable/SpecialMember.cs
@@ -198,8 +198,8 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T,
         System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask,
         System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T,
-        System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter,
-        System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter,
+        System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter,
+        System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter,
 
         Count
     }

--- a/src/Compilers/Core/Portable/SpecialMember.cs
+++ b/src/Compilers/Core/Portable/SpecialMember.cs
@@ -165,7 +165,6 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_RuntimeFeature__NumericIntPtr,
         System_Runtime_CompilerServices_RuntimeFeature__ByRefFields,
         System_Runtime_CompilerServices_RuntimeFeature__ByRefLikeGenerics,
-        System_Runtime_CompilerServices_RuntimeFeature__Async,
 
         System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor,
         System_Runtime_CompilerServices_InlineArrayAttribute__ctor,

--- a/src/Compilers/Core/Portable/SpecialMembers.cs
+++ b/src/Compilers/Core/Portable/SpecialMembers.cs
@@ -1526,10 +1526,10 @@ namespace Microsoft.CodeAnalysis
                 "Empty",                                    // System_Array__Empty
                 "SetValue",                                 // System_Array__SetValue
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
-                "AwaitTask",                                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
-                "AwaitTaskT",                               // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
-                "AwaitValueTask",                           // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
-                "AwaitValueTaskT",                          // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
+                "Await",                                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
+                "Await",                               // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
+                "Await",                           // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
+                "Await",                          // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
                 "AwaitAwaiterFromRuntimeAsync",             // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
                 "UnsafeAwaitAwaiterFromRuntimeAsync",       // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
             };

--- a/src/Compilers/Core/Portable/SpecialMembers.cs
+++ b/src/Compilers/Core/Portable/SpecialMembers.cs
@@ -1319,6 +1319,58 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Type, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_RuntimeTypeHandle,
+
+                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_Task,
+
+                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
+                1,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return Type
+                    (byte)SignatureTypeCode.GenericTypeInstance, (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_Task_T,
+                    1,
+                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
+
+                // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_ValueTask,
+
+                // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
+                1,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return Type
+                    (byte)SignatureTypeCode.GenericTypeInstance, (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_ValueTask_T,
+                    1,
+                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
+
+                // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
+                1,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
+
+                // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
+                1,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
             };
 
             string[] allNames = new string[(int)SpecialMember.Count]
@@ -1481,6 +1533,12 @@ namespace Microsoft.CodeAnalysis
                 "Empty",                                    // System_Array__Empty
                 "SetValue",                                 // System_Array__SetValue
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
+                "AwaitTask",                                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
+                "AwaitTaskT",                               // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
+                "AwaitValueTask",                           // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
+                "AwaitValueTaskT",                          // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
+                "AwaitAwaiterFromRuntimeAsync",             // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
+                "UnsafeAwaitAwaiterFromRuntimeAsync",       // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/SpecialMembers.cs
+++ b/src/Compilers/Core/Portable/SpecialMembers.cs
@@ -1141,12 +1141,6 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,                                    // Field Signature
 
-                // System_Runtime_CompilerServices_RuntimeFeature__Async
-                (byte)(MemberFlags.Field | MemberFlags.Static),                                                             // Flags
-                (byte)SpecialType.System_Runtime_CompilerServices_RuntimeFeature,                                           // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,                                    // Field Signature
-
                 // System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
                 (byte)SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute,                           // DeclaringTypeId
@@ -1510,7 +1504,6 @@ namespace Microsoft.CodeAnalysis
                 "NumericIntPtr",                            // System_Runtime_CompilerServices_RuntimeFeature__NumericIntPtr
                 "ByRefFields",                              // System_Runtime_CompilerServices_RuntimeFeature__ByRefFields
                 "ByRefLikeGenerics",                        // System_Runtime_CompilerServices_RuntimeFeature__ByRefLikeGenerics
-                "Async",                                    // System_Runtime_CompilerServices_RuntimeFeature__Async
                 ".ctor",                                    // System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_InlineArrayAttribute__ctor
                 ".ctor",                                    // System_ReadOnlySpan_T__ctor_Reference

--- a/src/Compilers/Core/Portable/SpecialMembers.cs
+++ b/src/Compilers/Core/Portable/SpecialMembers.cs
@@ -1350,7 +1350,7 @@ namespace Microsoft.CodeAnalysis
                     1,
                     (byte)SignatureTypeCode.GenericMethodParameter, 0,
 
-                // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
+                // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
                 1,                                                                                                          // Arity
@@ -1358,7 +1358,7 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                     (byte)SignatureTypeCode.GenericMethodParameter, 0,
 
-                // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+                // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
                 1,                                                                                                          // Arity
@@ -1526,12 +1526,12 @@ namespace Microsoft.CodeAnalysis
                 "Empty",                                    // System_Array__Empty
                 "SetValue",                                 // System_Array__SetValue
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
-                "Await",                                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
-                "Await",                               // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
-                "Await",                           // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
-                "Await",                          // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
-                "AwaitAwaiterFromRuntimeAsync",             // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
-                "UnsafeAwaitAwaiterFromRuntimeAsync",       // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
+                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
+                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
+                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
+                "AwaitAwaiter",                             // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter
+                "UnsafeAwaitAwaiter",                       // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/SpecialTypes.cs
+++ b/src/Compilers/Core/Portable/SpecialTypes.cs
@@ -76,6 +76,10 @@ namespace Microsoft.CodeAnalysis
             "System.Reflection.MethodBase",
             "System.Reflection.MethodInfo",
             "System.Runtime.CompilerServices.AsyncHelpers",
+            "System.Threading.Tasks.Task",
+            "System.Threading.Tasks.Task`1",
+            "System.Threading.Tasks.ValueTask",
+            "System.Threading.Tasks.ValueTask`1",
         };
 
         private static readonly Dictionary<string, ExtendedSpecialType> s_nameToTypeIdMap;

--- a/src/Compilers/Core/Portable/SpecialTypes.cs
+++ b/src/Compilers/Core/Portable/SpecialTypes.cs
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis
             "System.Type",
             "System.Reflection.MethodBase",
             "System.Reflection.MethodInfo",
+            "System.Runtime.CompilerServices.AsyncHelpers",
         };
 
         private static readonly Dictionary<string, ExtendedSpecialType> s_nameToTypeIdMap;

--- a/src/Compilers/Core/Portable/SpecialTypes.cs
+++ b/src/Compilers/Core/Portable/SpecialTypes.cs
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis
             "System.Threading.Tasks.Task`1",
             "System.Threading.Tasks.ValueTask",
             "System.Threading.Tasks.ValueTask`1",
+            "System.Runtime.CompilerServices.ICriticalNotifyCompletion",
         };
 
         private static readonly Dictionary<string, ExtendedSpecialType> s_nameToTypeIdMap;

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -150,12 +150,6 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_RuntimeHelpers__get_OffsetToStringData,
         System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T,
         System_Runtime_CompilerServices_RuntimeHelpers__EnsureSufficientExecutionStack,
-        System_Runtime_CompilerServices_RuntimeHelpers__AwaitTask,
-        System_Runtime_CompilerServices_RuntimeHelpers__AwaitTaskT_T,
-        System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTask,
-        System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTaskT_T,
-        System_Runtime_CompilerServices_RuntimeHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter,
-        System_Runtime_CompilerServices_RuntimeHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter,
 
         System_Runtime_CompilerServices_Unsafe__Add_T,
         System_Runtime_CompilerServices_Unsafe__As_T,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2588,7 +2588,7 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Windows_Forms_Form,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Windows_Forms_Form - WellKnownType.ExtSentinel),
 
                 // System_Environment__CurrentManagedThreadId
                 (byte)(MemberFlags.Property | MemberFlags.Static),                                                          // Flags

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -1033,6 +1033,15 @@ namespace Microsoft.CodeAnalysis
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
 
+                // System_Runtime_CompilerServices_Unsafe__Add_T
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_Unsafe - WellKnownType.ExtSentinel), // DeclaringTypeId
+                1,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericMethodParameter, 0,                 // Return type
+                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericMethodParameter, 0,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
                 // System_Runtime_CompilerServices_Unsafe__As_T
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_Unsafe - WellKnownType.ExtSentinel), // DeclaringTypeId

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2663,7 +2663,7 @@ namespace Microsoft.CodeAnalysis
 
                 // System_ValueTuple_T1__Item1
                 (byte)MemberFlags.Field,                                                                                    // Flags
-                (byte)WellKnownType.System_ValueTuple_T1,                                                                   // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ValueTuple_T1 - WellKnownType.ExtSentinel),    // DeclaringTypeId
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
 
@@ -2879,7 +2879,7 @@ namespace Microsoft.CodeAnalysis
 
                 // System_ValueTuple_T1__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
-                (byte)WellKnownType.System_ValueTuple_T1,                                                                   // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ValueTuple_T1 - WellKnownType.ExtSentinel),    // DeclaringTypeId
                 0,                                                                                                          // Arity
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -1033,65 +1033,6 @@ namespace Microsoft.CodeAnalysis
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
 
-                // System_Runtime_CompilerServices_RuntimeHelpers__AwaitTask
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_RuntimeHelpers,                                         // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Threading_Tasks_Task,
-
-                // System_Runtime_CompilerServices_RuntimeHelpers__AwaitTaskT_T
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_RuntimeHelpers,                                         // DeclaringTypeId
-                1,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return Type
-                    (byte)SignatureTypeCode.GenericTypeInstance, (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Threading_Tasks_Task_T, 1,
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
-
-                // System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTask
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_RuntimeHelpers,                                         // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_Tasks_ValueTask - WellKnownType.ExtSentinel),
-
-                // System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTaskT_T
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_RuntimeHelpers,                                         // DeclaringTypeId
-                1,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return Type
-                    (byte)SignatureTypeCode.GenericTypeInstance, (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_Tasks_ValueTask_T - WellKnownType.ExtSentinel), 1,
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
-
-                // System_Runtime_CompilerServices_RuntimeHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_RuntimeHelpers,                                         // DeclaringTypeId
-                1,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
-
-                // System_Runtime_CompilerServices_RuntimeHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_RuntimeHelpers,                                         // DeclaringTypeId
-                1,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
-
-                // System_Runtime_CompilerServices_Unsafe__Add_T
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_Unsafe - WellKnownType.ExtSentinel), // DeclaringTypeId
-                1,                                                                                                          // Arity
-                    2,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericMethodParameter, 0,                 // Return type
-                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericMethodParameter, 0,
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
-
                 // System_Runtime_CompilerServices_Unsafe__As_T
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_Unsafe - WellKnownType.ExtSentinel), // DeclaringTypeId
@@ -2634,7 +2575,7 @@ namespace Microsoft.CodeAnalysis
 
                 // System_Windows_Forms_Application__RunForm
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Windows_Forms_Application,                                                       // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Windows_Forms_Application - WellKnownType.ExtSentinel), // DeclaringTypeId
                 0,                                                                                                          // Arity
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
@@ -2642,7 +2583,7 @@ namespace Microsoft.CodeAnalysis
 
                 // System_Environment__CurrentManagedThreadId
                 (byte)(MemberFlags.Property | MemberFlags.Static),                                                          // Flags
-                (byte)WellKnownType.System_Environment,                                                                     // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Environment - WellKnownType.ExtSentinel),      // DeclaringTypeId
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32, // Return Type
@@ -2657,9 +2598,9 @@ namespace Microsoft.CodeAnalysis
 
                 // System_Runtime_GCLatencyMode__SustainedLowLatency
                 (byte)(MemberFlags.Field | MemberFlags.Static),                                                             // Flags
-                (byte)WellKnownType.System_Runtime_GCLatencyMode,                                                           // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_GCLatencyMode - WellKnownType.ExtSentinel), // DeclaringTypeId
                 0,                                                                                                          // Arity
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_GCLatencyMode,                   // Field Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_GCLatencyMode - WellKnownType.ExtSentinel), // Field Signature
 
                 // System_ValueTuple_T1__Item1
                 (byte)MemberFlags.Field,                                                                                    // Flags
@@ -5375,12 +5316,6 @@ namespace Microsoft.CodeAnalysis
                 "get_OffsetToStringData",                   // System_Runtime_CompilerServices_RuntimeHelpers__get_OffsetToStringData
                 "GetSubArray",                              // System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T
                 "EnsureSufficientExecutionStack",           // System_Runtime_CompilerServices_RuntimeHelpers__EnsureSufficientExecutionStack
-                "Await",                                    // System_Runtime_CompilerServices_RuntimeHelpers__AwaitTask
-                "Await",                                    // System_Runtime_CompilerServices_RuntimeHelpers__AwaitTaskT_T
-                "Await",                                    // System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTask
-                "Await",                                    // System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTaskT_T
-                "AwaitAwaiterFromRuntimeAsync",             // System_Runtime_CompilerServices_RuntimeHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter
-                "UnsafeAwaitAwaiterFromRuntimeAsync",       // System_Runtime_CompilerServices_RuntimeHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
                 "Add",                                      // System_Runtime_CompilerServices_Unsafe__Add_T
                 "As",                                       // System_Runtime_CompilerServices_Unsafe__As_T,
                 "AsRef",                                    // System_Runtime_CompilerServices_Unsafe__AsRef_T,

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -237,10 +237,9 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_AsyncStateMachineAttribute,
         System_Runtime_CompilerServices_IteratorStateMachineAttribute,
 
-        System_Windows_Forms_Form,
-
         ExtSentinel, // Not a real type, just a marker for types above 255 and strictly below 512
 
+        System_Windows_Forms_Form,
         System_Windows_Forms_Application,
 
         System_Environment,
@@ -587,10 +586,9 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
             "System.Runtime.CompilerServices.IteratorStateMachineAttribute",
 
-            "System.Windows.Forms.Form",
-
             "", // WellKnownType.ExtSentinel extension marker
 
+            "System.Windows.Forms.Form",
             "System.Windows.Forms.Application",
 
             "System.Environment",

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -248,10 +248,9 @@ namespace Microsoft.CodeAnalysis
 
         System_ValueTuple,
 
-        System_ValueTuple_T1,
-
         ExtSentinel, // Not a real type, just a marker for types above 255 and strictly below 512
 
+        System_ValueTuple_T1,
         System_ValueTuple_T2,
         System_ValueTuple_T3,
         System_ValueTuple_T4,
@@ -595,10 +594,10 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.GCLatencyMode",
 
             "System.ValueTuple",
-            "System.ValueTuple`1",
 
             "", // WellKnownType.ExtSentinel extension marker
 
+            "System.ValueTuple`1",
             "System.ValueTuple`2",
             "System.ValueTuple`3",
             "System.ValueTuple`4",
@@ -758,8 +757,9 @@ namespace Microsoft.CodeAnalysis
             // Some compile time asserts
             {
                 // We should not add new types to CSharp7 set
-                _ = new int[(int)WellKnownType.CSharp7Sentinel - 252];
-                _ = new int[252 - (int)WellKnownType.CSharp7Sentinel];
+                const int ExpectedCSharp7SentinelValue = 200 + (int)InternalSpecialType.NextAvailable;
+                _ = new int[(int)WellKnownType.CSharp7Sentinel - ExpectedCSharp7SentinelValue];
+                _ = new int[ExpectedCSharp7SentinelValue - (int)WellKnownType.CSharp7Sentinel];
 
                 // The WellKnownType.ExtSentinel value must be 255
                 _ = new int[(int)WellKnownType.ExtSentinel - 255];

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -238,6 +238,9 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_IteratorStateMachineAttribute,
 
         System_Windows_Forms_Form,
+
+        ExtSentinel, // Not a real type, just a marker for types above 255 and strictly below 512
+
         System_Windows_Forms_Application,
 
         System_Environment,
@@ -247,8 +250,6 @@ namespace Microsoft.CodeAnalysis
         CSharp7Sentinel = System_Runtime_GCLatencyMode, // all types that were known before CSharp7 should remain above this sentinel
 
         System_ValueTuple,
-
-        ExtSentinel, // Not a real type, just a marker for types above 255 and strictly below 512
 
         System_ValueTuple_T1,
         System_ValueTuple_T2,
@@ -587,6 +588,9 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.CompilerServices.IteratorStateMachineAttribute",
 
             "System.Windows.Forms.Form",
+
+            "", // WellKnownType.ExtSentinel extension marker
+
             "System.Windows.Forms.Application",
 
             "System.Environment",
@@ -594,8 +598,6 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.GCLatencyMode",
 
             "System.ValueTuple",
-
-            "", // WellKnownType.ExtSentinel extension marker
 
             "System.ValueTuple`1",
             "System.ValueTuple`2",
@@ -757,7 +759,7 @@ namespace Microsoft.CodeAnalysis
             // Some compile time asserts
             {
                 // We should not add new types to CSharp7 set
-                const int ExpectedCSharp7SentinelValue = 200 + (int)InternalSpecialType.NextAvailable;
+                const int ExpectedCSharp7SentinelValue = 200 + (int)InternalSpecialType.NextAvailable + 1 /* Placeholder for ExtSentinel */;
                 _ = new int[(int)WellKnownType.CSharp7Sentinel - ExpectedCSharp7SentinelValue];
                 _ = new int[ExpectedCSharp7SentinelValue - (int)WellKnownType.CSharp7Sentinel];
 

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -802,9 +802,9 @@ namespace System.Diagnostics.CodeAnalysis
             {
                 public static class AsyncHelpers
                 {
-                    public static void AwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion
+                    public static void AwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion
                     {}
-                    public static void UnsafeAwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion
+                    public static void UnsafeAwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion
                     {}
 
                     public static void Await(System.Threading.Tasks.Task task) => task.GetAwaiter().GetResult();

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -800,7 +800,7 @@ namespace System.Diagnostics.CodeAnalysis
         internal const string RuntimeAsyncAwaitHelpers = """
             namespace System.Runtime.CompilerServices
             {
-                public static class RuntimeHelpers
+                public static class AsyncHelpers
                 {
                     public static void AwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion
                     {}

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -426,7 +426,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property RuntimeSupportsAsyncMethods As Boolean
             Get
                 ' Keep in sync with C#'s AssemblySymbol.RuntimeSupportsAsyncMethods
-                Return RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__Async)
+                Dim asyncHelpers = GetSpecialType(InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers)
+                Return asyncHelpers IsNot Nothing AndAlso
+                       asyncHelpers.IsClassType() AndAlso
+                       asyncHelpers.IsMetadataAbstract AndAlso
+                       asyncHelpers.IsMetadataSealed
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
@@ -50,14 +50,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences({NetCoreApp.SystemRuntime})
             Dim msCorLibRef As MetadataOrSourceAssemblySymbol = DirectCast(assemblies(0), MetadataOrSourceAssemblySymbol)
 
-            Dim knownMissingTypes As HashSet(Of Integer) = New HashSet(Of Integer) From {SpecialType.System_Runtime_CompilerServices_InlineArrayAttribute}
+            Dim knownMissingSpecialTypes As HashSet(Of SpecialType) = New HashSet(Of SpecialType) From {SpecialType.System_Runtime_CompilerServices_InlineArrayAttribute}
+            Dim knownMissingInternalSpecialTypes As HashSet(Of InternalSpecialType) = New HashSet(Of InternalSpecialType) From {InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers}
 
             For i As Integer = 1 To SpecialType.Count
-                Dim t = msCorLibRef.GetSpecialType(CType(i, SpecialType))
+                Dim specialType = CType(i, SpecialType)
+                Dim t = msCorLibRef.GetSpecialType(specialType)
                 Assert.Equal(CType(i, SpecialType), t.SpecialType)
                 Assert.Equal(CType(i, ExtendedSpecialType), t.ExtendedSpecialType)
                 Assert.Same(msCorLibRef, t.ContainingAssembly)
-                If knownMissingTypes.Contains(i) Then
+                If knownMissingSpecialTypes.Contains(specialType) Then
                     ' not present on dotnet core 3.1
                     Assert.Equal(TypeKind.Error, t.TypeKind)
                 Else
@@ -66,11 +68,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
             Next
 
             For i As Integer = InternalSpecialType.First To InternalSpecialType.NextAvailable - 1
-                Dim t = msCorLibRef.GetSpecialType(CType(i, InternalSpecialType))
+                Dim internalSpecialType = CType(i, InternalSpecialType)
+                Dim t = msCorLibRef.GetSpecialType(internalSpecialType)
                 Assert.Equal(SpecialType.None, t.SpecialType)
                 Assert.Equal(CType(i, ExtendedSpecialType), t.ExtendedSpecialType)
                 Assert.Same(msCorLibRef, t.ContainingAssembly)
-                If knownMissingTypes.Contains(i) Then
+                If knownMissingInternalSpecialTypes.Contains(internalSpecialType) Then
                     ' not present on dotnet core 3.1
                     Assert.Equal(TypeKind.Error, t.TypeKind)
                 Else
@@ -106,8 +109,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
                 Next
             End While
 
-            Assert.Equal(count + knownMissingTypes.Count, CType(SpecialType.Count, Integer))
-            Assert.Equal(knownMissingTypes.Any(), msCorLibRef.KeepLookingForDeclaredSpecialTypes)
+            Assert.Equal(count + knownMissingSpecialTypes.Count, CType(SpecialType.Count, Integer))
+            Assert.Equal(knownMissingSpecialTypes.Any(), msCorLibRef.KeepLookingForDeclaredSpecialTypes)
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -498,8 +498,8 @@ End Namespace
                    special = SpecialMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor OrElse
                    special = SpecialMember.System_Runtime_CompilerServices_InlineArrayAttribute__ctor OrElse
                    special = SpecialMember.System_ReadOnlySpan_T__ctor_Reference OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter OrElse
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter OrElse
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter OrElse
                    special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask OrElse
                    special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T OrElse
                    special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask OrElse

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -498,7 +498,12 @@ End Namespace
                    special = SpecialMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor OrElse
                    special = SpecialMember.System_Runtime_CompilerServices_InlineArrayAttribute__ctor OrElse
                    special = SpecialMember.System_ReadOnlySpan_T__ctor_Reference OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__Async Then
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter OrElse
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter OrElse
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask OrElse
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T OrElse
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask OrElse
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T Then
                     Assert.Null(symbol) ' Not available
                 Else
                     Assert.NotNull(symbol)
@@ -759,13 +764,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__CreateSpanRuntimeFieldHandle,
                          WellKnownMember.System_Runtime_CompilerServices_RequiresLocationAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_ParamCollectionAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTask,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTaskT_T,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTask,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTaskT_T,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+                         WellKnownMember.System_Runtime_CompilerServices_ParamCollectionAttribute__ctor
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -976,13 +975,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__CreateSpanRuntimeFieldHandle,
                          WellKnownMember.System_Runtime_CompilerServices_RequiresLocationAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_ParamCollectionAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTask,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitTaskT_T,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTask,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitValueTaskT_T,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__AwaitAwaiterFromRuntimeAsync_TAwaiter,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__UnsafeAwaitAwaiterFromRuntimeAsync_TAwaiter
+                         WellKnownMember.System_Runtime_CompilerServices_ParamCollectionAttribute__ctor
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,


### PR DESCRIPTION
We now do method construction and validation for runtime async helpers up front in initial binding, rather than doing it in `RuntimeAsyncRewriter`. I've also renamed the APIs as per https://github.com/dotnet/runtime/issues/114310#issuecomment-2822093178 (though I haven't added ConfigureAwait support yet, that will be the next PR). We now validate:

* The helpers come from `System.Runtime.CompilerServices.AsyncHelpers`, defined in corelib. This means that I now need a fairly extensive corelib mock to be able to compile. When we have a testing runtime that defines these helpers, we can remove the giant mock and use the real one.
* We properly error when expected helpers aren't present.
* We properly check to make sure that constraints are satisfied when doing generic substitution in one of the runtime helpers.
* Runtime async is not turned on if the async method does not return `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>`.

Relates to test plan https://github.com/dotnet/roslyn/issues/75960