### PR TITLE
Recommend `#define`d preprocessing symbols within a file

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -9488,6 +9488,7 @@ public unsafe class AA
             End Using
         End Function
 
+        <WorkItem("https://github.com/dotnet/roslyn/issues/78447")>
         <WpfTheory, CombinatorialData>
         Public Async Function CompletionInPreprocessorWithDefinedElements(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateTestStateFromWorkspace(
@@ -9512,12 +9513,14 @@ public unsafe class AA
             End Using
         End Function
 
+        <WorkItem("https://github.com/dotnet/roslyn/issues/78447")>
         <WpfTheory, CombinatorialData>
         Public Async Function CompletionInPreprocessorWithStatementsUsingUndefinedSymbols(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateTestStateFromWorkspace(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true" PreprocessorSymbols="GOO,BAR,BAZ">
                             <Document>
+#define BLE
 #undef FOO
 
 #if UNDEFINED_1
@@ -9531,7 +9534,7 @@ public unsafe class AA
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.SendInvokeCompletionList()
-                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "true", "false"})
+                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "BLE", "true", "false"})
                 state.SendTypeChars("GO")
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
@@ -9539,12 +9542,14 @@ public unsafe class AA
             End Using
         End Function
 
+        <WorkItem("https://github.com/dotnet/roslyn/issues/78447")>
         <WpfTheory, CombinatorialData>
         Public Async Function CompletionInPreprocessorWithStatementsUsingUndefinedSymbolsInsideElse(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateTestStateFromWorkspace(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true" PreprocessorSymbols="GOO,BAR,BAZ">
                             <Document>
+#define BLE
 #undef FOO
 
 #if UNDEFINED_1
@@ -9557,7 +9562,7 @@ public unsafe class AA
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.SendInvokeCompletionList()
-                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "true", "false"})
+                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "BLE", "true", "false"})
                 state.SendTypeChars("GO")
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
@@ -9565,12 +9570,14 @@ public unsafe class AA
             End Using
         End Function
 
+        <WorkItem("https://github.com/dotnet/roslyn/issues/78447")>
         <WpfTheory, CombinatorialData>
         Public Async Function CompletionInPreprocessorWithStatementsUsingUndefinedSymbolsInsideElseAfterOr(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateTestStateFromWorkspace(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true" PreprocessorSymbols="GOO,BAR,BAZ">
                             <Document>
+#define BLE
 #undef FOO
 
 #if UNDEFINED_1
@@ -9583,7 +9590,7 @@ public unsafe class AA
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.SendInvokeCompletionList()
-                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "true", "false"})
+                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "BLE", "true", "false"})
                 state.SendTypeChars("GO")
                 state.SendTab()
                 Await state.AssertNoCompletionSession()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -9488,6 +9488,83 @@ public unsafe class AA
             End Using
         End Function
 
+        <WpfTheory, CombinatorialData>
+        Public Async Function CompletionInPreprocessorWithDefinedElements(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateTestStateFromWorkspace(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" PreprocessorSymbols="GOO,BAR,BAZ">
+                            <Document>
+#define FOO
+#undef BAR
+
+#if $$
+                            </Document>
+                        </Project>
+                    </Workspace>,
+                              showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContainAll({"GOO", "FOO", "BAR", "BAZ", "true", "false"})
+                state.SendTypeChars("FO")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("#if FOO", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function CompletionInPreprocessorWithStatementsUsingUndefinedSymbols(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateTestStateFromWorkspace(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" PreprocessorSymbols="GOO,BAR,BAZ">
+                            <Document>
+#undef FOO
+
+#if UNDEFINED_1
+#elif UNDEFINED_2 || UNDEFINED_3
+#endif
+
+#if $$
+                            </Document>
+                        </Project>
+                    </Workspace>,
+                              showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "true", "false"})
+                state.SendTypeChars("GO")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("#if GOO", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function CompletionInPreprocessorWithStatementsUsingUndefinedSymbolsInsideElse(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateTestStateFromWorkspace(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" PreprocessorSymbols="GOO,BAR,BAZ">
+                            <Document>
+#undef FOO
+
+#if UNDEFINED_1
+#else
+    #if $$
+#endif
+                            </Document>
+                        </Project>
+                    </Workspace>,
+                              showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "true", "false"})
+                state.SendTypeChars("GO")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("#if GOO", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
         <WpfFact>
         <WorkItem("https://github.com/dotnet/roslyn/issues/63922")>
         <WorkItem("https://github.com/dotnet/roslyn/issues/55546")>

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -9535,6 +9535,7 @@ public unsafe class AA
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "BLE", "true", "false"})
+                Await state.AssertCompletionItemsDoNotContainAny({"FOO", "UNDEFINED_1", "UNDEFINED_2", "UNDEFINED_3"})
                 state.SendTypeChars("GO")
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
@@ -9563,6 +9564,7 @@ public unsafe class AA
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "BLE", "true", "false"})
+                Await state.AssertCompletionItemsDoNotContainAny({"FOO", "UNDEFINED_1"})
                 state.SendTypeChars("GO")
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
@@ -9591,6 +9593,7 @@ public unsafe class AA
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll({"GOO", "BAR", "BAZ", "BLE", "true", "false"})
+                Await state.AssertCompletionItemsDoNotContainAny({"FOO", "UNDEFINED_1", "UNDEFINED_2"})
                 state.SendTypeChars("GO")
                 state.SendTab()
                 Await state.AssertNoCompletionSession()

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPreprocessorCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPreprocessorCompletionProvider.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -35,6 +35,15 @@ internal abstract class AbstractPreprocessorCompletionProvider : LSPCompletionPr
             var currentSyntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
             preprocessorNames.AddRange(currentSyntaxTree.Options.PreprocessorSymbolNames);
+
+            var root = await currentSyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+            {
+                if (DefinesPreprocessingSymbolName(trivia, out var definedName))
+                {
+                    preprocessorNames.Add(definedName);
+                }
+            }
         }
 
         // Keep all the preprocessor symbol names together.  We don't want to intermingle them with any keywords we
@@ -49,4 +58,6 @@ internal abstract class AbstractPreprocessorCompletionProvider : LSPCompletionPr
                 sortText: "_0_" + name));
         }
     }
+
+    protected abstract bool DefinesPreprocessingSymbolName(SyntaxTrivia trivia, [NotNullWhen(true)] out string? definedName);
 }

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PreprocessorCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PreprocessorCompletionProvider.vb
@@ -4,11 +4,12 @@
 
 Imports System.Collections.Immutable
 Imports System.Composition
+Imports System.Diagnostics.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.Host.Mef
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     <ExportCompletionProvider(NameOf(PreprocessorCompletionProvider), LanguageNames.VisualBasic)>
@@ -33,5 +34,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         End Function
 
         Public Overrides ReadOnly Property TriggerCharacters As ImmutableHashSet(Of Char) = CommonTriggerCharsAndParen
+
+        Protected Overrides Function DefinesPreprocessingSymbolName(trivia As SyntaxTrivia, <NotNullWhen(True)> ByRef definedName As String) As Boolean
+            definedName = Nothing
+            Dim isConst = trivia.IsKind(SyntaxKind.ConstDirectiveTrivia)
+            Dim defines = False
+            If (isConst) Then
+                Dim [structure] = trivia.GetStructure()
+                Contract.ThrowIfFalse(TypeOf [structure] Is ConstDirectiveTriviaSyntax)
+                Dim directive = DirectCast([structure], ConstDirectiveTriviaSyntax)
+                Dim valueString = directive.Value.ToString()
+                Dim undefines = valueString.Equals("false", StringComparison.OrdinalIgnoreCase) OrElse
+                    valueString.Equals("0")
+                defines = Not undefines
+                If (defines) Then
+                    definedName = directive.Name.Text
+                End If
+            End If
+            Return defines
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Closes #78447

Note that this does not apply the requested behavior of #76469.

CC @CyrusNajmabadi 