### PR TITLE
Allow Razor cohosting to hook into configuration change notifications

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler.cs
@@ -62,8 +62,16 @@ internal sealed partial class DidChangeConfigurationNotificationHandler : ILspSe
 
     public bool RequiresLSPSolution => false;
 
-    public Task HandleNotificationAsync(DidChangeConfigurationParams request, RequestContext requestContext, CancellationToken cancellationToken)
-        => RefreshOptionsAsync(cancellationToken);
+    public async Task HandleNotificationAsync(DidChangeConfigurationParams request, RequestContext requestContext, CancellationToken cancellationToken)
+    {
+        await RefreshOptionsAsync(cancellationToken).ConfigureAwait(false);
+
+        var onChangedList = requestContext.GetRequiredServices<IOnConfigurationChanged>();
+        foreach (var onConfigurationChanged in onChangedList)
+        {
+            await onConfigurationChanged.OnConfigurationChangedAsync(requestContext, cancellationToken).ConfigureAwait(false);
+        }
+    }
 
     private async Task RefreshOptionsAsync(CancellationToken cancellationToken)
     {

--- a/src/LanguageServer/Protocol/IOnConfigurationChanged.cs
+++ b/src/LanguageServer/Protocol/IOnConfigurationChanged.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+namespace Microsoft.CodeAnalysis.LanguageServer;
+
+internal interface IOnConfigurationChanged
+{
+    Task OnConfigurationChangedAsync(RequestContext context, CancellationToken cancellationToken);
+}

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/ICohostConfigurationChangedService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/ICohostConfigurationChangedService.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+internal interface ICohostConfigurationChangedService
+{
+    Task OnConfigurationChangedAsync(RazorCohostRequestContext requestContext, CancellationToken cancellationToken);
+}

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorConfigurationChangedServiceFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorConfigurationChangedServiceFactory.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 
-[ExportCSharpVisualBasicLspServiceFactory(typeof(RazorConfigurationChangedService), WellKnownLspServerKinds.Any), Shared]
+[ExportCSharpVisualBasicLspServiceFactory(typeof(RazorConfigurationChangedService)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class RazorConfigurationChangedServiceFactory(

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorConfigurationChangedServiceFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorConfigurationChangedServiceFactory.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+[ExportCSharpVisualBasicLspServiceFactory(typeof(RazorConfigurationChangedService), WellKnownLspServerKinds.Any), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class RazorConfigurationChangedServiceFactory(
+    [Import(AllowDefault = true)] Lazy<ICohostConfigurationChangedService>? cohostConfigurationChangedService) : ILspServiceFactory
+{
+    public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
+    {
+        return new RazorConfigurationChangedService(cohostConfigurationChangedService);
+    }
+
+    private class RazorConfigurationChangedService(
+        Lazy<ICohostConfigurationChangedService>? cohostConfigurationChangedService) : ILspService, IOnConfigurationChanged
+    {
+        public Task OnConfigurationChangedAsync(RequestContext context, CancellationToken cancellationToken)
+        {
+            if (context.ServerKind is not (WellKnownLspServerKinds.AlwaysActiveVSLspServer or WellKnownLspServerKinds.CSharpVisualBasicLspServer))
+            {
+                return Task.CompletedTask;
+            }
+
+            if (cohostConfigurationChangedService is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            using var languageScope = context.Logger.CreateLanguageContext(Constants.RazorLanguageName);
+            var requestContext = new RazorCohostRequestContext(context);
+            return cohostConfigurationChangedService.Value.OnConfigurationChangedAsync(requestContext, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Since Roslyn uses dynamic registration for configuration change requests, Razor can't. Even if we could, as a document-less request, it couldn't be routed to us anyway. So this exposes a hook for us through our EA.

Razor side is at https://github.com/dotnet/razor/pull/11800

Part of https://github.com/dotnet/razor/issues/11759