### PR TITLE
Allow batch updating of ProjectUpdateState's RemovedMetadataReferences and AddedMetadataReferences members

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -687,6 +687,8 @@ internal sealed partial class ProjectSystemProject
             List<(string path, MetadataReferenceProperties properties)> metadataReferencesAddedInBatch)
         {
             var projectId = projectBeforeMutation.Id;
+            using var _1 = ArrayBuilder<PortableExecutableReference>.GetInstance(out var peReferencesRemoved);
+            using var _2 = ArrayBuilder<PortableExecutableReference>.GetInstance(out var peReferencesAdded);
 
             // Metadata reference removing. Do this before adding in case this removes a project reference that we are also
             // going to add in the same batch. This could happen if case is changing, or we're targeting a different output
@@ -706,12 +708,15 @@ internal sealed partial class ProjectSystemProject
                         .OfType<PortableExecutableReference>()
                         .Single(m => m.FilePath == path && m.Properties == properties);
 
-                    projectUpdateState = projectUpdateState.WithIncrementalMetadataReferenceRemoved(metadataReference);
+                    peReferencesRemoved.Add(metadataReference);
 
                     solutionChanges.UpdateSolutionForProjectAction(
                         projectId, solutionChanges.Solution.RemoveMetadataReference(projectId, metadataReference));
                 }
             }
+
+            if (peReferencesRemoved.Count > 0)
+                projectUpdateState = projectUpdateState.WithIncrementalMetadataReferencesRemoved(peReferencesRemoved);
 
             // Metadata reference adding...
             if (metadataReferencesAddedInBatch.Count > 0)
@@ -730,9 +735,12 @@ internal sealed partial class ProjectSystemProject
                     else
                     {
                         var metadataReference = CreateMetadataReference_NoLock(path, properties, solutionChanges.Solution.Services);
-                        projectUpdateState = projectUpdateState.WithIncrementalMetadataReferenceAdded(metadataReference);
+                        peReferencesAdded.Add(metadataReference);
                     }
                 }
+
+                if (peReferencesAdded.Count > 0)
+                    projectUpdateState = projectUpdateState.WithIncrementalMetadataReferencesAdded(peReferencesAdded);
 
                 solutionChanges.UpdateSolutionForProjectAction(
                     projectId,

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
@@ -117,8 +118,14 @@ internal sealed partial class ProjectSystemProjectFactory
         public ProjectUpdateState WithIncrementalMetadataReferenceRemoved(PortableExecutableReference reference)
             => this with { RemovedMetadataReferences = RemovedMetadataReferences.Add(reference) };
 
+        public ProjectUpdateState WithIncrementalMetadataReferencesRemoved(ArrayBuilder<PortableExecutableReference> references)
+            => this with { RemovedMetadataReferences = RemovedMetadataReferences.AddRange(references) };
+
         public ProjectUpdateState WithIncrementalMetadataReferenceAdded(PortableExecutableReference reference)
             => this with { AddedMetadataReferences = AddedMetadataReferences.Add(reference) };
+
+        public ProjectUpdateState WithIncrementalMetadataReferencesAdded(ArrayBuilder<PortableExecutableReference> references)
+            => this with { AddedMetadataReferences = AddedMetadataReferences.AddRange(references) };
 
         public ProjectUpdateState WithIncrementalAnalyzerReferenceRemoved(string reference)
             => this with { RemovedAnalyzerReferences = RemovedAnalyzerReferences.Add(reference) };


### PR DESCRIPTION
ProjectSystemProject.UpdateMetadataReferences was previously updating the added/removed metadata references in ProjectUpdateState one at a time. The WithIncrementalMetadataReferences(Added/Removed) code would allocate a new ImmutableArray on each invocation. Instead, we can batch up those changes. With this change, allocations under UpdateMetdataReferences went from 87 MB (0.7%) of allocations during solution load to 30 MB (0.3%)

Test insertion PR: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/631996

*** Before allocations during solution load ***
![image](https://github.com/user-attachments/assets/e53e3bb2-7014-49a1-89d0-0b7d716bd5ce)

*** After allocations during solution load ***
![image](https://github.com/user-attachments/assets/57ae7eb7-db67-4049-abe8-463d9dbc576c)