### PR TITLE
For IsAtDotDotToken, ensure the current token is a DotToken before parsing the next token to see if it's also a DotToken.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -11477,7 +11477,13 @@ done:
 
         /// <summary>Check if we're currently at a .. sequence that can then be parsed out as a <see cref="SyntaxKind.DotDotToken"/>.</summary>
         public bool IsAtDotDotToken()
-            => IsAtDotDotToken(this.CurrentToken, this.PeekToken(1));
+        {
+            if (this.CurrentToken.Kind != SyntaxKind.DotToken)
+                return false;
+
+            var nextToken = this.PeekToken(1);
+            return nextToken.Kind == SyntaxKind.DotToken && NoTriviaBetween(this.CurrentToken, nextToken);
+        }
 
         public static bool IsAtDotDotToken(SyntaxToken token1, SyntaxToken token2)
             => token1.Kind == SyntaxKind.DotToken &&


### PR DESCRIPTION
I see LanguageParser.IsAtDotToken accounting for about 1 second of CPU time (0.5%) in the C# editing speedometer test. Local testing indicates about 85% of calls into this method will be filtered by this check.

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/631973

Speedometer results look good:

*** Old allocations under IsAtDotDotToken ***
![image](https://github.com/user-attachments/assets/2971d49c-b7b0-402a-a50a-b932a7e45089)

*** Old CPU under IsAtDotDotToken ***
![image](https://github.com/user-attachments/assets/1126a3f5-b2c2-4918-a8d2-6d603a16f3ab)

*** New allocations under IsAtDotDotToken ***
![image](https://github.com/user-attachments/assets/5c5e261a-df4b-4cf2-be48-44e4cbdad82b)

*** New CPU under IsAtDotDotToken ***
![image](https://github.com/user-attachments/assets/ff20e2c2-d5b3-475e-8c08-9e12dde82f9c)
