### PR TITLE
Fix go to definition for conversions on invalid constructor overloads

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1918,7 +1918,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 OneOrMany<Symbol> highestSymbols = GetSemanticSymbols(
                     highestBoundExpr, boundNodeForSyntacticParent, binderOpt, options, out highestIsDynamic, out highestResultKind, out unusedHighestMemberGroup);
 
-                if ((symbols.Count != 1 || resultKind == LookupResultKind.OverloadResolutionFailure) && highestSymbols.Count > 0)
+                if ((symbols.Count != 1 || resultKind == LookupResultKind.OverloadResolutionFailure) && highestSymbols.Count > 0
+                    && highestBoundExpr.Kind != BoundKind.Conversion)
                 {
                     symbols = highestSymbols;
                     resultKind = highestResultKind;

--- a/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
@@ -4530,5 +4530,121 @@ public partial class Program
 
             Await TestAsync(workspace)
         End Function
+
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77545")>
+        <WpfFact>
+        Public Async Function TestCSharpGoToConstructorWithMismatchingArguments_ImplicitConversion() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="preview">
+        <Document>
+            record [|R|](int I);
+
+            class C
+            {
+                public C Repro()
+                {
+                    M(new $$R(1u));
+                    return new R(1u);
+                }
+
+                public static void M(C c) { }
+                public static implicit operator C(R r) => throw null;
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77545")>
+        <WpfFact>
+        Public Async Function TestCSharpGoToConstructorWithMismatchingArguments_ExplicitConversion() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="preview">
+        <Document>
+            record [|R|](int I);
+
+            class C
+            {
+                public C Repro()
+                {
+                    M((C)new $$R(1u));
+                    return new (C)R(1u);
+                }
+
+                public static void M(C c) { }
+                public static explicit operator C(R r) => throw null;
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WorkItem("https://github.com/dotnet/roslyn/issues/73498")>
+        <WpfFact>
+        Public Async Function TestCSharpGoToClassMissingConstructor_ImplicitConversion() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="preview">
+        <Document>
+            public abstract class BaseThing;
+            public sealed class [|DerivedThing|] : BaseThing;
+
+            public struct Convertible
+            {
+                public static implicit operator Convertible(BaseThing thing) => new();
+            }
+
+            class C
+            {
+                void UseConvertible(Convertible convertible) { }
+
+                void CreateUseConvertible()
+                {
+                    UseConvertible(new $$DerivedThing(1, 2));
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WorkItem("https://github.com/dotnet/roslyn/issues/73498")>
+        <WpfFact>
+        Public Async Function TestCSharpGoToClassMissingConstructor_ExplicitConversion() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="preview">
+        <Document>
+            public abstract class BaseThing;
+            public sealed class [|DerivedThing|] : BaseThing;
+
+            public struct Convertible
+            {
+                public static explicit operator Convertible(BaseThing thing) => new();
+            }
+
+            class C
+            {
+                void UseConvertible(Convertible convertible) { }
+
+                void CreateUseConvertible()
+                {
+                    UseConvertible((Convertible)new $$DerivedThing(1, 2));
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Closes #73498
Closes #77545

This also adds tests for explicit conversions on object creation expressions.