### PR TITLE
Extensions: handle extensions in VB SymbolDisplay

### DIFF
--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -239,7 +239,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If symbolName Is Nothing Then
-                symbolName = symbol.Name
+                symbolName = If(symbol.IsExtension, symbol.MetadataName, symbol.Name)
             End If
 
             If Format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName) AndAlso
@@ -252,7 +252,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Select Case symbol.TypeKind
                 Case TypeKind.Class,
-                     TypeKind.Submission
+                     TypeKind.Submission,
+                     TypeKind.Extension
                     partKind = SymbolDisplayPartKind.ClassName
                 Case TypeKind.Delegate
                     partKind = SymbolDisplayPartKind.DelegateName

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
@@ -6062,7 +6062,7 @@ static class E
             Dim comp As Compilation
             If useMetadata Then
                 Dim libComp = CreateCSharpCompilation("c", text, parseOptions:=parseOptions)
-                comp = CreateCompilation("", references:={libComp.EmitToImageReference()})
+                comp = CreateCSharpCompilation("d", code:="", parseOptions:=parseOptions, referencedAssemblies:={libComp.EmitToImageReference()})
             Else
                 comp = CreateCSharpCompilation("c", text, parseOptions:=parseOptions)
             End If
@@ -6081,7 +6081,7 @@ static class E
 
             Dim skeletonM = extension.GetMembers("M").Single()
             If useMetadata Then
-                Assert.Equal("Public Overloads Sub E.<>E__0.M()", SymbolDisplay.ToDisplayString(skeletonM, format))
+                Assert.Equal("Public Sub E.<>E__0.M()", SymbolDisplay.ToDisplayString(skeletonM, format))
             Else
                 Assert.Equal("Public Sub E.<>E__0.M()", SymbolDisplay.ToDisplayString(skeletonM, format))
             End If
@@ -6120,7 +6120,7 @@ static class E
             Dim comp As Compilation
             If useMetadata Then
                 Dim libComp = CreateCSharpCompilation("c", text, parseOptions:=parseOptions)
-                comp = CreateCompilation("", references:={libComp.EmitToImageReference()})
+                comp = CreateCSharpCompilation("d", code:="", parseOptions:=parseOptions, referencedAssemblies:={libComp.EmitToImageReference()})
             Else
                 comp = CreateCSharpCompilation("c", text, parseOptions:=parseOptions)
             End If
@@ -6129,43 +6129,22 @@ static class E
             Dim extension = e.GetMembers().OfType(Of ITypeSymbol).Single()
 
             ' Tracked by https://github.com/dotnet/roslyn/issues/76130 : the arity should not be included in the extension type name
-            If useMetadata Then
-                Assert.Equal("E.<>E__0(Of T)", SymbolDisplay.ToDisplayString(extension, format))
-            Else
-                Assert.Equal("E.<>E__0`1(Of T)", SymbolDisplay.ToDisplayString(extension, format))
-            End If
+            Assert.Equal("E.<>E__0`1(Of T)", SymbolDisplay.ToDisplayString(extension, format))
 
             Dim parts = SymbolDisplay.ToDisplayParts(extension, format)
-            If useMetadata Then
-                Verify(parts,
-                       "E.<>E__0(Of T)",
-                       SymbolDisplayPartKind.ClassName,
-                       SymbolDisplayPartKind.Operator,
-                       SymbolDisplayPartKind.ClassName,
-                       SymbolDisplayPartKind.Punctuation,
-                       SymbolDisplayPartKind.Keyword,
-                       SymbolDisplayPartKind.Space,
-                       SymbolDisplayPartKind.TypeParameterName,
-                       SymbolDisplayPartKind.Punctuation)
-            Else
-                Verify(parts,
-                       "E.<>E__0`1(Of T)",
-                       SymbolDisplayPartKind.ClassName,
-                       SymbolDisplayPartKind.Operator,
-                       SymbolDisplayPartKind.ClassName,
-                       SymbolDisplayPartKind.Punctuation,
-                       SymbolDisplayPartKind.Keyword,
-                       SymbolDisplayPartKind.Space,
-                       SymbolDisplayPartKind.TypeParameterName,
-                       SymbolDisplayPartKind.Punctuation)
-            End If
+            Verify(parts,
+               "E.<>E__0`1(Of T)",
+               SymbolDisplayPartKind.ClassName,
+               SymbolDisplayPartKind.Operator,
+               SymbolDisplayPartKind.ClassName,
+               SymbolDisplayPartKind.Punctuation,
+               SymbolDisplayPartKind.Keyword,
+               SymbolDisplayPartKind.Space,
+               SymbolDisplayPartKind.TypeParameterName,
+               SymbolDisplayPartKind.Punctuation)
 
             Dim skeletonM = extension.GetMembers("M").Single()
-            If useMetadata Then
-                Assert.Equal("Public Overloads Sub E.<>E__0(Of T).M()", SymbolDisplay.ToDisplayString(skeletonM, format))
-            Else
-                Assert.Equal("Public Sub E.<>E__0`1(Of T).M()", SymbolDisplay.ToDisplayString(skeletonM, format))
-            End If
+            Assert.Equal("Public Sub E.<>E__0`1(Of T).M()", SymbolDisplay.ToDisplayString(skeletonM, format))
         End Sub
 
 #Region "Helpers"

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
@@ -5898,7 +5898,7 @@ class Program
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword)
-        End sub
+        End Sub
 
         <Fact>
         Public Sub UseLongHandValueTuple()
@@ -6030,6 +6030,103 @@ end class"
             Assert.Equal(
                 expected:=expectedDisplayParts,
                 actual:=displayParts)
+        End Sub
+
+        <Fact>
+        Public Sub TestExtensionBlockCSharp_01()
+            Dim text =
+<text>
+static class E
+{
+    extension(object o)
+    {
+        public void M() { }
+    }
+}
+</text>.Value
+
+            Dim format = New SymbolDisplayFormat(
+                                typeQualificationStyle:=SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                                memberOptions:=SymbolDisplayMemberOptions.IncludeParameters Or
+                                               SymbolDisplayMemberOptions.IncludeModifiers Or
+                                               SymbolDisplayMemberOptions.IncludeAccessibility Or
+                                               SymbolDisplayMemberOptions.IncludeType Or
+                                               SymbolDisplayMemberOptions.IncludeContainingType,
+                                kindOptions:=SymbolDisplayKindOptions.IncludeMemberKeyword,
+                                parameterOptions:=SymbolDisplayParameterOptions.IncludeType Or
+                                                  SymbolDisplayParameterOptions.IncludeName Or
+                                                  SymbolDisplayParameterOptions.IncludeDefaultValue,
+                                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
+
+            Dim parseOptions = CSharp.CSharpParseOptions.Default.WithLanguageVersion(CSharp.LanguageVersion.Preview)
+            Dim comp = CreateCSharpCompilation("c", text, parseOptions:=parseOptions)
+            Dim e = DirectCast(comp.GlobalNamespace.GetMembers("E").Single(), ITypeSymbol)
+            Dim extension = e.GetMembers().OfType(Of ITypeSymbol).Single()
+
+            Assert.Equal("E.<>E__0", SymbolDisplay.ToDisplayString(extension, format))
+
+            Dim parts = SymbolDisplay.ToDisplayParts(extension, format)
+            Verify(parts,
+                   "E.<>E__0",
+                   SymbolDisplayPartKind.ClassName,
+                   SymbolDisplayPartKind.Operator,
+                   SymbolDisplayPartKind.ClassName)
+
+            Dim skeletonM = extension.GetMembers("M").Single()
+            Assert.Equal("Public Sub E.<>E__0.M()", SymbolDisplay.ToDisplayString(skeletonM, format))
+        End Sub
+
+        <Fact>
+        Public Sub TestExtensionBlockCSharp_02()
+            Dim text =
+<text>
+    <![CDATA[
+static class E
+{
+    extension<T>(T t)
+    {
+        public void M() { }
+    }
+}
+    ]]>
+</text>.Value
+
+            Dim format = New SymbolDisplayFormat(
+                                typeQualificationStyle:=SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                                memberOptions:=SymbolDisplayMemberOptions.IncludeParameters Or
+                                               SymbolDisplayMemberOptions.IncludeModifiers Or
+                                               SymbolDisplayMemberOptions.IncludeAccessibility Or
+                                               SymbolDisplayMemberOptions.IncludeType Or
+                                               SymbolDisplayMemberOptions.IncludeContainingType,
+                                kindOptions:=SymbolDisplayKindOptions.IncludeMemberKeyword,
+                                genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                                parameterOptions:=SymbolDisplayParameterOptions.IncludeType Or
+                                                  SymbolDisplayParameterOptions.IncludeName Or
+                                                  SymbolDisplayParameterOptions.IncludeDefaultValue,
+                                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
+
+            Dim parseOptions = CSharp.CSharpParseOptions.Default.WithLanguageVersion(CSharp.LanguageVersion.Preview)
+            Dim comp = CreateCSharpCompilation("c", text, parseOptions:=parseOptions)
+            Dim e = DirectCast(comp.GlobalNamespace.GetMembers("E").Single(), ITypeSymbol)
+            Dim extension = e.GetMembers().OfType(Of ITypeSymbol).Single()
+
+            ' Tracked by https://github.com/dotnet/roslyn/issues/76130 : the arity should not be included in the extension type name
+            Assert.Equal("E.<>E__0`1(Of T)", SymbolDisplay.ToDisplayString(extension, format))
+
+            Dim parts = SymbolDisplay.ToDisplayParts(extension, format)
+            Verify(parts,
+                   "E.<>E__0`1(Of T)",
+                   SymbolDisplayPartKind.ClassName,
+                   SymbolDisplayPartKind.Operator,
+                   SymbolDisplayPartKind.ClassName,
+                   SymbolDisplayPartKind.Punctuation,
+                   SymbolDisplayPartKind.Keyword,
+                   SymbolDisplayPartKind.Space,
+                   SymbolDisplayPartKind.TypeParameterName,
+                   SymbolDisplayPartKind.Punctuation)
+
+            Dim skeletonM = extension.GetMembers("M").Single()
+            Assert.Equal("Public Sub E.<>E__0`1(Of T).M()", SymbolDisplay.ToDisplayString(skeletonM, format))
         End Sub
 
 #Region "Helpers"

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
@@ -6080,11 +6080,7 @@ static class E
                    SymbolDisplayPartKind.ClassName)
 
             Dim skeletonM = extension.GetMembers("M").Single()
-            If useMetadata Then
-                Assert.Equal("Public Sub E.<>E__0.M()", SymbolDisplay.ToDisplayString(skeletonM, format))
-            Else
-                Assert.Equal("Public Sub E.<>E__0.M()", SymbolDisplay.ToDisplayString(skeletonM, format))
-            End If
+            Assert.Equal("Public Sub E.<>E__0.M()", SymbolDisplay.ToDisplayString(skeletonM, format))
         End Sub
 
         <Theory, CombinatorialData>


### PR DESCRIPTION
This is not a complete solution (there's a follow-up comment) but avoids crashing.

Relates to test plan https://github.com/dotnet/roslyn/issues/76130