### PR TITLE
Do not offer use-expr-body for properties with initializers

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
@@ -153,24 +153,25 @@ internal abstract class UseExpressionBodyHelper<TDeclaration> : UseExpressionBod
         [NotNullWhen(true)] out ArrowExpressionClauseSyntax? arrowExpression,
         out SyntaxToken semicolonToken)
     {
-        // If we have `X Prop { ... } = ...;` we can't convert this as expr-bodied properties can't have initializers.
-        if (declaration is PropertyDeclarationSyntax { Initializer: null })
-        {
-            if (TryConvertToExpressionBodyWorker(declaration, conversionPreference, cancellationToken, out arrowExpression, out semicolonToken))
-                return true;
-
-            var getAccessor = GetSingleGetAccessor(declaration.AccessorList);
-            if (getAccessor?.ExpressionBody != null &&
-                BlockSyntaxExtensions.MatchesPreference(getAccessor.ExpressionBody.Expression, conversionPreference))
-            {
-                arrowExpression = ArrowExpressionClause(getAccessor.ExpressionBody.Expression);
-                semicolonToken = getAccessor.SemicolonToken;
-                return true;
-            }
-        }
-
         arrowExpression = null;
         semicolonToken = default;
+
+        // If we have `X Prop { ... } = ...;` we can't convert this as expr-bodied properties can't have initializers.
+        if (declaration is PropertyDeclarationSyntax { Initializer: not null })
+            return false;
+
+        if (TryConvertToExpressionBodyWorker(declaration, conversionPreference, cancellationToken, out arrowExpression, out semicolonToken))
+            return true;
+
+        var getAccessor = GetSingleGetAccessor(declaration.AccessorList);
+        if (getAccessor?.ExpressionBody != null &&
+            BlockSyntaxExtensions.MatchesPreference(getAccessor.ExpressionBody.Expression, conversionPreference))
+        {
+            arrowExpression = ArrowExpressionClause(getAccessor.ExpressionBody.Expression);
+            semicolonToken = getAccessor.SemicolonToken;
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/77473