### PR TITLE
Revert back to scouting queue

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -68,7 +68,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.amd64.open
+  default: windows.vs2022preview.scout.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open


### PR DESCRIPTION
dnceng reverted their image update.  the old non-scouting image is also broken, and so now it fails again.  revert back to the scouting queue to unblock.

![image](https://github.com/user-attachments/assets/89bc8dfe-5546-4903-b1ba-641f39151a78)

new broken version - Using VS Instance eb713cd8 (17.14.0 Preview 1.1) at "C:\Program Files\Microsoft Visual Studio\2022\Preview"


