### PR TITLE
Fix syntax tree creation when modifying source generated documents

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1641,7 +1641,7 @@ public partial class Solution
     }
 
     internal Solution WithFrozenSourceGeneratedDocuments(ImmutableArray<(SourceGeneratedDocumentIdentity documentIdentity, DateTime generationDateTime, SourceText text)> documents)
-        => WithCompilationState(CompilationState.WithFrozenSourceGeneratedDocuments(documents.SelectAsArray(d => (d.documentIdentity, d.generationDateTime, d.text, (SyntaxNode?)null))));
+        => WithCompilationState(CompilationState.WithFrozenSourceGeneratedDocuments(documents.SelectAsArray(d => (d.documentIdentity, d.generationDateTime, (SourceText?)d.text, (SyntaxNode?)null))));
 
     /// <inheritdoc cref="SolutionCompilationState.UpdateSpecificSourceGeneratorExecutionVersions"/>
     internal Solution UpdateSpecificSourceGeneratorExecutionVersions(SourceGeneratorExecutionVersionMap sourceGeneratorExecutionVersionMap)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1017,8 +1017,6 @@ internal sealed partial class SolutionCompilationState
                 }
                 else if (TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(doc.documentId) is { Identity: var identity })
                 {
-                    // Source generated documents always do a full parse, and source generator authors are only allowed to provide
-                    // strings, so we follow suit here and just take the text from the root.
                     sourceGeneratedDocuments.Add((identity, DateTime.UtcNow, null, doc.root));
                 }
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -797,13 +797,13 @@ internal sealed partial class SolutionCompilationState
                 SourceTextIsUnchanged(oldDocumentState, text) ? oldDocumentState : oldDocumentState.UpdateText(text, mode));
 
         (ImmutableArray<(DocumentId, SourceText)>,
-         ImmutableArray<(SourceGeneratedDocumentIdentity, DateTime, SourceText, SyntaxNode?)>) GetOrdinaryAndSourceGeneratedDocuments()
+         ImmutableArray<(SourceGeneratedDocumentIdentity, DateTime, SourceText?, SyntaxNode?)>) GetOrdinaryAndSourceGeneratedDocuments()
         {
             if (!texts.Any(static t => t.documentId.IsSourceGenerated))
                 return (texts, []);
 
             using var _1 = ArrayBuilder<(DocumentId, SourceText)>.GetInstance(capacity: texts.Length, out var ordinaryDocuments);
-            using var _2 = ArrayBuilder<(SourceGeneratedDocumentIdentity, DateTime, SourceText, SyntaxNode?)>.GetInstance(out var sourceGeneratedDocuments);
+            using var _2 = ArrayBuilder<(SourceGeneratedDocumentIdentity, DateTime, SourceText?, SyntaxNode?)>.GetInstance(out var sourceGeneratedDocuments);
             foreach (var doc in texts)
             {
                 if (!doc.documentId.IsSourceGenerated)
@@ -829,7 +829,7 @@ internal sealed partial class SolutionCompilationState
     /// </summary>
     private SolutionCompilationState UpdateDocumentsInMultipleProjects<TDocumentState, TDocumentData, TArg>(
         ImmutableArray<(DocumentId documentId, TDocumentData documentData)> documentsToUpdate,
-        ImmutableArray<(SourceGeneratedDocumentIdentity documentIdentity, DateTime generationDateTime, SourceText sourceText, SyntaxNode? syntaxNode)> sourceGeneratedDocuments,
+        ImmutableArray<(SourceGeneratedDocumentIdentity documentIdentity, DateTime generationDateTime, SourceText? sourceText, SyntaxNode? syntaxNode)> sourceGeneratedDocuments,
         TArg arg,
         Func<TDocumentState, TDocumentData, TArg, TDocumentState> updateDocument)
         where TDocumentState : TextDocumentState
@@ -1002,13 +1002,13 @@ internal sealed partial class SolutionCompilationState
                     : oldDocumentState.UpdateTree(root, mode));
 
         (ImmutableArray<(DocumentId, SyntaxNode)>,
-         ImmutableArray<(SourceGeneratedDocumentIdentity, DateTime, SourceText, SyntaxNode?)>) GetOrdinaryAndSourceGeneratedDocuments()
+         ImmutableArray<(SourceGeneratedDocumentIdentity, DateTime, SourceText?, SyntaxNode?)>) GetOrdinaryAndSourceGeneratedDocuments()
         {
             if (!syntaxRoots.Any(static t => t.documentId.IsSourceGenerated))
                 return (syntaxRoots, []);
 
             using var _1 = ArrayBuilder<(DocumentId, SyntaxNode)>.GetInstance(capacity: syntaxRoots.Length, out var ordinaryDocuments);
-            using var _2 = ArrayBuilder<(SourceGeneratedDocumentIdentity, DateTime, SourceText, SyntaxNode?)>.GetInstance(out var sourceGeneratedDocuments);
+            using var _2 = ArrayBuilder<(SourceGeneratedDocumentIdentity, DateTime, SourceText?, SyntaxNode?)>.GetInstance(out var sourceGeneratedDocuments);
             foreach (var doc in syntaxRoots)
             {
                 if (!doc.documentId.IsSourceGenerated)
@@ -1019,7 +1019,7 @@ internal sealed partial class SolutionCompilationState
                 {
                     // Source generated documents always do a full parse, and source generator authors are only allowed to provide
                     // strings, so we follow suit here and just take the text from the root.
-                    sourceGeneratedDocuments.Add((identity, DateTime.UtcNow, doc.root.GetText(), doc.root));
+                    sourceGeneratedDocuments.Add((identity, DateTime.UtcNow, null, doc.root));
                 }
             }
 
@@ -1386,7 +1386,7 @@ internal sealed partial class SolutionCompilationState
     /// generated file open, we need to make sure everything lines up.
     /// </summary>
     public SolutionCompilationState WithFrozenSourceGeneratedDocuments(
-        ImmutableArray<(SourceGeneratedDocumentIdentity documentIdentity, DateTime generationDateTime, SourceText sourceText, SyntaxNode? syntaxNode)> documents)
+        ImmutableArray<(SourceGeneratedDocumentIdentity documentIdentity, DateTime generationDateTime, SourceText? sourceText, SyntaxNode? syntaxNode)> documents)
     {
         if (documents.IsEmpty)
             return this;
@@ -1395,16 +1395,23 @@ internal sealed partial class SolutionCompilationState
         using var _ = PooledDictionary<DocumentId, SourceGeneratedDocumentState>.GetInstance(out var documentStates);
         foreach (var (documentIdentity, generationDateTime, sourceText, syntaxNode) in documents)
         {
+            Contract.ThrowIfTrue(sourceText is null && syntaxNode is null);
+            Contract.ThrowIfTrue(sourceText is not null && syntaxNode is not null);
+
             var existingGeneratedState = TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentIdentity.DocumentId);
             if (existingGeneratedState != null)
             {
                 var newGeneratedState = existingGeneratedState
-                    .WithText(sourceText)
                     .WithParseOptions(existingGeneratedState.ParseOptions)
                     .WithGenerationDateTime(generationDateTime);
 
-                if (syntaxNode != null)
+                if (sourceText != null)
                 {
+                    newGeneratedState = newGeneratedState.WithText(sourceText);
+                }
+                else
+                {
+                    Contract.ThrowIfNull(syntaxNode);
                     newGeneratedState = newGeneratedState.WithSyntaxRoot(syntaxNode);
                 }
 
@@ -1421,16 +1428,12 @@ internal sealed partial class SolutionCompilationState
                 var newGeneratedState = SourceGeneratedDocumentState.Create(
                     documentIdentity,
                     sourceText,
+                    syntaxNode,
                     projectState.ParseOptions!,
                     projectState.LanguageServices,
                     // Just compute the checksum from the source text passed in.
                     originalSourceTextChecksum: null,
                     generationDateTime);
-
-                if (syntaxNode != null)
-                {
-                    newGeneratedState = newGeneratedState.WithSyntaxRoot(syntaxNode);
-                }
 
                 documentStates.Add(newGeneratedState.Id, newGeneratedState);
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -47,18 +47,41 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         Checksum? originalSourceTextChecksum,
         DateTime generationDateTime)
     {
+        return Create(documentIdentity, generatedSourceText, syntaxNode: null, parseOptions, languageServices, originalSourceTextChecksum, generationDateTime);
+    }
+
+    public static SourceGeneratedDocumentState Create(
+        SourceGeneratedDocumentIdentity documentIdentity,
+        SourceText? generatedSourceText,
+        SyntaxNode? syntaxNode,
+        ParseOptions parseOptions,
+        LanguageServices languageServices,
+        Checksum? originalSourceTextChecksum,
+        DateTime generationDateTime)
+    {
+        Contract.ThrowIfTrue(generatedSourceText is null && syntaxNode is null);
+        Contract.ThrowIfTrue(generatedSourceText is not null && syntaxNode is not null);
+
+        if (generatedSourceText is null)
+        {
+            // We don't currently support lazy source text in source generated documents, so just use the syntax to get it
+            Contract.ThrowIfNull(syntaxNode);
+            generatedSourceText = syntaxNode.GetText();
+        }
+
         // If the caller explicitly provided us with the checksum for the source text, then we always defer to that.
         // This happens on the host side, when we are given the data computed by the OOP side.
         //
         // If the caller didn't provide us with the checksum, then we'll compute it on demand.  This happens on the OOP
         // side when we're actually producing the SG doc in the first place.
         var lazyTextChecksum = new Lazy<Checksum>(() => originalSourceTextChecksum ?? ComputeContentHash(generatedSourceText));
-        return Create(documentIdentity, generatedSourceText, parseOptions, languageServices, lazyTextChecksum, generationDateTime);
+        return Create(documentIdentity, generatedSourceText, syntaxNode, parseOptions, languageServices, lazyTextChecksum, generationDateTime);
     }
 
     private static SourceGeneratedDocumentState Create(
         SourceGeneratedDocumentIdentity documentIdentity,
         SourceText generatedSourceText,
+        SyntaxNode? syntaxNode,
         ParseOptions parseOptions,
         LanguageServices languageServices,
         Lazy<Checksum> lazyTextChecksum,
@@ -67,12 +90,23 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         var loadTextOptions = new LoadTextOptions(generatedSourceText.ChecksumAlgorithm);
         var textAndVersion = TextAndVersion.Create(generatedSourceText, VersionStamp.Create());
         var textSource = new ConstantTextAndVersionSource(textAndVersion);
-        var treeSource = CreateLazyFullyParsedTree(
-            textSource,
-            loadTextOptions,
-            documentIdentity.FilePath,
-            parseOptions,
-            languageServices);
+
+        ITreeAndVersionSource treeSource;
+        if (syntaxNode is null)
+        {
+            treeSource = CreateLazyFullyParsedTree(
+                textSource,
+                loadTextOptions,
+                documentIdentity.FilePath,
+                parseOptions,
+                languageServices);
+        }
+        else
+        {
+            var factory = languageServices.GetRequiredService<ISyntaxTreeFactoryService>();
+            var newTree = factory.CreateSyntaxTree(documentIdentity.FilePath, parseOptions, generatedSourceText, generatedSourceText.Encoding, generatedSourceText.ChecksumAlgorithm, syntaxNode);
+            treeSource = SimpleTreeAndVersionSource.Create(new TreeAndVersion(newTree, VersionStamp.Create()));
+        }
 
         return new SourceGeneratedDocumentState(
             documentIdentity,
@@ -160,6 +194,7 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         return Create(
             Identity,
             SourceText,
+            syntaxNode: null,
             parseOptions,
             LanguageServices,
             // We're just changing the parse options.  So the checksum will remain as is.
@@ -191,21 +226,21 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
 
     public SourceGeneratedDocumentState WithSyntaxRoot(SyntaxNode newRoot)
     {
-        SyntaxTree newTree;
-        if (this.TryGetSyntaxTree(out var tree))
+        // See if we can reuse this instance directly
+        if (this.TryGetSyntaxTree(out var tree) &&
+            tree.TryGetRoot(out var root) &&
+            root == newRoot)
         {
-            // See if we can reuse this instance directly
-            if (tree.TryGetRoot(out var root) && root == newRoot)
-                return this;
-
-            newTree = tree.WithRootAndOptions(newRoot, ParseOptions);
-        }
-        else
-        {
-            var factory = LanguageServices.GetRequiredService<ISyntaxTreeFactoryService>();
-            newTree = factory.CreateSyntaxTree(Attributes.SyntaxTreeFilePath, ParseOptions, SourceText, SourceText.Encoding, SourceText.ChecksumAlgorithm, newRoot);
+            return this;
         }
 
+        var sourceText = newRoot.GetText();
+        var factory = LanguageServices.GetRequiredService<ISyntaxTreeFactoryService>();
+        var newTree = factory.CreateSyntaxTree(Attributes.SyntaxTreeFilePath, ParseOptions, sourceText, sourceText.Encoding, sourceText.ChecksumAlgorithm, newRoot);
+
+        var lazyTextChecksum = new Lazy<Checksum>(() => ComputeContentHash(sourceText));
+        var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Create());
+        var textSource = new ConstantTextAndVersionSource(textAndVersion);
         var newTreeVersion = GetNewTreeVersionForUpdatedTree(newRoot, GetNewerVersion(), PreservationMode.PreserveValue);
         var newTreeSource = SimpleTreeAndVersionSource.Create(new TreeAndVersion(newTree, newTreeVersion));
 
@@ -215,11 +250,11 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
             this.DocumentServiceProvider,
             this.Attributes,
             this.ParseOptions,
-            this.TextAndVersionSource,
-            this.SourceText,
+            textSource,
+            sourceText,
             this.LoadTextOptions,
             newTreeSource,
-            this._lazyContentHash,
+            lazyTextChecksum,
             this.GenerationDateTime);
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -202,12 +202,8 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         }
         else
         {
-            // We don't have a tree yet, so we need to create one. Using "newRoot.SyntaxTree" is the last resort though
-            // as it could lazily create one, which doesn't know about our parse options.
-            var factory = LanguageServices.GetService<ISyntaxTreeFactoryService>();
-            newTree = factory is not null
-                ? factory.CreateSyntaxTree(Attributes.SyntaxTreeFilePath, ParseOptions, SourceText, SourceText.Encoding, SourceText.ChecksumAlgorithm, newRoot)
-                : newRoot.SyntaxTree;
+            var factory = LanguageServices.GetRequiredService<ISyntaxTreeFactoryService>();
+            newTree = factory.CreateSyntaxTree(Attributes.SyntaxTreeFilePath, ParseOptions, SourceText, SourceText.Encoding, SourceText.ChecksumAlgorithm, newRoot);
         }
 
         var newTreeVersion = GetNewTreeVersionForUpdatedTree(newRoot, GetNewerVersion(), PreservationMode.PreserveValue);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -11,6 +11,8 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -1035,6 +1037,46 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
         var updatedDocument = Assert.Single(generatedDocuments);
         sourceText = await updatedDocument.GetTextAsync();
         Assert.Equal("// Hello World!// Hello World!", sourceText.ToString());
+    }
+
+    [Theory, CombinatorialData]
+    public async Task WithSyntaxRootWorksOnSourceGeneratedDocument_OldCSharpVersion(TestHost testHost)
+    {
+        using var workspace = CreateWorkspaceWithPartialSemantics(testHost);
+        var generatorRan = false;
+        var analyzerReference = new TestGeneratorReference(new CallbackGenerator(_ => { }, onExecute: _ => { generatorRan = true; }, source: "// Hello World!"));
+        var project = AddEmptyProject(workspace.CurrentSolution)
+            .WithParseOptions(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7))
+            .AddAnalyzerReference(analyzerReference)
+            .AddDocument("RegularDocument.cs", "// Source File", filePath: "RegularDocument.cs").Project;
+
+        // Ensure generators are ran
+        var objectReference = await project.GetCompilationAsync();
+
+        Assert.True(generatorRan);
+
+        var generatedDocuments = await project.GetSourceGeneratedDocumentsAsync();
+        var sourceGeneratedDocument = generatedDocuments.First();
+        var root = await sourceGeneratedDocument.GetRequiredSyntaxRootAsync(CancellationToken.None);
+
+        var modifiedRoot = SyntaxFactory.ParseCompilationUnit("// Changed document");
+        // Default tree is the default language version
+        Assert.NotEqual(LanguageVersion.CSharp7, modifiedRoot.SyntaxTree.Options.LanguageVersion());
+
+        sourceGeneratedDocument = sourceGeneratedDocument.WithSyntaxRoot(modifiedRoot);
+        var sourceText = await sourceGeneratedDocument.GetTextAsync();
+        Assert.Equal("// Changed document", sourceText.ToString());
+
+        var newTree = await sourceGeneratedDocument.GetRequiredSyntaxTreeAsync(CancellationToken.None);
+        Assert.Equal(LanguageVersion.CSharp7, newTree.Options.LanguageVersion());
+
+        generatedDocuments = await sourceGeneratedDocument.Project.GetSourceGeneratedDocumentsAsync();
+        var updatedDocument = Assert.Single(generatedDocuments);
+        sourceText = await updatedDocument.GetTextAsync();
+        Assert.Equal("// Changed document", sourceText.ToString());
+
+        newTree = await updatedDocument.GetRequiredSyntaxTreeAsync(CancellationToken.None);
+        Assert.Equal(LanguageVersion.CSharp7, newTree.Options.LanguageVersion());
     }
 
     [Theory, CombinatorialData]


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11787

In my previous PR I naively called `syntaxRoot.SyntaxTree` to get a tree, but turns out that will just happily lazily create one with `CSharpLanguageVersion.Default`, which breaks things.