### PR TITLE
Fix unreachable code detection for throw statements and blocks

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
@@ -116,7 +116,7 @@ internal sealed class CSharpRemoveUnreachableCodeDiagnosticAnalyzer : AbstractBu
         // fix off of.
         var firstStatementLocation = root.SyntaxTree.GetLocation(firstUnreachableStatement.FullSpan);
 
-        // 'additionalLocations' is how we always pass along the locaiton of the first unreachable
+        // 'additionalLocations' is how we always pass along the location of the first unreachable
         // statement in this group.
         var additionalLocations = ImmutableArray.Create(firstStatementLocation);
 

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/RemoveUnreachableCodeHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/RemoveUnreachableCodeHelpers.cs
@@ -82,16 +82,6 @@ internal static class RemoveUnreachableCodeHelpers
         for (int i = firstUnreachableStatementIndex, n = siblingStatements.Length; i < n; i++)
         {
             var currentStatement = siblingStatements[i];
-            if (currentStatement.IsKind(SyntaxKind.LabeledStatement))
-            {
-                // In the case of a subsequent labeled statement, we don't want to consider it 
-                // unreachable as there may be a 'goto' somewhere else to that label.  If the 
-                // compiler actually thinks that label is unreachable, it will give an diagnostic 
-                // on that label itself  and we can use that diagnostic to handle it and any 
-                // subsequent sections.
-                break;
-            }
-
             if (currentStatement.IsKind(SyntaxKind.LocalFunctionStatement))
             {
                 // In the case of local functions, it is legal for a local function to be declared
@@ -105,6 +95,16 @@ internal static class RemoveUnreachableCodeHelpers
 
             if (i > firstUnreachableStatementIndex)
             {
+                if (currentStatement.IsKind(SyntaxKind.LabeledStatement))
+                {
+                    // In the case of a subsequent labeled statement, we don't want to consider it 
+                    // unreachable as there may be a 'goto' somewhere else to that label.  If the 
+                    // compiler actually thinks that label is unreachable, it will give an diagnostic 
+                    // on that label itself  and we can use that diagnostic to handle it and any 
+                    // subsequent sections.
+                    break;
+                }
+
                 currentSection.Add(currentStatement);
                 continue;
             }

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/RemoveUnreachableCodeHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/RemoveUnreachableCodeHelpers.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.RemoveUnreachableCode;
 
@@ -13,10 +14,23 @@ internal static class RemoveUnreachableCodeHelpers
     public static ImmutableArray<ImmutableArray<StatementSyntax>> GetSubsequentUnreachableSections(StatementSyntax firstUnreachableStatement)
     {
         ImmutableArray<StatementSyntax> siblingStatements;
+        BlockSyntax? unreachableStatementContainingBlock = null;
         switch (firstUnreachableStatement.Parent)
         {
             case BlockSyntax block:
-                siblingStatements = [.. block.Statements];
+                var topmostConsecutiveBlockParent = block;
+                while (true)
+                {
+                    var topmostParent = topmostConsecutiveBlockParent.Parent;
+                    if (!topmostParent.IsKind(SyntaxKind.Block))
+                    {
+                        break;
+                    }
+                    topmostConsecutiveBlockParent = (BlockSyntax)topmostParent;
+                }
+
+                unreachableStatementContainingBlock = topmostConsecutiveBlockParent;
+                siblingStatements = [.. unreachableStatementContainingBlock.Statements];
                 break;
 
             case SwitchSectionSyntax switchSection:
@@ -55,10 +69,17 @@ internal static class RemoveUnreachableCodeHelpers
 
         var sections = ArrayBuilder<ImmutableArray<StatementSyntax>>.GetInstance();
 
-        var currentSection = ArrayBuilder<StatementSyntax>.GetInstance();
-        var firstUnreachableStatementIndex = siblingStatements.IndexOf(firstUnreachableStatement);
+        var firstStatementSpan = firstUnreachableStatement.Span;
 
-        for (int i = firstUnreachableStatementIndex + 1, n = siblingStatements.Length; i < n; i++)
+        var currentSection = ArrayBuilder<StatementSyntax>.GetInstance();
+        var firstUnreachableStatementIndex = siblingStatements.IndexOf(s => s.Span.Contains(firstStatementSpan));
+
+        // Since the first unreachable statement may be contained inside a nested block,
+        // we iterate from the first statement that contains the first unreachable statement,
+        // which could either be the unreachable statement itself, or any of its ancestor blocks.
+        // The unreachable statement itself and all the previous ones will not be included in any
+        // of the sections.
+        for (int i = firstUnreachableStatementIndex, n = siblingStatements.Length; i < n; i++)
         {
             var currentStatement = siblingStatements[i];
             if (currentStatement.IsKind(SyntaxKind.LabeledStatement))
@@ -77,15 +98,58 @@ internal static class RemoveUnreachableCodeHelpers
                 // in code that is otherwise unreachable.  It can still be called elsewhere.  If
                 // the local function itself is not called, there will be a particular diagnostic
                 // for that ("The variable XXX is declared but never used") and the user can choose
-                // if they want to remove it or not. 
+                // if they want to remove it or not.
+                ConsumeCurrentSection();
+                continue;
+            }
+
+            if (i > firstUnreachableStatementIndex)
+            {
+                currentSection.Add(currentStatement);
+                continue;
+            }
+
+            if (currentStatement.IsKind(SyntaxKind.Block))
+            {
+                ProcessBlock((BlockSyntax)currentStatement);
+                continue;
+            }
+
+            void ProcessBlock(BlockSyntax block)
+            {
+                // In the case of raw blocks that are not part of other statements, like if, for, etc.
+                // we want to report all its contained statements as distinct unreachable segments, but
+                // only the statements that come after the first unreachable statement
+                ConsumeCurrentSection();
+
+                foreach (var statement in block.Statements)
+                {
+                    if (statement.IsKind(SyntaxKind.Block))
+                    {
+                        var innerBlock = (BlockSyntax)statement;
+                        if (innerBlock.SpanStart > firstStatementSpan.Start || innerBlock.Span.Contains(firstStatementSpan))
+                        {
+                            ProcessBlock(innerBlock);
+                        }
+                        continue;
+                    }
+
+                    if (statement.SpanStart > firstStatementSpan.Start)
+                    {
+                        currentSection.Add(statement);
+                    }
+                }
+
+                ConsumeCurrentSection();
+            }
+
+            void ConsumeCurrentSection()
+            {
                 var section = currentSection.ToImmutableAndFree();
                 AddIfNonEmpty(sections, section);
 
                 currentSection = ArrayBuilder<StatementSyntax>.GetInstance();
-                continue;
             }
-
-            currentSection.Add(currentStatement);
         }
 
         var lastSection = currentSection.ToImmutableAndFree();

--- a/src/Analyzers/CSharp/Tests/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
@@ -688,8 +688,8 @@ public sealed class RemoveUnreachableCodeTests
                 void M(object o)
                 {
                     if (false)
-                        throw new System.Exception();
-
+            [|            throw new System.Exception();
+            |]
                     throw new System.Exception();
             [|        return;
             |]    }
@@ -701,7 +701,8 @@ public sealed class RemoveUnreachableCodeTests
                 void M(object o)
                 {
                     if (false)
-                        throw new System.Exception();
+                    {
+                    }
 
                     throw new System.Exception();
                 }

--- a/src/Analyzers/CSharp/Tests/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
@@ -1188,4 +1188,152 @@ public sealed class RemoveUnreachableCodeTests
             LanguageVersion = LanguageVersion.CSharp13,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75605")]
+    public async Task Test_ThrowsAndScopesAfterNestedScopedReturn()
+    {
+        var code = """
+            using System;
+
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        {
+                            return a + b;
+                        }
+            [|            throw new InvalidOperationException();
+            |]        }
+            [|
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    {
+                        const int x = 523;
+                        throw new InvalidOperationException();
+                    }
+
+                    {
+                        throw new InvalidOperationException();
+                    }
+            |]
+                }
+            }
+            """;
+        var fixedCode = """
+            using System;
+            
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        {
+                            return a + b;
+                        }
+                    }
+
+                }
+            }
+            """;
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            LanguageVersion = LanguageVersion.CSharp13,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75605")]
+    public async Task Test_ThrowsAndNestedScopesAfterComplexNestedScopedReturn()
+    {
+        var code = """
+            using System;
+
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        if (a == b)
+                        {
+                            const int c = 1;
+                            return a + c;
+                        }
+
+                        if (a > b)
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        var p = a * b;
+                        {
+                            return a + b;
+                        }
+            [|            throw new InvalidOperationException();
+            |]            {
+            [|                const int d = 2;
+            |]                {
+            [|                    throw new InvalidOperationException();
+            |]                }
+                        }
+                    }
+            [|
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    throw new InvalidOperationException();
+
+                    {
+                        const int x = 523;
+                        throw new InvalidOperationException();
+                    }
+
+                    throw new InvalidOperationException();
+            |]
+                }
+            }
+            """;
+        var fixedCode = """
+            using System;
+            
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        if (a == b)
+                        {
+                            const int c = 1;
+                            return a + c;
+                        }
+
+                        if (a > b)
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        var p = a * b;
+                        {
+                            return a + b;
+                        }
+                        {
+                            {
+                            }
+                        }
+                    }
+
+                }
+            }
+            """;
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            LanguageVersion = LanguageVersion.CSharp13,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
@@ -1078,4 +1078,113 @@ public sealed class RemoveUnreachableCodeTests
             LanguageVersion = LanguageVersion.CSharp9,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75605")]
+    public async Task Test_ThrowStatementAfterScopedReturn()
+    {
+        var code = """
+            using System;
+
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        return a + b;
+                    }
+            [|
+                    throw new InvalidOperationException();
+            |][|
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    {
+                        const int x = 523;
+                        throw new InvalidOperationException();
+                    }
+
+                    {
+                        throw new InvalidOperationException();
+                    }
+            |]
+                }
+            }
+            """;
+        var fixedCode = """
+            using System;
+            
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        return a + b;
+                    }
+
+                }
+            }
+            """;
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            LanguageVersion = LanguageVersion.CSharp13,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75605")]
+    public async Task Test_ScopedThrowStatementAfterScopedReturn()
+    {
+        var code = """
+            using System;
+
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        return a + b;
+                    }
+            
+                    {
+            [|            throw new InvalidOperationException();
+            |]        }
+            [|
+                    {
+                        const int x = 523;
+                        throw new InvalidOperationException();
+                    }
+
+                    {
+                        throw new InvalidOperationException();
+                    }
+            |]
+                }
+            }
+            """;
+        var fixedCode = """
+            using System;
+            
+            class C
+            {
+                public static int Add(int a, int b)
+                {
+                    {
+                        return a + b;
+                    }
+            
+                    {
+                    }
+            
+                }
+            }
+            """;
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            LanguageVersion = LanguageVersion.CSharp13,
+        }.RunAsync();
+    }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -243,7 +243,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case BoundKind.NoOpStatement:
                 case BoundKind.Block:
-                case BoundKind.ThrowStatement:
                 case BoundKind.LabeledStatement:
                 case BoundKind.LocalFunctionStatement:
                     base.VisitStatement(statement);

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowDiagnosticTests.cs
@@ -762,7 +762,10 @@ public struct S
     }
 }
 ";
-            CreateCompilation(program).VerifyDiagnostics();
+            CreateCompilation(program).VerifyDiagnostics(
+                // (6,9): warning CS0162: Unreachable code detected
+                //         throw Goo();
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "throw").WithLocation(6, 9));
         }
 
         [WorkItem(542585, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542585")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -19252,6 +19252,82 @@ class Program
                 VerifyDiagnostics(Diagnostic(ErrorCode.WRN_UnreachableCode, @"Console"));
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75605")]
+        public void CS0162WRN_UnreachableCode08_ThrowAfterScopedReturn()
+        {
+            var text = """
+                using System;
+                class Program
+                {
+                    static int Add(int a, int b)
+                    {
+                        {
+                            return a + b;
+                        }
+
+                        throw new InvalidOperationException();
+
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        {
+                            const int x = 523;
+                            throw new InvalidOperationException();
+                        }
+
+                        {
+                            throw new InvalidOperationException();
+                        }
+                    }
+                }
+                """;
+            CreateCompilation(text).VerifyDiagnostics(
+                // (10,9): warning CS0162: Unreachable code detected
+                //         throw new InvalidOperationException();
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "throw").WithLocation(10, 9),
+                // (17,23): warning CS0219: The variable 'x' is assigned but its value is never used
+                //             const int x = 523;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(17, 23));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75605")]
+        public void CS0162WRN_UnreachableCode09_ScopedThrowAfterScopedReturn()
+        {
+            var text = """
+                using System;
+                class Program
+                {
+                    static int Add(int a, int b)
+                    {
+                        {
+                            return a + b;
+                        }
+
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        {
+                            const int x = 523;
+                            throw new InvalidOperationException();
+                        }
+
+                        {
+                            throw new InvalidOperationException();
+                        }
+                    }
+                }
+                """;
+            CreateCompilation(text).VerifyDiagnostics(
+                // (11,13): warning CS0162: Unreachable code detected
+                //             throw new InvalidOperationException();
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "throw").WithLocation(11, 13),
+                // (15,23): warning CS0219: The variable 'x' is assigned but its value is never used
+                //             const int x = 523;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(15, 23));
+        }
+
         [Fact]
         public void CS0164WRN_UnreferencedLabel()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -2126,16 +2126,19 @@ class C
                 // (5,20): warning CS0169: The field 'C._f' is never used
                 //     private object _f;
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(5, 20),
-                // (11,14): warning CS8618: Non-nullable field '_f' is uninitialized. Consider declaring the field as nullable.
+                // (11,14): warning CS8618: Non-nullable field '_f' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
                 //     internal C(object o) { }
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(11, 14),
-                // (13,14): warning CS8618: Non-nullable field '_f' is uninitialized. Consider declaring the field as nullable.
+                // (13,14): warning CS8618: Non-nullable field '_f' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
                 //     internal C(string s)
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(13, 14),
-                // (19,14): warning CS8618: Non-nullable field '_f' is uninitialized. Consider declaring the field as nullable.
+                // (16,9): warning CS0162: Unreachable code detected
+                //         throw new NotImplementedException();
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "throw").WithLocation(16, 9),
+                // (19,14): warning CS8618: Non-nullable field '_f' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
                 //     internal C(int x)
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(19, 14),
-                // (28,14): warning CS8618: Non-nullable field '_f' is uninitialized. Consider declaring the field as nullable.
+                // (28,14): warning CS8618: Non-nullable field '_f' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
                 //     internal C(char c)
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(28, 14));
         }


### PR DESCRIPTION
This includes changes in both the compiler and the IDE areas.

## Compiler

`ControlFlowPass` now checks throw statements for reachability. Tests were added to reflect that change.

## Analyzer + Code Fix

The code fix now accounts for unreachable code reported inside a block statement without a different-kinded statement parent (i.e. not a block of an if, for, etc.). Now the analyzer reports as subsequent unreachable statements the siblings of the outermost block that contains a non-block parent containing the reported first unreachable statement, and not just the siblings of the block that directly contains the first unreachable statement.

To avoid changing the behavior too much, the reported segments are still not unified, even if entire blocks are considered unreachable. This causes the code fix to not clean up empty leftover blocks whose unreachable statements were removed. This behavior can be handled manually in the fixer after cleaning up the blocks' statements, or by avoiding splitting the first unreachable statement and its subsequent.

Tests were added that cover the case in the original issue, and two other cases with more complex block nesting.

CC @CyrusNajmabadi 