### PR TITLE
Selectively persist the commandline to temporary storage

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs
@@ -11,13 +11,14 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem.Legacy;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim;
 
 internal partial class CSharpProjectShim
 {
-    private sealed class OptionsProcessor : ProjectSystemProjectOptionsProcessor
+    private sealed class OptionsProcessor : AbstractLegacyProjectSystemProjectOptionsProcessor
     {
         private readonly ProjectSystemProject _projectSystemProject;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem.Legacy;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
@@ -32,7 +33,7 @@ internal abstract partial class AbstractLegacyProject
 {
     public IVsHierarchy Hierarchy { get; }
     protected ProjectSystemProject ProjectSystemProject { get; }
-    internal ProjectSystemProjectOptionsProcessor ProjectSystemProjectOptionsProcessor { get; set; }
+    internal AbstractLegacyProjectSystemProjectOptionsProcessor ProjectSystemProjectOptionsProcessor { get; set; }
     protected IProjectCodeModel ProjectCodeModel { get; set; }
     protected VisualStudioWorkspace Workspace { get; }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProjectSystemProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProjectSystemProjectOptionsProcessor.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem.Legacy;
 
-internal class AbstractLegacyProjectSystemProjectOptionsProcessor : ProjectSystemProjectOptionsProcessor
+internal abstract class AbstractLegacyProjectSystemProjectOptionsProcessor : ProjectSystemProjectOptionsProcessor
 {
     private string? _explicitRuleSetFilePath;
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProjectSystemProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProjectSystemProjectOptionsProcessor.cs
@@ -11,8 +11,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem.Legacy;
 
 internal abstract class AbstractLegacyProjectSystemProjectOptionsProcessor : ProjectSystemProjectOptionsProcessor
 {
-    private string? _explicitRuleSetFilePath;
-
     public AbstractLegacyProjectSystemProjectOptionsProcessor(
         ProjectSystemProject project,
         SolutionServices workspaceServices)
@@ -22,18 +20,17 @@ internal abstract class AbstractLegacyProjectSystemProjectOptionsProcessor : Pro
 
     public string? ExplicitRuleSetFilePath
     {
-        get => _explicitRuleSetFilePath;
-
+        get;
         set
         {
             lock (_gate)
             {
-                if (_explicitRuleSetFilePath == value)
+                if (field == value)
                 {
                     return;
                 }
 
-                _explicitRuleSetFilePath = value;
+                field = value;
 
                 UpdateProjectOptions_NoLock();
             }
@@ -43,10 +40,10 @@ internal abstract class AbstractLegacyProjectSystemProjectOptionsProcessor : Pro
     protected override string? GetEffectiveRulesetFilePath()
         => ExplicitRuleSetFilePath ?? base.GetEffectiveRulesetFilePath();
 
-    protected override void UpdateCommandLine(ImmutableArray<string> arguments)
+    protected override bool ShouldSaveCommandLine(ImmutableArray<string> arguments)
     {
         // Legacy projects require this to be kept as it may be needed if ExplicitRuleSetFilePath is changed
-        _commandLine = arguments;
+        return true;
     }
 
     /// <summary>

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProjectSystemProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProjectSystemProjectOptionsProcessor.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
+
+namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem.Legacy;
+
+internal class AbstractLegacyProjectSystemProjectOptionsProcessor : ProjectSystemProjectOptionsProcessor
+{
+    private string? _explicitRuleSetFilePath;
+
+    public AbstractLegacyProjectSystemProjectOptionsProcessor(
+        ProjectSystemProject project,
+        SolutionServices workspaceServices)
+        : base(project, workspaceServices)
+    {
+    }
+
+    public string? ExplicitRuleSetFilePath
+    {
+        get => _explicitRuleSetFilePath;
+
+        set
+        {
+            lock (_gate)
+            {
+                if (_explicitRuleSetFilePath == value)
+                {
+                    return;
+                }
+
+                _explicitRuleSetFilePath = value;
+
+                UpdateProjectOptions_NoLock();
+            }
+        }
+    }
+
+    protected override string? GetEffectiveRulesetFilePath()
+        => ExplicitRuleSetFilePath ?? base.GetEffectiveRulesetFilePath();
+
+    protected override void UpdateCommandLine(ImmutableArray<string> arguments)
+    {
+        // Legacy projects require this to be kept as it may be needed if ExplicitRuleSetFilePath is changed
+        _commandLine = arguments;
+    }
+
+    /// <summary>
+    /// Called by a derived class to notify that we need to update the settings in the project system for something that will be provided
+    /// by either <see cref="ProjectSystemProjectOptionsProcessor.ComputeCompilationOptionsWithHostValues(CompilationOptions, IRuleSetFile)"/>
+    /// or <see cref="ProjectSystemProjectOptionsProcessor.ComputeParseOptionsWithHostValues(ParseOptions)"/>.
+    /// </summary>
+    protected void UpdateProjectForNewHostValues()
+    {
+        lock (_gate)
+        {
+            UpdateProjectOptions_NoLock();
+        }
+    }
+}

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.Workspaces.ProjectSystem
-Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Microsoft.VisualStudio.LanguageServices.ProjectSystem.Legacy
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
     ''' <remarks></remarks>
     Partial Friend NotInheritable Class VisualBasicProject
         Friend NotInheritable Class OptionsProcessor
-            Inherits ProjectSystemProjectOptionsProcessor
+            Inherits AbstractLegacyProjectSystemProjectOptionsProcessor
 
             Private _rawOptions As VBCompilerOptions
             Private ReadOnly _imports As New List(Of GlobalImport)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.CodeAnalysis.Host;
 using Roslyn.Utilities;
@@ -30,8 +31,7 @@ internal class ProjectSystemProjectOptionsProcessor : IDisposable
     private Checksum? _commandLineChecksum;
 
     /// <summary>
-    /// To save space in the managed heap, we only cache the command line if we have an
-    /// effective ruleset.
+    /// To save space in the managed heap, we only cache the command line if we have a ruleset.
     /// </summary>
     private ImmutableArray<string> _commandLine;
 
@@ -68,7 +68,7 @@ internal class ProjectSystemProjectOptionsProcessor : IDisposable
 
         // Only bother storing the command line if there is an effective ruleset, as that may
         // require a later reparse using it.
-        _commandLine = GetEffectiveRulesetFilePath() != null ? arguments : [];
+        _commandLine = GetEffectiveRulesetFilePath() != null ? arguments : default;
 
         return true;
     }
@@ -144,6 +144,9 @@ internal class ProjectSystemProjectOptionsProcessor : IDisposable
 
     private void ReparseCommandLine_NoLock(ImmutableArray<string> arguments)
     {
+        // If arguments isn't set, we somehow lost the command line
+        Debug.Assert(!arguments.IsDefault);
+
         _commandLineArgumentsForCommandLine = _commandLineParserService.Parse(arguments, Path.GetDirectoryName(_project.FilePath), isInteractive: false, sdkDirectory: null);
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
@@ -32,6 +32,7 @@ internal class ProjectSystemProjectOptionsProcessor : IDisposable
     /// <summary>
     /// To save space in the managed heap, we only cache the command line if we have an
     /// effective ruleset.
+    /// </summary>
     private ImmutableArray<string> _commandLine;
 
     private CommandLineArguments _commandLineArgumentsForCommandLine;


### PR DESCRIPTION
Only write command lines to temporary storage when they may later be needed.

Persisting project command line arguments is surprisingly costly, as evidenced by the profile image below. As this storage is only needed when there is an effective ruleset path, we can limit when we persist to storage to be limited to that scenario.

Here are the relevant CPU usage numbers from speedometer runs with/without this change under SetCommandLine:

*** Before ***
![image](https://github.com/user-attachments/assets/41ad0575-cf58-41ce-942a-f949f70926c6)

*** After ***
![image](https://github.com/user-attachments/assets/53e6f2c7-ab25-49c2-9b29-e637d87bc2e0)