### PR TITLE
Ensure we generate a full package for LanguageServices.Xaml

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Microsoft.VisualStudio.LanguageServices.Xaml.csproj
+++ b/src/VisualStudio/Xaml/Impl/Microsoft.VisualStudio.LanguageServices.Xaml.csproj
@@ -7,7 +7,6 @@
     <DeployExtension>false</DeployExtension>
     <TargetFramework>net472</TargetFramework>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
 
     <IsPackable>true</IsPackable>
     <PackageDescription>


### PR DESCRIPTION
This otherwise overrides everything and creates only a symbol package.