### PR TITLE
Implement SeparatedSyntaxList.Count(Func<T, bool>)

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -116,6 +116,22 @@ namespace Microsoft.CodeAnalysis
             return list.IndexOf(kind) >= 0;
         }
 
+        internal static int Count<TNode>(this SeparatedSyntaxList<TNode> list, Func<TNode, bool> predicate)
+            where TNode : SyntaxNode
+        {
+            int n = list.Count;
+            int count = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (predicate(list[i]))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
         /// <summary>
         /// Returns the index of the first trivia of a specified kind in the trivia list.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -116,22 +116,6 @@ namespace Microsoft.CodeAnalysis
             return list.IndexOf(kind) >= 0;
         }
 
-        internal static int Count<TNode>(this SeparatedSyntaxList<TNode> list, Func<TNode, bool> predicate)
-            where TNode : SyntaxNode
-        {
-            int n = list.Count;
-            int count = 0;
-            for (int i = 0; i < n; i++)
-            {
-                if (predicate(list[i]))
-                {
-                    count++;
-                }
-            }
-
-            return count;
-        }
-
         /// <summary>
         /// Returns the index of the first trivia of a specified kind in the trivia list.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -6,16 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Reflection;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -90,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attributeType.IsErrorType());
 
             int argumentCount = (attributeSyntax.ArgumentList != null) ?
-                attributeSyntax.ArgumentList.Arguments.Count<AttributeArgumentSyntax>((arg) => arg.NameEquals == null) :
+                attributeSyntax.ArgumentList.Arguments.Count(static (arg) => arg.NameEquals == null) :
                 0;
             return AttributeData.IsTargetEarlyAttribute(attributeType, argumentCount, description);
         }
@@ -138,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 string className = this.AttributeClass.ToDisplayString(SymbolDisplayFormat.TestFormat);
 
-                if (!this.CommonConstructorArguments.Any() & !this.CommonNamedArguments.Any())
+                if (this.CommonConstructorArguments.IsEmpty && this.CommonNamedArguments.IsEmpty)
                 {
                     return className;
                 }
@@ -343,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(this.IsSecurityAttribute(compilation));
 
             var ctorArgs = this.CommonConstructorArguments;
-            if (!ctorArgs.Any())
+            if (ctorArgs.IsEmpty)
             {
                 // NOTE:    Security custom attributes must have a valid SecurityAction as its first argument, we have none here.
                 // NOTE:    Ideally, we should always generate 'CS7048: First argument to a security attribute must be a valid SecurityAction' for this case.
@@ -365,7 +363,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                TypedConstant firstArg = ctorArgs.First();
+                TypedConstant firstArg = ctorArgs[0];
                 var firstArgType = (TypeSymbol?)firstArg.TypeInternal;
                 if (firstArgType is object && firstArgType.Equals(compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityAction)))
                 {

--- a/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxListExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxListExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class SeparatedSyntaxListExtensions
+    {
+        internal static int Count<TNode>(this SeparatedSyntaxList<TNode> list, Func<TNode, bool> predicate)
+            where TNode : SyntaxNode
+        {
+            int n = list.Count;
+            int count = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (predicate(list[i]))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
CSharpAttributeData.IsTargetEarlyAttribute was calling the Linq version of this list, and thus boxing the SeparatedSyntaxList enumerator, showing up as 5.9 MB (0.1%) of allocations in our OOP process during solution load.

Not a huge win, but it's nice to add to the pit of success for using this type.

Modifications to CSharpAttributeData started with a small cleanup to IsTargetEarlyAttribute to demonstrate the Count() usage. I then looked to see what other Linq usage was in the file, and it made sense to change those too.

*** Allocations in question ***
![image](https://github.com/user-attachments/assets/ae7db84e-e9f9-4f05-ab8c-ec20801ce4c9)