### PR TITLE
Insert missing space in XML documentation

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueProvider.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <typeparam name="T">The type of the value the syntax node is transformed into</typeparam>
         /// <param name="predicate">A function that determines if the given <see cref="SyntaxNode"/> should be transformed</param>
-        /// <param name="transform">A function that performs the transform, when <paramref name="predicate"/>returns <c>true</c> for a given node</param>
+        /// <param name="transform">A function that performs the transform, when <paramref name="predicate"/> returns <c>true</c> for a given node</param>
         /// <returns>An <see cref="IncrementalValueProvider{T}"/> that provides the results of the transformation</returns>
         public IncrementalValuesProvider<T> CreateSyntaxProvider<T>(Func<SyntaxNode, CancellationToken, bool> predicate, Func<GeneratorSyntaxContext, CancellationToken, T> transform)
         {


### PR DESCRIPTION
Added missing space between “predicate” and “returns”