### PR TITLE
Ensure hover markdown for supported platforms uses non-breaking spaces for indentation

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8785,8 +8785,8 @@ expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
         var expectedDescription = $"""
             ({FeaturesResources.field}) int C.x
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """;
@@ -8825,9 +8825,9 @@ expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
         var expectedDescription = $"""
             ({FeaturesResources.field}) int C.x
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
-            {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """;
@@ -8869,8 +8869,8 @@ expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
         var expectedDescription = $"""
             ({FeaturesResources.field}) int C.x
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """;
@@ -8916,9 +8916,9 @@ expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
         var expectedDescription = $"""
             void G.DoGStuff()
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Not_Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """;
@@ -8981,8 +8981,8 @@ expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
         var expectedDescription = $"""
             ({FeaturesResources.local_variable}) int xyz
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """;

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6295,8 +6295,8 @@ Documentation("This example shows how to specify the GenericClass<T> cref.",
             """;
         var expectedDescription = Usage($"""
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """, expectsWarningGlyph: true);
@@ -6331,8 +6331,8 @@ Documentation("This example shows how to specify the GenericClass<T> cref.",
             """;
         var expectedDescription = Usage($"""
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Not_Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """, expectsWarningGlyph: true);
@@ -6371,9 +6371,9 @@ Documentation("This example shows how to specify the GenericClass<T> cref.",
         var expectedDescription = Usage(
             $"""
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
-            {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """,
@@ -6415,8 +6415,8 @@ Documentation("This example shows how to specify the GenericClass<T> cref.",
             """;
         var expectedDescription = Usage($"""
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """, expectsWarningGlyph: true);
@@ -6507,8 +6507,8 @@ Documentation("This example shows how to specify the GenericClass<T> cref.",
 
         await VerifyWithReferenceWorkerAsync(markup, [MainDescription($"({FeaturesResources.local_variable}) int x"), Usage($"""
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """, expectsWarningGlyph: true)]);

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -998,7 +998,14 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
                 </Project>
             </Workspace>
             """;
-        var expectedDescription = new SignatureHelpTestItem($"Secret()\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            Secret()
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 
@@ -1036,7 +1043,14 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             </Workspace>
             """;
 
-        var expectedDescription = new SignatureHelpTestItem($"Secret()\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            Secret()
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
@@ -597,7 +597,14 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 </Project>
             </Workspace>
             """;
-        var expectedDescription = new SignatureHelpTestItem($"Secret(int secret)\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            Secret(int secret)
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 
@@ -638,7 +645,14 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
             </Workspace>
             """;
 
-        var expectedDescription = new SignatureHelpTestItem($"Secret(int secret)\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            Secret(int secret)
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
@@ -816,7 +816,14 @@ public sealed class ElementAccessExpressionSignatureHelpProviderTests : Abstract
                 </Project>
             </Workspace>
             """;
-        var expectedDescription = new SignatureHelpTestItem($"int C[int z]\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            int C[int z]
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 
@@ -858,7 +865,14 @@ public sealed class ElementAccessExpressionSignatureHelpProviderTests : Abstract
             </Workspace>
             """;
 
-        var expectedDescription = new SignatureHelpTestItem($"int C[int z]\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            int C[int z]
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -782,7 +782,14 @@ public sealed class GenericNameSignatureHelpProviderTests : AbstractCSharpSignat
                 </Project>
             </Workspace>
             """;
-        var expectedDescription = new SignatureHelpTestItem($"D<T>\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            D<T>
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 
@@ -820,7 +827,14 @@ public sealed class GenericNameSignatureHelpProviderTests : AbstractCSharpSignat
             </Workspace>
             """;
 
-        var expectedDescription = new SignatureHelpTestItem($"D<T>\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0);
+        var expectedDescription = new SignatureHelpTestItem($"""
+            D<T>
+
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+            """, currentParameterIndex: 0);
         await VerifyItemWithReferenceWorkerAsync(markup, [expectedDescription], false);
     }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -2082,8 +2082,8 @@ public sealed class InvocationExpressionSignatureHelpProviderTests : AbstractCSh
         await VerifyItemWithReferenceWorkerAsync(markup, [new SignatureHelpTestItem($"""
             void C.bar()
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """, currentParameterIndex: 0)], hideAdvancedMembers: false);
@@ -2126,8 +2126,8 @@ public sealed class InvocationExpressionSignatureHelpProviderTests : AbstractCSh
         await VerifyItemWithReferenceWorkerAsync(markup, [new SignatureHelpTestItem($"""
             void C.bar()
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """, currentParameterIndex: 0)], hideAdvancedMembers: false);
@@ -2341,8 +2341,8 @@ public sealed class InvocationExpressionSignatureHelpProviderTests : AbstractCSh
         await VerifyItemWithReferenceWorkerAsync(markup, [new SignatureHelpTestItem($"""
             void C.Do(int x)
 
-            {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-            {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
             {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
             """, currentParameterIndex: 0)], hideAdvancedMembers: false);
@@ -2613,8 +2613,8 @@ public sealed class InvocationExpressionSignatureHelpProviderTests : AbstractCSh
             expectedItems.Add(new SignatureHelpTestItem($"""
                 void C.M<object>(Action<object> arg1, object arg2, bool flag)
 
-                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                    {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                    {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
                 {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
                 """, currentParameterIndex: 0));
@@ -2625,8 +2625,8 @@ public sealed class InvocationExpressionSignatureHelpProviderTests : AbstractCSh
             expectedItems.Add(new SignatureHelpTestItem($"""
                 void C.M<T>(Action<T> arg1, T arg2, bool flag)
 
-                {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
-                {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+                    {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                    {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
 
                 {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
                 """, currentParameterIndex: 0));

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
@@ -615,7 +615,14 @@ public sealed class ObjectCreationExpressionSignatureHelpProviderTests : Abstrac
             """;
 
         await VerifyItemWithReferenceWorkerAsync(
-            markup, [new($"D()\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0)], false);
+            markup, [new($"""
+                D()
+
+                    {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                    {string.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available)}
+
+                {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+                """, currentParameterIndex: 0)], false);
     }
 
     [Fact]
@@ -653,7 +660,14 @@ public sealed class ObjectCreationExpressionSignatureHelpProviderTests : Abstrac
             """;
 
         await VerifyItemWithReferenceWorkerAsync(
-            markup, [new($"D()\r\n\r\n{string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}", currentParameterIndex: 0)], false);
+            markup, [new($"""
+                D()
+
+                    {string.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}
+                    {string.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}
+
+                {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}
+                """, currentParameterIndex: 0)], false);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1067933")]

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -5640,7 +5640,7 @@ Class C
                              </Project>
                          </Workspace>.ToString().NormalizeLineEndings()
 
-            Dim expectedDescription = $"({FeaturesResources.field}) C.x As Integer" + vbCrLf + vbCrLf + String.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available) + vbCrLf + String.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available) + vbCrLf + vbCrLf + FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts
+            Dim expectedDescription = $"({FeaturesResources.field}) C.x As Integer" + vbCrLf + vbCrLf + "    " + String.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available) + vbCrLf + "    " + String.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available) + vbCrLf + vbCrLf + FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts
             Await VerifyItemInLinkedFilesAsync(markup, "x", expectedDescription)
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -1822,7 +1822,7 @@ end class
                                  <Document IsLinkFile="true" LinkAssemblyName="Proj1" LinkFilePath="SourceDocument"/>
                              </Project>
                          </Workspace>]]></text>.Value.NormalizeLineEndings()
-            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + vbCrLf + vbCrLf + String.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available) + vbCrLf + String.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available) + vbCrLf + vbCrLf + FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts, currentParameterIndex:=0)
+            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + vbCrLf + vbCrLf + "    " + String.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available) + vbCrLf + "    " + String.Format(FeaturesResources._0_1, "Proj2", FeaturesResources.Not_Available) + vbCrLf + vbCrLf + FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts, currentParameterIndex:=0)
             Await VerifyItemWithReferenceWorkerAsync(markup, {expectedDescription}, False)
         End Function
 
@@ -1852,7 +1852,7 @@ class C
                              </Project>
                          </Workspace>]]></text>.Value.NormalizeLineEndings()
 
-            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + $"\r\n\r\n{String.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n{String.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}".Replace("\r\n", vbCrLf), currentParameterIndex:=0)
+            Dim expectedDescription = New SignatureHelpTestItem("C.bar()" + $"\r\n\r\n    {String.Format(FeaturesResources._0_1, "Proj1", FeaturesResources.Available)}\r\n    {String.Format(FeaturesResources._0_1, "Proj3", FeaturesResources.Not_Available)}\r\n\r\n{FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts}".Replace("\r\n", vbCrLf), currentParameterIndex:=0)
             Await VerifyItemWithReferenceWorkerAsync(markup, {expectedDescription}, False)
         End Function
 

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -566,7 +566,7 @@ Do you want to continue?</value>
     <value>Not Available ⚠</value>
   </data>
   <data name="_0_1" xml:space="preserve">
-    <value>    {0} - {1}</value>
+    <value>{0} - {1}</value>
   </data>
   <data name="You_can_use_the_navigation_bar_to_switch_contexts" xml:space="preserve">
     <value>You can use the navigation bar to switch contexts.</value>

--- a/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
@@ -31,6 +31,7 @@ internal sealed class SupportedPlatformData(Solution solution, ImmutableArray<Pr
         foreach (var project in projects)
         {
             var text = string.Format(FeaturesResources._0_1, project.Name, Supported(!InvalidProjects.Contains(project.Id)));
+            builder.AddSpace("    ");
             builder.AddText(text);
             builder.AddLineBreak();
         }

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -4191,8 +4191,8 @@ Chcete pokračovat?</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} – {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} – {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -4191,8 +4191,8 @@ Möchten Sie fortfahren?</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -4191,8 +4191,8 @@ Do you want to continue?</source>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -4191,8 +4191,8 @@ Voulez-vous continuer ?</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -4191,8 +4191,8 @@ Continuare?</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -4191,8 +4191,8 @@ Do you want to continue?</source>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">{0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">{0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -4191,8 +4191,8 @@ Do you want to continue?</source>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -4191,8 +4191,8 @@ Czy chcesz kontynuować?</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -4191,8 +4191,8 @@ Deseja continuar?</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -4191,8 +4191,8 @@ Do you want to continue?</source>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -4191,8 +4191,8 @@ Devam etmek istiyor musunuz?</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -4191,8 +4191,8 @@ Do you want to continue?</source>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -4191,8 +4191,8 @@ Do you want to continue?</source>
         <note />
       </trans-unit>
       <trans-unit id="_0_1">
-        <source>    {0} - {1}</source>
-        <target state="translated">    {0} - {1}</target>
+        <source>{0} - {1}</source>
+        <target state="needs-review-translation">    {0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="in_Source">

--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -7,6 +7,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Test.Utilities;
 using Roslyn.Text.Adornments;
@@ -525,6 +526,64 @@ class C
             testLspServer,
             expectedLocation).ConfigureAwait(false);
         Assert.Equal(expectedMarkdown, results.Contents.Fourth.Value);
+    }
+    [Theory, CombinatorialData]
+    public async Task TestGetHoverAsync_UsesNonBreakingSpaceForSupportedPlatforms(bool mutatingLspWorkspace)
+    {
+        var source = """
+            using System;
+            class WithConstant
+            {
+            #if NET472
+                public const string Target = "Target in net472";
+            #endif
+            }
+            class Program
+            {
+                static void Main(string[] args)
+                {
+                    Console.WriteLine(WithConstant.{|caret:Target|});
+                }
+            }
+            """;
+
+        var workspaceXml =
+            $"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="Net472" PreprocessorSymbols="NET472">
+                    <Document FilePath="C:\C.cs"><![CDATA[${source}]]></Document>
+                </Project>
+                <Project Language="C#" CommonReferences="true" AssemblyName="NetCoreApp3" PreprocessorSymbols="NETCOREAPP3.1">
+                    <Document IsLinkFile="true" LinkFilePath="C:\C.cs" LinkAssemblyName="Net472"></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        var expectedMarkdown = """
+            ```csharp
+            (constant) string WithConstant.Target = "Target in net472"
+            ```
+              
+              
+            &nbsp;&nbsp;&nbsp;&nbsp;Net472 \- Available  
+            &nbsp;&nbsp;&nbsp;&nbsp;NetCoreApp3 \- Not Available ⚠  
+              
+            You can use the navigation bar to switch contexts\.  
+            
+            """;
+
+        var clientCapabilities = new LSP.ClientCapabilities
+        {
+            TextDocument = new LSP.TextDocumentClientCapabilities { Hover = new LSP.HoverSetting { ContentFormat = [LSP.MarkupKind.Markdown] } }
+        };
+        await using var testLspServer = await CreateXmlTestLspServerAsync(workspaceXml, mutatingLspWorkspace, initializationOptions: new InitializationOptions { ClientCapabilities = clientCapabilities });
+        var location = testLspServer.GetLocations("caret").Single();
+
+        var project = testLspServer.GetCurrentSolution().Projects.Single(p => p.AssemblyName == "Net472");
+        var result = await RunGetHoverAsync(testLspServer, location, project.Id);
+
+        AssertEx.NotNull(result);
+        Assert.Equal(expectedMarkdown, result.Contents.Fourth.Value);
     }
 
     private static async Task<LSP.Hover> RunGetHoverAsync(

--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -559,16 +559,16 @@ class C
             </Workspace>
             """;
 
-        var expectedMarkdown = """
+        var expectedMarkdown = $"""
             ```csharp
-            (constant) string WithConstant.Target = "Target in net472"
+            ({FeaturesResources.constant}) string WithConstant.Target = "Target in net472"
             ```
               
               
-            &nbsp;&nbsp;&nbsp;&nbsp;Net472 \- Available  
-            &nbsp;&nbsp;&nbsp;&nbsp;NetCoreApp3 \- Not Available ⚠  
+            &nbsp;&nbsp;&nbsp;&nbsp;{string.Format(FeaturesResources._0_1, "Net472", FeaturesResources.Available).Replace("-", "\\-")}  
+            &nbsp;&nbsp;&nbsp;&nbsp;{string.Format(FeaturesResources._0_1, "NetCoreApp3", FeaturesResources.Not_Available).Replace("-", "\\-")}  
               
-            You can use the navigation bar to switch contexts\.  
+            {FeaturesResources.You_can_use_the_navigation_bar_to_switch_contexts.Replace(".", "\\.")}  
             
             """;
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/8204

Supported platform information uses 4 spaces in its resource string `    {0} - {1}` for indentation in tool tips.  However, 4 spaces at the beginning of the line in markdown indicates a code block, breaking the rendering of the supported platform info in LSP (thanks to @JoeRobich  for spotting that!)

Since the 4 spaces are intended to be structural indentation, we need to use non breaking spaces (`&nbsp`) in markdown.  We already handle that generally when we see a `TextTags.Space` kind.   However in this case the 4 spaces were combined with the rest of the string and therefore tagged as `Text` instead of `Space`

The fix is to separate out the structural spacing from the rest of the string, and tag it as such.  This lets our existing handling of spaces convert to non breaking spaces when it needs to.