### PR TITLE
File based programs IDE support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -169,7 +169,7 @@
       "type": "process",
       "options": {
         "env": {
-          "DOTNET_ROSLYN_SERVER_PATH": "${workspaceRoot}/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net8.0/Microsoft.CodeAnalysis.LanguageServer.dll"
+          "DOTNET_ROSLYN_SERVER_PATH": "${workspaceRoot}/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net9.0/Microsoft.CodeAnalysis.LanguageServer.dll"
         }
       },
       "dependsOn": [ "build language server" ]

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -1,0 +1,67 @@
+# File-based programs VS Code support
+
+See also [dotnet-run-file.md](https://github.com/dotnet/sdk/blob/main/documentation/general/dotnet-run-file.md).
+
+## Feature overview
+
+A file-based program embeds a subset of MSBuild project capabilities into C# code, allowing single files to stand alone as ordinary projects.
+
+The following is a file-based program:
+
+```cs
+Console.WriteLine("Hello World!");
+```
+
+So is the following:
+
+```cs
+#!/usr/bin/env dotnet run
+#:sdk Microsoft.Net.Sdk
+#:package Newtonsoft.Json@13.0.3
+#:property LangVersion=preview
+
+using Newtonsoft.Json;
+
+Main();
+
+void Main()
+{
+    if (args is not [_, var jsonPath, ..])
+    {
+        Console.Error.WriteLine("Usage: app <json-file>");
+        return;
+    }
+
+    var json = File.ReadAllText(jsonPath);
+    var data = JsonConvert.DeserializeObject<Data>(json);
+    // ...
+}
+
+record Data(string field1, int field2);
+```
+
+This basically works by having the `dotnet` command line interpret the `#:` directives in source files, produce a C# project XML document in memory, and pass it off to MSBuild. The in-memory project is sometimes called a "virtual project".
+
+## Miscellaneous files changes
+
+There is a long-standing backlog item to enhance the experience of working with miscellaneous files ("loose files" not associated with any project). We think that as part of the "file-based program" work, we can enable the following in such files without substantial issues:
+- Syntax diagnostics.
+- Intellisense for the "default" set of references. e.g. those references which are included in the project created by `dotnet new console` with the current SDK.
+
+## High-level IDE layer changes
+
+The following outline is for "single-file" scenarios. We are interested in expanding to multi-file as well, and this document will be expanded in the future with additional explanation of how to handle that scenario.
+
+### Prerequisite work
+- MSBuildHost is updated to allow passing project content along with a file path. (https://github.com/dotnet/roslyn/pull/78303)
+- LanguageServerProjectSystem has a base type extracted so that a FileBasedProgramProjectSystem can be added. The latter handles loading file-based program projects, and makes the appropriate call to obtain the file-based program project XML. (https://github.com/dotnet/roslyn/pull/78329)
+
+### Heuristic
+The IDE considers a file to be a file-based program, if:
+- It has any `#:` directives which configure the file-based program project, or,
+- It has any top-level statements.
+- Any of the above is met, and, the file is not included in an ordinary `.csproj` project (i.e. it is not part of any ordinary project's list of `Compile` items).
+
+### Opt-out
+
+We added an opt-out flag with option name `dotnet.projects.enableFileBasedPrograms`. If issues arise with the file-based program experience, then VS Code users should set the corresponding setting `"dotnet.projects.enableFileBasedPrograms": false` to revert back to the old miscellaneous files experience.

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -60,7 +60,7 @@ The following outline is for "single-file" scenarios. We are interested in expan
 The IDE considers a file to be a file-based program, if:
 - It has any `#:` directives which configure the file-based program project, or,
 - It has any top-level statements.
-- Any of the above is met, and, the file is not included in an ordinary `.csproj` project (i.e. it is not part of any ordinary project's list of `Compile` items).
+Any of the above is met, and, the file is not included in an ordinary `.csproj` project (i.e. it is not part of any ordinary project's list of `Compile` items).
 
 ### Opt-out
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -48,14 +48,6 @@ There is a long-standing backlog item to enhance the experience of working with 
 - Syntax diagnostics.
 - Intellisense for the "default" set of references. e.g. those references which are included in the project created by `dotnet new console` with the current SDK.
 
-## High-level IDE layer changes
-
-The following outline is for "single-file" scenarios. We are interested in expanding to multi-file as well, and this document will be expanded in the future with additional explanation of how to handle that scenario.
-
-### Prerequisite work
-- MSBuildHost is updated to allow passing project content along with a file path. (https://github.com/dotnet/roslyn/pull/78303)
-- LanguageServerProjectSystem has a base type extracted so that a FileBasedProgramProjectSystem can be added. The latter handles loading file-based program projects, and makes the appropriate call to obtain the file-based program project XML. (https://github.com/dotnet/roslyn/pull/78329)
-
 ### Heuristic
 The IDE considers a file to be a file-based program, if:
 - It has any `#:` directives which configure the file-based program project, or,

--- a/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
+++ b/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
@@ -46,6 +46,12 @@ internal static class MiscellaneousFileUtilities
             compilationOptions = GetCompilationOptionsWithScriptReferenceResolvers(services, compilationOptions, filePath);
         }
 
+        if (parseOptions != null && fileExtension != languageInformation.ScriptExtension)
+        {
+            // Any non-script misc file should not complain about usage of '#:' ignored directives.
+            parseOptions = parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "true")]);
+        }
+
         var projectId = ProjectId.CreateNewId(debugName: $"{workspace.GetType().Name} Files Project for {filePath}");
         var documentId = DocumentId.CreateNewId(projectId, debugName: filePath);
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
@@ -14,13 +14,11 @@ public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper)
 {
     private async Task<ITelemetryReporter> CreateReporterAsync()
     {
-        var exportProvider = await LanguageServerTestComposition.CreateExportProviderAsync(
+        var (exportProvider, _) = await LanguageServerTestComposition.CreateExportProviderAsync(
             LoggerFactory,
             includeDevKitComponents: true,
             MefCacheDirectory.Path,
-            [],
-            out var _,
-            out var _);
+            []);
 
         // VS Telemetry requires this environment variable to be set.
         Environment.SetEnvironmentVariable("CommonPropertyBagPath", Path.GetTempFileName());

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
@@ -46,8 +46,8 @@ public abstract class AbstractLanguageServerHostTests : IDisposable
 
         internal static async Task<TestLspServer> CreateAsync(ClientCapabilities clientCapabilities, ILoggerFactory loggerFactory, string cacheDirectory, bool includeDevKitComponents = true, string[]? extensionPaths = null)
         {
-            var exportProvider = await LanguageServerTestComposition.CreateExportProviderAsync(
-                loggerFactory, includeDevKitComponents, cacheDirectory, extensionPaths, out var _, out var assemblyLoader);
+            var (exportProvider, assemblyLoader) = await LanguageServerTestComposition.CreateExportProviderAsync(
+                loggerFactory, includeDevKitComponents, cacheDirectory, extensionPaths);
             var testLspServer = new TestLspServer(exportProvider, loggerFactory, assemblyLoader);
             var initializeResponse = await testLspServer.ExecuteRequestAsync<InitializeParams, InitializeResult>(Methods.InitializeName, new InitializeParams { Capabilities = clientCapabilities }, CancellationToken.None);
             Assert.NotNull(initializeResponse?.Capabilities);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -18,11 +18,10 @@ public sealed class WorkspaceProjectFactoryServiceTests(ITestOutputHelper testOu
     public async Task CreateProjectAndBatch()
     {
         var loggerFactory = new LoggerFactory();
-        using var exportProvider = await LanguageServerTestComposition.CreateExportProviderAsync(
-            loggerFactory, includeDevKitComponents: false, MefCacheDirectory.Path, [], out var serverConfiguration, out var _);
+        var (exportProvider, _) = await LanguageServerTestComposition.CreateExportProviderAsync(
+            loggerFactory, includeDevKitComponents: false, MefCacheDirectory.Path, []);
+        using var _ = exportProvider;
 
-        exportProvider.GetExportedValue<ServerConfigurationFactory>()
-            .InitializeConfiguration(serverConfiguration);
         await exportProvider.GetExportedValue<ServiceBrokerFactory>().CreateAsync();
 
         var workspaceFactory = exportProvider.GetExportedValue<LanguageServerWorkspaceFactory>();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -48,7 +48,7 @@ public sealed class WorkspaceProjectFactoryServiceTests(ITestOutputHelper testOu
         await batch.ApplyAsync(CancellationToken.None);
 
         // Verify it actually did something; we won't exclusively test each method since those are tested at lower layers
-        var project = workspaceFactory.Workspace.CurrentSolution.Projects.Single();
+        var project = workspaceFactory.HostWorkspace.CurrentSolution.Projects.Single();
 
         var document = Assert.Single(project.Documents);
         Assert.Equal(sourceFilePath, document.FilePath);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
@@ -143,11 +143,11 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
 
         var loader = ProjectFactory.CreateFileTextLoader(documentPath);
         var textAndVersion = await loader.LoadTextAsync(new LoadTextOptions(SourceHashAlgorithms.Default), cancellationToken);
-        var (virtualProjectContent, isFileBasedProgram) = VirtualProject.MakeVirtualProjectContent(documentPath, textAndVersion.Text);
+        var (virtualProjectContent, isFileBasedProgram) = VirtualCSharpFileBasedProgramProject.MakeVirtualProjectContent(documentPath, textAndVersion.Text);
 
         // When loading a virtual project, the path to the on-disk source file is not used. Instead the path is adjusted to end with .csproj.
         // This is necessary in order to get msbuild to apply the standard c# props/targets to the project.
-        var virtualProjectPath = VirtualProject.GetVirtualProjectPath(documentPath);
+        var virtualProjectPath = VirtualCSharpFileBasedProgramProject.GetVirtualProjectPath(documentPath);
         var loadedFile = await buildHost.LoadProjectAsync(virtualProjectPath, virtualProjectContent, languageName: LanguageNames.CSharp, cancellationToken);
         return (loadedFile, hasAllInformation: isFileBasedProgram, preferred: buildHostKind, actual: buildHostKind);
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
@@ -24,6 +24,7 @@ using static Microsoft.CodeAnalysis.MSBuild.BuildHostProcessManager;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
+/// <summary>Handles loading both miscellaneous files and file-based program projects.</summary>
 internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoader, ILspMiscellaneousFilesWorkspaceProvider
 {
     private readonly ILspServices _lspServices;
@@ -80,7 +81,7 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
             && primordialDoc.Project.Language == LanguageNames.CSharp
             && GlobalOptionService.GetOption(LanguageServerProjectSystemOptionsStorage.EnableFileBasedPrograms))
         {
-            await BeginLoadingProjectAsync(primordialDoc.FilePath, primordialProjectId: primordialDoc.Project.Id);
+            await BeginLoadingProjectWithPrimordialAsync(primordialDoc.FilePath, primordialProjectId: primordialDoc.Project.Id);
         }
         else
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
@@ -72,8 +72,7 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         {
             var metadataWorkspace = _metadataAsSourceFileService.TryGetWorkspace();
             Contract.ThrowIfNull(metadataWorkspace);
-            var document = metadataWorkspace.CurrentSolution.GetRequiredDocument(documentId);
-            return document;
+            return metadataWorkspace.CurrentSolution.GetRequiredDocument(documentId);
         }
 
         var primordialDoc = AddPrimordialDocument(uri, documentText, languageId);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Security;
+using Microsoft.CodeAnalysis.Features.Workspaces;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.ProjectSystem;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Composition;
+using Roslyn.LanguageServer.Protocol;
+using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.MSBuild.BuildHostProcessManager;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+
+internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoader, ILspMiscellaneousFilesWorkspaceProvider
+{
+    private readonly ILspServices _lspServices;
+    private readonly ILogger<FileBasedProgramsProjectSystem> _logger;
+    private readonly IMetadataAsSourceFileService _metadataAsSourceFileService;
+
+    public FileBasedProgramsProjectSystem(
+        ILspServices lspServices,
+        IMetadataAsSourceFileService metadataAsSourceFileService,
+        LanguageServerWorkspaceFactory workspaceFactory,
+        IFileChangeWatcher fileChangeWatcher,
+        IGlobalOptionService globalOptionService,
+        ILoggerFactory loggerFactory,
+        IAsynchronousOperationListenerProvider listenerProvider,
+        ProjectLoadTelemetryReporter projectLoadTelemetry,
+        ServerConfigurationFactory serverConfigurationFactory,
+        BinlogNamer binlogNamer)
+            : base(
+                workspaceFactory.FileBasedProgramsProjectFactory,
+                workspaceFactory.TargetFrameworkManager,
+                workspaceFactory.ProjectSystemHostInfo,
+                fileChangeWatcher,
+                globalOptionService,
+                loggerFactory,
+                listenerProvider,
+                projectLoadTelemetry,
+                serverConfigurationFactory,
+                binlogNamer)
+    {
+        _lspServices = lspServices;
+        _logger = loggerFactory.CreateLogger<FileBasedProgramsProjectSystem>();
+        _metadataAsSourceFileService = metadataAsSourceFileService;
+    }
+
+    public Workspace Workspace => ProjectFactory.Workspace;
+
+    public async Task<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
+    {
+        var (documentPath, isFile) = uri.ParsedUri is { } parsedUri
+            ? (ProtocolConversions.GetDocumentFilePathFromUri(parsedUri), isFile: parsedUri.IsFile)
+            : (uri.UriString, isFile: false);
+
+        var container = documentText.Container;
+        if (_metadataAsSourceFileService.TryAddDocumentToWorkspace(documentPath, container, out var documentId))
+        {
+            var metadataWorkspace = _metadataAsSourceFileService.TryGetWorkspace();
+            Contract.ThrowIfNull(metadataWorkspace);
+            var metadataDoc = metadataWorkspace.CurrentSolution.GetRequiredDocument(documentId);
+            return metadataDoc;
+        }
+
+        var languageInfoProvider = _lspServices.GetRequiredService<ILanguageInfoProvider>();
+        if (!languageInfoProvider.TryGetLanguageInformation(uri, languageId, out var languageInformation))
+        {
+            // Only log here since throwing here could take down the LSP server.
+            logger.LogError($"Could not find language information for {uri} with absolute path {documentPath}");
+            return null;
+        }
+
+        if (!isFile || !GlobalOptionService.GetOption(LanguageServerProjectSystemOptionsStorage.EnableFileBasedPrograms))
+        {
+            // For now, we cannot provide intellisense etc on files which are not on disk or are not C#.
+            var sourceTextLoader = new SourceTextLoader(documentText, documentPath);
+            var projectInfo = MiscellaneousFileUtilities.CreateMiscellaneousProjectInfoForDocument(
+                Workspace, documentPath, sourceTextLoader, languageInformation, documentText.ChecksumAlgorithm, Workspace.CurrentSolution.Services, []);
+            await ProjectFactory.ApplyChangeToWorkspaceAsync(ws => ws.OnProjectAdded(projectInfo), cancellationToken: default);
+
+            var newSolution = Workspace.CurrentSolution;
+            if (languageInformation.LanguageName == "Razor")
+            {
+                var docId = projectInfo.AdditionalDocuments.Single().Id;
+                return newSolution.GetRequiredAdditionalDocument(docId);
+            }
+
+            var id = projectInfo.Documents.Single().Id;
+            return newSolution.GetRequiredDocument(id);
+        }
+
+        // We have a file on disk. Light up the file-based program experience.
+        // For Razor files we need to override the language name to C# as that's what code is generated
+        var isRazor = languageInformation.LanguageName == "Razor";
+        var languageName = isRazor ? LanguageNames.CSharp : languageInformation.LanguageName;
+        var documentFileInfo = new DocumentFileInfo(documentPath, logicalPath: documentPath, isLinked: false, isGenerated: false, folders: default);
+        var projectFileInfo = new ProjectFileInfo()
+        {
+            Language = languageName,
+            FilePath = VirtualProject.GetVirtualProjectPath(documentPath),
+            CommandLineArgs = ["/langversion:preview", "/features:FileBasedProgram=true"],
+            Documents = isRazor ? [] : [documentFileInfo],
+            AdditionalDocuments = isRazor ? [documentFileInfo] : [],
+            AnalyzerConfigDocuments = [],
+            ProjectReferences = [],
+            PackageReferences = [],
+            ProjectCapabilities = [],
+            ContentFilePaths = [],
+            FileGlobs = []
+        };
+
+        var projectSet = AddLoadedProjectSet(documentPath);
+        Project workspaceProject;
+        using (await projectSet.Semaphore.DisposableWaitAsync())
+        {
+            var loadedProject = await this.CreateAndTrackInitialProjectAsync_NoLock(projectSet, documentPath, language: languageName);
+            await loadedProject.UpdateWithNewProjectInfoAsync(projectFileInfo, hasAllInformation: false, _logger);
+
+            ProjectsToLoadAndReload.AddWork(new ProjectToLoad(documentPath, ProjectGuid: null, ReportTelemetry: true));
+            loadedProject.NeedsReload += (_, _) => ProjectsToLoadAndReload.AddWork(new ProjectToLoad(documentPath, ProjectGuid: null, ReportTelemetry: false));
+            workspaceProject = ProjectFactory.Workspace.CurrentSolution.GetRequiredProject(loadedProject.ProjectId);
+        }
+
+        var document = isRazor ? workspaceProject.AdditionalDocuments.Single() : workspaceProject.Documents.Single();
+
+        _ = Task.Run(async () =>
+        {
+            await ProjectsToLoadAndReload.WaitUntilCurrentBatchCompletesAsync();
+            await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
+        });
+
+        Contract.ThrowIfFalse(document.FilePath == documentPath);
+        return document;
+    }
+
+    public async ValueTask TryRemoveMiscellaneousDocumentAsync(DocumentUri uri, bool removeFromMetadataWorkspace)
+    {
+        var documentPath = uri.ParsedUri is { } parsedUri ? ProtocolConversions.GetDocumentFilePathFromUri(parsedUri) : uri.UriString;
+        await TryUnloadProjectSetAsync(documentPath);
+
+        // also do an unload in case this was the non-file scenario
+        if (removeFromMetadataWorkspace && uri.ParsedUri is not null && _metadataAsSourceFileService.TryRemoveDocumentFromWorkspace(ProtocolConversions.GetDocumentFilePathFromUri(uri.ParsedUri)))
+        {
+            return;
+        }
+
+        var matchingDocument = Workspace.CurrentSolution.GetDocumentIds(uri).SingleOrDefault();
+        if (matchingDocument != null)
+        {
+            var project = Workspace.CurrentSolution.GetRequiredProject(matchingDocument.ProjectId);
+            Workspace.OnProjectRemoved(project.Id);
+        }
+    }
+
+    protected override async Task<(RemoteProjectFile? projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)> TryLoadProjectAsync(
+        BuildHostProcessManager buildHostProcessManager, string documentPath, CancellationToken cancellationToken)
+    {
+        const BuildHostProcessKind buildHostKind = BuildHostProcessKind.NetCore;
+        var buildHost = await buildHostProcessManager.GetBuildHostAsync(buildHostKind, cancellationToken);
+        Contract.ThrowIfFalse(Path.GetExtension(documentPath) == ".cs");
+
+        var fakeProjectPath = VirtualProject.GetVirtualProjectPath(documentPath);
+        var loader = ProjectFactory.CreateFileTextLoader(documentPath);
+        var textAndVersion = await loader.LoadTextAsync(new LoadTextOptions(SourceHashAlgorithms.Default), cancellationToken: default);
+        var (contentToLoad, isFileBasedProgram) = VirtualProject.MakeVirtualProjectContent(documentPath, textAndVersion.Text);
+
+        var loadedFile = await buildHost.LoadProjectAsync(fakeProjectPath, contentToLoad, languageName: LanguageNames.CSharp, cancellationToken);
+        return (loadedFile, hasAllInformation: isFileBasedProgram, preferred: buildHostKind, actual: buildHostKind);
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsProjectSystem.cs
@@ -139,7 +139,7 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         var buildHost = await buildHostProcessManager.GetBuildHostAsync(buildHostKind, cancellationToken);
 
         var loader = ProjectFactory.CreateFileTextLoader(documentPath);
-        var textAndVersion = await loader.LoadTextAsync(new LoadTextOptions(SourceHashAlgorithms.Default), cancellationToken: default);
+        var textAndVersion = await loader.LoadTextAsync(new LoadTextOptions(SourceHashAlgorithms.Default), cancellationToken);
         var (virtualProjectContent, isFileBasedProgram) = VirtualProject.MakeVirtualProjectContent(documentPath, textAndVersion.Text);
 
         // When loading a virtual project, the path to the on-disk source file is not used. Instead the path is adjusted to end with .csproj.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsWorkspaceProviderFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileBasedProgramsWorkspaceProviderFactory.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.ProjectSystem;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+
+/// <summary>
+/// Service to create <see cref="LspMiscellaneousFilesWorkspaceProvider"/> instances.
+/// This is not exported as a <see cref="ILspServiceFactory"/> as it requires
+/// special base language server dependencies such as the <see cref="HostServices"/>
+/// </summary>
+[ExportCSharpVisualBasicStatelessLspService(typeof(ILspMiscellaneousFilesWorkspaceProviderFactory), WellKnownLspServerKinds.CSharpVisualBasicLspServer), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class FileBasedProgramsWorkspaceProviderFactory(
+    IMetadataAsSourceFileService metadataAsSourceFileService,
+    LanguageServerWorkspaceFactory workspaceFactory,
+    IFileChangeWatcher fileChangeWatcher,
+    IGlobalOptionService globalOptionService,
+    ILoggerFactory loggerFactory,
+    IAsynchronousOperationListenerProvider listenerProvider,
+    ProjectLoadTelemetryReporter projectLoadTelemetry,
+    ServerConfigurationFactory serverConfigurationFactory,
+    BinlogNamer binlogNamer) : ILspMiscellaneousFilesWorkspaceProviderFactory
+{
+    public ILspMiscellaneousFilesWorkspaceProvider CreateLspMiscellaneousFilesWorkspaceProvider(ILspServices lspServices, HostServices hostServices)
+    {
+        return new FileBasedProgramsProjectSystem(lspServices, metadataAsSourceFileService, workspaceFactory, fileChangeWatcher, globalOptionService, loggerFactory, listenerProvider, projectLoadTelemetry, serverConfigurationFactory, binlogNamer);
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -282,7 +282,10 @@ internal abstract class LanguageServerProjectLoader
 
                 if (currentLoadState is ProjectLoadState.Primordial(var projectId))
                 {
-                    // Remove the primordial project now that the design-time build pass is finished.
+                    // Remove the primordial project now that the design-time build pass is finished. This ensures that
+                    // we have the new project in place before we remove the primordial project; otherwise for
+                    // Miscellaneous Files we could have a case where we'd get another request to create a project
+                    // for the project we're currently processing.
                     await ProjectFactory.ApplyChangeToWorkspaceAsync(workspace => workspace.OnProjectRemoved(projectId), cancellationToken);
                 }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -365,6 +365,9 @@ internal abstract class LanguageServerProjectLoader
         }
     }
 
+    /// <summary>
+    /// Begins loading a project with an associated primordial project. Must not be called for a project which has already begun loading.
+    /// </summary>
     /// <param name="doDesignTimeBuild">
     /// If <see langword="true"/>, initiates a design-time build now, and starts file watchers to repeat the design-time build on relevant changes.
     /// If <see langword="false"/>, only tracks the primordial project.
@@ -373,7 +376,9 @@ internal abstract class LanguageServerProjectLoader
     {
         using (await _gate.DisposableWaitAsync(CancellationToken.None))
         {
-            // If project has already begun loading, no need to do any further work.
+            // If this project has already begun loading, we need to throw.
+            // This is because we can't ensure that the workspace and project system will remain in a consistent state after this call.
+            // For example, there could be a need for the project system to track both a primordial project and list of loaded targets, which we don't support.
             if (_loadedProjects.ContainsKey(projectPath))
             {
                 Contract.Fail($"Cannot begin loading project '{projectPath}' because it has already begun loading.");
@@ -387,6 +392,9 @@ internal abstract class LanguageServerProjectLoader
         }
     }
 
+    /// <summary>
+    /// Begins loading a project. If the project has already begun loading, returns without doing any additional work.
+    /// </summary>
     protected async Task BeginLoadingProjectAsync(string projectPath, string? projectGuid)
     {
         using (await _gate.DisposableWaitAsync(CancellationToken.None))

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -231,7 +231,6 @@ internal abstract class LanguageServerProjectLoader
             var projectLanguage = loadedProjectInfos.FirstOrDefault()?.Language;
             if (projectLanguage != null && ProjectFactory.Workspace.Services.GetLanguageService<ICommandLineParserService>(projectLanguage) == null)
             {
-                _logger.LogWarning($"Could not run a design-time build for '{projectPath}' because it uses unsupported language '{projectLanguage}'.");
                 return false;
             }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -72,7 +72,7 @@ internal abstract class LanguageServerProjectLoader
         /// <summary>
         /// The initial state used when we are asked to design-time build a project for the first time.
         /// </summary>
-        internal sealed record BeginLoading : ProjectLoadState;
+        public sealed record BeginLoading : ProjectLoadState;
 
         /// <summary>
         /// Similar to <see cref="BeginLoading"/>, except including a <see cref="ProjectId"/> for a "primordial project".
@@ -81,7 +81,7 @@ internal abstract class LanguageServerProjectLoader
         /// ID of the project which LSP uses to fulfill requests until the first design-time build is complete.
         /// The project with this ID is removed from the workspace when unloading or when transitioning to <see cref="Loaded"/> state.
         /// </param>
-        internal sealed record BeginLoadingWithPrimordial(ProjectId PrimordialProjectId) : ProjectLoadState;
+        public sealed record BeginLoadingWithPrimordial(ProjectId PrimordialProjectId) : ProjectLoadState;
 
         /// <summary>
         /// The state after the first design-time build is finished.
@@ -89,12 +89,12 @@ internal abstract class LanguageServerProjectLoader
         /// The <see cref="LoadedProjectTargets"/> are disposed when unloading.
         /// </summary>
         /// <param name="LoadedProjectTargets">List of target frameworks which have been loaded for this project so far.</param>
-        internal sealed record Loaded(List<LoadedProject> LoadedProjectTargets) : ProjectLoadState;
+        public sealed record Loaded(List<LoadedProject> LoadedProjectTargets) : ProjectLoadState;
 
         /// <summary>
         /// Tracks a primordial project for which we never intend to do a design-time build, for example, due to it not being on disk.
         /// </summary>
-        internal sealed record PrimordialOnly(ProjectId PrimordialProjectId) : ProjectLoadState;
+        public sealed record PrimordialOnly(ProjectId PrimordialProjectId) : ProjectLoadState;
     }
 
     protected LanguageServerProjectLoader(

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -49,7 +49,7 @@ internal abstract class LanguageServerProjectLoader
     /// Guards access to <see cref="_loadedProjects"/>.
     /// To keep the LSP queue responsive, <see cref="_gate"/> must not be held while performing design-time builds.
     /// </summary>
-    private readonly SemaphoreSlim _gate = new SemaphoreSlim(1);
+    private readonly SemaphoreSlim _gate = new(initialCount: 1);
 
     /// <summary>
     /// Guarded by <see cref="_gate"/>.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -53,7 +53,6 @@ internal abstract class LanguageServerProjectLoader
     private readonly SemaphoreSlim _gate = new(initialCount: 1);
 
     /// <summary>
-    /// Guarded by <see cref="_gate"/>.
     /// Maps the file path of a tracked project to the load state for the project.
     /// Absence of an entry indicates the project is not tracked, e.g. it was never loaded, or it was unloaded.
     /// <see cref="_gate"/> must be held when modifying the dictionary or objects contained in it.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -229,7 +229,7 @@ internal abstract class LanguageServerProjectLoader
                     }
                     else
                     {
-                        var loadedProject = await CreateAndTrackInitialProjectAsync_NoLock(
+                        var loadedProject = await CreateAndTrackInitialProject_NoLockAsync(
                             loadedProjectSet,
                             projectPath,
                             loadedProjectInfo.Language,
@@ -333,7 +333,7 @@ internal abstract class LanguageServerProjectLoader
         }
     }
 
-    protected async Task<LoadedProject> CreateAndTrackInitialProjectAsync_NoLock(LoadedProjectSet projectSet, string projectPath, string language, string? targetFramework = null, string? intermediateOutputFilePath = null)
+    protected async Task<LoadedProject> CreateAndTrackInitialProject_NoLockAsync(LoadedProjectSet projectSet, string projectPath, string language, string? targetFramework = null, string? intermediateOutputFilePath = null)
     {
         var projectSystemName = targetFramework is null ? projectPath : $"{projectPath} (${targetFramework})";
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -375,6 +375,7 @@ internal abstract class LanguageServerProjectLoader
     {
         using (await _gate.DisposableWaitAsync(CancellationToken.None))
         {
+            // If project has already begun loading, no need to do any further work.
             if (_loadedProjects.ContainsKey(projectPath))
             {
                 return;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -183,9 +183,8 @@ internal abstract class LanguageServerProjectLoader
         }
     }
 
-    /// <summary>
-    /// Loads a project in the MSBuild host.
-    /// </summary>
+    /// <summary>Loads a project in the MSBuild host.</summary>
+    /// <remarks>Caller needs to catch exceptions to avoid bringing down the project loader queue.</remarks>
     protected abstract Task<(RemoteProjectFile projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)?> TryLoadProjectInMSBuildHostAsync(
         BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken);
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -253,6 +253,7 @@ internal abstract class LanguageServerProjectLoader
 
                     if (targetAlreadyExists)
                     {
+                        // https://github.com/dotnet/roslyn/issues/78561: Automatic restore should run even when the target is already loaded
                         _ = await target.UpdateWithNewProjectInfoAsync(loadedProjectInfo, hasAllInformation, _logger);
                     }
                     else

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -434,7 +434,7 @@ internal abstract class LanguageServerProjectLoader
             }
             else
             {
-                throw ExceptionUtilities.Unreachable();
+                throw ExceptionUtilities.UnexpectedValue(loadState);
             }
         }
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -4,23 +4,24 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
+using System.IO;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DebugConfiguration;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.ProjectSystem;
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Threading;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.Composition;
 using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.MSBuild.BuildHostProcessManager;
 using LSP = Roslyn.LanguageServer.Protocol;
@@ -35,21 +36,27 @@ internal abstract class LanguageServerProjectLoader
     private readonly ProjectTargetFrameworkManager _targetFrameworkManager;
     private readonly ProjectSystemHostInfo _projectSystemHostInfo;
     private readonly IFileChangeWatcher _fileChangeWatcher;
-    private readonly IGlobalOptionService _globalOptionService;
+    protected readonly IGlobalOptionService GlobalOptionService;
     protected readonly ILoggerFactory LoggerFactory;
     private readonly ILogger _logger;
     private readonly ProjectLoadTelemetryReporter _projectLoadTelemetryReporter;
     private readonly BinlogNamer _binlogNamer;
-    private readonly ProjectFileExtensionRegistry _projectFileExtensionRegistry;
     protected readonly ImmutableDictionary<string, string> AdditionalProperties;
 
     /// <summary>
-    /// The list of loaded projects in the workspace, keyed by project file path. The outer dictionary is a concurrent dictionary since we may be loading
-    /// multiple projects at once; the key is a single List we just have a single thread processing any given project file. This is only to be used
-    /// in <see cref="LoadOrReloadProjectsAsync" /> and downstream calls; any other updating of this (like unloading projects) should be achieved by adding
-    /// things to the <see cref="ProjectsToLoadAndReload" />.
+    /// Stores LoadedProjects representing all the TFMs of a single project (whose file path is the key in <see cref="_loadedProjects"/>)
     /// </summary>
-    private readonly ConcurrentDictionary<string, List<LoadedProject>> _loadedProjects = [];
+    /// <param name="Semaphore">
+    /// Synchronizes access to and disposal of items in <see cref="LoadedProjects"/>.
+    /// This must be obtained prior to any actions on LoadedProjects.
+    /// </param>
+    /// <param name="CancellationTokenSource">
+    /// When cancelled, signals that some thread has started disposing the <see cref="LoadedProjects"/>.
+    /// This must be checked after acquiring <see cref="Semaphore"/>, prior to performing any actions on LoadedProjects.
+    /// </param>
+    protected record LoadedProjectSet(List<LoadedProject> LoadedProjects, SemaphoreSlim Semaphore, CancellationTokenSource CancellationTokenSource);
+
+    private readonly ConcurrentDictionary<string, LoadedProjectSet> _loadedProjects = [];
 
     protected LanguageServerProjectLoader(
         ProjectSystemProjectFactory projectFactory,
@@ -67,13 +74,12 @@ internal abstract class LanguageServerProjectLoader
         _targetFrameworkManager = targetFrameworkManager;
         _projectSystemHostInfo = projectSystemHostInfo;
         _fileChangeWatcher = fileChangeWatcher;
-        _globalOptionService = globalOptionService;
+        GlobalOptionService = globalOptionService;
         LoggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger(nameof(LanguageServerProjectLoader));
         _projectLoadTelemetryReporter = projectLoadTelemetry;
         _binlogNamer = binlogNamer;
         var workspace = projectFactory.Workspace;
-        _projectFileExtensionRegistry = new ProjectFileExtensionRegistry(workspace.CurrentSolution.Services, new DiagnosticReporter(workspace));
         var razorDesignTimePath = serverConfigurationFactory.ServerConfiguration?.RazorDesignTimePath;
 
         AdditionalProperties = razorDesignTimePath is null
@@ -130,7 +136,7 @@ internal abstract class LanguageServerProjectLoader
                 args: (@this: this, toastErrorReporter, buildHostProcessManager),
                 cancellationToken).ConfigureAwait(false);
 
-            if (_globalOptionService.GetOption(LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore) && projectsThatNeedRestore.Any())
+            if (GlobalOptionService.GetOption(LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore) && projectsThatNeedRestore.Any())
             {
                 // Tell the client to restore any projects with unresolved dependencies.
                 // This should eventually move entirely server side once we have a mechanism for reporting generic project load progress.
@@ -146,108 +152,125 @@ internal abstract class LanguageServerProjectLoader
         }
     }
 
+    protected abstract Task<(RemoteProjectFile? projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)> TryLoadProjectAsync(
+        BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken);
+
     /// <returns>True if the project needs a NuGet restore, false otherwise.</returns>
     private async Task<bool> LoadOrReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken)
     {
         BuildHostProcessKind? preferredBuildHostKindThatWeDidNotGet = null;
         var projectPath = projectToLoad.Path;
+        Contract.ThrowIfFalse(PathUtilities.IsAbsolute(projectPath));
 
         try
         {
-            var preferredBuildHostKind = GetKindForProject(projectPath);
-            var (buildHost, actualBuildHostKind) = await buildHostProcessManager.GetBuildHostWithFallbackAsync(preferredBuildHostKind, projectPath, cancellationToken);
-            if (preferredBuildHostKind != actualBuildHostKind)
-                preferredBuildHostKindThatWeDidNotGet = preferredBuildHostKind;
-
-            if (!_projectFileExtensionRegistry.TryGetLanguageNameFromProjectPath(projectPath, DiagnosticReportingMode.Ignore, out var languageName))
-                return false;
-
-            var loadedFile = await buildHost.LoadProjectFileAsync(projectPath, languageName, cancellationToken);
-            var diagnosticLogItems = await loadedFile.GetDiagnosticLogItemsAsync(cancellationToken);
-            if (diagnosticLogItems.Any(item => item.Kind is DiagnosticLogItemKind.Error))
+            if (!_loadedProjects.TryGetValue(projectPath, out var loadedProjectSet) || loadedProjectSet.CancellationTokenSource.IsCancellationRequested)
             {
-                await LogDiagnosticsAsync(diagnosticLogItems);
-                // We have total failures in evaluation, no point in continuing.
+                // project was already unloaded or in process of unloading.
                 return false;
             }
 
-            var loadedProjectInfos = await loadedFile.GetProjectFileInfosAsync(cancellationToken);
-
-            // The out-of-proc build host supports more languages than we may actually have Workspace binaries for, so ensure we can actually process that
-            // language in-process.
-            var projectLanguage = loadedProjectInfos.FirstOrDefault()?.Language;
-            if (projectLanguage != null && ProjectFactory.Workspace.Services.GetLanguageService<ICommandLineParserService>(projectLanguage) == null)
+            var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(loadedProjectSet.CancellationTokenSource.Token, cancellationToken);
+            try
             {
-                return false;
-            }
+                var (loadedFile, hasAllInformation, preferredBuildHostKind, actualBuildHostKind) = await TryLoadProjectAsync(buildHostProcessManager, projectPath, cancellationToken);
+                if (preferredBuildHostKind != actualBuildHostKind)
+                    preferredBuildHostKindThatWeDidNotGet = preferredBuildHostKind;
 
-            var existingProjects = _loadedProjects.GetOrAdd(projectPath, static _ => []);
-
-            Dictionary<ProjectFileInfo, ProjectLoadTelemetryReporter.TelemetryInfo> telemetryInfos = [];
-            var needsRestore = false;
-
-            HashSet<LoadedProject> projectsToRemove = [.. existingProjects];
-            foreach (var loadedProjectInfo in loadedProjectInfos)
-            {
-                // If we already have the project with this same target framework, just update it
-                var existingProject = existingProjects.Find(p => p.GetTargetFramework() == loadedProjectInfo.TargetFramework);
-                bool targetNeedsRestore;
-                ProjectLoadTelemetryReporter.TelemetryInfo targetTelemetryInfo;
-
-                if (existingProject != null)
+                if (loadedFile is null)
                 {
-                    projectsToRemove.Remove(existingProject);
-                    (targetTelemetryInfo, targetNeedsRestore) = await existingProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo, _logger);
+                    _logger.LogWarning($"Unable to load project '{projectPath}'.");
+                    return false;
+                }
+
+                var diagnosticLogItems = await loadedFile.GetDiagnosticLogItemsAsync(cancellationToken);
+                if (diagnosticLogItems.Any(item => item.Kind is DiagnosticLogItemKind.Error))
+                {
+                    await LogDiagnosticsAsync(diagnosticLogItems);
+                    // We have total failures in evaluation, no point in continuing.
+                    return false;
+                }
+
+                var loadedProjectInfos = await loadedFile.GetProjectFileInfosAsync(cancellationToken);
+
+                // The out-of-proc build host supports more languages than we may actually have Workspace binaries for, so ensure we can actually process that
+                // language in-process.
+                var projectLanguage = loadedProjectInfos.FirstOrDefault()?.Language;
+                if (projectLanguage != null && ProjectFactory.Workspace.Services.GetLanguageService<ICommandLineParserService>(projectLanguage) == null)
+                {
+                    return false;
+                }
+
+                Dictionary<ProjectFileInfo, ProjectLoadTelemetryReporter.TelemetryInfo> telemetryInfos = [];
+                var needsRestore = false;
+
+                using var _ = await loadedProjectSet.Semaphore.DisposableWaitAsync(cancellationToken);
+                // last chance for someone to cancel out from under us.
+                if (loadedProjectSet.CancellationTokenSource.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                var existingProjects = loadedProjectSet.LoadedProjects;
+
+                // We want to remove projects for targets that don't exist anymore; if we update projects we'll remove them from  
+                // this list -- what's left we can then remove.
+                HashSet<LoadedProject> projectsToRemove = [.. existingProjects];
+                foreach (var loadedProjectInfo in loadedProjectInfos)
+                {
+                    var existingProject = existingProjects.FirstOrDefault(p => p.GetTargetFramework() == loadedProjectInfo.TargetFramework);
+                    bool targetNeedsRestore;
+                    ProjectLoadTelemetryReporter.TelemetryInfo targetTelemetryInfo;
+
+                    if (existingProject != null)
+                    {
+                        projectsToRemove.Remove(existingProject);
+                        (targetTelemetryInfo, targetNeedsRestore) = await existingProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo, hasAllInformation, _logger);
+                    }
+                    else
+                    {
+                        var loadedProject = await CreateAndTrackInitialProjectAsync_NoLock(
+                            loadedProjectSet,
+                            projectPath,
+                            loadedProjectInfo.Language,
+                            loadedProjectInfo.TargetFramework,
+                            loadedProjectInfo.IntermediateOutputFilePath);
+                        loadedProject.NeedsReload += (_, _) => ProjectsToLoadAndReload.AddWork(projectToLoad with { ReportTelemetry = false });
+
+                        (targetTelemetryInfo, targetNeedsRestore) = await loadedProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo, hasAllInformation, _logger);
+
+                        needsRestore |= targetNeedsRestore;
+                        telemetryInfos[loadedProjectInfo] = targetTelemetryInfo with { IsSdkStyle = preferredBuildHostKind == BuildHostProcessKind.NetCore };
+                    }
+                }
+
+                foreach (var project in projectsToRemove)
+                {
+                    project.Dispose();
+                    existingProjects.Remove(project);
+                }
+
+                if (projectToLoad.ReportTelemetry)
+                {
+                    await _projectLoadTelemetryReporter.ReportProjectLoadTelemetryAsync(telemetryInfos, projectToLoad, cancellationToken);
+                }
+
+                diagnosticLogItems = await loadedFile.GetDiagnosticLogItemsAsync(cancellationToken);
+                if (diagnosticLogItems.Any())
+                {
+                    await LogDiagnosticsAsync(diagnosticLogItems);
                 }
                 else
                 {
-                    var projectSystemName = $"{projectPath} (${loadedProjectInfo.TargetFramework})";
-                    var projectCreationInfo = new ProjectSystemProjectCreationInfo
-                    {
-                        AssemblyName = projectSystemName,
-                        FilePath = projectPath,
-                        CompilationOutputAssemblyFilePath = loadedProjectInfo.IntermediateOutputFilePath
-                    };
-
-                    var projectSystemProject = await ProjectFactory.CreateAndAddToWorkspaceAsync(
-                        projectSystemName,
-                        loadedProjectInfo.Language,
-                        projectCreationInfo,
-                        _projectSystemHostInfo);
-
-                    var loadedProject = new LoadedProject(projectSystemProject, ProjectFactory.Workspace.Services.SolutionServices, _fileChangeWatcher, _targetFrameworkManager);
-                    loadedProject.NeedsReload += (_, _) => ProjectsToLoadAndReload.AddWork(projectToLoad with { ReportTelemetry = false });
-                    existingProjects.Add(loadedProject);
-
-                    (targetTelemetryInfo, targetNeedsRestore) = await loadedProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo, _logger);
-
-                    needsRestore |= targetNeedsRestore;
-                    telemetryInfos[loadedProjectInfo] = targetTelemetryInfo with { IsSdkStyle = preferredBuildHostKind == BuildHostProcessKind.NetCore };
+                    _logger.LogInformation(string.Format(LanguageServerResources.Successfully_completed_load_of_0, projectPath));
                 }
-            }
 
-            foreach (var project in projectsToRemove)
-            {
-                project.Dispose();
-                _loadedProjects.AddOrUpdate(projectPath, addValueFactory: _ => throw new InvalidOperationException(), updateValueFactory: (_, arr) => arr.Remove(project));
+                return needsRestore;
             }
-
-            if (projectToLoad.ReportTelemetry)
+            catch (OperationCanceledException e) when (e.CancellationToken == linkedTokenSource.Token)
             {
-                await _projectLoadTelemetryReporter.ReportProjectLoadTelemetryAsync(telemetryInfos, projectToLoad, cancellationToken);
+                return false;
             }
-
-            diagnosticLogItems = await loadedFile.GetDiagnosticLogItemsAsync(cancellationToken);
-            if (diagnosticLogItems.Any())
-            {
-                await LogDiagnosticsAsync(diagnosticLogItems);
-            }
-            else
-            {
-                _logger.LogInformation(string.Format(LanguageServerResources.Successfully_completed_load_of_0, projectPath));
-            }
-
-            return needsRestore;
         }
         catch (Exception e)
         {
@@ -280,5 +303,55 @@ internal abstract class LanguageServerProjectLoader
 
             await toastErrorReporter.ReportErrorAsync(worstLspMessageKind, message, cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// Creates a <see cref="LoadedProject"/> which has bare minimum information, but, which documents can be added to and obtained from.
+    /// </summary>
+    protected LoadedProjectSet AddLoadedProjectSet(string projectPath)
+    {
+        var projectSet = new LoadedProjectSet([], new SemaphoreSlim(1), new CancellationTokenSource());
+        return _loadedProjects.GetOrAdd(projectPath, projectSet);
+    }
+
+    protected async ValueTask TryUnloadProjectSetAsync(string projectPath)
+    {
+        if (_loadedProjects.TryRemove(projectPath, out var loadedProjectSet))
+        {
+            using var _ = await loadedProjectSet.Semaphore.DisposableWaitAsync();
+            if (loadedProjectSet.CancellationTokenSource.IsCancellationRequested)
+            {
+                // don't need to cancel again.
+                return;
+            }
+
+            loadedProjectSet.CancellationTokenSource.Cancel();
+            foreach (var project in loadedProjectSet.LoadedProjects)
+            {
+                project.Dispose();
+            }
+        }
+    }
+
+    protected async Task<LoadedProject> CreateAndTrackInitialProjectAsync_NoLock(LoadedProjectSet projectSet, string projectPath, string language, string? targetFramework = null, string? intermediateOutputFilePath = null)
+    {
+        var projectSystemName = targetFramework is null ? projectPath : $"{projectPath} (${targetFramework})";
+
+        var projectCreationInfo = new ProjectSystemProjectCreationInfo
+        {
+            AssemblyName = projectSystemName,
+            FilePath = projectPath,
+            CompilationOutputAssemblyFilePath = intermediateOutputFilePath,
+        };
+
+        var projectSystemProject = await ProjectFactory.CreateAndAddToWorkspaceAsync(
+            projectSystemName,
+            language,
+            projectCreationInfo,
+            _projectSystemHostInfo);
+
+        var loadedProject = new LoadedProject(projectSystemProject, ProjectFactory.Workspace.Services.SolutionServices, _fileChangeWatcher, _targetFrameworkManager);
+        projectSet.LoadedProjects.Add(loadedProject);
+        return loadedProject;
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -70,11 +70,11 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         }
 
         var projects = await buildHost.GetProjectsInSolutionAsync(solutionFilePath, CancellationToken.None);
-        // TODO: this '!' is doing a "nullable covariant" conversion of the ImmutableArray tuple elements.
-        // This doesn't introduce any null safety issue as the elements can't be modified.
-        // It's not clear if there's a simple pattern that lets us get rid of this,
-        // except perhaps by making the nullabilities exactly match all the way down the chain that this value flows from.
-        await LoadProjectsAsync(projects!, CancellationToken.None);
+        foreach (var (path, guid) in projects)
+        {
+            await BeginLoadingProjectAsync(path, guid);
+        }
+        await WaitForProjectsToFinishLoadingAsync();
         await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
     }
 
@@ -83,7 +83,11 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         if (!projectFilePaths.Any())
             return;
 
-        await LoadProjectsAsync(projectFilePaths, CancellationToken.None);
+        foreach (var (path, guid) in projectFilePaths)
+        {
+            await BeginLoadingProjectAsync(path, guid);
+        }
+        await WaitForProjectsToFinishLoadingAsync();
         await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
 {
     private readonly ILogger _logger;
-    private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
     private readonly ProjectFileExtensionRegistry _projectFileExtensionRegistry;
 
     [ImportingConstructor]
@@ -55,33 +54,24 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
 
     public async Task OpenSolutionAsync(string solutionFilePath)
     {
-        using (await _gate.DisposableWaitAsync())
+        _logger.LogInformation(string.Format(LanguageServerResources.Loading_0, solutionFilePath));
+        ProjectFactory.SolutionPath = solutionFilePath;
+
+        // We'll load solutions out-of-proc, since it's possible we might be running on a runtime that doesn't have a matching SDK installed,
+        // and we don't want any MSBuild registration to set environment variables in our process that might impact child processes.
+        await using var buildHostProcessManager = new BuildHostProcessManager(globalMSBuildProperties: AdditionalProperties, loggerFactory: LoggerFactory);
+        var buildHost = await buildHostProcessManager.GetBuildHostAsync(BuildHostProcessKind.NetCore, CancellationToken.None);
+
+        // If we don't have a .NET Core SDK on this machine at all, try .NET Framework
+        if (!await buildHost.HasUsableMSBuildAsync(solutionFilePath, CancellationToken.None))
         {
-            _logger.LogInformation(string.Format(LanguageServerResources.Loading_0, solutionFilePath));
-            ProjectFactory.SolutionPath = solutionFilePath;
-
-            // We'll load solutions out-of-proc, since it's possible we might be running on a runtime that doesn't have a matching SDK installed,
-            // and we don't want any MSBuild registration to set environment variables in our process that might impact child processes.
-            await using var buildHostProcessManager = new BuildHostProcessManager(globalMSBuildProperties: AdditionalProperties, loggerFactory: LoggerFactory);
-            var buildHost = await buildHostProcessManager.GetBuildHostAsync(BuildHostProcessKind.NetCore, CancellationToken.None);
-
-            // If we don't have a .NET Core SDK on this machine at all, try .NET Framework
-            if (!await buildHost.HasUsableMSBuildAsync(solutionFilePath, CancellationToken.None))
-            {
-                var kind = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? BuildHostProcessKind.NetFramework : BuildHostProcessKind.Mono;
-                buildHost = await buildHostProcessManager.GetBuildHostAsync(kind, CancellationToken.None);
-            }
-
-            foreach (var project in await buildHost.GetProjectsInSolutionAsync(solutionFilePath, CancellationToken.None))
-            {
-                _ = AddLoadedProjectSet(project.ProjectPath);
-                ProjectsToLoadAndReload.AddWork(new ProjectToLoad(project.ProjectPath, project.ProjectGuid, ReportTelemetry: true));
-            }
-
-            // Wait for the in progress batch to complete and send a project initialized notification to the client.
-            await ProjectsToLoadAndReload.WaitUntilCurrentBatchCompletesAsync();
-            await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
+            var kind = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? BuildHostProcessKind.NetFramework : BuildHostProcessKind.Mono;
+            buildHost = await buildHostProcessManager.GetBuildHostAsync(kind, CancellationToken.None);
         }
+
+        var projects = await buildHost.GetProjectsInSolutionAsync(solutionFilePath, CancellationToken.None);
+        await LoadProjectsAsync(projects, CancellationToken.None);
+        await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
     }
 
     public async Task OpenProjectsAsync(ImmutableArray<string> projectFilePaths)
@@ -89,28 +79,18 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         if (!projectFilePaths.Any())
             return;
 
-        using (await _gate.DisposableWaitAsync())
-        {
-            foreach (var projectPath in projectFilePaths)
-            {
-                _ = AddLoadedProjectSet(projectPath);
-                ProjectsToLoadAndReload.AddWork(new ProjectToLoad(projectPath, ProjectGuid: null, ReportTelemetry: true));
-            }
-
-            // Wait for the in progress batch to complete and send a project initialized notification to the client.
-            await ProjectsToLoadAndReload.WaitUntilCurrentBatchCompletesAsync();
-            await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
-        }
+        await LoadProjectsAsync(projectFilePaths, CancellationToken.None);
+        await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
     }
 
-    protected override async Task<(RemoteProjectFile? projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)> TryLoadProjectAsync(
+    protected override async Task<(RemoteProjectFile projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)?> TryLoadRemoteProjectAsync(
             BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken)
     {
+        if (!_projectFileExtensionRegistry.TryGetLanguageNameFromProjectPath(projectPath, DiagnosticReportingMode.Ignore, out var languageName))
+            return null;
+
         var preferredBuildHostKind = GetKindForProject(projectPath);
         var (buildHost, actualBuildHostKind) = await buildHostProcessManager.GetBuildHostWithFallbackAsync(preferredBuildHostKind, projectPath, cancellationToken);
-
-        if (!_projectFileExtensionRegistry.TryGetLanguageNameFromProjectPath(projectPath, DiagnosticReportingMode.Ignore, out var languageName))
-            return (null, false, preferredBuildHostKind, actualBuildHostKind);
 
         var loadedFile = await buildHost.LoadProjectFileAsync(projectPath, languageName, cancellationToken);
         return (loadedFile, hasAllInformation: true, preferredBuildHostKind, actualBuildHostKind);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -70,11 +70,15 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         }
 
         var projects = await buildHost.GetProjectsInSolutionAsync(solutionFilePath, CancellationToken.None);
-        await LoadProjectsAsync(projects, CancellationToken.None);
+        // TODO: this '!' is doing a "nullable covariant" conversion of the ImmutableArray tuple elements.
+        // This doesn't introduce any null safety issue as the elements can't be modified.
+        // It's not clear if there's a simple pattern that lets us get rid of this,
+        // except perhaps by making the nullabilities exactly match all the way down the chain that this value flows from.
+        await LoadProjectsAsync(projects!, CancellationToken.None);
         await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
     }
 
-    public async Task OpenProjectsAsync(ImmutableArray<string> projectFilePaths)
+    public async Task OpenProjectsAsync(ImmutableArray<(string ProjectPath, string? ProjectGuid)> projectFilePaths)
     {
         if (!projectFilePaths.Any())
             return;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -78,14 +78,14 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
     }
 
-    public async Task OpenProjectsAsync(ImmutableArray<(string ProjectPath, string? ProjectGuid)> projectFilePaths)
+    public async Task OpenProjectsAsync(ImmutableArray<string> projectFilePaths)
     {
         if (!projectFilePaths.Any())
             return;
 
-        foreach (var (path, guid) in projectFilePaths)
+        foreach (var path in projectFilePaths)
         {
-            await BeginLoadingProjectAsync(path, guid);
+            await BeginLoadingProjectAsync(path, projectGuid: null);
         }
         await WaitForProjectsToFinishLoadingAsync();
         await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -87,7 +87,7 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         await ProjectInitializationHandler.SendProjectInitializationCompleteNotificationAsync();
     }
 
-    protected override async Task<(RemoteProjectFile projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)?> TryLoadRemoteProjectAsync(
+    protected override async Task<(RemoteProjectFile projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)?> TryLoadProjectInMSBuildHostAsync(
         BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken)
     {
         if (!_projectFileExtensionRegistry.TryGetLanguageNameFromProjectPath(projectPath, DiagnosticReportingMode.Ignore, out var languageName))

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -88,7 +88,7 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
     }
 
     protected override async Task<(RemoteProjectFile projectFile, bool hasAllInformation, BuildHostProcessKind preferred, BuildHostProcessKind actual)?> TryLoadRemoteProjectAsync(
-            BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken)
+        BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken)
     {
         if (!_projectFileExtensionRegistry.TryGetLanguageNameFromProjectPath(projectPath, DiagnosticReportingMode.Ignore, out var languageName))
             return null;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
@@ -107,7 +107,9 @@ internal sealed class LanguageServerWorkspace : Workspace, ILspWorkspace
                 {
                     TextLoader loader;
                     var document = textDocument as Document;
-                    if (document is not null && (document.DocumentState.Attributes.DesignTimeOnly == true || !PathUtilities.IsAbsolute(filePath)))
+
+                    // 'DesignTimeOnly == true' or 'filePath' not being absolute indicates the document is for a virtual file (in-memory, not on-disk).
+                    if (document is not null && (document.DocumentState.Attributes.DesignTimeOnly || !PathUtilities.IsAbsolute(filePath)))
                     {
                         // Dynamic files don't exist on disk so if we were to use the FileTextLoader we'd effectively be emptying out the document.
                         // We also assume they're not user editable, and hence can't have "unsaved" changes that are expected to go away on close.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
@@ -5,6 +5,7 @@
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
+using Roslyn.Utilities;
 using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
@@ -44,8 +45,8 @@ internal sealed class LanguageServerWorkspace : Workspace, ILspWorkspace
     /// </summary>
     public ProjectSystemProjectFactory ProjectSystemProjectFactory { private get; set; } = null!;
 
-    public LanguageServerWorkspace(HostServices host)
-        : base(host, WorkspaceKind.Host)
+    public LanguageServerWorkspace(HostServices host, string workspaceKind)
+        : base(host, workspaceKind)
     {
     }
 
@@ -106,7 +107,7 @@ internal sealed class LanguageServerWorkspace : Workspace, ILspWorkspace
                 {
                     TextLoader loader;
                     var document = textDocument as Document;
-                    if (document?.DocumentState.Attributes.DesignTimeOnly == true)
+                    if (document is not null && (document.DocumentState.Attributes.DesignTimeOnly == true || !PathUtilities.IsAbsolute(filePath)))
                     {
                         // Dynamic files don't exist on disk so if we were to use the FileTextLoader we'd effectively be emptying out the document.
                         // We also assume they're not user editable, and hence can't have "unsaved" changes that are expected to go away on close.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
@@ -37,6 +38,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 /// it will use the local information it has outside of the workspace to ensure it is always matched with the lsp
 /// client.
 /// </summary>
+[DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
 internal sealed class LanguageServerWorkspace : Workspace, ILspWorkspace
 {
     /// <summary>
@@ -135,5 +137,10 @@ internal sealed class LanguageServerWorkspace : Workspace, ILspWorkspace
                 }
             },
             cancellationToken);
+    }
+
+    private string GetDebuggerDisplay()
+    {
+        return $"""LanguageServerWorkspace(Kind: "{Kind}")""";
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -53,7 +53,7 @@ internal sealed class LanguageServerWorkspaceFactory
             CancellationToken.None); // TODO: do we need to introduce a shutdown cancellation token for this?
         workspace.ProjectSystemProjectFactory = HostProjectFactory;
 
-        // TODO: Move this workspace creation to 'FileBasedProgramsWorkspaceProviderFactory'.
+        // https://github.com/dotnet/roslyn/issues/78560: Move this workspace creation to 'FileBasedProgramsWorkspaceProviderFactory'.
         // 'CreateSolutionLevelAnalyzerReferencesForWorkspace' needs to be broken out into its own service for us to be able to move this.
         var fileBasedProgramsWorkspace = new LanguageServerWorkspace(hostServicesProvider.HostServices, WorkspaceKind.MiscellaneousFiles);
         fileBasedProgramsWorkspace.SetCurrentSolution(s => s.WithAnalyzerReferences(CreateSolutionLevelAnalyzerReferencesForWorkspace(fileBasedProgramsWorkspace)), WorkspaceChangeKind.SolutionChanged);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -53,12 +53,14 @@ internal sealed class LanguageServerWorkspaceFactory
             CancellationToken.None); // TODO: do we need to introduce a shutdown cancellation token for this?
         workspace.ProjectSystemProjectFactory = HostProjectFactory;
 
-        var fbpWorkspace = new LanguageServerWorkspace(hostServicesProvider.HostServices, WorkspaceKind.MiscellaneousFiles);
-        fbpWorkspace.SetCurrentSolution(s => s.WithAnalyzerReferences(CreateSolutionLevelAnalyzerReferencesForWorkspace(fbpWorkspace)), WorkspaceChangeKind.SolutionChanged);
+        // TODO: Move this workspace creation to 'FileBasedProgramsWorkspaceProviderFactory'.
+        // 'CreateSolutionLevelAnalyzerReferencesForWorkspace' needs to be broken out into its own service for us to be able to move this.
+        var fileBasedProgramsWorkspace = new LanguageServerWorkspace(hostServicesProvider.HostServices, WorkspaceKind.MiscellaneousFiles);
+        fileBasedProgramsWorkspace.SetCurrentSolution(s => s.WithAnalyzerReferences(CreateSolutionLevelAnalyzerReferencesForWorkspace(fileBasedProgramsWorkspace)), WorkspaceChangeKind.SolutionChanged);
 
         FileBasedProgramsProjectFactory = new ProjectSystemProjectFactory(
-            fbpWorkspace, fileChangeWatcher, static (_, _) => Task.CompletedTask, _ => { }, CancellationToken.None);
-        fbpWorkspace.ProjectSystemProjectFactory = FileBasedProgramsProjectFactory;
+            fileBasedProgramsWorkspace, fileChangeWatcher, static (_, _) => Task.CompletedTask, _ => { }, CancellationToken.None);
+        fileBasedProgramsWorkspace.ProjectSystemProjectFactory = FileBasedProgramsProjectFactory;
 
         var razorSourceGenerator = serverConfigurationFactory?.ServerConfiguration?.RazorSourceGenerator;
         ProjectSystemHostInfo = new ProjectSystemHostInfo(

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -107,6 +107,7 @@ internal sealed class LoadedProject : IDisposable
         _fileChangeContext.Dispose();
         _optionsProcessor.Dispose();
         _projectSystemProject.RemoveFromWorkspace();
+        NeedsReload = null;
     }
 
     public async ValueTask<(ProjectLoadTelemetryReporter.TelemetryInfo, bool NeedsRestore)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, bool hasAllInformation, ILogger logger)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -102,6 +102,7 @@ internal sealed class LoadedProject : IDisposable
 
     public void Dispose()
     {
+        _fileChangeContext.Dispose();
         _optionsProcessor.Dispose();
         _projectSystemProject.RemoveFromWorkspace();
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -60,6 +60,8 @@ internal sealed class LoadedProject : IDisposable
         _fileChangeContext.EnqueueWatchingFile(_projectFilePath);
     }
 
+    public ProjectId ProjectId => _projectSystemProject.Id;
+
     private void FileChangedContext_FileChanged(object? sender, string filePath)
     {
         // If the project file itself changed, we almost certainly need to reload the project.
@@ -107,7 +109,7 @@ internal sealed class LoadedProject : IDisposable
         _projectSystemProject.RemoveFromWorkspace();
     }
 
-    public async ValueTask<(ProjectLoadTelemetryReporter.TelemetryInfo, bool NeedsRestore)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, ILogger logger)
+    public async ValueTask<(ProjectLoadTelemetryReporter.TelemetryInfo, bool NeedsRestore)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, bool hasAllInformation, ILogger logger)
     {
         if (_mostRecentFileInfo != null)
         {
@@ -135,6 +137,7 @@ internal sealed class LoadedProject : IDisposable
         _projectSystemProject.GeneratedFilesOutputDirectory = newProjectInfo.GeneratedFilesOutputDirectory;
         _projectSystemProject.CompilationOutputAssemblyFilePath = newProjectInfo.IntermediateOutputFilePath;
         _projectSystemProject.DefaultNamespace = newProjectInfo.DefaultNamespace;
+        _projectSystemProject.HasAllInformation = hasAllInformation;
 
         if (newProjectInfo.TargetFrameworkIdentifier != null)
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -60,8 +60,6 @@ internal sealed class LoadedProject : IDisposable
         _fileChangeContext.EnqueueWatchingFile(_projectFilePath);
     }
 
-    public ProjectId ProjectId => _projectSystemProject.Id;
-
     private void FileChangedContext_FileChanged(object? sender, string filePath)
     {
         // If the project file itself changed, we almost certainly need to reload the project.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -102,12 +102,14 @@ internal sealed class LoadedProject : IDisposable
         return _mostRecentFileInfo.TargetFramework;
     }
 
+    /// <summary>
+    /// Unloads the project and removes it from the workspace.
+    /// </summary>
     public void Dispose()
     {
         _fileChangeContext.Dispose();
         _optionsProcessor.Dispose();
         _projectSystemProject.RemoveFromWorkspace();
-        NeedsReload = null;
     }
 
     public async ValueTask<(ProjectLoadTelemetryReporter.TelemetryInfo, bool NeedsRestore)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, bool hasAllInformation, ILogger logger)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
@@ -31,7 +31,7 @@ internal sealed class OpenProjectHandler : ILspServiceNotificationHandler<OpenPr
 
     Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
-        return _projectSystem.OpenProjectsAsync(request.Projects.SelectAsArray(p => p.LocalPath));
+        return _projectSystem.OpenProjectsAsync(request.Projects.SelectAsArray(p => (ProjectPath: p.LocalPath, ProjectGuid: (string?)null)));
     }
 
     internal sealed class NotificationParams

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
@@ -31,7 +31,7 @@ internal sealed class OpenProjectHandler : ILspServiceNotificationHandler<OpenPr
 
     Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
-        return _projectSystem.OpenProjectsAsync(request.Projects.SelectAsArray(p => (ProjectPath: p.LocalPath, ProjectGuid: (string?)null)));
+        return _projectSystem.OpenProjectsAsync(request.Projects.SelectAsArray(p => p.LocalPath));
     }
 
     internal sealed class NotificationParams

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectToLoad.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectToLoad.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
 /// <summary>
-/// The project path (and the guid if it game from a solution) of the project to load.
+/// The project path (and the guid if it came from a solution) of the project to load.
 /// </summary>
 internal sealed record ProjectToLoad(string Path, string? ProjectGuid, bool ReportTelemetry)
 {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.cs
@@ -37,7 +37,7 @@ internal sealed partial class RazorDynamicFileInfoProvider(Lazy<LanguageServerWo
 
         _razorWorkspaceService.NotifyDynamicFile(projectId);
 
-        var dynamicInfo = await _dynamicFileInfoProvider.GetDynamicFileInfoAsync(workspaceFactory.Value.Workspace, projectId, projectFilePath, filePath, cancellationToken).ConfigureAwait(false);
+        var dynamicInfo = await _dynamicFileInfoProvider.GetDynamicFileInfoAsync(workspaceFactory.Value.HostWorkspace, projectId, projectFilePath, filePath, cancellationToken).ConfigureAwait(false);
         if (dynamicInfo is null)
         {
             return null;
@@ -78,6 +78,6 @@ internal sealed partial class RazorDynamicFileInfoProvider(Lazy<LanguageServerWo
             return;
         }
 
-        await _dynamicFileInfoProvider.RemoveDynamicFileInfoAsync(workspaceFactory.Value.Workspace, projectId, projectFilePath, filePath, cancellationToken).ConfigureAwait(false);
+        await _dynamicFileInfoProvider.RemoveDynamicFileInfoAsync(workspaceFactory.Value.HostWorkspace, projectId, projectFilePath, filePath, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
@@ -35,7 +35,7 @@ internal static class VirtualProject
 
                 <PropertyGroup>
                     <OutputType>Exe</OutputType>
-                    <TargetFramework>net9.0</TargetFramework>
+                    <TargetFramework>net8.0</TargetFramework>
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <Features>$(Features);FileBasedProgram</Features>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 /// <summary>
 /// Soon this will be replaced invoke dotnet run-api command implemented in https://github.com/dotnet/sdk/pull/48749
 /// </summary>
-internal static class VirtualProject
+internal static class VirtualCSharpFileBasedProgramProject
 {
     /// <summary>
     /// Adjusts a path to a file-based program for use in passing the virtual project to msbuild.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
@@ -10,7 +10,7 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
 /// <summary>
-/// Soon this will be replaced invoke dotnet run-api command implemented in https://github.com/dotnet/sdk/pull/48749
+/// This will be replaced invoke dotnet run-api command implemented in https://github.com/dotnet/sdk/pull/48749
 /// </summary>
 internal static class VirtualCSharpFileBasedProgramProject
 {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VirtualProject.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+
+/// <summary>
+/// Soon this will be replaced invoke dotnet run-api command implemented in https://github.com/dotnet/sdk/pull/48749
+/// </summary>
+internal static class VirtualProject
+{
+    /// <summary>
+    /// Adjusts a path to a file-based program for use in passing the virtual project to msbuild.
+    /// (msbuild needs the path to end in .csproj to recognize as a C# project and apply all the standard props/targets to it.)
+    /// </summary>
+    internal static string GetVirtualProjectPath(string documentFilePath)
+        => Path.ChangeExtension(documentFilePath, ".csproj");
+
+    internal static (string virtualProjectXml, bool isFileBasedProgram) MakeVirtualProjectContent(string documentFilePath, SourceText text)
+    {
+        Contract.ThrowIfFalse(PathUtilities.IsAbsolute(documentFilePath));
+        // NB: this is a temporary solution for running our heuristic.
+        // When we adopt the dotnet run-api, we need to get rid of this or adjust it to be more sustainable (e.g. using the appropriate document to get a syntax tree)
+        var tree = CSharpSyntaxTree.ParseText(text, options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview), path: documentFilePath);
+        var root = tree.GetRoot();
+        var isFileBasedProgram = root.GetLeadingTrivia().Any(SyntaxKind.IgnoredDirectiveTrivia) || root.ChildNodes().Any(node => node.IsKind(SyntaxKind.GlobalStatement));
+
+        var virtualProjectXml = $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+                <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <Features>$(Features);FileBasedProgram</Features>
+                    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+                </PropertyGroup>
+
+                <ItemGroup>
+                    <Compile Include="{SecurityElement.Escape(documentFilePath)}" />
+                </ItemGroup>
+
+                <!--
+                  Override targets which don't work with project files that are not present on disk.
+                  See https://github.com/NuGet/Home/issues/14148.
+                -->
+
+                <Target Name="_FilterRestoreGraphProjectInputItems"
+                        DependsOnTargets="_LoadRestoreGraphEntryPoints"
+                        Returns="@(FilteredRestoreGraphProjectInputItems)">
+                  <ItemGroup>
+                    <FilteredRestoreGraphProjectInputItems Include="@(RestoreGraphProjectInputItems)" />
+                  </ItemGroup>
+                </Target>
+
+                <Target Name="_GetAllRestoreProjectPathItems"
+                        DependsOnTargets="_FilterRestoreGraphProjectInputItems"
+                        Returns="@(_RestoreProjectPathItems)">
+                  <ItemGroup>
+                    <_RestoreProjectPathItems Include="@(FilteredRestoreGraphProjectInputItems)" />
+                  </ItemGroup>
+                </Target>
+
+                <Target Name="_GenerateRestoreGraph"
+                        DependsOnTargets="_FilterRestoreGraphProjectInputItems;_GetAllRestoreProjectPathItems;_GenerateRestoreGraphProjectEntry;_GenerateProjectRestoreGraph"
+                        Returns="@(_RestoreGraphEntry)">
+                  <!-- Output from dependency _GenerateRestoreGraphProjectEntry and _GenerateProjectRestoreGraph -->
+                </Target>
+            </Project>
+            """;
+
+        return (virtualProjectXml, isFileBasedProgram);
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/WorkspaceProjectFactoryService.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/WorkspaceProjectFactoryService.cs
@@ -48,16 +48,16 @@ internal sealed class WorkspaceProjectFactoryService : IWorkspaceProjectFactoryS
         {
             if (creationInfo.BuildSystemProperties.TryGetValue("SolutionPath", out var solutionPath))
             {
-                _workspaceFactory.ProjectSystemProjectFactory.SolutionPath = solutionPath;
+                _workspaceFactory.HostProjectFactory.SolutionPath = solutionPath;
             }
 
-            var project = await _workspaceFactory.ProjectSystemProjectFactory.CreateAndAddToWorkspaceAsync(
+            var project = await _workspaceFactory.HostProjectFactory.CreateAndAddToWorkspaceAsync(
                 creationInfo.DisplayName,
                 creationInfo.Language,
                 new Workspaces.ProjectSystem.ProjectSystemProjectCreationInfo { FilePath = creationInfo.FilePath },
                 _workspaceFactory.ProjectSystemHostInfo);
 
-            var workspaceProject = new WorkspaceProject(project, _workspaceFactory.Workspace.Services.SolutionServices, _workspaceFactory.TargetFrameworkManager, _loggerFactory);
+            var workspaceProject = new WorkspaceProject(project, _workspaceFactory.HostWorkspace.Services.SolutionServices, _workspaceFactory.TargetFrameworkManager, _loggerFactory);
 
             // We've created a new project, so initialize properties we have
             await workspaceProject.SetBuildSystemPropertiesAsync(creationInfo.BuildSystemProperties, CancellationToken.None);

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -832,7 +832,7 @@ internal static partial class ProtocolConversions
         {
             Id = ProjectIdToProjectContextId(project.Id),
             Label = project.Name,
-            IsMiscellaneous = project.Solution.WorkspaceKind == WorkspaceKind.MiscellaneousFiles,
+            IsMiscellaneous = project.Solution.WorkspaceKind == WorkspaceKind.MiscellaneousFiles && !project.State.HasAllInformation,
         };
 
         if (project.Language == LanguageNames.CSharp)

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -832,6 +832,8 @@ internal static partial class ProtocolConversions
         {
             Id = ProjectIdToProjectContextId(project.Id),
             Label = project.Name,
+            // IsMiscellaneous controls whether a toast appears which warns that editor features are not available.
+            // In case HasAllInformation is true, though, we do actually have all information needed to light up any features user is trying to use related to the project.
             IsMiscellaneous = project.Solution.WorkspaceKind == WorkspaceKind.MiscellaneousFiles && !project.State.HasAllInformation,
         };
 

--- a/src/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
@@ -19,4 +19,9 @@ internal static class LanguageServerProjectSystemOptionsStorage
     /// Whether or not automatic nuget restore is enabled.
     /// </summary>
     public static readonly Option2<bool> EnableAutomaticRestore = new Option2<bool>("dotnet_enable_automatic_restore", defaultValue: true, s_optionGroup);
+
+    /// <summary>
+    /// Whether to use the new 'dotnet run app.cs' (file-based programs) experience.
+    /// </summary>
+    public static readonly Option2<bool> EnableFileBasedPrograms = new Option2<bool>("dotnet_enable_file_based_programs", defaultValue: true, s_optionGroup);
 }

--- a/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -58,6 +58,7 @@ internal sealed partial class DidChangeConfigurationNotificationHandler
         LspOptionsStorage.LspEnableAutoInsert,
         LanguageServerProjectSystemOptionsStorage.BinaryLogPath,
         LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore,
+        LanguageServerProjectSystemOptionsStorage.EnableFileBasedPrograms,
         MetadataAsSourceOptionsStorage.NavigateToSourceLinkAndEmbeddedSources,
         LspOptionsStorage.LspOrganizeImportsOnFormat,
     ];

--- a/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
@@ -15,6 +16,10 @@ internal interface ILspMiscellaneousFilesWorkspaceProvider : ILspService
     /// Returns the actual workspace that the documents are added to or removed from.
     /// </summary>
     Workspace Workspace { get; }
-    TextDocument? AddMiscellaneousDocument(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger);
+    /// <summary>
+    /// Adds a document to the workspace. Note that the implementation of this method should not depend on anything expensive such as RPC calls.
+    /// async is used here to allow taking locks asynchronously and "relatively fast" stuff like that.
+    /// </summary>
+    Task<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger);
     void TryRemoveMiscellaneousDocument(DocumentUri uri, bool removeFromMetadataWorkspace);
 }

--- a/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
@@ -21,5 +21,5 @@ internal interface ILspMiscellaneousFilesWorkspaceProvider : ILspService
     /// async is used here to allow taking locks asynchronously and "relatively fast" stuff like that.
     /// </summary>
     Task<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger);
-    void TryRemoveMiscellaneousDocument(DocumentUri uri, bool removeFromMetadataWorkspace);
+    ValueTask TryRemoveMiscellaneousDocumentAsync(DocumentUri uri, bool removeFromMetadataWorkspace);
 }

--- a/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
@@ -20,6 +20,6 @@ internal interface ILspMiscellaneousFilesWorkspaceProvider : ILspService
     /// Adds a document to the workspace. Note that the implementation of this method should not depend on anything expensive such as RPC calls.
     /// async is used here to allow taking locks asynchronously and "relatively fast" stuff like that.
     /// </summary>
-    Task<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger);
+    ValueTask<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger);
     ValueTask TryRemoveMiscellaneousDocumentAsync(DocumentUri uri, bool removeFromMetadataWorkspace);
 }

--- a/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/ILspMiscellaneousFilesWorkspaceProvider.cs
@@ -16,10 +16,18 @@ internal interface ILspMiscellaneousFilesWorkspaceProvider : ILspService
     /// Returns the actual workspace that the documents are added to or removed from.
     /// </summary>
     Workspace Workspace { get; }
+
     /// <summary>
     /// Adds a document to the workspace. Note that the implementation of this method should not depend on anything expensive such as RPC calls.
     /// async is used here to allow taking locks asynchronously and "relatively fast" stuff like that.
     /// </summary>
     ValueTask<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger);
+
+    /// <summary>
+    /// Removes the document with the given <paramref name="uri"/> from the workspace.
+    /// If the workspace already does not contain such a document, does nothing.
+    /// Note that the implementation of this method should not depend on anything expensive such as RPC calls.
+    /// async is used here to allow taking locks asynchronously and "relatively fast" stuff like that.
+    /// </summary>
     ValueTask TryRemoveMiscellaneousDocumentAsync(DocumentUri uri, bool removeFromMetadataWorkspace);
 }

--- a/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
@@ -40,7 +40,10 @@ internal sealed class LspMiscellaneousFilesWorkspaceProvider(ILspServices lspSer
     /// Calls to this method and <see cref="TryRemoveMiscellaneousDocument(DocumentUri, bool)"/> are made
     /// from LSP text sync request handling which do not run concurrently.
     /// </summary>
-    public TextDocument? AddMiscellaneousDocument(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
+    public Task<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
+        => Task.FromResult(AddMiscellaneousDocument(uri, documentText, languageId, logger));
+
+    private TextDocument? AddMiscellaneousDocument(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
     {
         var documentFilePath = uri.UriString;
         if (uri.ParsedUri is not null)

--- a/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
@@ -40,8 +40,8 @@ internal sealed class LspMiscellaneousFilesWorkspaceProvider(ILspServices lspSer
     /// Calls to this method and <see cref="TryRemoveMiscellaneousDocumentAsync(DocumentUri, bool)"/> are made
     /// from LSP text sync request handling which do not run concurrently.
     /// </summary>
-    public Task<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
-        => Task.FromResult(AddMiscellaneousDocument(uri, documentText, languageId, logger));
+    public ValueTask<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
+        => ValueTaskFactory.FromResult(AddMiscellaneousDocument(uri, documentText, languageId, logger));
 
     private TextDocument? AddMiscellaneousDocument(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
     {

--- a/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
@@ -37,7 +37,7 @@ internal sealed class LspMiscellaneousFilesWorkspaceProvider(ILspServices lspSer
     /// <summary>
     /// Takes in a file URI and text and creates a misc project and document for the file.
     /// 
-    /// Calls to this method and <see cref="TryRemoveMiscellaneousDocument(DocumentUri, bool)"/> are made
+    /// Calls to this method and <see cref="TryRemoveMiscellaneousDocumentAsync(DocumentUri, bool)"/> are made
     /// from LSP text sync request handling which do not run concurrently.
     /// </summary>
     public Task<TextDocument?> AddMiscellaneousDocumentAsync(DocumentUri uri, SourceText documentText, string languageId, ILspLogger logger)
@@ -90,11 +90,11 @@ internal sealed class LspMiscellaneousFilesWorkspaceProvider(ILspServices lspSer
     /// Calls to this method and <see cref="AddMiscellaneousDocument(DocumentUri, SourceText, string, ILspLogger)"/> are made
     /// from LSP text sync request handling which do not run concurrently.
     /// </summary>
-    public void TryRemoveMiscellaneousDocument(DocumentUri uri, bool removeFromMetadataWorkspace)
+    public ValueTask TryRemoveMiscellaneousDocumentAsync(DocumentUri uri, bool removeFromMetadataWorkspace)
     {
         if (removeFromMetadataWorkspace && uri.ParsedUri is not null && metadataAsSourceFileService.TryRemoveDocumentFromWorkspace(ProtocolConversions.GetDocumentFilePathFromUri(uri.ParsedUri)))
         {
-            return;
+            return ValueTaskFactory.CompletedTask;
         }
 
         // We'll only ever have a single document matching this URI in the misc solution.
@@ -115,6 +115,8 @@ internal sealed class LspMiscellaneousFilesWorkspaceProvider(ILspServices lspSer
             var project = CurrentSolution.GetRequiredProject(matchingDocument.ProjectId);
             OnProjectRemoved(project.Id);
         }
+
+        return ValueTaskFactory.CompletedTask;
     }
 
     public ValueTask UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText, CancellationToken cancellationToken)

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -153,7 +153,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         _cachedLspSolutions.Clear();
 
         // Also remove it from our loose files or metadata workspace if it is still there.
-        _lspMiscellaneousFilesWorkspaceProvider?.TryRemoveMiscellaneousDocument(uri, removeFromMetadataWorkspace: true);
+        if (_lspMiscellaneousFilesWorkspaceProvider is not null)
+            await _lspMiscellaneousFilesWorkspaceProvider.TryRemoveMiscellaneousDocumentAsync(uri, removeFromMetadataWorkspace: true).ConfigureAwait(false);
 
         LspTextChanged?.Invoke(this, EventArgs.Empty);
 
@@ -254,7 +255,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 if (workspace != _lspMiscellaneousFilesWorkspaceProvider?.Workspace)
                 {
                     // Do not attempt to remove the file from the metadata workspace (the document is still open).
-                    _lspMiscellaneousFilesWorkspaceProvider?.TryRemoveMiscellaneousDocument(uri, removeFromMetadataWorkspace: false);
+                    if (_lspMiscellaneousFilesWorkspaceProvider is not null)
+                        await _lspMiscellaneousFilesWorkspaceProvider.TryRemoveMiscellaneousDocumentAsync(uri, removeFromMetadataWorkspace: false).ConfigureAwait(false);
                 }
 
                 return (workspace, document.Project.Solution, document);

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -159,7 +160,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
             {
                 await _lspMiscellaneousFilesWorkspaceProvider.TryRemoveMiscellaneousDocumentAsync(uri, removeFromMetadataWorkspace: true).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (FatalError.ReportAndCatch(ex))
             {
                 this._logger.LogException(ex);
             }
@@ -263,14 +264,14 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 // if it happens to be in there as well.
                 if (workspace != _lspMiscellaneousFilesWorkspaceProvider?.Workspace)
                 {
-                    // Do not attempt to remove the file from the metadata workspace (the document is still open).
                     if (_lspMiscellaneousFilesWorkspaceProvider is not null)
                     {
                         try
                         {
+                            // Do not attempt to remove the file from the metadata workspace (the document is still open).
                             await _lspMiscellaneousFilesWorkspaceProvider.TryRemoveMiscellaneousDocumentAsync(uri, removeFromMetadataWorkspace: false).ConfigureAwait(false);
                         }
-                        catch (Exception ex)
+                        catch (Exception ex) when (FatalError.ReportAndCatch(ex))
                         {
                             _logger.LogException(ex);
                         }
@@ -296,7 +297,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 if (miscDocument is not null)
                     return (miscDocument.Project.Solution.Workspace, miscDocument.Project.Solution, miscDocument);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (FatalError.ReportAndCatch(ex))
             {
                 _logger.LogException(ex);
             }

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -268,9 +268,9 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
 
         // Add the document to our loose files workspace (if we have one) if it is open.
-        if (_trackedDocuments.TryGetValue(uri, out var trackedDocument))
+        if (_trackedDocuments.TryGetValue(uri, out var trackedDocument) && _lspMiscellaneousFilesWorkspaceProvider is not null)
         {
-            var miscDocument = _lspMiscellaneousFilesWorkspaceProvider?.AddMiscellaneousDocument(uri, trackedDocument.Text, trackedDocument.LanguageId, _logger);
+            var miscDocument = await _lspMiscellaneousFilesWorkspaceProvider.AddMiscellaneousDocumentAsync(uri, trackedDocument.Text, trackedDocument.LanguageId, _logger).ConfigureAwait(false);
             if (miscDocument is not null)
                 return (miscDocument.Project.Solution.Workspace, miscDocument.Project.Solution, miscDocument);
         }

--- a/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -147,6 +147,7 @@ public class A { }";
             "auto_insert.dotnet_enable_auto_insert",
             "projects.dotnet_binary_log_path",
             "projects.dotnet_enable_automatic_restore",
+            "projects.dotnet_enable_file_based_programs",
             "navigation.dotnet_navigate_to_source_link_and_embedded_sources",
             "formatting.dotnet_organize_imports_on_format",
         };

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -236,6 +236,7 @@ public sealed class VisualStudioOptionStorageTests
             "dotnet_style_prefer_foreach_explicit_cast_in_source",                          // For a small customer segment, doesn't warrant VS UI.
             "dotnet_binary_log_path",                                                       // VSCode only option for the VS Code project system; does not apply to VS
             "dotnet_enable_automatic_restore",                                              // VSCode only option for the VS Code project system; does not apply to VS
+            "dotnet_enable_file_based_programs",                                            // VSCode only option for the VS Code project system; does not apply to VS
             "dotnet_lsp_using_devkit",                                                      // VSCode internal only option.  Does not need any UI.
             "dotnet_enable_references_code_lens",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_tests_code_lens",                                                // VSCode only option.  Does not apply to VS.


### PR DESCRIPTION
Replaces #78208

Design doc: https://github.com/rikkigibson/roslyn/blob/file-based-programs-ide/docs/features/file-based-programs-vscode.md

Issues we are punting on:
- language server failing to notify client when project finishes loading?
    - impact of the issue is that colorization doesn't happen when the FBP project finishes loading, until the user scrolls or otherwise triggers a refresh.

See also dotnet/vscode-csharp#8253

Preceding PRs in this area:
- MSBuildHost is updated to allow passing project content along with a file path. (https://github.com/dotnet/roslyn/pull/78303)
- LanguageServerProjectSystem has a base type extracted so that a FileBasedProgramProjectSystem can be added. The latter handles loading file-based program projects, and makes the appropriate call to obtain the file-based program project XML. (https://github.com/dotnet/roslyn/pull/78329)
