### PR TITLE
Update GetFirstRelatedDocumentId to not return documents with the same path within the same project

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1280,16 +1280,7 @@ internal sealed partial class SolutionState
 
         // Do a quick check if the full info for that path has already been computed and cached.
         if (_lazyFilePathToRelatedDocumentIds.TryGetValue(filePath, out var relatedDocumentIds))
-        {
-            foreach (var relatedDocumentId in relatedDocumentIds)
-            {
-                // Don't return documents from the same project
-                if (relatedDocumentId.ProjectId != documentId.ProjectId)
-                    return relatedDocumentId;
-            }
-
-            return null;
-        }
+            return FindRelatedDocument(documentId, relatedDocumentIds);
 
         var relatedProject = relatedProjectIdHint is null ? null : GetProjectState(relatedProjectIdHint);
         Contract.ThrowIfTrue(relatedProject == projectState);
@@ -1302,14 +1293,20 @@ internal sealed partial class SolutionState
 
         // Wasn't in the cache or hinted project, do the full linear search and update the cache.
         var documentIdsWithFilePath = GetDocumentIdsWithFilePath(filePath);
-        foreach (var relatedDocumentId in documentIdsWithFilePath)
-        {
-            // Don't return documents from the same project
-            if (relatedDocumentId.ProjectId != documentId.ProjectId)
-                return relatedDocumentId;
-        }
 
-        return null;
+        return FindRelatedDocument(documentId, documentIdsWithFilePath);
+
+        static DocumentId? FindRelatedDocument(DocumentId documentId, ImmutableArray<DocumentId> relatedDocumentIds)
+        {
+            foreach (var relatedDocumentId in relatedDocumentIds)
+            {
+                // Don't return documents from the same project
+                if (relatedDocumentId.ProjectId != documentId.ProjectId)
+                    return relatedDocumentId;
+            }
+
+            return null;
+        }
     }
 
     public ImmutableArray<DocumentId> GetRelatedDocumentIds(DocumentId documentId, bool includeDifferentLanguages)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1283,7 +1283,8 @@ internal sealed partial class SolutionState
         {
             foreach (var relatedDocumentId in relatedDocumentIds)
             {
-                if (relatedDocumentId != documentId)
+                // Don't return documents from the same project
+                if (relatedDocumentId.ProjectId != documentId.ProjectId)
                     return relatedDocumentId;
             }
 
@@ -1303,7 +1304,8 @@ internal sealed partial class SolutionState
         var documentIdsWithFilePath = GetDocumentIdsWithFilePath(filePath);
         foreach (var relatedDocumentId in documentIdsWithFilePath)
         {
-            if (relatedDocumentId != documentId)
+            // Don't return documents from the same project
+            if (relatedDocumentId.ProjectId != documentId.ProjectId)
                 return relatedDocumentId;
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1279,8 +1279,7 @@ internal sealed partial class SolutionState
             return null;
 
         // Do a quick check if the full info for that path has already been computed and cached.
-        var fileMap = _lazyFilePathToRelatedDocumentIds;
-        if (fileMap != null && fileMap.TryGetValue(filePath, out var relatedDocumentIds))
+        if (_lazyFilePathToRelatedDocumentIds.TryGetValue(filePath, out var relatedDocumentIds))
         {
             foreach (var relatedDocumentId in relatedDocumentIds)
             {
@@ -1300,16 +1299,12 @@ internal sealed partial class SolutionState
                 return siblingDocumentId;
         }
 
-        // Wasn't in cache, do the linear search.
-        foreach (var siblingProjectState in this.SortedProjectStates)
+        // Wasn't in the cache or hinted project, do the full linear search and update the cache.
+        var documentIdsWithFilePath = GetDocumentIdsWithFilePath(filePath);
+        foreach (var relatedDocumentId in documentIdsWithFilePath)
         {
-            // Don't want to search the same project that document already came from, or from the related-project we had a hint for.
-            if (siblingProjectState == projectState || siblingProjectState == relatedProject)
-                continue;
-
-            var siblingDocumentId = siblingProjectState.GetFirstDocumentIdWithFilePath(filePath);
-            if (siblingDocumentId is not null)
-                return siblingDocumentId;
+            if (relatedDocumentId != documentId)
+                return relatedDocumentId;
         }
 
         return null;

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2436,6 +2436,29 @@ public sealed class SolutionTests : TestBase
     }
 
     [Fact]
+    public async Task GetFirstRelatedDocumentIdWithDuplicatedDocuments()
+    {
+        using var workspace = CreateWorkspaceWithProjectAndDocuments();
+        var origSolution = workspace.CurrentSolution;
+        var project = origSolution.Projects.Single();
+
+        var origDocumentId = project.DocumentIds.Single();
+        var newDocumentId = DocumentId.CreateNewId(project.Id);
+
+        var document = project.GetRequiredDocument(origDocumentId);
+        var sourceText = await document.GetTextAsync();
+
+        var newSolution = origSolution.AddDocument(newDocumentId, document.Name, sourceText, filePath: document.FilePath!);
+
+        // Populate the SolutionState cache for this document id
+        _ = newSolution.GetRelatedDocumentIds(origDocumentId);
+
+        // Ensure a GetFirstRelatedDocumentId call with a poulated cache doesn't return newDocumentId
+        var relatedDocument = newSolution.GetFirstRelatedDocumentId(origDocumentId, relatedProjectIdHint: null);
+        Assert.Null(relatedDocument);
+    }
+
+    [Fact]
     public void AddDocument_SyntaxRoot()
     {
         var projectId = ProjectId.CreateNewId();


### PR DESCRIPTION
GetFirstRelatedDocumentId had a mismatch in behavior for files within the same project that have the same path (shouldn't really happen, would cause compile errors). Previously, the code would return files from the same proejct when searching the cache, but not when doing the linear walk. Talked with Jason, and he indicated that it was better to have the code not return files from the same project, as callers wouldn't expect that.