### PR TITLE
Targeted perf changes to CommandLineParser

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
@@ -120,6 +120,7 @@ namespace Microsoft.CodeAnalysis
 
             return true;
 
+#if DEBUG
             static bool isAllAscii(ReadOnlySpan<char> span)
             {
                 foreach (char ch in span)
@@ -129,6 +130,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 return true;
             }
+#endif
         }
 
         internal static bool IsOption(string arg) => IsOption(arg.AsSpan());
@@ -1071,7 +1073,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     inQuotes = !inQuotes;
                 }
-                else if (!inQuotes && separators.IndexOf(c) >= 0)
+                else if (!inQuotes && separators.Contains(c))
                 {
                     var current = memory.Slice(nextPiece, i - nextPiece);
                     if (current.Length > 0 || !removeEmptyEntries)

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
@@ -99,22 +99,26 @@ namespace Microsoft.CodeAnalysis
         internal static bool IsOptionName(string optionName, ReadOnlySpan<char> value)
         {
             Debug.Assert(isAllAscii(optionName.AsSpan()));
-            if (isAllAscii(value))
-            {
-                if (optionName.Length != value.Length)
-                    return false;
 
-                for (int i = 0; i < optionName.Length; i++)
+            if (optionName.Length != value.Length)
+                return false;
+
+            for (int i = 0; i < optionName.Length; i++)
+            {
+                char ch = value[i];
+                if (ch > 127)
                 {
-                    if (optionName[i] != char.ToLowerInvariant(value[i]))
-                    {
-                        return false;
-                    }
+                    // If a non-ascii character is encountered, do an InvariantCultureIgnoreCase comparison
+                    return optionName.AsSpan().Equals(value, StringComparison.InvariantCultureIgnoreCase);
                 }
-                return true;
+
+                if (optionName[i] != char.ToLowerInvariant(ch))
+                {
+                    return false;
+                }
             }
 
-            return optionName.AsSpan().Equals(value, StringComparison.InvariantCultureIgnoreCase);
+            return true;
 
             static bool isAllAscii(ReadOnlySpan<char> span)
             {
@@ -167,7 +171,7 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
-            int colon = arg.IndexOf(':');
+            int colon = arg.IndexOf(':', 1);
 
             // temporary heuristic to detect Unix-style rooted paths
             // pattern /goo/*  or  //* will not be treated as a compiler option
@@ -175,8 +179,11 @@ namespace Microsoft.CodeAnalysis
             // TODO: consider introducing "/s:path" to disambiguate paths starting with /
             if (arg.Length > 1 && arg[0] != '-')
             {
-                int separator = arg.IndexOf('/', 1);
-                if (separator > 0 && (colon < 0 || separator < colon))
+                int separator = colon < 0
+                    ? arg.IndexOf('/', 1)
+                    : arg.IndexOf('/', 1, colon - 1);
+
+                if (separator > 0)
                 {
                     //   "/goo/
                     //   "//
@@ -1064,11 +1071,10 @@ namespace Microsoft.CodeAnalysis
                 {
                     inQuotes = !inQuotes;
                 }
-
-                if (!inQuotes && separators.IndexOf(c) >= 0)
+                else if (!inQuotes && separators.IndexOf(c) >= 0)
                 {
                     var current = memory.Slice(nextPiece, i - nextPiece);
-                    if (!removeEmptyEntries || current.Length > 0)
+                    if (current.Length > 0 || !removeEmptyEntries)
                     {
                         builder.Add(current);
                     }
@@ -1078,7 +1084,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             var last = memory.Slice(nextPiece);
-            if (!removeEmptyEntries || last.Length > 0)
+            if (last.Length > 0 || !removeEmptyEntries)
             {
                 builder.Add(last);
             }

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         internal static bool IsOptionName(string optionName, ReadOnlySpan<char> value)
         {
-            Debug.Assert(isAllAscii(optionName.AsSpan()));
+            assertAllAscii(optionName.AsSpan());
 
             if (optionName.Length != value.Length)
                 return false;
@@ -120,17 +120,18 @@ namespace Microsoft.CodeAnalysis
 
             return true;
 
-#if DEBUG
-            static bool isAllAscii(ReadOnlySpan<char> span)
+            [Conditional("DEBUG")]
+            static void assertAllAscii(ReadOnlySpan<char> span)
             {
                 foreach (char ch in span)
                 {
                     if (ch > 127)
-                        return false;
+                    {
+                        Debug.Assert(false);
+                        break;
+                    }
                 }
-                return true;
             }
-#endif
         }
 
         internal static bool IsOption(string arg) => IsOption(arg.AsSpan());


### PR DESCRIPTION
CommandLineParser shows up as surprisingly expensive in the speedometer traces I've been looking at for solution load. This PR attempts a couple small, targeted fixes for a slight improvement.

1) IsOptionName was doing either 1 or 2 passes in the standard ascii case. Instead, do a length check upfront so that we commonly do 0 passes, and if the lengths match, do 1 pass in the ascii case. In the non-ascii case, fall back to using the ReadOnlySpan's Equals as the code did before. This is a small CPU win reflected by the first two images below.

2) TryParseOption's calls to IndexOf are showing up in the trace. We can limit the span we search significantly as colon typically is found towards the beginning of arg and arg can be quite long. Small CPU win again, reflected by the 3rd and 4th images below.

3) ParseSeparatedStrings is a very commonly tread codepath. Small micro-optimizations in the loop to not do the IndexOf call when c is a quote and to check the common condition first.

Test insertion PR: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/634213

*** Without IsOptionName change ***
![image](https://github.com/user-attachments/assets/799a53b5-531d-494d-b994-1ac248158e2e)

*** With IsOptionName change ***
![image](https://github.com/user-attachments/assets/3711e10b-de89-45b4-a59e-51d4140da42e)

*** Without TryParseOption change ***
![image](https://github.com/user-attachments/assets/da185d69-54d1-40e4-9baa-a9163c07c181)

*** With TryParseOption change ***
![image](https://github.com/user-attachments/assets/3a4c5e4b-4c21-4536-9d02-cd90774f29e0)