### PR TITLE
Allow Razor logs to be directed to the right output window in VS Code

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspLoggingScope.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspLoggingScope.cs
@@ -4,5 +4,5 @@
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Logging
 {
-    internal sealed record LspLoggingScope(string Context);
+    internal sealed record LspLoggingScope(string? Context, string? Language);
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspServiceLogger.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspServiceLogger.cs
@@ -19,7 +19,12 @@ internal sealed class LspServiceLogger : AbstractLspLogger, ILspService
         _hostLogger = hostLogger;
     }
 
-    public override IDisposable? CreateContext(string context) => _hostLogger.BeginScope(new LspLoggingScope(context));
+    public override IDisposable? CreateContext(string context) => _hostLogger.BeginScope(new LspLoggingScope(context, null));
+
+    public override IDisposable? CreateLanguageContext(string? language)
+        => language is null
+            ? null
+            : _hostLogger.BeginScope(new LspLoggingScope(null, language));
 
     public override void LogDebug(string message, params object[] @params) => _hostLogger.LogDebug(message, @params);
 

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLspLogger.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLspLogger.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework;
 internal abstract class AbstractLspLogger : ILspLogger
 {
     public abstract IDisposable? CreateContext(string context);
+    public abstract IDisposable? CreateLanguageContext(string? language);
 
     public abstract void LogDebug(string message, params object[] @params);
     public abstract void LogInformation(string message, params object[] @params);

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/ILspLogger.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/ILspLogger.cs
@@ -8,9 +8,11 @@
 using System;
 
 namespace Microsoft.CommonLanguageServerProtocol.Framework;
+
 internal interface ILspLogger
 {
     IDisposable? CreateContext(string context);
+    IDisposable? CreateLanguageContext(string? language);
 
     void LogDebug(string message, params object[] @params);
     void LogInformation(string message, params object[] @params);

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -248,6 +248,8 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
                     // the didOpen, ensuring that this line will only run once all prior didOpens have completed.
                     var didGetLanguage = _languageServer.TryGetLanguageForRequest(work.MethodName, work.SerializedRequest, out var language);
 
+                    using var languageScope = _logger.CreateLanguageContext(language);
+
                     // Now that we know the actual language, we can deserialize the request and start creating the request context.
                     var (metadata, handler, methodInfo) = GetHandlerForRequest(work, language ?? LanguageServerConstants.DefaultLanguageName);
 

--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/TestOutputLspLogger.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/TestOutputLspLogger.cs
@@ -18,6 +18,7 @@ internal sealed class TestOutputLspLogger : AbstractLspLogger, ILspService
     }
 
     public override IDisposable? CreateContext(string context) => null;
+    public override IDisposable? CreateLanguageContext(string? context) => null;
 
     public override void LogDebug(string message, params object[] @params) => Log("Debug", message, @params);
 

--- a/src/LanguageServer/Protocol/NoOpLspLogger.cs
+++ b/src/LanguageServer/Protocol/NoOpLspLogger.cs
@@ -14,6 +14,7 @@ internal sealed class NoOpLspLogger : AbstractLspLogger, ILspService
     private NoOpLspLogger() { }
 
     public override IDisposable? CreateContext(string context) => null;
+    public override IDisposable? CreateLanguageContext(string? context) => null;
 
     public override void LogDebug(string message, params object[] @params)
     {

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorStartupServiceFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorStartupServiceFactory.cs
@@ -83,6 +83,8 @@ internal sealed class RazorStartupServiceFactory(
 
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
 
+            using var languageScope = context.Logger.CreateLanguageContext(Constants.RazorLanguageName);
+
             // We use a string to pass capabilities to/from Razor to avoid version issues with the Protocol DLL
             var serializedClientCapabilities = JsonSerializer.Serialize(clientCapabilities, ProtocolConversions.LspJsonSerializerOptions);
 

--- a/src/VisualStudio/Core/Def/LanguageClient/LogHubLspLogger.cs
+++ b/src/VisualStudio/Core/Def/LanguageClient/LogHubLspLogger.cs
@@ -38,6 +38,7 @@ internal sealed class LogHubLspLogger : AbstractLspLogger, ILspService
     }
 
     public override IDisposable? CreateContext(string context) => null;
+    public override IDisposable? CreateLanguageContext(string? language) => null;
 
     public override void LogDebug(string message, params object[] @params)
     {


### PR DESCRIPTION
In VS Code, Razor cohosting logs to the Razor Log output category as you would expect, but all of the CLaSP logging ends up in the C# output, including all of the MEF composition and ALC processing stuff, which is relatively noisy. This fixes that by remapping logs to the Razor log endpoint for contexts that specify the Razor language, and makes requests for Razor specify that context.

This is a bit of speculative work on a Sunday, so feel free to reject or suggest a different API. I don't really love having a separate method for this, but having one method with two parameters would mean nobody ever passes in both parameters.

The results at runtime in VS Code are huge though, and will make investigating issues easier for us and you.

Part of https://github.com/dotnet/razor/issues/11759