### PR TITLE
Don't unnecessarily create a document when only the document state is needed

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -43,6 +43,21 @@ internal readonly partial record struct Checksum
         return From(hash);
     }
 
+    public static Checksum Create(ImmutableArray<string> values)
+    {
+        using var pooledHash = s_incrementalHashPool.GetPooledObject();
+
+        foreach (var value in values)
+        {
+            pooledHash.Object.Append(MemoryMarshal.AsBytes(value.AsSpan()));
+            pooledHash.Object.Append(MemoryMarshal.AsBytes("\0".AsSpan()));
+        }
+
+        Span<byte> hash = stackalloc byte[XXHash128SizeBytes];
+        pooledHash.Object.GetHashAndReset(hash);
+        return From(hash);
+    }
+
     public static Checksum Create(string? value)
     {
         Span<byte> destination = stackalloc byte[XXHash128SizeBytes];

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -368,13 +368,16 @@ public abstract partial class Workspace : IDisposable
 
         static Solution UpdateExistingDocumentsToChangedDocumentContents(Solution solution, HashSet<DocumentId> changedDocumentIds)
         {
+            if (changedDocumentIds.Count == 0)
+                return solution;
+
             // Changing a document in a linked-doc-chain will end up producing N changed documents.  We only want to
             // process that chain once.
             using var _ = PooledDictionary<DocumentId, DocumentState>.GetInstance(out var relatedDocumentIdsAndStates);
 
             foreach (var changedDocumentId in changedDocumentIds)
             {
-                Document? changedDocument = null;
+                DocumentState? changedDocumentState = null;
                 var relatedDocumentIds = solution.GetRelatedDocumentIds(changedDocumentId);
 
                 foreach (var relatedDocumentId in relatedDocumentIds)
@@ -384,8 +387,8 @@ public abstract partial class Workspace : IDisposable
 
                     if (!changedDocumentIds.Contains(relatedDocumentId))
                     {
-                        changedDocument ??= solution.GetRequiredDocument(changedDocumentId);
-                        relatedDocumentIdsAndStates[relatedDocumentId] = changedDocument.DocumentState;
+                        changedDocumentState ??= solution.SolutionState.GetRequiredDocumentState(changedDocumentId);
+                        relatedDocumentIdsAndStates[relatedDocumentId] = changedDocumentState;
                     }
                 }
             }

--- a/src/Workspaces/CoreTest/ChecksumTests.cs
+++ b/src/Workspaces/CoreTest/ChecksumTests.cs
@@ -177,7 +177,7 @@ public sealed class ChecksumTests
 
         Assert.NotEqual(Checksum.Null, Checksum.Create([""]));
         Assert.NotEqual(Checksum.Null, Checksum.Create(["\0"]));
-        Assert.NotEqual(Checksum.Null, Checksum.Create([null]));
+        Assert.NotEqual(Checksum.Null, Checksum.Create(new string?[] { null }));
         Assert.NotEqual(Checksum.Null, Checksum.Create(new MemoryStream()));
         Assert.NotEqual(Checksum.Null, Checksum.Create(stackalloc Checksum[] { Checksum.Null }));
         Assert.NotEqual(Checksum.Null, Checksum.Create(ImmutableArray.Create(Checksum.Null)));


### PR DESCRIPTION
Cyrus noticed this during a chat where I was considering a larger change to this code. Might as well make the simple/safe change while I consider the larger change too. I saw about 25% fewer documents created during loading of the Roslyn solution with this change.

Other small changes:
1) Early exit if no changed documents
2) Unrelated change adding Checksum overload as I noticed a high frequency caller during solution load (ProjectSystemProjectOptionsProcessor.ReparseCommandLineIfChanged_NoLock) had an ImmutableArray and it was getting boxed and enumerator alloced.