### PR TITLE
Do not offer 'remove unnecessary parens' when it would change a collection initializer

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
@@ -3552,4 +3552,32 @@ compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLib
             }
             """);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78331")]
+    public async Task TestCollectionExpressionInInitializer()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            class C
+            {
+                public void M()
+                {
+                    var v = new List<int[]>() { $$([]) };
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78331")]
+    public async Task TestAttributedLambdaExpressionInInitializer()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            class C
+            {
+                public void M()
+                {
+                    var v = new List<Action>() { $$([X] () => { }) };
+                }
+            }
+            """);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/78331