### PR TITLE
Disable nuget warning new in net10 as is likely false positives for roslyn

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -17,6 +17,9 @@
     <!-- TODO: https://github.com/dotnet/roslyn/issues/71667 -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
 
+    <!-- Suppress package reference warnings new in net10 as they are often wrong for Roslyn -->
+    <NoWarn>$(NoWarn);NU1510</NoWarn>
+
     <NoWarn>$(NoWarn);RSEXPERIMENTAL005</NoWarn>
 
     <CommonExtensionInstallationRoot>CommonExtensions</CommonExtensionInstallationRoot>


### PR DESCRIPTION
Below is the full list if there are any here you want to fix.

Severity	Code	Description	Project	File	Line	Suppression State	Details
Warning (active)	NU1510	PackageReference System.Threading.Channels will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Workspaces (net8.0), Microsoft.CodeAnalysis.Workspaces (net9.0), Microsoft.CodeAnalysis.Workspaces (netstandard2.0)	C:\repos\roslyn\src\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj	1		
Warning (active)	NU1510	PackageReference System.Text.Json will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Features (net8.0), Microsoft.CodeAnalysis.Features (net9.0), Microsoft.CodeAnalysis.Features (netstandard2.0)	C:\repos\roslyn\src\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj	1		
Warning (active)	NU1510	PackageReference System.Runtime.CompilerServices.Unsafe will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Test.Utilities (net472), Microsoft.CodeAnalysis.Test.Utilities (net8.0), Microsoft.CodeAnalysis.Test.Utilities (net9.0)	C:\repos\roslyn\src\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj	1		
Warning (active)	NU1510	PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	CSharpSyntaxGenerator (net9.0), CSharpSyntaxGenerator (netstandard2.0)	C:\repos\roslyn\src\Tools\Source\CompilerGeneratorTools\Source\CSharpSyntaxGenerator\CSharpSyntaxGenerator.csproj	1		
Warning (active)	NU1510	PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis (net8.0), Microsoft.CodeAnalysis (net9.0), Microsoft.CodeAnalysis (netstandard2.0)	C:\repos\roslyn\src\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj	1		
Warning (active)	NU1510	PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Rebuild (net8.0), Microsoft.CodeAnalysis.Rebuild (net9.0), Microsoft.CodeAnalysis.Rebuild (netstandard2.0)	C:\repos\roslyn\src\Compilers\Core\Rebuild\Microsoft.CodeAnalysis.Rebuild.csproj	1		
Warning (active)	NU1510	PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	BuildValidator (net472), BuildValidator (net9.0)	C:\repos\roslyn\src\Tools\BuildValidator\BuildValidator.csproj	1		
Warning (active)	NU1510	PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Roslyn.Test.PdbUtilities (net472), Roslyn.Test.PdbUtilities (net8.0), Roslyn.Test.PdbUtilities (net9.0)	C:\repos\roslyn\src\Test\PdbUtilities\Roslyn.Test.PdbUtilities.csproj	1		
Warning (active)	NU1510	PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	RunTests	C:\repos\roslyn\src\Tools\Source\RunTests\RunTests.csproj	1		
Warning (active)	NU1510	PackageReference System.IO.Pipelines will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Workspaces (net8.0), Microsoft.CodeAnalysis.Workspaces (net9.0), Microsoft.CodeAnalysis.Workspaces (netstandard2.0)	C:\repos\roslyn\src\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj	1		
Warning (active)	NU1510	PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	CSharpSyntaxGenerator (net9.0), CSharpSyntaxGenerator (netstandard2.0)	C:\repos\roslyn\src\Tools\Source\CompilerGeneratorTools\Source\CSharpSyntaxGenerator\CSharpSyntaxGenerator.csproj	1		
Warning (active)	NU1510	PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis (net8.0), Microsoft.CodeAnalysis (net9.0), Microsoft.CodeAnalysis (netstandard2.0)	C:\repos\roslyn\src\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj	1		
Warning (active)	NU1510	PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Collections.Package (net9.0), Microsoft.CodeAnalysis.Collections.Package (netstandard2.0)	C:\repos\roslyn\src\Dependencies\Collections\Microsoft.CodeAnalysis.Collections.Package.csproj	1		
Warning (active)	NU1510	PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Contracts.Package (net8.0), Microsoft.CodeAnalysis.Contracts.Package (net9.0), Microsoft.CodeAnalysis.Contracts.Package (netstandard2.0)	C:\repos\roslyn\src\Dependencies\Contracts\Microsoft.CodeAnalysis.Contracts.Package.csproj	1		
Warning (active)	NU1510	PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Roslyn.Test.PdbUtilities (net472), Roslyn.Test.PdbUtilities (net8.0), Roslyn.Test.PdbUtilities (net9.0)	C:\repos\roslyn\src\Test\PdbUtilities\Roslyn.Test.PdbUtilities.csproj	1		
Warning (active)	NU1510	PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	RunTests	C:\repos\roslyn\src\Tools\Source\RunTests\RunTests.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.Win32.Registry will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	BuildValidator (net472), BuildValidator (net9.0)	C:\repos\roslyn\src\Tools\BuildValidator\BuildValidator.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.VisualBasic will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.VisualBasic.Scripting (net8.0), Microsoft.CodeAnalysis.VisualBasic.Scripting (net9.0), Microsoft.CodeAnalysis.VisualBasic.Scripting (netstandard2.0)	C:\repos\roslyn\src\Scripting\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.Scripting.vbproj	1		
Warning (active)	NU1510	PackageReference Microsoft.VisualBasic will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	vbi (net472), vbi (net8.0), vbi (net9.0)	C:\repos\roslyn\src\Interactive\vbi\vbi.vbproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.CSharp.Scripting (net8.0), Microsoft.CodeAnalysis.CSharp.Scripting (net9.0), Microsoft.CodeAnalysis.CSharp.Scripting (netstandard2.0)	C:\repos\roslyn\src\Scripting\CSharp\Microsoft.CodeAnalysis.CSharp.Scripting.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Test.Utilities (net472), Microsoft.CodeAnalysis.Test.Utilities (net8.0), Microsoft.CodeAnalysis.Test.Utilities (net9.0)	C:\repos\roslyn\src\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.Scripting.TestUtilities (net472), Microsoft.CodeAnalysis.Scripting.TestUtilities (net9.0)	C:\repos\roslyn\src\Scripting\CoreTestUtilities\Microsoft.CodeAnalysis.Scripting.TestUtilities.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	csi (net472), csi (net8.0), csi (net9.0)	C:\repos\roslyn\src\Interactive\csi\csi.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.CSharp.Emit.UnitTests (net472), Microsoft.CodeAnalysis.CSharp.Emit.UnitTests (net9.0)	C:\repos\roslyn\src\Compilers\CSharp\Test\Emit\Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests (net472), Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests (net9.0)	C:\repos\roslyn\src\Compilers\CSharp\Test\Emit2\Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.CSharp.Emit3.UnitTests (net472), Microsoft.CodeAnalysis.CSharp.Emit3.UnitTests (net9.0)	C:\repos\roslyn\src\Compilers\CSharp\Test\Emit3\Microsoft.CodeAnalysis.CSharp.Emit3.UnitTests.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests (net472), Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests (net9.0)	C:\repos\roslyn\src\Compilers\CSharp\Test\EndToEnd\Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests (net472), Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests (net9.0)	C:\repos\roslyn\src\Compilers\CSharp\Test\IOperation\Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests.csproj	1		
Warning (active)	NU1510	PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.	Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests (net472), Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests (net9.0)	C:\repos\roslyn\src\Compilers\CSharp\Test\Semantic\Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.csproj	1		
