### PR TITLE
Implement PDG.WithProjectsRemoved

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
@@ -58,6 +58,7 @@ public partial class ProjectDependencyGraph
     {
         var builder = existingForwardReferencesMap.ToBuilder();
 
+        // TODO: Consider optimizing when a large number of projects are being removed simultaneously
         if (existingReverseReferencesMap is not null)
         {
             foreach (var removedProjectId in removedProjectIds)
@@ -82,7 +83,7 @@ public partial class ProjectDependencyGraph
             }
         }
 
-        // Finally, remove 'projectId' itself.
+        // Finally, remove each item in removedProjectIds
         foreach (var removedProjectId in removedProjectIds)
             builder.Remove(removedProjectId);
 
@@ -103,6 +104,7 @@ public partial class ProjectDependencyGraph
         if (existingReverseReferencesMap is null)
             return null;
 
+        // TODO: Consider optimizing when a large number of projects are being removed simultaneously
         var builder = existingReverseReferencesMap.ToBuilder();
         foreach (var removedProjectId in removedProjectIds)
         {
@@ -116,7 +118,7 @@ public partial class ProjectDependencyGraph
                 builder.MultiRemove(referencedProjectId, removedProjectId);
         }
 
-        // Finally, remove 'removedProjectId' itself.
+        // Finally, remove each item in removedProjectIds
         foreach (var removedProjectId in removedProjectIds)
             builder.Remove(removedProjectId);
 
@@ -150,7 +152,7 @@ public partial class ProjectDependencyGraph
             }
         }
 
-        // Finally, remove 'projectId' itself.
+        // Finally, remove each item in removedProjectIds
         foreach (var removedProjectId in removedProjectIds)
             builder.Remove(removedProjectId);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
@@ -3,32 +3,35 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
 
 public partial class ProjectDependencyGraph
 {
-    internal ProjectDependencyGraph WithProjectRemoved(ProjectId projectId)
+    internal ProjectDependencyGraph WithProjectsRemoved(ArrayBuilder<ProjectId> removedProjectIds)
     {
-        Contract.ThrowIfFalse(ProjectIds.Contains(projectId));
-
         // Project ID set and direct forward references are trivially updated by removing the key corresponding to
         // the project getting removed.
-        var projectIds = ProjectIds.Remove(projectId);
+        var projectIdsBuilder = ProjectIds.ToBuilder();
+        foreach (var projectId in removedProjectIds)
+            Contract.ThrowIfFalse(projectIdsBuilder.Remove(projectId));
+        var projectIds = projectIdsBuilder.ToImmutable();
+
         var referencesMap = ComputeNewReferencesMapForRemovedProject(
             existingForwardReferencesMap: _referencesMap,
             existingReverseReferencesMap: _lazyReverseReferencesMap,
-            projectId);
+            removedProjectIds);
 
         // The direct reverse references map is updated by removing the key for the project getting removed, and
         // also updating any direct references to the removed project.
         var reverseReferencesMap = ComputeNewReverseReferencesMapForRemovedProject(
             existingForwardReferencesMap: _referencesMap,
             existingReverseReferencesMap: _lazyReverseReferencesMap,
-            projectId);
-        var transitiveReferencesMap = ComputeNewTransitiveReferencesMapForRemovedProject(_transitiveReferencesMap, projectId);
-        var reverseTransitiveReferencesMap = ComputeNewReverseTransitiveReferencesMapForRemovedProject(_reverseTransitiveReferencesMap, projectId);
+            removedProjectIds);
+        var transitiveReferencesMap = ComputeNewTransitiveReferencesMapForRemovedProject(_transitiveReferencesMap, removedProjectIds);
+        var reverseTransitiveReferencesMap = ComputeNewReverseTransitiveReferencesMapForRemovedProject(_reverseTransitiveReferencesMap, removedProjectIds);
         return new ProjectDependencyGraph(
             projectIds,
             referencesMap,
@@ -46,24 +49,25 @@ public partial class ProjectDependencyGraph
     /// <param name="existingReverseReferencesMap">The <see cref="_lazyReverseReferencesMap"/> prior to the removal.
     /// This map serves as a hint to the removal process; i.e. it is assumed correct if it contains data, but may be
     /// omitted without impacting correctness.</param>
-    /// <param name="removedProjectId">The ID of the project which is being removed.</param>
+    /// <param name="removedProjectIds">IDs of projects which are being removed.</param>
     /// <returns>The <see cref="_referencesMap"/> for the project dependency graph once the project is removed.</returns>
     private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReferencesMapForRemovedProject(
         ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingForwardReferencesMap,
         ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? existingReverseReferencesMap,
-        ProjectId removedProjectId)
+        ArrayBuilder<ProjectId> removedProjectIds)
     {
         var builder = existingForwardReferencesMap.ToBuilder();
 
-        if (existingReverseReferencesMap is object)
+        if (existingReverseReferencesMap is not null)
         {
-            // We know all the projects directly referencing 'projectId', so remove 'projectId' from the set of
-            // references in each of those cases directly.
-            if (existingReverseReferencesMap.TryGetValue(removedProjectId, out var referencingProjects))
+            foreach (var removedProjectId in removedProjectIds)
             {
-                foreach (var id in referencingProjects)
+                // We know all the projects directly referencing 'projectId', so remove 'projectId' from the set of
+                // references in each of those cases directly.
+                if (existingReverseReferencesMap.TryGetValue(removedProjectId, out var referencingProjects))
                 {
-                    builder.MultiRemove(id, removedProjectId);
+                    foreach (var id in referencingProjects)
+                        builder.MultiRemove(id, removedProjectId);
                 }
             }
         }
@@ -73,12 +77,15 @@ public partial class ProjectDependencyGraph
             // 'projectId' from the set of references if it exists.
             foreach (var (id, _) in existingForwardReferencesMap)
             {
-                builder.MultiRemove(id, removedProjectId);
+                foreach (var removedProjectId in removedProjectIds)
+                    builder.MultiRemove(id, removedProjectId);
             }
         }
 
         // Finally, remove 'projectId' itself.
-        builder.Remove(removedProjectId);
+        foreach (var removedProjectId in removedProjectIds)
+            builder.Remove(removedProjectId);
+
         return builder.ToImmutable();
     }
 
@@ -90,31 +97,29 @@ public partial class ProjectDependencyGraph
     private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? ComputeNewReverseReferencesMapForRemovedProject(
         ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingForwardReferencesMap,
         ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? existingReverseReferencesMap,
-        ProjectId removedProjectId)
+        ArrayBuilder<ProjectId> removedProjectIds)
     {
+        // If the map was never calculated for the previous graph, so there is nothing to update.
         if (existingReverseReferencesMap is null)
-        {
-            // The map was never calculated for the previous graph, so there is nothing to update.
             return null;
-        }
-
-        if (!existingForwardReferencesMap.TryGetValue(removedProjectId, out var forwardReferences))
-        {
-            // The removed project did not reference any other projects, so we simply remove it.
-            return existingReverseReferencesMap.Remove(removedProjectId);
-        }
 
         var builder = existingReverseReferencesMap.ToBuilder();
-
-        // Iterate over each project referenced by 'removedProjectId', which is now being removed. Update the
-        // reverse references map for the project to no longer include 'removedProjectId' in the list.
-        foreach (var referencedProjectId in forwardReferences)
+        foreach (var removedProjectId in removedProjectIds)
         {
-            builder.MultiRemove(referencedProjectId, removedProjectId);
+            // If the removed project did not reference any other projects, nothing to do for this project.
+            if (!existingForwardReferencesMap.TryGetValue(removedProjectId, out var forwardReferences))
+                continue;
+
+            // Iterate over each project referenced by 'removedProjectId', which is now being removed. Update the
+            // reverse references map for the project to no longer include 'removedProjectId' in the list.
+            foreach (var referencedProjectId in forwardReferences)
+                builder.MultiRemove(referencedProjectId, removedProjectId);
         }
 
         // Finally, remove 'removedProjectId' itself.
-        builder.Remove(removedProjectId);
+        foreach (var removedProjectId in removedProjectIds)
+            builder.Remove(removedProjectId);
+
         return builder.ToImmutable();
     }
 
@@ -124,7 +129,7 @@ public partial class ProjectDependencyGraph
     /// <seealso cref="ComputeNewReverseTransitiveReferencesMapForRemovedProject"/>
     private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewTransitiveReferencesMapForRemovedProject(
         ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingTransitiveReferencesMap,
-        ProjectId removedProjectId)
+        ArrayBuilder<ProjectId> removedProjectIds)
     {
         var builder = existingTransitiveReferencesMap.ToBuilder();
 
@@ -132,17 +137,22 @@ public partial class ProjectDependencyGraph
         // existing transitive reference to 'removedProjectId'.
         foreach (var (project, references) in existingTransitiveReferencesMap)
         {
-            if (references.Contains(removedProjectId))
+            foreach (var removedProjectId in removedProjectIds)
             {
-                // The project transitively referenced 'removedProjectId', so any transitive references brought in
-                // exclusively through this reference are no longer valid. Remove the project from the map and the
-                // new transitive references will be recomputed the first time they are needed.
-                builder.Remove(project);
+                if (references.Contains(removedProjectId))
+                {
+                    // The project transitively referenced 'removedProjectId', so any transitive references brought in
+                    // exclusively through this reference are no longer valid. Remove the project from the map and the
+                    // new transitive references will be recomputed the first time they are needed.
+                    builder.Remove(project);
+                }
             }
         }
 
         // Finally, remove 'projectId' itself.
-        builder.Remove(removedProjectId);
+        foreach (var removedProjectId in removedProjectIds)
+            builder.Remove(removedProjectId);
+
         return builder.ToImmutable();
     }
 
@@ -152,7 +162,7 @@ public partial class ProjectDependencyGraph
     /// <seealso cref="ComputeNewTransitiveReferencesMapForRemovedProject"/>
     private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReverseTransitiveReferencesMapForRemovedProject(
         ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingReverseTransitiveReferencesMap,
-        ProjectId removedProjectId)
+        ArrayBuilder<ProjectId> removedProjectIds)
     {
         var builder = existingReverseTransitiveReferencesMap.ToBuilder();
 
@@ -160,17 +170,22 @@ public partial class ProjectDependencyGraph
         // has an existing transitive reverse reference to 'removedProjectId'.
         foreach (var (project, references) in existingReverseTransitiveReferencesMap)
         {
-            if (references.Contains(removedProjectId))
+            foreach (var removedProjectId in removedProjectIds)
             {
-                // 'removedProjectId' transitively referenced the project, so any transitive reverse references
-                // brought in exclusively through this reverse reference are no longer valid. Remove the project
-                // from the map and the new transitive reverse references will be recomputed the first time they are
-                // needed.
-                builder.Remove(project);
+                if (references.Contains(removedProjectId))
+                {
+                    // 'removedProjectId' transitively referenced the project, so any transitive reverse references
+                    // brought in exclusively through this reverse reference are no longer valid. Remove the project
+                    // from the map and the new transitive reverse references will be recomputed the first time they are
+                    // needed.
+                    builder.Remove(project);
+                }
             }
         }
 
-        builder.Remove(removedProjectId);
+        foreach (var removedProjectId in removedProjectIds)
+            builder.Remove(removedProjectId);
+
         return builder.ToImmutable();
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProject.cs
@@ -145,6 +145,7 @@ public partial class ProjectDependencyGraph
                     // exclusively through this reference are no longer valid. Remove the project from the map and the
                     // new transitive references will be recomputed the first time they are needed.
                     builder.Remove(project);
+                    break;
                 }
             }
         }
@@ -179,6 +180,7 @@ public partial class ProjectDependencyGraph
                     // from the map and the new transitive reverse references will be recomputed the first time they are
                     // needed.
                     builder.Remove(project);
+                    break;
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -464,11 +464,7 @@ internal sealed partial class SolutionState
 
         var newProjectIds = ProjectIds.Where(p => !projectIdsSet.Contains(p)).ToBoxedImmutableArray();
         var newProjectStates = SortedProjectStates.WhereAsArray(static (p, projectIdsSet) => !projectIdsSet.Contains(p.Id), projectIdsSet);
-
-        // Note: it would be nice to not cause N forks of the dependency graph here.
-        var newDependencyGraph = _dependencyGraph;
-        foreach (var projectId in projectIds)
-            newDependencyGraph = newDependencyGraph.WithProjectRemoved(projectId);
+        var newDependencyGraph = _dependencyGraph.WithProjectsRemoved(projectIds);
 
         var languageCountDeltas = new TemporaryArray<(string language, int count)>();
         foreach (var projectId in projectIds)


### PR DESCRIPTION
This allows batch removal of projects from the ProjectDependencyGraph. This *should* eventually give us a small perf benefit, but only at the point where our projects can be disposed (or processed) in batches, which is not something we currently do.