### PR TITLE
Move remaining legacy workspace event listeners over to new APIs.

### DIFF
--- a/src/EditorFeatures/Core/EditAndContinue/PdbMatchingSourceTextProvider.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/PdbMatchingSourceTextProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,6 +35,8 @@ internal sealed class PdbMatchingSourceTextProvider() : IEventListener, IPdbMatc
 
     public void StartListening(Workspace workspace)
     {
+        Debug.Assert(_workspaceChangedDisposer == null);
+
         _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(WorkspaceChanged);
     }
 

--- a/src/EditorFeatures/Core/EditAndContinue/PdbMatchingSourceTextProvider.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/PdbMatchingSourceTextProvider.cs
@@ -30,14 +30,20 @@ internal sealed class PdbMatchingSourceTextProvider() : IEventListener, IPdbMatc
     private bool _isActive;
     private int _baselineSolutionVersion;
     private readonly Dictionary<string, (DocumentState state, int solutionVersion)> _documentsWithChangedLoaderByPath = [];
+    private WorkspaceEventRegistration? _workspaceChangedDisposer;
 
     public void StartListening(Workspace workspace)
-        => workspace.WorkspaceChanged += WorkspaceChanged;
+    {
+        _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(WorkspaceChanged);
+    }
 
     public void StopListening(Workspace workspace)
-        => workspace.WorkspaceChanged -= WorkspaceChanged;
+    {
+        _workspaceChangedDisposer?.Dispose();
+        _workspaceChangedDisposer = null;
+    }
 
-    private void WorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
+    private void WorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         if (!_isActive)
         {

--- a/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
@@ -32,7 +32,7 @@ internal sealed partial class SettingsAggregator : ISettingsAggregator
         IAsynchronousOperationListener listener)
     {
         _workspace = workspace;
-        _workspace.WorkspaceChanged += UpdateProviders;
+        _ = workspace.RegisterWorkspaceChangedHandler(UpdateProviders);
 
         var currentSolution = _workspace.CurrentSolution.SolutionState;
         UpdateProviders(currentSolution);
@@ -48,7 +48,7 @@ internal sealed partial class SettingsAggregator : ISettingsAggregator
             threadingContext.DisposalToken);
     }
 
-    private void UpdateProviders(object? sender, WorkspaceChangeEventArgs e)
+    private void UpdateProviders(WorkspaceChangeEventArgs e)
     {
         switch (e.Kind)
         {

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -51,13 +51,14 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
     private readonly ITextView _triggerView;
     private readonly IDisposable _inlineRenameSessionDurationLogBlock;
     private readonly IThreadingContext _threadingContext;
+    private readonly WorkspaceEventRegistration _workspaceChangedDisposer;
+
     public readonly InlineRenameService RenameService;
 
     private bool _dismissed;
     private bool _isApplyingEdit;
     private string _replacementText;
     private readonly Dictionary<ITextBuffer, OpenTextBufferManager> _openTextBuffers = [];
-    private WorkspaceEventRegistration _workspaceChangedDisposer;
 
     /// <summary>
     /// The original <see cref="Document"/> where rename was triggered
@@ -704,8 +705,7 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
 
         void DismissUIAndRollbackEdits()
         {
-            _workspaceChangedDisposer?.Dispose();
-            _workspaceChangedDisposer = null;
+            _workspaceChangedDisposer.Dispose();
 
             _textBufferAssociatedViewService.SubjectBuffersConnected -= OnSubjectBuffersConnected;
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -57,7 +57,7 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
     private bool _isApplyingEdit;
     private string _replacementText;
     private readonly Dictionary<ITextBuffer, OpenTextBufferManager> _openTextBuffers = [];
-    private WorkspaceEventRegistration? _workspaceChangedDisposer;
+    private WorkspaceEventRegistration _workspaceChangedDisposer;
 
     /// <summary>
     /// The original <see cref="Document"/> where rename was triggered

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
@@ -17,6 +18,7 @@ internal partial class TaggerEventSources
 
         protected override void ConnectToWorkspace(Workspace workspace)
         {
+            Debug.Assert(_workspaceChangedDisposer == null);
             _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
         }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
@@ -13,13 +13,20 @@ internal partial class TaggerEventSources
 {
     private sealed class ParseOptionChangedEventSource(ITextBuffer subjectBuffer) : AbstractWorkspaceTrackingTaggerEventSource(subjectBuffer)
     {
+        private WorkspaceEventRegistration? _workspaceChangedDisposer;
+
         protected override void ConnectToWorkspace(Workspace workspace)
-            => workspace.WorkspaceChanged += OnWorkspaceChanged;
+        {
+            _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
+        }
 
         protected override void DisconnectFromWorkspace(Workspace workspace)
-            => workspace.WorkspaceChanged -= OnWorkspaceChanged;
+        {
+            _workspaceChangedDisposer?.Dispose();
+            _workspaceChangedDisposer = null;
+        }
 
-        private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
+        private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
         {
             if (e.Kind == WorkspaceChangeKind.ProjectChanged)
             {

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceChangedEventSource.cs
@@ -15,6 +15,7 @@ internal partial class TaggerEventSources
     private sealed class WorkspaceChangedEventSource : AbstractWorkspaceTrackingTaggerEventSource
     {
         private readonly AsyncBatchingWorkQueue _asyncDelay;
+        private WorkspaceEventRegistration? _workspaceChangedDisposer;
 
         public WorkspaceChangedEventSource(
             ITextBuffer subjectBuffer,
@@ -36,17 +37,19 @@ internal partial class TaggerEventSources
 
         protected override void ConnectToWorkspace(Workspace workspace)
         {
-            workspace.WorkspaceChanged += OnWorkspaceChanged;
+            _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
             this.RaiseChanged();
         }
 
         protected override void DisconnectFromWorkspace(Workspace workspace)
         {
-            workspace.WorkspaceChanged -= OnWorkspaceChanged;
+            _workspaceChangedDisposer?.Dispose();
+            _workspaceChangedDisposer = null;
+
             this.RaiseChanged();
         }
 
-        private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs eventArgs)
+        private void OnWorkspaceChanged(WorkspaceChangeEventArgs eventArgs)
             => _asyncDelay.AddWork();
     }
 }

--- a/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
+++ b/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
@@ -33,7 +33,7 @@ internal sealed partial class HostLegacySolutionEventsWorkspaceEventListener : I
     private readonly AsyncBatchingWorkQueue<WorkspaceChangeEventArgs> _eventQueue;
 
     private WorkspaceEventRegistration? _workspaceChangedDisposer;
-    
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public HostLegacySolutionEventsWorkspaceEventListener(

--- a/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
+++ b/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
@@ -32,6 +32,8 @@ internal sealed partial class HostLegacySolutionEventsWorkspaceEventListener : I
     private readonly IThreadingContext _threadingContext;
     private readonly AsyncBatchingWorkQueue<WorkspaceChangeEventArgs> _eventQueue;
 
+    private WorkspaceEventRegistration? _workspaceChangedDisposer;
+    
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public HostLegacySolutionEventsWorkspaceEventListener(
@@ -53,16 +55,19 @@ internal sealed partial class HostLegacySolutionEventsWorkspaceEventListener : I
         // We only support this option to disable crawling in internal speedometer and ddrit perf runs to lower noise.
         // It is not exposed to the user.
         if (_globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-            workspace.WorkspaceChanged += OnWorkspaceChanged;
+            _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
     }
 
     public void StopListening(Workspace workspace)
     {
         if (_globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-            workspace.WorkspaceChanged -= OnWorkspaceChanged;
+        {
+            _workspaceChangedDisposer?.Dispose();
+            _workspaceChangedDisposer = null;
+        }
     }
 
-    private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         // Legacy workspace events exist solely to let unit testing continue to work using their own fork of solution
         // crawler.  As such, they only need events for the project types they care about.  Specifically, that is only

--- a/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
@@ -11,8 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Shared.Utilities;
-using Microsoft.CodeAnalysis.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
@@ -56,10 +54,12 @@ internal sealed class CodeAnalysisDiagnosticAnalyzerServiceFactory() : IWorkspac
             _diagnosticAnalyzerService = diagnosticAnalyzerService;
             _workspace = workspace;
 
-            _workspace.WorkspaceChanged += OnWorkspaceChanged;
+            // Main thread as OnWorkspaceChanged's call to IDiagnosticAnalyzerService.RequestDiagnosticRefresh isn't clear on
+            // threading requirements
+            _ = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged, WorkspaceEventOptions.RequiresMainThreadOptions);
         }
 
-        private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
+        private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
         {
             switch (e.Kind)
             {

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -65,7 +65,7 @@ internal sealed class CompileTimeSolutionProvider : ICompileTimeSolutionProvider
 
     public CompileTimeSolutionProvider(Workspace workspace)
     {
-        workspace.WorkspaceChanged += (s, e) =>
+        _ = workspace.RegisterWorkspaceChangedHandler((e) =>
         {
             if (e.Kind is WorkspaceChangeKind.SolutionCleared or WorkspaceChangeKind.SolutionRemoved)
             {
@@ -79,7 +79,7 @@ internal sealed class CompileTimeSolutionProvider : ICompileTimeSolutionProvider
                     _lastCompileTimeSolution = null;
                 }
             }
-        };
+        });
     }
 
     private static bool IsRazorAnalyzerConfig(TextDocumentState documentState)

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -60,6 +60,8 @@ internal sealed class VisualStudioDesignerAttributeService :
     // deliver them to VS in batches to prevent flooding the UI thread.
     private readonly AsyncBatchingWorkQueue<DesignerAttributeData> _projectSystemNotificationQueue;
 
+    private WorkspaceEventRegistration? _workspaceChangedDisposer;
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public VisualStudioDesignerAttributeService(
@@ -92,7 +94,7 @@ internal sealed class VisualStudioDesignerAttributeService :
         if (workspace != _workspace)
             return;
 
-        _workspace.WorkspaceChanged += OnWorkspaceChanged;
+        _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
         _workQueue.AddWork(cancelExistingWork: true);
     }
 
@@ -101,10 +103,11 @@ internal sealed class VisualStudioDesignerAttributeService :
         if (workspace != _workspace)
             return;
 
-        _workspace.WorkspaceChanged -= OnWorkspaceChanged;
+        _workspaceChangedDisposer?.Dispose();
+        _workspaceChangedDisposer = null;
     }
 
-    private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         _workQueue.AddWork(cancelExistingWork: true);
     }

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -41,7 +41,7 @@ internal abstract partial class AbstractObjectBrowserLibraryManager : AbstractLi
     private ObjectListItem _activeListItem;
     private AbstractListItemFactory _listItemFactory;
     private readonly object _classMemberGate = new();
-    private WorkspaceEventRegistration? _workspaceChangedDisposer;
+    private WorkspaceEventRegistration _workspaceChangedDisposer;
 
     protected AbstractObjectBrowserLibraryManager(
         string languageName,

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -41,6 +41,7 @@ internal abstract partial class AbstractObjectBrowserLibraryManager : AbstractLi
     private ObjectListItem _activeListItem;
     private AbstractListItemFactory _listItemFactory;
     private readonly object _classMemberGate = new();
+    private WorkspaceEventRegistration? _workspaceChangedDisposer;
 
     protected AbstractObjectBrowserLibraryManager(
         string languageName,
@@ -53,7 +54,7 @@ internal abstract partial class AbstractObjectBrowserLibraryManager : AbstractLi
         _languageName = languageName;
 
         Workspace = workspace;
-        Workspace.WorkspaceChanged += OnWorkspaceChanged;
+        _workspaceChangedDisposer = Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
 
         _libraryService = new Lazy<ILibraryService>(() => Workspace.Services.GetLanguageServices(_languageName).GetService<ILibraryService>());
     }
@@ -73,9 +74,12 @@ internal abstract partial class AbstractObjectBrowserLibraryManager : AbstractLi
     }
 
     public void Dispose()
-        => this.Workspace.WorkspaceChanged -= OnWorkspaceChanged;
+    {
+        _workspaceChangedDisposer?.Dispose();
+        _workspaceChangedDisposer = null;
+    }
 
-    private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         switch (e.Kind)
         {

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -232,7 +232,7 @@ internal sealed partial class PackageInstallerService : AbstractDelayStartedServ
         var packageSourceProvider = await GetPackageSourceProviderAsync().ConfigureAwait(false);
 
         // Start listening to additional events workspace changes.
-        Workspace.WorkspaceChanged += OnWorkspaceChanged;
+        _ = Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
         packageSourceProvider.SourcesChanged += OnSourceProviderSourcesChanged;
 
         // Kick off an initial set of work that will analyze the entire solution.
@@ -421,7 +421,7 @@ internal sealed partial class PackageInstallerService : AbstractDelayStartedServ
         }
     }
 
-    private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         // ThisCanBeCalledOnAnyThread();
 

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -50,7 +50,7 @@ internal sealed class GraphQueryManager
         // indicating a change happened.  And when UpdateExistingQueriesAsync fires, it will just see that there are
         // no live queries and immediately return.  So it's just simple to do things this way instead of trying to 
         // have state management where we try to decide if we should listen or not.
-        _workspace.WorkspaceChanged += (_, _) => _updateQueue.AddWork();
+        _ = _workspace.RegisterWorkspaceChangedHandler((_) => _updateQueue.AddWork());
     }
 
     public async Task AddQueriesAsync(IGraphContext context, ImmutableArray<IGraphQuery> graphQueries, CancellationToken disposalToken)

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerViewModel.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerViewModel.cs
@@ -5,8 +5,8 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.StackTraceExplorer;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.StackTraceExplorer;
 using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Microsoft.VisualStudio.Text.Classification;
 
@@ -53,7 +53,9 @@ internal sealed class StackTraceExplorerViewModel : ViewModelBase
         _threadingContext = threadingContext;
         _workspace = workspace;
 
-        workspace.WorkspaceChanged += Workspace_WorkspaceChanged;
+        // Main thread dependency as Workspace_WorkspaceChanged modifies an ObservableCollection
+        _ = workspace.RegisterWorkspaceChangedHandler(Workspace_WorkspaceChanged, WorkspaceEventOptions.RequiresMainThreadOptions);
+
         _classificationTypeMap = classificationTypeMap;
         _formatMap = formatMap;
 
@@ -104,7 +106,7 @@ internal sealed class StackTraceExplorerViewModel : ViewModelBase
         NotifyPropertyChanged(nameof(IsInstructionTextVisible));
     }
 
-    private void Workspace_WorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void Workspace_WorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         if (e.Kind == WorkspaceChangeKind.SolutionChanged)
         {

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingToolWindow.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingToolWindow.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.ValueTracking;
 
@@ -65,10 +65,10 @@ internal sealed class ValueTrackingToolWindow : ToolWindowPane
         _workspace = workspace;
         _threadingContext = threadingContext;
 
-        _workspace.WorkspaceChanged += OnWorkspaceChanged;
+        _ = _workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
     }
 
-    private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         Contract.ThrowIfFalse(Initialized);
 

--- a/src/VisualStudio/Core/Def/Workspace/SourceGeneratedFileManager.cs
+++ b/src/VisualStudio/Core/Def/Workspace/SourceGeneratedFileManager.cs
@@ -262,6 +262,7 @@ internal sealed class SourceGeneratedFileManager : IOpenTextBufferEventListener
         private VisualStudioInfoBar.InfoBarMessage? _currentInfoBarMessage;
 
         private InfoBarInfo? _infoToShow = null;
+        private WorkspaceEventRegistration? _workspaceChangedDisposer;
 
         public OpenSourceGeneratedFile(SourceGeneratedFileManager fileManager, ITextBuffer textBuffer, SourceGeneratedDocumentIdentity documentIdentity)
         {
@@ -284,7 +285,7 @@ internal sealed class SourceGeneratedFileManager : IOpenTextBufferEventListener
                 readOnlyRegionEdit.Apply();
             }
 
-            this.Workspace.WorkspaceChanged += OnWorkspaceChanged;
+            _workspaceChangedDisposer = this.Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
 
             _batchingWorkQueue = new AsyncBatchingWorkQueue(
                 TimeSpan.FromSeconds(1),
@@ -311,7 +312,8 @@ internal sealed class SourceGeneratedFileManager : IOpenTextBufferEventListener
         {
             _fileManager._threadingContext.ThrowIfNotOnUIThread();
 
-            this.Workspace.WorkspaceChanged -= OnWorkspaceChanged;
+            _workspaceChangedDisposer?.Dispose();
+            _workspaceChangedDisposer = null;
 
             // Disconnect the buffer from the workspace before making it eligible for edits
             DisconnectFromWorkspaceIfOpen();
@@ -422,7 +424,7 @@ internal sealed class SourceGeneratedFileManager : IOpenTextBufferEventListener
             await EnsureWindowFrameInfoBarUpdatedAsync(cancellationToken).ConfigureAwait(true);
         }
 
-        private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+        private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
         {
             var projectId = _documentIdentity.DocumentId.ProjectId;
 

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -61,7 +61,7 @@ internal sealed class ProjectCodeModelFactory : IProjectCodeModelFactory
             Listener,
             threadingContext.DisposalToken);
 
-        _visualStudioWorkspace.WorkspaceChanged += OnWorkspaceChanged;
+        _ = _visualStudioWorkspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
     }
 
     internal IAsynchronousOperationListener Listener { get; }
@@ -153,7 +153,7 @@ internal sealed class ProjectCodeModelFactory : IProjectCodeModelFactory
         }
     }
 
-    private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         // Events that can't change existing code model items.  Can just ignore them.
         switch (e.Kind)

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
@@ -37,6 +37,8 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
     protected ProjectId ProjectId { get; }
     protected IAnalyzersCommandHandler CommandHandler { get; }
 
+    private WorkspaceEventRegistration? _workspaceChangedDisposer;
+
     /// <summary>
     /// The analyzer reference that has been found. Once it's been assigned a non-null value, it'll never be assigned
     /// <see langword="null"/> again.
@@ -77,7 +79,7 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
 
             // Listen for changes that would affect the set of analyzers/generators in this reference, and kick off work
             // to now get the items for this source.
-            Workspace.WorkspaceChanged += OnWorkspaceChanged;
+            _workspaceChangedDisposer = Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
             _workQueue.AddWork();
         }
     }
@@ -101,7 +103,8 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
         var project = this.Workspace.CurrentSolution.GetProject(this.ProjectId);
         if (project is null || !project.AnalyzerReferences.Contains(analyzerReference))
         {
-            this.Workspace.WorkspaceChanged -= OnWorkspaceChanged;
+            _workspaceChangedDisposer?.Dispose();
+            _workspaceChangedDisposer = null;
 
             _cancellationTokenSource.Cancel();
 
@@ -204,7 +207,7 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
         }
     }
 
-    private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         switch (e.Kind)
         {

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
@@ -43,6 +43,7 @@ internal sealed class SourceGeneratedFileItemSource(
 
     private readonly CancellationSeries _cancellationSeries = new();
     private ResettableDelay? _resettableDelay;
+    private WorkspaceEventRegistration? _workspaceChangedDisposer;
 
     public object SourceItem => _parentGeneratorItem;
 
@@ -167,14 +168,13 @@ internal sealed class SourceGeneratedFileItemSource(
                         // in AfterCollapse, and _then_ subscribed here again.
 
                         cancellationToken.ThrowIfCancellationRequested();
-                        _workspace.WorkspaceChanged += OnWorkpaceChanged;
+                        _workspaceChangedDisposer = _workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
                         if (_workspace.CurrentSolution != solution)
                         {
                             // The workspace changed while we were doing our initial population, so
                             // refresh it. We'll just call our OnWorkspaceChanged event handler
                             // so this looks like any other change.
-                            OnWorkpaceChanged(this,
-                                new WorkspaceChangeEventArgs(WorkspaceChangeKind.SolutionChanged, solution, _workspace.CurrentSolution));
+                            OnWorkspaceChanged(new WorkspaceChangeEventArgs(WorkspaceChangeKind.SolutionChanged, solution, _workspace.CurrentSolution));
                         }
                     }
                 },
@@ -192,12 +192,13 @@ internal sealed class SourceGeneratedFileItemSource(
         lock (_gate)
         {
             _cancellationSeries.CreateNext(new CancellationToken(canceled: true));
-            _workspace.WorkspaceChanged -= OnWorkpaceChanged;
+            _workspaceChangedDisposer?.Dispose();
+            _workspaceChangedDisposer = null;
             _resettableDelay = null;
         }
     }
 
-    private void OnWorkpaceChanged(object sender, WorkspaceChangeEventArgs e)
+    private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
     {
         if (!e.NewSolution.ContainsProject(_parentGeneratorItem.ProjectId))
         {
@@ -216,7 +217,7 @@ internal sealed class SourceGeneratedFileItemSource(
             {
                 // Time to start the work all over again. We'll ensure any previous work is cancelled
                 var cancellationToken = _cancellationSeries.CreateNext();
-                var asyncToken = _asyncListener.BeginAsyncOperation(nameof(SourceGeneratedFileItemSource) + "." + nameof(OnWorkpaceChanged));
+                var asyncToken = _asyncListener.BeginAsyncOperation(nameof(SourceGeneratedFileItemSource) + "." + nameof(OnWorkspaceChanged));
 
                 // We're going to go with a really long delay: once the user expands this we will keep it updated, but it's fairly
                 // unlikely to change in a lot of cases if a generator only produces a stable set of names.

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -61,7 +61,7 @@ internal sealed partial class SemanticModelReuseWorkspaceServiceFactory : IWorks
         public SemanticModelReuseWorkspaceService(Workspace workspace)
         {
             _workspace = workspace;
-            _workspace.WorkspaceChanged += (_, e) =>
+            _workspace.RegisterWorkspaceChangedHandler((e) =>
             {
                 // if our map points at documents not in the current solution, then we want to clear things out.
                 // this way we don't hold onto semantic models past, say, the c#/vb solutions closing.
@@ -78,7 +78,7 @@ internal sealed partial class SemanticModelReuseWorkspaceServiceFactory : IWorks
                         return;
                     }
                 }
-            };
+            });
         }
 
         public async ValueTask<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -26,7 +26,8 @@ namespace Microsoft.CodeAnalysis;
 [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
 public partial class Project
 {
-    // Only access these dictionaries when holding them as a lock
+    // Only access these dictionaries when holding them as a lock. These are intentionally simple dictionaries
+    // rather than ConcurrentDictionaries or ImmutableDictionaries for performance reasons.
     private Dictionary<DocumentId, Document?>? _idToDocumentMap;
     private Dictionary<DocumentId, SourceGeneratedDocument>? _idToSourceGeneratedDocumentMap;
     private Dictionary<DocumentId, AdditionalDocument?>? _idToAdditionalDocumentMap;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -28,6 +28,8 @@ namespace Microsoft.CodeAnalysis;
 public partial class Solution
 {
     // Values for all these are created on demand. Only access when holding the dictionary as a lock.
+    // Intentionally a simple dictionary rather than a ConcurrentDictionary or ImmutableDictionary
+    // for performance reasons.
     private readonly Dictionary<ProjectId, Project> _projectIdToProjectMap = [];
 
     /// <summary>


### PR DESCRIPTION
About 4.1% of main thread CPU costs during solution load are in workspace eventing. This moves nearly all those costs to background threads. The majority of the workspace changed handler costs are associated with ProjectCodeModelFactoy. 

If there were any questions about the event handler needing the main thread, this PR attempts to be safe, and continue to use the main thread. 

Future PRs can judiciously look at moving event handlers to work on background threads. 

Test insertion PR: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/631924

*** Before, all threads ***
![image](https://github.com/user-attachments/assets/4c1bd12e-0d7d-4a7c-8848-8a66601193d0)

*** Before, filtered to main thead ***
![image](https://github.com/user-attachments/assets/4c082024-3205-40fe-bea6-f7ccb7b2232f)

*** After, all threads ***
![image](https://github.com/user-attachments/assets/3b3a6b85-4106-4a6b-aed2-0586c2418d30)

*** After, filtered to main thead ***
![image](https://github.com/user-attachments/assets/81791e87-314a-4392-9d56-56e5f58f1b2f)