### PR TITLE
Unset CompilerType from Csc

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -487,10 +487,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return _store.GetOrDefault(nameof(ReportIVTs), false); }
         }
 
+        // Keeping this for a while to avoid failures if someone uses sdk targets that still set this.
         public string? CompilerType
         {
-            set { _store[nameof(CompilerType)] = value; }
-            get { return (string?)_store[nameof(CompilerType)]; }
+            set { }
+            get { return null; }
         }
 
         #endregion

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -94,7 +94,6 @@
          ChecksumAlgorithm="$(ChecksumAlgorithm)"
          CodeAnalysisRuleSet="$(ResolvedCodeAnalysisRuleSet)"
          CodePage="$(CodePage)"
-         CompilerType="$(RoslynCompilerType)"
          DebugType="$(DebugType)"
          DefineConstants="$(DefineConstants)"
          DelaySign="$(DelaySign)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -51,7 +51,6 @@
          ChecksumAlgorithm="$(ChecksumAlgorithm)"
          CodeAnalysisRuleSet="$(ResolvedCodeAnalysisRuleSet)"
          CodePage="$(CodePage)"
-         CompilerType="$(RoslynCompilerType)"
          DebugType="$(DebugType)"
          DefineConstants="$(FinalDefineConstants)"
          DelaySign="$(DelaySign)"


### PR DESCRIPTION
Keeping the property on the ManagedTool task itself so when someone has a build that still sets it, it doesn't fail.