### PR TITLE
Move RestoreUseStaticGraphEvaluation setting inside repo

### DIFF
--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- For solution restore, msbuild doesn't honor the property set in Directory.Build.props. -->
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,7 +1,7 @@
 <Project>
 
-  <PropertyGroup>
-    <!-- For solution restore, msbuild doesn't honor the property set in Directory.Build.props. -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <!-- For solution restore, msbuild doesn't honor the property set in Settings.props. -->
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,3 +1,4 @@
+<!-- Build.props is imported by Arcade SDK's Build.proj and controls how the repository gets built. -->
 <Project>
 
   <!-- RestoreUseStaticGraphEvaluation will cause prebuilts when building source-only. -->

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <!-- RestoreUseStaticGraphEvaluation will cause prebuilts when building source-only. -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+  </PropertyGroup>
+
+</Project>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -27,7 +27,6 @@
   <Target Name="ConfigureInnerBuildArg" BeforeTargets="GetSourceBuildCommandConfiguration">
     <PropertyGroup>
       <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)Roslyn.sln"</InnerBuildArgs>
-      <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)'=='true'">$(InnerBuildArgs) /p:RestoreUseStaticGraphEvaluation=false</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -266,8 +266,6 @@ function BuildSolution() {
   $generateDocumentationFile = if ($skipDocumentation) { "/p:GenerateDocumentationFile=false" } else { "" }
   $roslynUseHardLinks = if ($ci) { "/p:ROSLYNUSEHARDLINKS=true" } else { "" }
 
-  $restoreUseStaticGraphEvaluation = $true
-
   try {
     MSBuild $toolsetBuildProj `
       $bl `
@@ -287,7 +285,6 @@ function BuildSolution() {
       /p:TreatWarningsAsErrors=$warnAsError `
       /p:EnableNgenOptimization=$applyOptimizationData `
       /p:IbcOptimizationDataDir=$ibcDir `
-      /p:RestoreUseStaticGraphEvaluation=$restoreUseStaticGraphEvaluation `
       /p:VisualStudioIbcDrop=$ibcDropName `
       /p:VisualStudioDropAccessToken=$officialVisualStudioDropAccessToken `
       $suppressExtensionDeployment `

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -80,7 +80,6 @@ prepare_machine=false
 warn_as_error=false
 properties=""
 source_build=false
-restoreUseStaticGraphEvaluation=true
 solution_to_build="Compilers.slnf"
 
 args=""
@@ -174,10 +173,8 @@ while [[ $# > 0 ]]; do
     --warnaserror)
       warn_as_error=true
       ;;
-    --sourcebuild)
+    --sourcebuild|-sb)
       source_build=true
-      # RestoreUseStaticGraphEvaluation will cause prebuilts
-      restoreUseStaticGraphEvaluation=false
       ;;
     --solution)
       solution_to_build=$2
@@ -307,7 +304,6 @@ function BuildSolution {
     /p:Publish=$publish \
     /p:Sign=$sign \
     /p:RunAnalyzersDuringBuild=$run_analyzers \
-    /p:RestoreUseStaticGraphEvaluation=$restoreUseStaticGraphEvaluation \
     /p:BootstrapBuildPath="$bootstrap_dir" \
     /p:ContinuousIntegrationBuild=$ci \
     /p:TreatWarningsAsErrors=true \

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -20,6 +20,7 @@
     <CommonExtensionInstallationRoot>CommonExtensions</CommonExtensionInstallationRoot>
     <LanguageServicesExtensionInstallationFolder>Microsoft\VBCSharp\LanguageServices</LanguageServicesExtensionInstallationFolder>
 
+    <!-- RestoreUseStaticGraphEvaluation will cause prebuilts when building source-only. -->
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
 
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -21,7 +21,7 @@
     <LanguageServicesExtensionInstallationFolder>Microsoft\VBCSharp\LanguageServices</LanguageServicesExtensionInstallationFolder>
 
     <!-- RestoreUseStaticGraphEvaluation will cause prebuilts when building source-only. -->
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <RestoreUseStaticGraphEvaluation Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</RestoreUseStaticGraphEvaluation>
 
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -73,7 +73,6 @@ function Run-Build([string]$rootDir, [string]$logFileName) {
      /p:DeterministicSourcePaths=true `
      /p:RunAnalyzers=false `
      /p:RunAnalyzersDuringBuild=false `
-     /p:RestoreUseStaticGraphEvaluation=$restoreUseStaticGraphEvaluation `
      /bl:$logFilePath
 
   Stop-Processes

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -57,8 +57,6 @@ function Run-Build([string]$rootDir, [string]$logFileName) {
 
   Stop-Processes
 
-  $restoreUseStaticGraphEvaluation = $true
-
   Write-Host "Building $solution using $bootstrapDir"
   MSBuild $toolsetBuildProj `
      /p:Projects=$solution `

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -8,8 +8,6 @@
     <UseWpf>true</UseWpf>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);EDITOR_FEATURES</DefineConstants>
-    <!-- For whatever reason doesn't work in this project. -->
-    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
 
     <!-- NuGet -->
     <PackageId>Microsoft.CodeAnalysis.EditorFeatures.Common</PackageId>

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -8,6 +8,8 @@
     <UseWpf>true</UseWpf>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);EDITOR_FEATURES</DefineConstants>
+    <!-- For whatever reason doesn't work in this project. -->
+    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
 
     <!-- NuGet -->
     <PackageId>Microsoft.CodeAnalysis.EditorFeatures.Common</PackageId>


### PR DESCRIPTION
Extracted from https://github.com/dotnet/dotnet/pull/176 - which removes the DotNetBuild.props VMR / SB entrypoint. All settings will move into the repo infra eventually.

- The `RestoreUseStaticGraphEvaluation` property needs to be set before Arcade's Build.proj builds the solution and in the repo infra so that dotnet/msbuild/NuGet commands use that static graph restore. This works today by passing the property in as a global property in the build scripts. Source-build has issues with static graph which is why it was disabled in DotNetBuild.props. As we now move settings from DotNetBuild.props into the repo infra, define that in eng/Build.props (Arcade extension point) and remove the unnecessary global property from the build scripts.

- Also set `RestoreUseStaticGraphEvaluation` in Directory.Solution.props so that VS uses the same restore algorithm.

- Unrelated: Add the short `-sb` form for `--sourcebuild` in eng/build.sh. Arcade's eng/common support the short form.