### PR TITLE
Simplify Impl interface tests

### DIFF
--- a/src/Analyzers/CSharp/Tests/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs
@@ -68,7 +68,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -225,7 +224,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -319,7 +317,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -417,7 +414,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -590,7 +586,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -631,7 +626,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -665,7 +659,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -801,7 +794,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 2,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -972,7 +964,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -1135,7 +1126,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -1233,7 +1223,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -1320,7 +1309,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -1363,7 +1351,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -1399,7 +1386,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 1,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }
@@ -1510,7 +1496,6 @@ public sealed class ConflictMarkerResolutionTests
             TestCode = source,
             FixedCode = fixedSource,
             NumberOfIncrementalIterations = 2,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
         }.RunAsync();
     }

--- a/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceTests.cs
@@ -566,7 +566,6 @@ public sealed class ImplementInterfaceTests
                 },
             },
             CodeActionEquivalenceKey = "False;False;True:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         };
 
         test.Options.AddRange(AllOptionsOff);
@@ -2303,7 +2302,6 @@ codeAction: ("True;False;False:global::i1;Microsoft.CodeAnalysis.ImplementInterf
             Options = { AllOptionsOff },
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
             CodeActionEquivalenceKey = "False;False;True:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
 
         await new VerifyCS.Test
@@ -7219,7 +7217,6 @@ codeAction: ("True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterfa
                 },
             },
             CodeActionEquivalenceKey = "False;False;True:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -7288,7 +7285,6 @@ codeAction: ("True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterfa
                 },
             },
             CodeActionEquivalenceKey = "False;False;True:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         };
 
         test.Options.AddRange(AllOptionsOff);
@@ -8732,7 +8728,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             DiagnosticSelector = diagnostics => diagnostics[1],
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
             CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -8896,7 +8891,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             },
             Options = { AllOptionsOff },
             CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -11095,7 +11089,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
             CodeActionEquivalenceKey = "False;False;True:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -11204,7 +11197,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
             CodeActionEquivalenceKey = "True;False;False:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -11239,7 +11231,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
             CodeActionEquivalenceKey = "True;False;False:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -11281,7 +11272,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
             CodeActionEquivalenceKey = "False;False;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -11316,7 +11306,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
             CodeActionEquivalenceKey = "False;False;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -11458,8 +11447,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
             CodeActionEquivalenceKey = "False;False;True:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
-
         }.RunAsync();
     }
 
@@ -11494,8 +11481,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
             CodeActionEquivalenceKey = "False;False;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
-
         }.RunAsync();
     }
 
@@ -11719,7 +11704,6 @@ interface I
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
             CodeActionEquivalenceKey = "False;False;True:global::I1<global::C3>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 

--- a/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceTests.cs
@@ -69,7 +69,6 @@ public sealed class ImplementInterfaceTests
             TestCode = initialMarkup,
             FixedCode = expectedMarkup,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = codeAction?.equivalenceKey,
             CodeActionIndex = codeAction?.index,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
@@ -108,7 +107,6 @@ public sealed class ImplementInterfaceTests
         {
             TestCode = initialMarkup,
             FixedCode = expectedMarkup,
-            CodeActionEquivalenceKey = codeAction?.equivalenceKey,
             CodeActionIndex = codeAction?.index,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
@@ -565,7 +563,6 @@ public sealed class ImplementInterfaceTests
                     """,
                 },
             },
-            CodeActionEquivalenceKey = "False;False;True:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         };
 
         test.Options.AddRange(AllOptionsOff);
@@ -1251,7 +1248,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
                 MarkupHandling = MarkupMode.Allow,
             },
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
-            CodeActionEquivalenceKey = "False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;i",
             CodeActionIndex = 1,
         };
 
@@ -2301,7 +2297,6 @@ codeAction: ("True;False;False:global::i1;Microsoft.CodeAnalysis.ImplementInterf
             """,
             Options = { AllOptionsOff },
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
-            CodeActionEquivalenceKey = "False;False;True:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
 
         await new VerifyCS.Test
@@ -2325,7 +2320,6 @@ codeAction: ("True;False;False:global::i1;Microsoft.CodeAnalysis.ImplementInterf
             """,
             Options = { AllOptionsOff },
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
-            CodeActionEquivalenceKey = "False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;i",
             CodeActionIndex = 1,
         }.RunAsync();
 
@@ -2350,7 +2344,6 @@ codeAction: ("True;False;False:global::i1;Microsoft.CodeAnalysis.ImplementInterf
             """,
             Options = { AllOptionsOff },
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
-            CodeActionEquivalenceKey = "True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 2,
         }.RunAsync();
     }
@@ -2584,7 +2577,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
             DiagnosticSelector = diagnostics => diagnostics[0],
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
-            CodeActionEquivalenceKey = "False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;a",
             CodeActionIndex = 1,
         }.RunAsync();
 
@@ -2664,7 +2656,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
             DiagnosticSelector = diagnostics => diagnostics[1],
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
-            CodeActionEquivalenceKey = "False;False;False:global::I2;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;a",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -2728,7 +2719,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
             },
             Options = { AllOptionsOff },
             CodeActionsVerifier = codeActions => Assert.Equal(4, codeActions.Length),
-            CodeActionEquivalenceKey = "False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;a",
             CodeActionIndex = 1,
         }.RunAsync();
 
@@ -2788,7 +2778,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
             },
             Options = { AllOptionsOff },
             CodeActionsVerifier = codeActions => Assert.Equal(4, codeActions.Length),
-            CodeActionEquivalenceKey = "False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;aa",
             CodeActionIndex = 2,
         }.RunAsync();
     }
@@ -2880,7 +2869,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
             DiagnosticSelector = diagnostics => diagnostics[0],
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
-            CodeActionEquivalenceKey = "False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;a",
             CodeActionIndex = 1,
         }.RunAsync();
 
@@ -2968,7 +2956,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
             DiagnosticSelector = diagnostics => diagnostics[1],
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
-            CodeActionEquivalenceKey = "False;False;False:global::I2;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;b",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -3013,7 +3000,6 @@ codeAction: ("False;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterf
             """,
             Options = { AllOptionsOff },
             CodeActionsVerifier = codeActions => Assert.Equal(3, codeActions.Length),
-            CodeActionEquivalenceKey = "False;False;False:global::IB;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;IA.B",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -6283,7 +6269,6 @@ class C : System.IDisposable
 {DisposePattern("protected virtual ", "C", "void System.IDisposable.", gcPrefix: "System.")}
 }}
 ",
-            CodeActionEquivalenceKey = "True;False;False:global::System.IDisposable;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceWithDisposePatternCodeAction;",
             CodeActionIndex = 3,
 
             // 🐛 generated QualifiedName where SimpleMemberAccessExpression was expected
@@ -7094,7 +7079,6 @@ codeAction: ("True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterfa
             },
             Options = { AllOptionsOff },
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
-            CodeActionEquivalenceKey = "True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -7153,7 +7137,6 @@ codeAction: ("True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterfa
                     """,
                 },
             },
-            CodeActionEquivalenceKey = "True;False;False:global::IGoo;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         };
 
@@ -7216,7 +7199,6 @@ codeAction: ("True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterfa
                     """,
                 },
             },
-            CodeActionEquivalenceKey = "False;False;True:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -7284,7 +7266,6 @@ codeAction: ("True;False;False:global::I;Microsoft.CodeAnalysis.ImplementInterfa
                     """,
                 },
             },
-            CodeActionEquivalenceKey = "False;False;True:global::I;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         };
 
         test.Options.AddRange(AllOptionsOff);
@@ -7475,7 +7456,6 @@ class Program : IDisposable
             {
                 _options.FieldNamesAreCamelCaseWithUnderscorePrefix,
             },
-            CodeActionEquivalenceKey = "False;False;True:global::System.IDisposable;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceWithDisposePatternCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -8580,7 +8560,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -8619,7 +8598,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "False;True;True:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -8727,7 +8705,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             Options = { AllOptionsOff },
             DiagnosticSelector = diagnostics => diagnostics[1],
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
-            CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -9016,7 +8993,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -9055,7 +9031,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "False;True;True:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -9170,7 +9145,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
                 MarkupHandling = MarkupMode.Allow,
             },
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -9782,7 +9756,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
                 MarkupHandling = MarkupMode.Allow,
             },
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -9919,7 +9892,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -9958,7 +9930,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "False;True;True:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -10048,7 +10019,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "True;False;False:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -10091,7 +10061,6 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             }
             """,
             Options = { AllOptionsOff },
-            CodeActionEquivalenceKey = "False;True;True:global::IInterface;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -11088,7 +11057,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
-            CodeActionEquivalenceKey = "False;False;True:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11124,7 +11092,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
-            CodeActionEquivalenceKey = "True;False;False:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -11161,7 +11128,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface_abstractly, codeAction.Title),
-            CodeActionEquivalenceKey = "False;True;True:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -11196,7 +11162,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
-            CodeActionEquivalenceKey = "True;False;False:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11230,7 +11195,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
-            CodeActionEquivalenceKey = "True;False;False:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11271,7 +11235,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
-            CodeActionEquivalenceKey = "False;False;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11305,7 +11268,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
-            CodeActionEquivalenceKey = "False;False;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11339,7 +11301,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
-            CodeActionEquivalenceKey = "True;False;False:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -11374,7 +11335,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface_abstractly, codeAction.Title),
-            CodeActionEquivalenceKey = "False;True;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
 
         }.RunAsync();
@@ -11410,7 +11370,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
-            CodeActionEquivalenceKey = "True;False;False:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
 
         }.RunAsync();
@@ -11446,7 +11405,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
-            CodeActionEquivalenceKey = "False;False;True:global::ITest;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11480,7 +11438,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
-            CodeActionEquivalenceKey = "False;False;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11514,7 +11471,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
-            CodeActionEquivalenceKey = "True;False;False:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
 
         }.RunAsync();
@@ -11550,7 +11506,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface_abstractly, codeAction.Title),
-            CodeActionEquivalenceKey = "False;True;True:global::ITest<global::C>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
 
         }.RunAsync();
@@ -11627,7 +11582,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
-            CodeActionEquivalenceKey = "True;False;False:global::I1<global::C3>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -11703,7 +11657,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface, codeAction.Title),
-            CodeActionEquivalenceKey = "False;False;True:global::I1<global::C3>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
         }.RunAsync();
     }
 
@@ -11778,7 +11731,6 @@ interface I
             }
             """,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_interface_abstractly, codeAction.Title),
-            CodeActionEquivalenceKey = "False;True;True:global::I1<global::C3>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionIndex = 1,
         }.RunAsync();
     }
@@ -12049,7 +12001,6 @@ interface I
                 }
                 """,
             CodeActionIndex = 1,
-            CodeActionEquivalenceKey = "True;False;False:global::I11<global::C11>;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(CodeFixesResources.Implement_all_members_explicitly, codeAction.Title),
         }.RunAsync();
     }

--- a/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceTests_FixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceTests_FixAllTests.cs
@@ -158,7 +158,6 @@ public sealed class ImplementInterfaceTests_FixAllTests
             },
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllInProjectCheck | CodeFixTestBehaviors.SkipFixAllInSolutionCheck,
             CodeActionEquivalenceKey = "False;False;True:global::I1;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 
@@ -310,7 +309,6 @@ public sealed class ImplementInterfaceTests_FixAllTests
             },
             CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllInDocumentCheck | CodeFixTestBehaviors.SkipFixAllInSolutionCheck,
             CodeActionEquivalenceKey = "False;False;True:global::I1;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction;",
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -4096,7 +4096,6 @@ public sealed class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            CodeActionIndex = 0,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }

--- a/src/Analyzers/VisualBasic/Tests/ConflictMarkerResolution/ConflictMarkerResolutionTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/ConflictMarkerResolution/ConflictMarkerResolutionTests.vb
@@ -51,7 +51,6 @@ end namespace"
                 .TestCode = source,
                 .FixedCode = fixedSource,
                 .NumberOfIncrementalIterations = 1,
-                .CodeActionIndex = 0,
                 .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey
             }.RunAsync()
         End Function
@@ -191,7 +190,6 @@ end namespace"
                 .TestCode = source,
                 .FixedCode = fixedSource,
                 .NumberOfIncrementalIterations = 2,
-                .CodeActionIndex = 0,
                 .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey
             }.RunAsync()
         End Function
@@ -331,7 +329,6 @@ end namespace"
                 .TestCode = source,
                 .FixedCode = fixedSource,
                 .NumberOfIncrementalIterations = 1,
-                .CodeActionIndex = 0,
                 .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey
             }.RunAsync()
         End Function
@@ -483,7 +480,6 @@ end namespace"
                 .TestCode = source,
                 .FixedCode = fixedSource,
                 .NumberOfIncrementalIterations = 2,
-                .CodeActionIndex = 0,
                 .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey
             }.RunAsync()
         End Function

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -544,7 +544,6 @@ public sealed class GenerateEqualsAndGetHashCodeFromMembersTests
         {
             TestCode = code,
             FixedCode = fixedCode,
-            CodeActionIndex = 0,
             LanguageVersion = LanguageVersion.CSharp6,
             Options = { PreferImplicitTypeWithInfo() },
         }.RunAsync();
@@ -1333,7 +1332,6 @@ public sealed class GenerateEqualsAndGetHashCodeFromMembersTests
         {
             TestCode = code,
             FixedCode = fixedCode,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = FeaturesResources.Generate_Equals_object,
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(FeaturesResources.Generate_Equals_object, codeAction.Title),
         }.RunAsync();
@@ -1490,7 +1488,6 @@ public sealed class GenerateEqualsAndGetHashCodeFromMembersTests
         {
             TestCode = code,
             FixedCode = fixedCode,
-            CodeActionIndex = 0,
             LanguageVersion = LanguageVersion.CSharp6,
             Options = { PreferImplicitTypeWithInfo() },
         }.RunAsync();
@@ -2540,7 +2537,6 @@ public sealed class GenerateEqualsAndGetHashCodeFromMembersTests
         {
             TestCode = code,
             FixedCode = fixedCode,
-            CodeActionIndex = 0,
             LanguageVersion = LanguageVersion.CSharp6,
             Options = { PreferImplicitTypeWithInfo() },
         }.RunAsync();
@@ -2614,7 +2610,6 @@ public sealed class GenerateEqualsAndGetHashCodeFromMembersTests
         {
             TestCode = code,
             FixedCode = fixedCode,
-            CodeActionIndex = 0,
             LanguageVersion = LanguageVersion.CSharp6,
             Options = { PreferImplicitTypeWithInfo() },
         }.RunAsync();
@@ -3949,7 +3944,6 @@ DiagnosticResult.CompilerError("CS1069").WithSpan(18, 52, 18, 57).WithArguments(
         {
             TestCode = code,
             FixedCode = fixedCode,
-            CodeActionIndex = 0,
         }.RunAsync();
     }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InitializeParameter/AddParameterCheckTests.cs
@@ -756,7 +756,6 @@ public sealed class AddParameterCheckTests
                 }
             }
             """,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Add_null_checks_for_all_parameters)
         }.RunAsync();
     }

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5193,7 +5193,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5234,7 +5233,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5283,7 +5281,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }
@@ -5336,7 +5333,6 @@ class Program
             },
             FixedCode = expected,
             LanguageVersion = LanguageVersion.CSharp9,
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = nameof(FeaturesResources.Extract_local_function),
         }.RunAsync();
     }

--- a/src/Features/CSharpTest/GenerateComparisonOperators/GenerateComparisonOperatorsTests.cs
+++ b/src/Features/CSharpTest/GenerateComparisonOperators/GenerateComparisonOperatorsTests.cs
@@ -434,7 +434,6 @@ class C : IComparable<C>, IComparable<int>
         {
             TestCode = code,
             FixedCode = GetFixedCode("C"),
-            CodeActionIndex = 0,
             CodeActionEquivalenceKey = "Generate_for_0_C",
         }.RunAsync();
 

--- a/src/Features/CSharpTest/GenerateComparisonOperators/GenerateComparisonOperatorsTests.cs
+++ b/src/Features/CSharpTest/GenerateComparisonOperators/GenerateComparisonOperatorsTests.cs
@@ -402,33 +402,35 @@ public sealed class GenerateComparisonOperatorsTests
             }
             """;
         static string GetFixedCode(string type)
-=> $@"using System;
+            => $$"""
+            using System;
 
-class C : IComparable<C>, IComparable<int>
-{{
-    public int CompareTo(C c) => 0;
-    public int CompareTo(int c) => 0;
+            class C : IComparable<C>, IComparable<int>
+            {
+                public int CompareTo(C c) => 0;
+                public int CompareTo(int c) => 0;
 
-    public static bool operator <(C left, {type} right)
-    {{
-        return left.CompareTo(right) < 0;
-    }}
+                public static bool operator <(C left, {{type}} right)
+                {
+                    return left.CompareTo(right) < 0;
+                }
 
-    public static bool operator >(C left, {type} right)
-    {{
-        return left.CompareTo(right) > 0;
-    }}
+                public static bool operator >(C left, {{type}} right)
+                {
+                    return left.CompareTo(right) > 0;
+                }
 
-    public static bool operator <=(C left, {type} right)
-    {{
-        return left.CompareTo(right) <= 0;
-    }}
+                public static bool operator <=(C left, {{type}} right)
+                {
+                    return left.CompareTo(right) <= 0;
+                }
 
-    public static bool operator >=(C left, {type} right)
-    {{
-        return left.CompareTo(right) >= 0;
-    }}
-}}";
+                public static bool operator >=(C left, {{type}} right)
+                {
+                    return left.CompareTo(right) >= 0;
+                }
+            }
+            """;
 
         await new VerifyCS.Test
         {

--- a/src/Features/VisualBasicTest/IntroduceParameter/IntroduceParameterTests.vb
+++ b/src/Features/VisualBasicTest/IntroduceParameter/IntroduceParameterTests.vb
@@ -30,7 +30,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -74,7 +74,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -102,7 +102,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -162,7 +162,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -606,7 +606,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -629,7 +629,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -671,7 +671,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -700,7 +700,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -839,7 +839,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -972,7 +972,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 
@@ -1003,7 +1003,7 @@ End Class"
             Await New VerifyVB.Test With
                 {
                    .TestCode = source,
-                   .FixedCode = expected,
+                   .FixedCode = expected
                 }.RunAsync()
         End Function
 

--- a/src/Features/VisualBasicTest/IntroduceParameter/IntroduceParameterTests.vb
+++ b/src/Features/VisualBasicTest/IntroduceParameter/IntroduceParameterTests.vb
@@ -31,7 +31,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -76,7 +75,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -105,7 +103,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -166,7 +163,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -611,7 +607,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -635,7 +630,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -678,7 +672,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -708,7 +701,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -848,7 +840,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -982,7 +973,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 
@@ -1014,7 +1004,6 @@ End Class"
                 {
                    .TestCode = source,
                    .FixedCode = expected,
-                   .CodeActionIndex = 0
                 }.RunAsync()
         End Function
 

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingDiagnosticAnalyzerAttributeRuleTests.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingDiagnosticAnalyzerAttributeRuleTests.cs
@@ -7,23 +7,23 @@
 using System.Threading.Tasks;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers;
+using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.Fixers;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.VisualBasic.Analyzers.MetaAnalyzers.CodeFixes;
+using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.DiagnosticAnalyzerAttributeAnalyzer,
-    Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.Fixers.CSharpApplyDiagnosticAnalyzerAttributeFix>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.DiagnosticAnalyzerAttributeAnalyzer,
-    Microsoft.CodeAnalysis.VisualBasic.Analyzers.MetaAnalyzers.CodeFixes.BasicApplyDiagnosticAnalyzerAttributeFix>;
 
-namespace Microsoft.CodeAnalysis.Analyzers.UnitTests.MetaAnalyzers
+namespace Microsoft.CodeAnalysis.Analyzers.UnitTests.MetaAnalyzers;
+
+using VerifyCS = CSharpCodeFixVerifier<DiagnosticAnalyzerAttributeAnalyzer, CSharpApplyDiagnosticAnalyzerAttributeFix>;
+using VerifyVB = VisualBasicCodeFixVerifier<DiagnosticAnalyzerAttributeAnalyzer, BasicApplyDiagnosticAnalyzerAttributeFix>;
+
+public class MissingDiagnosticAnalyzerAttributeRuleTests
 {
-    public class MissingDiagnosticAnalyzerAttributeRuleTests
+    [Fact]
+    public async Task CSharp_VerifyDiagnosticAndFixesAsync()
     {
-        [Fact]
-        public async Task CSharp_VerifyDiagnosticAndFixesAsync()
-        {
-            var source = @"
+        var source = @"
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -44,11 +44,11 @@ class MyAnalyzer : DiagnosticAnalyzer
     }
 }";
 #pragma warning disable RS0030 // Do not use banned APIs
-            DiagnosticResult expected = VerifyCS.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(7, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
+        DiagnosticResult expected = VerifyCS.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(7, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
 #pragma warning restore RS0030 // Do not use banned APIs
-            await VerifyCS.VerifyAnalyzerAsync(source, expected);
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
 
-            var fixedCode_WithCSharpAttribute = @"
+        var fixedCode_WithCSharpAttribute = @"
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -70,18 +70,18 @@ class MyAnalyzer : DiagnosticAnalyzer
     }
 }";
 
-            await new VerifyCS.Test
+        await new VerifyCS.Test
+        {
+            TestState =
             {
-                TestState =
-                {
-                    Sources = { source },
-                    ExpectedDiagnostics = { expected },
-                },
-                FixedState = { Sources = { fixedCode_WithCSharpAttribute } },
-                CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_1, LanguageNames.CSharp),
-            }.RunAsync();
+                Sources = { source },
+                ExpectedDiagnostics = { expected },
+            },
+            FixedState = { Sources = { fixedCode_WithCSharpAttribute } },
+            CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_1, LanguageNames.CSharp),
+        }.RunAsync();
 
-            var fixedCode_WithCSharpAndVBAttributes = @"
+        var fixedCode_WithCSharpAndVBAttributes = @"
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -103,23 +103,23 @@ class MyAnalyzer : DiagnosticAnalyzer
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { source },
-                    ExpectedDiagnostics = { expected },
-                },
-                FixedState = { Sources = { fixedCode_WithCSharpAndVBAttributes } },
-                CodeActionIndex = 2,
-                CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_2, LanguageNames.CSharp, LanguageNames.VisualBasic),
-            }.RunAsync();
-        }
-
-        [Fact]
-        public async Task VisualBasic_VerifyDiagnosticAndFixesAsync()
+        await new VerifyCS.Test
         {
-            var source = @"
+            TestState =
+            {
+                Sources = { source },
+                ExpectedDiagnostics = { expected },
+            },
+            FixedState = { Sources = { fixedCode_WithCSharpAndVBAttributes } },
+            CodeActionIndex = 2,
+            CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_2, LanguageNames.CSharp, LanguageNames.VisualBasic),
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task VisualBasic_VerifyDiagnosticAndFixesAsync()
+    {
+        var source = @"
 Imports System
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
@@ -138,11 +138,11 @@ Class MyAnalyzer
 End Class
 ";
 #pragma warning disable RS0030 // Do not use banned APIs
-            DiagnosticResult expected = VerifyVB.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(7, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
+        DiagnosticResult expected = VerifyVB.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(7, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
 #pragma warning restore RS0030 // Do not use banned APIs
-            await VerifyVB.VerifyAnalyzerAsync(source, expected);
+        await VerifyVB.VerifyAnalyzerAsync(source, expected);
 
-            var fixedCode_WithVBAttribute = @"
+        var fixedCode_WithVBAttribute = @"
 Imports System
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
@@ -162,19 +162,19 @@ Class MyAnalyzer
 End Class
 ";
 
-            await new VerifyVB.Test
+        await new VerifyVB.Test
+        {
+            TestState =
             {
-                TestState =
-                {
-                    Sources = { source },
-                    ExpectedDiagnostics = { expected },
-                },
-                FixedState = { Sources = { fixedCode_WithVBAttribute } },
-                CodeActionIndex = 1,
-                CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_1, LanguageNames.VisualBasic),
-            }.RunAsync();
+                Sources = { source },
+                ExpectedDiagnostics = { expected },
+            },
+            FixedState = { Sources = { fixedCode_WithVBAttribute } },
+            CodeActionIndex = 1,
+            CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_1, LanguageNames.VisualBasic),
+        }.RunAsync();
 
-            var fixedCode_WithCSharpAndVBAttributes = @"
+        var fixedCode_WithCSharpAndVBAttributes = @"
 Imports System
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
@@ -194,23 +194,23 @@ Class MyAnalyzer
 End Class
 ";
 
-            await new VerifyVB.Test
-            {
-                TestState =
-                {
-                    Sources = { source },
-                    ExpectedDiagnostics = { expected },
-                },
-                FixedState = { Sources = { fixedCode_WithCSharpAndVBAttributes } },
-                CodeActionIndex = 2,
-                CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_2, LanguageNames.CSharp, LanguageNames.VisualBasic),
-            }.RunAsync();
-        }
-
-        [Fact]
-        public async Task CSharp_NoDiagnosticCasesAsync()
+        await new VerifyVB.Test
         {
-            var source = @"
+            TestState =
+            {
+                Sources = { source },
+                ExpectedDiagnostics = { expected },
+            },
+            FixedState = { Sources = { fixedCode_WithCSharpAndVBAttributes } },
+            CodeActionIndex = 2,
+            CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_2, LanguageNames.CSharp, LanguageNames.VisualBasic),
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task CSharp_NoDiagnosticCasesAsync()
+    {
+        var source = @"
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -236,13 +236,13 @@ public abstract class MyAbstractAnalyzerWithoutAttribute : DiagnosticAnalyzer
 {
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(source);
-        }
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
 
-        [Fact]
-        public async Task VisualBasic_NoDiagnosticCasesAsync()
-        {
-            var source = @"
+    [Fact]
+    public async Task VisualBasic_NoDiagnosticCasesAsync()
+    {
+        var source = @"
 Imports System
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
@@ -265,7 +265,6 @@ Public MustInherit Class MyAbstractAnalyzerWithoutAttribute
 	Inherits DiagnosticAnalyzer
 End Class
 ";
-            await VerifyVB.VerifyAnalyzerAsync(source);
-        }
+        await VerifyVB.VerifyAnalyzerAsync(source);
     }
 }

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingDiagnosticAnalyzerAttributeRuleTests.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingDiagnosticAnalyzerAttributeRuleTests.cs
@@ -18,57 +18,59 @@ namespace Microsoft.CodeAnalysis.Analyzers.UnitTests.MetaAnalyzers;
 using VerifyCS = CSharpCodeFixVerifier<DiagnosticAnalyzerAttributeAnalyzer, CSharpApplyDiagnosticAnalyzerAttributeFix>;
 using VerifyVB = VisualBasicCodeFixVerifier<DiagnosticAnalyzerAttributeAnalyzer, BasicApplyDiagnosticAnalyzerAttributeFix>;
 
-public class MissingDiagnosticAnalyzerAttributeRuleTests
+public sealed class MissingDiagnosticAnalyzerAttributeRuleTests
 {
     [Fact]
     public async Task CSharp_VerifyDiagnosticAndFixesAsync()
     {
-        var source = @"
-using System;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+        var source = """
+            using System;
+            using System.Collections.Immutable;
+            using Microsoft.CodeAnalysis;
+            using Microsoft.CodeAnalysis.Diagnostics;
 
-class MyAnalyzer : DiagnosticAnalyzer
-{
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-    {
-        get
-        {
-            throw new NotImplementedException();
-        }
-    }
+            class MyAnalyzer : DiagnosticAnalyzer
+            {
+                public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+                {
+                    get
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
 
-    public override void Initialize(AnalysisContext context)
-    {
-    }
-}";
+                public override void Initialize(AnalysisContext context)
+                {
+                }
+            }
+            """;
 #pragma warning disable RS0030 // Do not use banned APIs
-        DiagnosticResult expected = VerifyCS.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(7, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
+        DiagnosticResult expected = VerifyCS.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(6, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
 #pragma warning restore RS0030 // Do not use banned APIs
         await VerifyCS.VerifyAnalyzerAsync(source, expected);
 
-        var fixedCode_WithCSharpAttribute = @"
-using System;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+        var fixedCode_WithCSharpAttribute = """
+            using System;
+            using System.Collections.Immutable;
+            using Microsoft.CodeAnalysis;
+            using Microsoft.CodeAnalysis.Diagnostics;
 
-[DiagnosticAnalyzer(LanguageNames.CSharp)]
-class MyAnalyzer : DiagnosticAnalyzer
-{
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-    {
-        get
-        {
-            throw new NotImplementedException();
-        }
-    }
+            [DiagnosticAnalyzer(LanguageNames.CSharp)]
+            class MyAnalyzer : DiagnosticAnalyzer
+            {
+                public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+                {
+                    get
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
 
-    public override void Initialize(AnalysisContext context)
-    {
-    }
-}";
+                public override void Initialize(AnalysisContext context)
+                {
+                }
+            }
+            """;
 
         await new VerifyCS.Test
         {
@@ -81,27 +83,28 @@ class MyAnalyzer : DiagnosticAnalyzer
             CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_1, LanguageNames.CSharp),
         }.RunAsync();
 
-        var fixedCode_WithCSharpAndVBAttributes = @"
-using System;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+        var fixedCode_WithCSharpAndVBAttributes = """
+            using System;
+            using System.Collections.Immutable;
+            using Microsoft.CodeAnalysis;
+            using Microsoft.CodeAnalysis.Diagnostics;
 
-[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-class MyAnalyzer : DiagnosticAnalyzer
-{
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-    {
-        get
-        {
-            throw new NotImplementedException();
-        }
-    }
+            [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+            class MyAnalyzer : DiagnosticAnalyzer
+            {
+                public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+                {
+                    get
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
 
-    public override void Initialize(AnalysisContext context)
-    {
-    }
-}";
+                public override void Initialize(AnalysisContext context)
+                {
+                }
+            }
+            """;
 
         await new VerifyCS.Test
         {
@@ -119,48 +122,48 @@ class MyAnalyzer : DiagnosticAnalyzer
     [Fact]
     public async Task VisualBasic_VerifyDiagnosticAndFixesAsync()
     {
-        var source = @"
-Imports System
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Diagnostics
+        var source = """
+            Imports System
+            Imports System.Collections.Immutable
+            Imports Microsoft.CodeAnalysis
+            Imports Microsoft.CodeAnalysis.Diagnostics
 
-Class MyAnalyzer
-	Inherits DiagnosticAnalyzer
-	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
-		Get
-			Throw New NotImplementedException()
-		End Get
-	End Property
+            Class MyAnalyzer
+            	Inherits DiagnosticAnalyzer
+            	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+            		Get
+            			Throw New NotImplementedException()
+            		End Get
+            	End Property
 
-	Public Overrides Sub Initialize(context As AnalysisContext)
-	End Sub
-End Class
-";
+            	Public Overrides Sub Initialize(context As AnalysisContext)
+            	End Sub
+            End Class
+            """;
 #pragma warning disable RS0030 // Do not use banned APIs
-        DiagnosticResult expected = VerifyVB.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(7, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
+        DiagnosticResult expected = VerifyVB.Diagnostic(DiagnosticAnalyzerAttributeAnalyzer.MissingDiagnosticAnalyzerAttributeRule).WithLocation(6, 7).WithArguments(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzerAttribute);
 #pragma warning restore RS0030 // Do not use banned APIs
         await VerifyVB.VerifyAnalyzerAsync(source, expected);
 
-        var fixedCode_WithVBAttribute = @"
-Imports System
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Diagnostics
+        var fixedCode_WithVBAttribute = """
+            Imports System
+            Imports System.Collections.Immutable
+            Imports Microsoft.CodeAnalysis
+            Imports Microsoft.CodeAnalysis.Diagnostics
 
-<DiagnosticAnalyzer(LanguageNames.VisualBasic)>
-Class MyAnalyzer
-	Inherits DiagnosticAnalyzer
-	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
-		Get
-			Throw New NotImplementedException()
-		End Get
-	End Property
+            <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+            Class MyAnalyzer
+            	Inherits DiagnosticAnalyzer
+            	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+            		Get
+            			Throw New NotImplementedException()
+            		End Get
+            	End Property
 
-	Public Overrides Sub Initialize(context As AnalysisContext)
-	End Sub
-End Class
-";
+            	Public Overrides Sub Initialize(context As AnalysisContext)
+            	End Sub
+            End Class
+            """;
 
         await new VerifyVB.Test
         {
@@ -174,25 +177,25 @@ End Class
             CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_1, LanguageNames.VisualBasic),
         }.RunAsync();
 
-        var fixedCode_WithCSharpAndVBAttributes = @"
-Imports System
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Diagnostics
+        var fixedCode_WithCSharpAndVBAttributes = """
+            Imports System
+            Imports System.Collections.Immutable
+            Imports Microsoft.CodeAnalysis
+            Imports Microsoft.CodeAnalysis.Diagnostics
 
-<DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
-Class MyAnalyzer
-	Inherits DiagnosticAnalyzer
-	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
-		Get
-			Throw New NotImplementedException()
-		End Get
-	End Property
+            <DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+            Class MyAnalyzer
+            	Inherits DiagnosticAnalyzer
+            	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+            		Get
+            			Throw New NotImplementedException()
+            		End Get
+            	End Property
 
-	Public Overrides Sub Initialize(context As AnalysisContext)
-	End Sub
-End Class
-";
+            	Public Overrides Sub Initialize(context As AnalysisContext)
+            	End Sub
+            End Class
+            """;
 
         await new VerifyVB.Test
         {
@@ -210,61 +213,61 @@ End Class
     [Fact]
     public async Task CSharp_NoDiagnosticCasesAsync()
     {
-        var source = @"
-using System;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+        var source = """
+            using System;
+            using System.Collections.Immutable;
+            using Microsoft.CodeAnalysis;
+            using Microsoft.CodeAnalysis.Diagnostics;
 
-[DiagnosticAnalyzer(LanguageNames.CSharp)]
-class MyAnalyzerWithLanguageSpecificAttribute : DiagnosticAnalyzer
-{
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-    {
-        get
-        {
-            throw new NotImplementedException();
-        }
-    }
+            [DiagnosticAnalyzer(LanguageNames.CSharp)]
+            class MyAnalyzerWithLanguageSpecificAttribute : DiagnosticAnalyzer
+            {
+                public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+                {
+                    get
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
 
-    public override void Initialize(AnalysisContext context)
-    {
-    }
-}
+                public override void Initialize(AnalysisContext context)
+                {
+                }
+            }
 
-public abstract class MyAbstractAnalyzerWithoutAttribute : DiagnosticAnalyzer
-{
-}
-";
+            public abstract class MyAbstractAnalyzerWithoutAttribute : DiagnosticAnalyzer
+            {
+            }
+            """;
         await VerifyCS.VerifyAnalyzerAsync(source);
     }
 
     [Fact]
     public async Task VisualBasic_NoDiagnosticCasesAsync()
     {
-        var source = @"
-Imports System
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Diagnostics
+        var source = """
+            Imports System
+            Imports System.Collections.Immutable
+            Imports Microsoft.CodeAnalysis
+            Imports Microsoft.CodeAnalysis.Diagnostics
 
-<DiagnosticAnalyzer(LanguageNames.VisualBasic)>
-Class MyAnalyzerWithLanguageSpecificAttribute
-	Inherits DiagnosticAnalyzer
-	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
-		Get
-			Throw New NotImplementedException()
-		End Get
-	End Property
+            <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+            Class MyAnalyzerWithLanguageSpecificAttribute
+            	Inherits DiagnosticAnalyzer
+            	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+            		Get
+            			Throw New NotImplementedException()
+            		End Get
+            	End Property
 
-	Public Overrides Sub Initialize(context As AnalysisContext)
-	End Sub
-End Class
+            	Public Overrides Sub Initialize(context As AnalysisContext)
+            	End Sub
+            End Class
 
-Public MustInherit Class MyAbstractAnalyzerWithoutAttribute
-	Inherits DiagnosticAnalyzer
-End Class
-";
+            Public MustInherit Class MyAbstractAnalyzerWithoutAttribute
+            	Inherits DiagnosticAnalyzer
+            End Class
+            """;
         await VerifyVB.VerifyAnalyzerAsync(source);
     }
 }

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingDiagnosticAnalyzerAttributeRuleTests.cs
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingDiagnosticAnalyzerAttributeRuleTests.cs
@@ -78,7 +78,6 @@ class MyAnalyzer : DiagnosticAnalyzer
                     ExpectedDiagnostics = { expected },
                 },
                 FixedState = { Sources = { fixedCode_WithCSharpAttribute } },
-                CodeActionIndex = 0,
                 CodeActionEquivalenceKey = string.Format(CodeAnalysisDiagnosticsResources.ApplyDiagnosticAnalyzerAttribute_1, LanguageNames.CSharp),
             }.RunAsync();
 


### PR DESCRIPTION
`CodeActionIndex=0` is redundant.  It's the default.
Specifying equivalence key isn't desirable, and makes the tests brittle and hard to maintain.