### PR TITLE
Extensions: resolve some follow-up comments on signature conflicts and betterness

### DIFF
--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -28080,7 +28080,7 @@ static class E
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "i.P");
-        Assert.Equal("System.Int32 E.<>E__0.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal("E.extension(I<string>).P", model.GetSymbolInfo(memberAccess).Symbol.ToDisplayString());
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
     }
 
@@ -28111,7 +28111,7 @@ static class E
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "i.P");
-        Assert.Equal("System.Int32 E.<>E__1.P { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal("E.extension(I<string>).P", model.GetSymbolInfo(memberAccess).Symbol.ToDisplayString());
         Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
     }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -23945,7 +23945,6 @@ static class Extensions
 """;
         var comp = CreateCompilation(src);
 
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Despite the fact that we do not complain about M6, should we report an error for M2 (the only difference is receiver ref-ness)?
         comp.VerifyDiagnostics(
             // (10,21): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
             //         public void M1() {}
@@ -24150,22 +24149,15 @@ static class Extensions
             // (46,28): error CS0111: Type 'Extensions' already defines a member called 'M5' with the same parameter types
             //         static public void M5() {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M5").WithArguments("M5", "Extensions").WithLocation(46, 28),
-
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : It feels unfortunate that we generate conflicting signatures, the methods extend different types (refer to M6 and M7 cases)
-
             // (56,28): error CS0111: Type 'Extensions' already defines a member called 'M6' with the same parameter types
             //         static public void M6() {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M6").WithArguments("M6", "Extensions").WithLocation(56, 28),
             // (66,28): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
             //         static public long M7() => 0;
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(66, 28), // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Signatures in metadata are different in this case (return type is different), consider if we want to enable this specific case 
-
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(66, 28),
             // (76,28): error CS0111: Type 'Extensions' already defines a member called 'M8' with the same parameter types
             //         public static void M8() {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M8").WithArguments("M8", "Extensions").WithLocation(76, 28),
-
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Are we comfortable with these four conflicts?
-
             // (86,28): error CS0111: Type 'Extensions' already defines a member called 'M9' with the same parameter types
             //         public static void M9(int x) {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M9").WithArguments("M9", "Extensions").WithLocation(86, 28),
@@ -24517,7 +24509,6 @@ static class Extensions
 """;
         var comp = CreateCompilation(src);
 
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Should we report an error for M2 (the only difference is receiver ref-ness)?
         comp.VerifyDiagnostics(
             // (5,21): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
             //         public void M1() {}
@@ -24646,7 +24637,6 @@ static class Extensions
 """;
         var comp = CreateCompilation(src);
 
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Should we report an error for M2 (the only difference is receiver ref-ness)?
         comp.VerifyDiagnostics(
             // (7,21): error CS0111: Type 'Extensions' already defines a member called 'M1' with the same parameter types
             //         public void M1() {}
@@ -24765,15 +24755,9 @@ static class Extensions
             // (26,28): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'ref' and 'in'
             //         static public void M4(ref int x) {}
             Diagnostic(ErrorCode.ERR_OverloadRefKind, "M4").WithArguments("Extensions", "method", "ref", "in").WithLocation(26, 28),
-
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : It feels unfortunate that we generate conflicting signatures
-
             // (34,27): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
             //         static public int M7() => 0;
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(34, 27),
-
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Are we comfortable with these two conflicts?
-
             // (44,28): error CS0111: Type 'Extensions' already defines a member called 'M9' with the same parameter types
             //         public static void M9(int x) {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M9").WithArguments("M9", "Extensions").WithLocation(44, 28),
@@ -24889,15 +24873,9 @@ static class Extensions
             // (28,28): error CS0663: 'Extensions' cannot define an overloaded method that differs only on parameter modifiers 'ref' and 'in'
             //         static public void M4(ref int x) {}
             Diagnostic(ErrorCode.ERR_OverloadRefKind, "M4").WithArguments("Extensions", "method", "ref", "in").WithLocation(28, 28),
-
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : It feels unfortunate that we generate conflicting signatures
-
             // (35,27): error CS0111: Type 'Extensions' already defines a member called 'M7' with the same parameter types
             //         static public int M7() => 0;
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M7").WithArguments("M7", "Extensions").WithLocation(35, 27),
-
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Are we comfortable with these two conflicts?
-
             // (40,28): error CS0111: Type 'Extensions' already defines a member called 'M9' with the same parameter types
             //         public static void M9(int x) {}
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M9").WithArguments("M9", "Extensions").WithLocation(40, 28),
@@ -25045,12 +25023,9 @@ static class Extensions
         var comp = CreateCompilation(src);
 
         comp.VerifyDiagnostics(
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Are we comfortable reporting an error like this?
-
             // (8,23): error CS0082: Type 'Extensions' already reserves a member called 'get_P1' with the same parameter types
             //     public static int P1 {set{}}
             Diagnostic(ErrorCode.ERR_MemberReserved, "P1").WithArguments("get_P1", "Extensions").WithLocation(8, 23),
-
             // (11,23): error CS0082: Type 'Extensions' already reserves a member called 'get_P2' with the same parameter types
             //     public static int P2 {set{}}
             Diagnostic(ErrorCode.ERR_MemberReserved, "P2").WithArguments("get_P2", "Extensions").WithLocation(11, 23)
@@ -25077,12 +25052,9 @@ static class Extensions
         var comp = CreateCompilation(src);
 
         comp.VerifyDiagnostics(
-            // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Are we comfortable reporting an error like this?
-
             // (8,23): error CS0082: Type 'Extensions' already reserves a member called 'set_P1' with the same parameter types
             //     public static int P1 => 4;
             Diagnostic(ErrorCode.ERR_MemberReserved, "P1").WithArguments("set_P1", "Extensions").WithLocation(8, 23),
-
             // (11,23): error CS0082: Type 'Extensions' already reserves a member called 'set_P2' with the same parameter types
             //     public static int P2 => 4;
             Diagnostic(ErrorCode.ERR_MemberReserved, "P2").WithArguments("set_P2", "Extensions").WithLocation(11, 23)
@@ -26801,7 +26773,6 @@ interface I<out T> { }
 class C1 { }
 class C2 : C1 { }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm whether we want this betterness behavior (for methods and/or properties)
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
 
@@ -26923,7 +26894,6 @@ static class E2
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm whether we want this betterness behavior (for methods and/or properties)
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
 
@@ -26954,7 +26924,6 @@ static class E2
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm whether we want this betterness behavior for methods
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
             // (1,5): error CS0121: The call is ambiguous between the following methods or properties: 'E1.extension(int).M<T>(T)' and 'E2.extension<T>(T).M(int)'
@@ -26986,7 +26955,6 @@ static class E2
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm whether we want this betterness behavior for methods when the receiver is a type
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, expectedOutput: "ran ran2").VerifyDiagnostics();
 
@@ -28075,7 +28043,6 @@ static class E2
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm what betterness behavior we want for static properties
         var comp = CreateCompilation(source);
         CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
 
@@ -28107,7 +28074,6 @@ static class E
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm what betterness behavior we want for properties
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
 
@@ -28139,7 +28105,6 @@ static class E
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm what betterness behavior we want for properties
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
 
@@ -28171,7 +28136,6 @@ static class E2
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : confirm what betterness behavior we want for properties
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
 


### PR DESCRIPTION
From discussion in WG, the implementation follows the design that was discussed in LDM for signature conflicts and for betterness, and the implications were understood. This PR is a shout test, in case you find that any of the interesting scenarios should warrant a design change.

Relates to test plan https://github.com/dotnet/roslyn/issues/76130