### PR TITLE
Exclude EditorFeatures from rebuild check

### DIFF
--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -45,6 +45,7 @@ try {
   " --assembliesPath `"$ArtifactsDir/obj/`"" +
 
 # Rebuilds with output differences
+  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.dll" +
   " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll" +
   " --exclude net472\Microsoft.VisualStudio.LanguageServices.CSharp.dll" +
   " --exclude net472\Microsoft.VisualStudio.LanguageServices.dll" +


### PR DESCRIPTION
Unblocks CI builds.
EditorFeatures.Wpf was already excluded from the check and https://github.com/dotnet/roslyn/pull/78308 merges parts of the two projects, so I guess EditorFeatures project needs to be excluded as well.