### PR TITLE
Hot Reload: Handle document deletes

### DIFF
--- a/src/Compilers/Test/Core/FX/EncodingUtilities.cs
+++ b/src/Compilers/Test/Core/FX/EncodingUtilities.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Text;
 
 namespace Roslyn.Test.Utilities

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -179,22 +179,6 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
     protected override bool AreHandledEventsEqual(IMethodSymbol oldMethod, IMethodSymbol newMethod)
         => true;
 
-    protected override IEnumerable<SyntaxNode> GetVariableUseSites(IEnumerable<SyntaxNode> roots, ISymbol localOrParameter, SemanticModel model, CancellationToken cancellationToken)
-    {
-        Debug.Assert(localOrParameter is IParameterSymbol or ILocalSymbol or IRangeVariableSymbol);
-
-        // not supported (it's non trivial to find all places where "this" is used):
-        Debug.Assert(!localOrParameter.IsThisParameter());
-
-        return from root in roots
-               from node in root.DescendantNodesAndSelf()
-               where node.IsKind(SyntaxKind.IdentifierName)
-               let nameSyntax = (IdentifierNameSyntax)node
-               where (string?)nameSyntax.Identifier.Value == localOrParameter.Name &&
-                     (model.GetSymbolInfo(nameSyntax, cancellationToken).Symbol?.Equals(localOrParameter) ?? false)
-               select node;
-    }
-
     internal static SyntaxNode FindStatementAndPartner(
         TextSpan span,
         SyntaxNode body,
@@ -1042,8 +1026,8 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
         EditKind editKind,
         SyntaxNode? oldNode,
         SyntaxNode? newNode,
-        SemanticModel? oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         CancellationToken cancellationToken)
     {
         // Chnage in type of a field affects all its variable declarations.
@@ -1060,21 +1044,19 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
 
         OneOrMany<(ISymbol? oldSymbol, ISymbol? newSymbol)> AddFieldSymbolUpdates(SeparatedSyntaxList<VariableDeclaratorSyntax> oldVariables, SeparatedSyntaxList<VariableDeclaratorSyntax> newVariables)
         {
-            Debug.Assert(oldModel != null);
-
             if (oldVariables.Count == 1 && newVariables.Count == 1)
             {
-                return OneOrMany.Create((GetDeclaredSymbol(oldModel, oldVariables[0], cancellationToken), GetDeclaredSymbol(newModel, newVariables[0], cancellationToken)));
+                return OneOrMany.Create((GetDeclaredSymbol(oldModel.RequiredModel, oldVariables[0], cancellationToken), GetDeclaredSymbol(newModel.RequiredModel, newVariables[0], cancellationToken)));
             }
 
             return OneOrMany.Create(
                 (from oldVariable in oldVariables
                  join newVariable in newVariables on oldVariable.Identifier.Text equals newVariable.Identifier.Text
-                 select (GetDeclaredSymbol(oldModel, oldVariable, cancellationToken), GetDeclaredSymbol(newModel, newVariable, cancellationToken))).ToImmutableArray());
+                 select (GetDeclaredSymbol(oldModel.RequiredModel, oldVariable, cancellationToken), GetDeclaredSymbol(newModel.RequiredModel, newVariable, cancellationToken))).ToImmutableArray());
         }
 
-        var oldSymbol = (oldNode != null) ? GetSymbolForEdit(oldNode, oldModel!, cancellationToken) : null;
-        var newSymbol = (newNode != null) ? GetSymbolForEdit(newNode, newModel, cancellationToken) : null;
+        var oldSymbol = (oldNode != null) ? GetSymbolForEdit(oldNode, oldModel.RequiredModel, cancellationToken) : null;
+        var newSymbol = (newNode != null) ? GetSymbolForEdit(newNode, newModel.RequiredModel, cancellationToken) : null;
 
         return (oldSymbol == null && newSymbol == null)
             ? OneOrMany<(ISymbol?, ISymbol?)>.Empty
@@ -1088,8 +1070,8 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
         ISymbol? oldSymbol,
         SyntaxNode? newNode,
         ISymbol? newSymbol,
-        SemanticModel? oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         Match<SyntaxNode> topMatch,
         IReadOnlyDictionary<SyntaxNode, EditKind> editMap,
         SymbolInfoCache symbolCache,
@@ -1101,7 +1083,7 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
             var oldContainingMemberOrType = GetParameterContainingMemberOrType(oldNode, newNode, oldModel, topMatch.ReverseMatches, cancellationToken);
             var newContainingMemberOrType = GetParameterContainingMemberOrType(newNode, oldNode, newModel, topMatch.Matches, cancellationToken);
 
-            var matchingNewContainingMemberOrType = GetSemanticallyMatchingNewSymbol(oldContainingMemberOrType, newContainingMemberOrType, newModel, symbolCache, cancellationToken);
+            var matchingNewContainingMemberOrType = GetSemanticallyMatchingNewSymbol(oldContainingMemberOrType, newContainingMemberOrType, newModel.Compilation, symbolCache, cancellationToken);
 
             // Create candidate symbol edits to analyze:
             // 1) An update of the containing member or type
@@ -1189,7 +1171,6 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
             case EditKind.Update:
                 Contract.ThrowIfNull(oldNode);
                 Contract.ThrowIfNull(newNode);
-                Contract.ThrowIfNull(oldModel);
 
                 // Updates of a property/indexer/event node might affect its accessors.
                 // Return all affected symbols for these updates so that the changes in the accessor bodies get analyzed.
@@ -1372,7 +1353,6 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
             case EditKind.Move:
                 Contract.ThrowIfNull(oldNode);
                 Contract.ThrowIfNull(newNode);
-                Contract.ThrowIfNull(oldModel);
 
                 Debug.Assert(oldNode.RawKind == newNode.RawKind);
                 Debug.Assert(SupportsMove(oldNode));
@@ -1432,7 +1412,7 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
         return GetDeclaredSymbol(model, node, cancellationToken);
     }
 
-    private ISymbol? GetParameterContainingMemberOrType(SyntaxNode? node, SyntaxNode? otherNode, SemanticModel? model, IReadOnlyDictionary<SyntaxNode, SyntaxNode> fromOtherMap, CancellationToken cancellationToken)
+    private ISymbol? GetParameterContainingMemberOrType(SyntaxNode? node, SyntaxNode? otherNode, DocumentSemanticModel model, IReadOnlyDictionary<SyntaxNode, SyntaxNode> fromOtherMap, CancellationToken cancellationToken)
     {
         Debug.Assert(node is null or ParameterSyntax or TypeParameterSyntax or TypeParameterConstraintClauseSyntax);
 
@@ -1457,7 +1437,7 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
             declaration = declaration.Parent;
         }
 
-        return (declaration != null) ? GetDeclaredSymbol(model!, declaration, cancellationToken) : null;
+        return (declaration != null) ? GetDeclaredSymbol(model.RequiredModel, declaration, cancellationToken) : null;
 
         static SyntaxNode GetContainingDeclaration(SyntaxNode node)
             => node is TypeParameterSyntax ? node.Parent!.Parent! : node!.Parent!;
@@ -2857,10 +2837,10 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
         IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseMap,
         SyntaxNode oldActiveStatement,
         DeclarationBody oldBody,
-        SemanticModel oldModel,
+        DocumentSemanticModel oldModel,
         SyntaxNode newActiveStatement,
         DeclarationBody newBody,
-        SemanticModel newModel,
+        DocumentSemanticModel newModel,
         bool isNonLeaf,
         CancellationToken cancellationToken)
     {
@@ -2991,10 +2971,10 @@ internal sealed class CSharpEditAndContinueAnalyzer() : AbstractEditAndContinueA
         IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseMap,
         SyntaxNode oldActiveStatement,
         SyntaxNode oldEncompassingAncestor,
-        SemanticModel oldModel,
+        DocumentSemanticModel oldModel,
         SyntaxNode newActiveStatement,
         SyntaxNode newEncompassingAncestor,
-        SemanticModel newModel,
+        DocumentSemanticModel newModel,
         CancellationToken cancellationToken)
     {
         // Rude Edits for fixed/using/lock/foreach statements that are added/updated around an active statement.

--- a/src/Features/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -37,13 +37,9 @@ public sealed class CSharpEditAndContinueAnalyzerTests
         => new(composition: s_composition);
 
     private static Solution AddDefaultTestProject(Solution solution, string source)
-    {
-        var projectId = ProjectId.CreateNewId();
-
-        return solution.
-            AddProject(ProjectInfo.Create(projectId, VersionStamp.Create(), "proj", "proj", LanguageNames.CSharp)).GetProject(projectId).
-            AddDocument("test.cs", SourceText.From(source, Encoding.UTF8), filePath: Path.Combine(TempRoot.Root, "test.cs")).Project.Solution;
-    }
+        => solution.
+            AddTestProject("proj", LanguageNames.CSharp).
+            AddTestDocument(source, path: Path.Combine(TempRoot.Root, "test.cs")).Project.Solution;
 
     private static void TestSpans(string source, Func<SyntaxNode, bool> hasLabel)
     {
@@ -126,7 +122,7 @@ public sealed class CSharpEditAndContinueAnalyzerTests
         var baseActiveStatements = AsyncLazy.Create(activeStatementMap ?? ActiveStatementsMap.Empty);
         var lazyCapabilities = AsyncLazy.Create(capabilities);
         var log = new TraceLog("Test");
-        return await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, newActiveStatementSpans.NullToEmpty(), lazyCapabilities, log, CancellationToken.None);
+        return await analyzer.AnalyzeDocumentAsync(newDocument.Id, oldProject, newDocument.Project, baseActiveStatements, newActiveStatementSpans.NullToEmpty(), lazyCapabilities, log, CancellationToken.None);
     }
 
     #endregion
@@ -455,14 +451,12 @@ class C
 ";
         var experimentalFeatures = new Dictionary<string, string>(); // no experimental features to enable
         var experimental = TestOptions.Regular.WithFeatures(experimentalFeatures);
-        var root = SyntaxFactory.ParseCompilationUnit(source, options: experimental);
 
         using var workspace = CreateWorkspace();
 
-        var projectId = ProjectId.CreateNewId();
         var oldSolution = workspace.CurrentSolution.
-            AddProject(ProjectInfo.Create(projectId, VersionStamp.Create(), "proj", "proj", LanguageNames.CSharp)).GetProject(projectId).
-            AddDocument("test.cs", root, filePath: Path.Combine(TempRoot.Root, "test.cs")).Project.Solution;
+            AddTestProject("proj", LanguageNames.CSharp).WithParseOptions(experimental).
+            AddTestDocument(source, path: Path.Combine(TempRoot.Root, "test.cs")).Project.Solution;
 
         var oldProject = oldSolution.Projects.Single();
         var oldDocument = oldProject.Documents.Single();
@@ -760,7 +754,7 @@ class D
         };
 
         var log = new TraceLog("Test");
-        var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, [], capabilities, log, CancellationToken.None);
+        var result = await analyzer.AnalyzeDocumentAsync(newDocument.Id, oldProject, newDocument.Project, baseActiveStatements, [], capabilities, log, CancellationToken.None);
 
         var expectedDiagnostic = outOfMemory
             ? $"ENC0089: {string.Format(FeaturesResources.Modifying_source_file_0_requires_restarting_the_application_because_the_file_is_too_big, filePath)}"

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.ActiveMembersBuilder.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.ActiveMembersBuilder.cs
@@ -18,7 +18,7 @@ internal partial class AbstractEditAndContinueAnalyzer
     /// Constructor to which field/property initializers are emitted is active if its body or any of the field/property initializers has an active statement outside of a lambda.
     /// Fields and properties with initializers are considered active if any of the constructors that these initializers are emitted to are active.
     /// </summary>
-    private readonly struct ActiveMembersBuilder(AbstractEditAndContinueAnalyzer analyzer, SemanticModel? oldModel, SemanticModel newModel, CancellationToken cancellationToken) : IDisposable
+    private readonly struct ActiveMembersBuilder(AbstractEditAndContinueAnalyzer analyzer, DocumentSemanticModel oldModel, DocumentSemanticModel newModel, CancellationToken cancellationToken) : IDisposable
     {
         private readonly PooledHashSet<IMethodSymbol> _methods = PooledHashSet<IMethodSymbol>.GetInstance();
         private readonly PooledDictionary<SyntaxNode, SyntaxNode> _declarations = PooledDictionary<SyntaxNode, SyntaxNode>.GetInstance();

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -188,8 +188,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         ISymbol? oldSymbol,
         SyntaxNode? newNode,
         ISymbol? newSymbol,
-        SemanticModel? oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         Match<SyntaxNode> topMatch,
         IReadOnlyDictionary<SyntaxNode, EditKind> editMap,
         SymbolInfoCache symbolCache,
@@ -202,16 +202,16 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         EditKind editKind,
         SyntaxNode? oldNode,
         SyntaxNode? newNode,
-        SemanticModel? oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         CancellationToken cancellationToken);
 
     private OneOrMany<(ISymbol? oldSymbol, ISymbol? newSymbol, EditKind editKind)> GetSymbolEdits(
         EditKind editKind,
         SyntaxNode? oldNode,
         SyntaxNode? newNode,
-        SemanticModel? oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         Match<SyntaxNode> topMatch,
         IReadOnlyDictionary<SyntaxNode, EditKind> editMap,
         SymbolInfoCache symbolCache,
@@ -222,7 +222,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         var symbols = GetEditedSymbols(editKind, oldNode, newNode, oldModel, newModel, cancellationToken);
         foreach (var (oldSymbol, newSymbol) in symbols)
         {
-            Debug.Assert(oldSymbol != null || newSymbol != null);
+            Contract.ThrowIfFalse(oldSymbol != null || newSymbol != null);
 
             // Top-level members may be matched by syntax even when their name and signature are different.
             // An update edit is created for these matches that usually produces an insert + delete semantic edits.
@@ -233,7 +233,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             // Instead, a simple semantic update (or no edit at all if the body has not changed, other then trivia that can be expressed as a line delta) should be created.
             // When we detect this case we break the original update edit into two edits: delete and insert.
             // The logic in the analyzer then consolidates these edits into updates across partial type declarations if applicable.
-            if (editKind == EditKind.Update && GetSemanticallyMatchingNewSymbol(oldSymbol, newSymbol, newModel, symbolCache, cancellationToken) != null)
+            if (editKind == EditKind.Update && GetSemanticallyMatchingNewSymbol(oldSymbol, newSymbol, newModel.Compilation, symbolCache, cancellationToken) != null)
             {
                 AddSymbolEdits(ref result, EditKind.Delete, oldNode, oldSymbol, newNode: null, newSymbol: null, oldModel, newModel, topMatch, editMap, symbolCache, cancellationToken);
                 AddSymbolEdits(ref result, EditKind.Insert, oldNode: null, oldSymbol: null, newNode, newSymbol, oldModel, newModel, topMatch, editMap, symbolCache, cancellationToken);
@@ -251,11 +251,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             _ => OneOrMany.Create(result.ToImmutableAndClear())
         };
     }
-
-    /// <summary>
-    /// Enumerates all use sites of a specified variable within the specified syntax subtrees.
-    /// </summary>
-    protected abstract IEnumerable<SyntaxNode> GetVariableUseSites(IEnumerable<SyntaxNode> roots, ISymbol localOrParameter, SemanticModel model, CancellationToken cancellationToken);
 
     protected abstract bool AreHandledEventsEqual(IMethodSymbol oldMethod, IMethodSymbol newMethod);
 
@@ -420,10 +415,10 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         IReadOnlyDictionary<SyntaxNode, SyntaxNode> forwardMap,
         SyntaxNode oldActiveStatement,
         DeclarationBody oldBody,
-        SemanticModel oldModel,
+        DocumentSemanticModel oldModel,
         SyntaxNode newActiveStatement,
         DeclarationBody newBody,
-        SemanticModel newModel,
+        DocumentSemanticModel newModel,
         bool isNonLeaf,
         CancellationToken cancellationToken);
 
@@ -507,58 +502,53 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
     #region Document Analysis 
 
     public async Task<DocumentAnalysisResults> AnalyzeDocumentAsync(
+        DocumentId documentId,
         Project oldProject,
+        Project newProject,
         AsyncLazy<ActiveStatementsMap> lazyOldActiveStatementMap,
-        Document newDocument,
         ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         AsyncLazy<EditAndContinueCapabilities> lazyCapabilities,
         TraceLog log,
         CancellationToken cancellationToken)
     {
-        var filePath = newDocument.FilePath;
-
-        Debug.Assert(newDocument.State.SupportsEditAndContinue());
-        Debug.Assert(!newActiveStatementSpans.IsDefault);
-        Debug.Assert(newDocument.SupportsSyntaxTree);
-        Debug.Assert(newDocument.SupportsSemanticModel);
-        Debug.Assert(filePath != null);
+        Contract.ThrowIfFalse(oldProject.SupportsEditAndContinue());
+        Contract.ThrowIfFalse(newProject.SupportsEditAndContinue());
+        Contract.ThrowIfTrue(newActiveStatementSpans.IsDefault);
 
         // assume changes until we determine there are none so that EnC is blocked on unexpected exception:
         var hasChanges = true;
         var analysisStopwatch = SharedStopwatch.StartNew();
 
+        var (oldDocument, oldText) = await GetDocumentContentAsync(oldProject, documentId, cancellationToken).ConfigureAwait(false);
+        var (newDocument, newText) = await GetDocumentContentAsync(newProject, documentId, cancellationToken).ConfigureAwait(false);
+
+        var filePath = newDocument?.FilePath ?? oldDocument!.FilePath;
+        Contract.ThrowIfNull(filePath);
+
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            SyntaxTree? oldTree;
-            SyntaxNode oldRoot;
-            SourceText oldText;
+            Contract.ThrowIfFalse(newDocument == null || newDocument.State.SupportsEditAndContinue());
+            Contract.ThrowIfFalse(oldDocument == null || oldDocument.State.SupportsEditAndContinue());
+            Contract.ThrowIfFalse(oldDocument != null || newDocument != null);
 
-            var oldDocument = await oldProject.GetDocumentAsync(newDocument.Id, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
-            if (oldDocument != null)
-            {
-                oldTree = await oldDocument.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                oldRoot = await oldTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-                oldText = await oldDocument.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                oldTree = null;
-                oldRoot = EmptyCompilationUnit;
-                oldText = s_emptySource;
-            }
-
-            var newTree = await newDocument.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            Contract.ThrowIfNull(newTree);
-
-            // Changes in parse options might change the meaning of the code even if nothing else changed.
-            // The IDE should disallow changing the options during debugging session. 
-            Debug.Assert(oldTree == null || oldTree.Options.Equals(newTree.Options));
-
-            var newRoot = await newTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-            var newText = await newDocument.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
             hasChanges = !oldText.ContentEquals(newText);
+
+            if (!hasChanges)
+            {
+                // The document might have been closed and reopened, which might have triggered analysis. 
+                // If the document is unchanged don't continue the analysis since 
+                // a) comparing texts is cheaper than diffing trees
+                // b) we need to ignore errors in unchanged documents
+
+                log.Write($"Document unchanged: '{filePath}'");
+                return DocumentAnalysisResults.Unchanged(documentId, filePath, analysisStopwatch.Elapsed);
+            }
+
+            var (oldRoot, newRoot) = await GetSyntaxRootsAsync(oldDocument, newDocument, cancellationToken).ConfigureAwait(false);
+            var oldTree = oldRoot.SyntaxTree;
+            var newTree = newRoot.SyntaxTree;
 
             _testFaultInjector?.Invoke(newRoot);
             cancellationToken.ThrowIfCancellationRequested();
@@ -571,18 +561,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                 // Bail, since we can't do syntax diffing on broken trees (it would not produce useful results anyways).
                 // If we needed to do so for some reason, we'd need to harden the syntax tree comparers.
                 log.Write($"Syntax errors found in '{filePath}'");
-                return DocumentAnalysisResults.SyntaxErrors(newDocument.Id, filePath, [], syntaxError, analysisStopwatch.Elapsed, hasChanges);
-            }
-
-            if (!hasChanges)
-            {
-                // The document might have been closed and reopened, which might have triggered analysis. 
-                // If the document is unchanged don't continue the analysis since 
-                // a) comparing texts is cheaper than diffing trees
-                // b) we need to ignore errors in unchanged documents
-
-                log.Write($"Document unchanged: '{filePath}'");
-                return DocumentAnalysisResults.Unchanged(newDocument.Id, filePath, analysisStopwatch.Elapsed);
+                return DocumentAnalysisResults.SyntaxErrors(documentId, filePath, [], syntaxError, analysisStopwatch.Elapsed, hasChanges);
             }
 
             // Disallow modification of a file with experimental features enabled.
@@ -590,7 +569,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             if (ExperimentalFeaturesEnabled(newTree))
             {
                 log.Write($"Experimental features enabled in '{filePath}'");
-                return DocumentAnalysisResults.SyntaxErrors(newDocument.Id, filePath, [new RudeEditDiagnostic(RudeEditKind.ExperimentalFeaturesEnabled, default)], syntaxError: null, analysisStopwatch.Elapsed, hasChanges);
+                return DocumentAnalysisResults.SyntaxErrors(documentId, filePath, [new RudeEditDiagnostic(RudeEditKind.ExperimentalFeaturesEnabled, default)], syntaxError: null, analysisStopwatch.Elapsed, hasChanges);
             }
 
             var capabilities = new EditAndContinueCapabilitiesGrantor(await lazyCapabilities.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -599,8 +578,13 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             // If the document has changed at all, lets make sure Edit and Continue is supported
             if (!capabilities.Grant(EditAndContinueCapabilities.Baseline))
             {
-                return DocumentAnalysisResults.SyntaxErrors(newDocument.Id, filePath, [new RudeEditDiagnostic(RudeEditKind.NotSupportedByRuntime, default)], syntaxError: null, analysisStopwatch.Elapsed, hasChanges);
+                return DocumentAnalysisResults.SyntaxErrors(documentId, filePath, [new RudeEditDiagnostic(RudeEditKind.NotSupportedByRuntime, default)], syntaxError: null, analysisStopwatch.Elapsed, hasChanges);
             }
+
+            // TODO: https://github.com/dotnet/roslyn/issues/78486
+            // Changes in parse options might change the meaning of the code even if nothing else changed.
+            // The IDE should disallow changing the options during debugging session. 
+            Debug.Assert(oldTree.Options.Equals(newTree.Options));
 
             // We are in break state when there are no active statements.
             var inBreakState = !oldActiveStatementMap.IsEmpty;
@@ -635,17 +619,15 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var oldActiveStatements = (oldTree == null) ? [] :
-                oldActiveStatementMap.GetOldActiveStatements(this, oldTree, oldText, oldRoot, cancellationToken);
-
+            var oldActiveStatements = oldActiveStatementMap.GetOldActiveStatements(this, oldTree, oldText, oldRoot, cancellationToken);
             var newActiveStatements = ImmutableArray.CreateBuilder<ActiveStatement>(oldActiveStatements.Length);
             newActiveStatements.Count = oldActiveStatements.Length;
 
             var newExceptionRegions = ImmutableArray.CreateBuilder<ImmutableArray<SourceFileSpan>>(oldActiveStatements.Length);
             newExceptionRegions.Count = oldActiveStatements.Length;
 
-            var oldModel = (oldDocument != null) ? await oldDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false) : null;
-            var newModel = await newDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var oldModel = await GetDocumentSemanticModelAsync(oldProject, oldDocument, oldTree, cancellationToken).ConfigureAwait(false);
+            var newModel = await GetDocumentSemanticModelAsync(newProject, newDocument, newTree, cancellationToken).ConfigureAwait(false);
 
             // Accumulates all active members as we discover them while analyzing both changed and unchanged member bodies.
             using var oldActiveMembers = new ActiveMembersBuilder(this, oldModel, newModel, cancellationToken);
@@ -688,7 +670,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             var hasBlockingRudeEdits = finalDiagnostics.HasBlockingRudeEdits();
 
             return new DocumentAnalysisResults(
-                newDocument.Id,
+                documentId,
                 filePath,
                 newActiveStatements.MoveToImmutable(),
                 finalDiagnostics,
@@ -709,11 +691,11 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             // In such case we report a rude edit for the document. If the host is actually running out of memory,
             // it might throw another OOM here or later on.
             var diagnostic = (e is OutOfMemoryException)
-                ? new RudeEditDiagnostic(RudeEditKind.SourceFileTooBig, span: default, arguments: [newDocument.FilePath])
-                : new RudeEditDiagnostic(RudeEditKind.InternalError, span: default, arguments: [newDocument.FilePath, e.ToString()]);
+                ? new RudeEditDiagnostic(RudeEditKind.SourceFileTooBig, span: default, arguments: [filePath])
+                : new RudeEditDiagnostic(RudeEditKind.InternalError, span: default, arguments: [filePath, e.ToString()]);
 
             // Report as "syntax error" - we can't analyze the document
-            return DocumentAnalysisResults.SyntaxErrors(newDocument.Id, filePath, [diagnostic], syntaxError: null, analysisStopwatch.Elapsed, hasChanges);
+            return DocumentAnalysisResults.SyntaxErrors(documentId, filePath, [diagnostic], syntaxError: null, analysisStopwatch.Elapsed, hasChanges);
         }
 
         void LogRudeEdits(ImmutableArray<RudeEditDiagnostic> diagnostics, SourceText text, string filePath)
@@ -737,6 +719,61 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                 log.Write($"Rude edit {diagnostic.Kind}:{diagnostic.SyntaxKind} '{filePath}' line {lineNumber}: '{lineText}'");
             }
         }
+    }
+
+    private static async ValueTask<(Document? document, SourceText text)> GetDocumentContentAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
+    {
+        SourceText text;
+
+        var document = await project.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+        if (document != null)
+        {
+            text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            text = s_emptySource;
+        }
+
+        return (document, text);
+    }
+
+    private async ValueTask<(SyntaxNode oldRoot, SyntaxNode newRoot)> GetSyntaxRootsAsync(Document? oldDocument, Document? newDocument, CancellationToken cancellationToken)
+    {
+        SyntaxNode? oldRoot = null;
+        SyntaxNode? newRoot = null;
+
+        if (oldDocument != null)
+        {
+            var tree = await oldDocument.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            oldRoot = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (newDocument != null)
+        {
+            var tree = await newDocument.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            newRoot = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        oldRoot ??= GetEmptyRoot(newRoot!.SyntaxTree.Options);
+        newRoot ??= GetEmptyRoot(oldRoot.SyntaxTree.Options);
+
+        return (oldRoot, newRoot);
+
+        SyntaxNode GetEmptyRoot(ParseOptions options)
+            // Need to do this to ensure the parse options of the tree are set correctly (see https://github.com/dotnet/roslyn/issues/78510)
+            => EmptyCompilationUnit.SyntaxTree.WithRootAndOptions(EmptyCompilationUnit, options).GetRoot(cancellationToken);
+    }
+
+    private static async ValueTask<DocumentSemanticModel> GetDocumentSemanticModelAsync(Project project, Document? document, SyntaxTree tree, CancellationToken cancellationToken)
+    {
+        if (document != null)
+        {
+            return new DocumentSemanticModel(await document.GetRequiredNullableDisabledSemanticModelAsync(cancellationToken).ConfigureAwait(false));
+        }
+
+        var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+        return new DocumentSemanticModel(compilation, tree);
     }
 
     private void ReportTopLevelSyntacticRudeEdits(RudeEditDiagnosticsBuilder diagnostics, EditScript<SyntaxNode> syntacticEdits, Dictionary<SyntaxNode, EditKind> editMap)
@@ -946,11 +983,10 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         SyntaxNode? newDeclaration,
         MemberBody? oldMemberBody,
         MemberBody? newMemberBody,
-        SemanticModel? oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         ISymbol oldMember,
         ISymbol newMember,
-        Compilation oldCompilation,
         SourceText newText,
         Match<SyntaxNode> topMatch,
         ImmutableArray<UnmappedActiveStatement> oldActiveStatements,
@@ -1086,7 +1122,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
             ReportMemberOrLambdaBodyUpdateRudeEdits(
                 diagnosticContext,
-                oldCompilation,
+                oldModel.Compilation,
                 oldDeclaration,
                 oldMember,
                 oldMemberBody,
@@ -1121,7 +1157,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             // Updating an entry point, a method marked with RestartRequiredOnMetadataUpdateAttribute,
             // a static constructor or a static member with an initializer will most likely have no effect,
             // unless the update is in a lambda body.
-            if (IsRestartRequired(oldMember, oldDeclaration, oldCompilation, newMember, newDeclaration, cancellationToken))
+            if (IsRestartRequired(oldMember, oldDeclaration, oldModel.Compilation, newMember, newDeclaration, cancellationToken))
             {
                 var oldTokens = oldMemberBody?.GetUserCodeTokens(DescendantTokensIgnoringLambdaBodies) ?? [];
                 var newTokens = newMemberBody?.GetUserCodeTokens(DescendantTokensIgnoringLambdaBodies) ?? [];
@@ -1213,7 +1249,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                 {
                     Contract.ThrowIfNull(newStatementSyntax);
                     Contract.ThrowIfNull(newBody);
-                    Contract.ThrowIfNull(oldModel);
 
                     // The matching node doesn't produce sequence points.
                     // E.g. "const" keyword is inserted into a local variable declaration with an initializer.
@@ -1846,10 +1881,10 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseMap,
         SyntaxNode oldActiveStatement,
         SyntaxNode oldEncompassingAncestor,
-        SemanticModel oldModel,
+        DocumentSemanticModel oldModel,
         SyntaxNode newActiveStatement,
         SyntaxNode newEncompassingAncestor,
-        SemanticModel newModel,
+        DocumentSemanticModel newModel,
         Func<SyntaxNode, bool> nodeSelector,
         Func<TSyntaxNode, OneOrMany<SyntaxNode>> getTypedNodes,
         Func<TSyntaxNode, TSyntaxNode, bool> areEquivalent,
@@ -1868,12 +1903,12 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         int matchCount;
         if (oldNodes != null)
         {
-            matchCount = MatchNodes(oldNodes, oldModel, newNodes, newModel, diagnostics, reverseMap, getTypedNodes, comparer: areEquivalent, exactMatch: true, cancellationToken);
+            matchCount = MatchNodes(oldNodes, oldModel.RequiredModel, newNodes, newModel.RequiredModel, diagnostics, reverseMap, getTypedNodes, comparer: areEquivalent, exactMatch: true, cancellationToken);
 
             // Do another pass over the nodes to improve error messages.
             if (areSimilar != null && matchCount < Math.Min(oldNodes.Count, newNodes.Count))
             {
-                matchCount += MatchNodes(oldNodes, oldModel, newNodes, newModel, diagnostics, reverseMap: null, getTypedNodes, comparer: areSimilar, exactMatch: false, cancellationToken);
+                matchCount += MatchNodes(oldNodes, oldModel.RequiredModel, newNodes, newModel.RequiredModel, diagnostics, reverseMap: null, getTypedNodes, comparer: areSimilar, exactMatch: false, cancellationToken);
             }
         }
         else
@@ -2523,8 +2558,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         IReadOnlyList<(SyntaxNode OldNode, SyntaxNode NewNode, TextSpan DiagnosticSpan)> triviaEdits,
         Project oldProject,
-        SemanticModel? oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         SourceText newText,
         RudeEditDiagnosticsBuilder diagnostics,
         ActiveMembersBuilder oldActiveMembers,
@@ -2553,8 +2588,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
         try
         {
-            var oldCompilation = oldModel?.Compilation ?? await oldProject.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var newCompilation = newModel.Compilation;
             var oldTree = editScript.Match.OldRoot.SyntaxTree;
             var newTree = editScript.Match.NewRoot.SyntaxTree;
 
@@ -2564,9 +2597,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
                 Debug.Assert(edit.OldNode is null || edit.NewNode is null || IsNamespaceDeclaration(edit.OldNode) == IsNamespaceDeclaration(edit.NewNode));
 
-                // We can ignore namespace nodes in newly added documents (old model is not available) since 
-                // all newly added types in these namespaces will have their own syntax edit.
-                var symbolEdits = oldModel != null && IsNamespaceDeclaration(edit.OldNode ?? edit.NewNode!)
+                var symbolEdits = IsNamespaceDeclaration(edit.OldNode ?? edit.NewNode!)
                     ? OneOrMany.Create(GetNamespaceSymbolEdits(oldModel, newModel, cancellationToken))
                     : GetSymbolEdits(edit.Kind, edit.OldNode, edit.NewNode, oldModel, newModel, editScript.Match, editMap, symbolCache, cancellationToken);
 
@@ -2584,8 +2615,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                             continue;
                         }
 
-                        var oldSymbolInNewCompilation = symbolCache.GetKey(oldSymbol, cancellationToken).Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
-                        var newSymbolInOldCompilation = symbolCache.GetKey(newSymbol, cancellationToken).Resolve(oldCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                        var oldSymbolInNewCompilation = symbolCache.GetKey(oldSymbol, cancellationToken).Resolve(newModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                        var newSymbolInOldCompilation = symbolCache.GetKey(newSymbol, cancellationToken).Resolve(oldModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
 
                         if (oldSymbolInNewCompilation == null || newSymbolInOldCompilation == null)
                         {
@@ -2630,7 +2661,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                     // Treat the edit as Insert/Delete. This may happen e.g. when all C# global statements are removed, the first one is added or they are moved to another file.
                     if (syntacticEditKind == EditKind.Update)
                     {
-                        if (oldSymbol == null || oldDeclaration == null || oldDeclaration != null && oldDeclaration.SyntaxTree != oldModel?.SyntaxTree)
+                        if (oldSymbol == null || oldDeclaration == null || oldDeclaration != null && oldDeclaration.SyntaxTree != oldModel.SyntaxTree)
                         {
                             syntacticEditKind = EditKind.Insert;
                         }
@@ -2653,8 +2684,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                         if (containingType != null && (syntacticEditKind != EditKind.Delete || newSymbol == null))
                         {
                             var containingTypeSymbolKey = symbolCache.GetKey(containingType, cancellationToken);
-                            oldContainingType ??= (INamedTypeSymbol?)containingTypeSymbolKey.Resolve(oldCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
-                            newContainingType ??= (INamedTypeSymbol?)containingTypeSymbolKey.Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                            oldContainingType ??= (INamedTypeSymbol?)containingTypeSymbolKey.Resolve(oldModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                            newContainingType ??= (INamedTypeSymbol?)containingTypeSymbolKey.Resolve(newModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
 
                             if (oldContainingType != null && newContainingType != null && IsReloadable(oldContainingType))
                             {
@@ -2716,7 +2747,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                     {
                         case EditKind.Delete:
                             {
-                                Contract.ThrowIfNull(oldModel);
                                 Contract.ThrowIfNull(oldSymbol);
                                 Contract.ThrowIfNull(oldDeclaration);
 
@@ -2728,7 +2758,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                                     editKind = SemanticEditKind.Update;
 
                                     // Ignore the delete if there is going to be an insert corresponding to the new symbol that will create an update edit.
-                                    if (DeleteEditImpliesInsertEdit(oldSymbol, newSymbol, oldCompilation, cancellationToken))
+                                    if (DeleteEditImpliesInsertEdit(oldSymbol, newSymbol, oldModel.Compilation, cancellationToken))
                                     {
                                         // We need to update any active statements that are in the deleted member body.
                                         ReportDeletedMemberActiveStatementsRudeEdits();
@@ -2787,7 +2817,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                                 // If so, skip the member deletion and only report the containing symbol deletion.
                                 var oldContainingType = oldSymbol.ContainingType;
                                 var containingTypeKey = symbolCache.GetKey(oldContainingType, cancellationToken);
-                                var newContainingType = (INamedTypeSymbol?)containingTypeKey.Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                                var newContainingType = (INamedTypeSymbol?)containingTypeKey.Resolve(newModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
                                 if (newContainingType == null)
                                 {
                                     // If a type parameter is deleted from the parameter list of a type declaration, the symbol key won't be resolved (because the arities do not match).
@@ -2842,7 +2872,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                                         var oldPrimaryConstructor = (IMethodSymbol)oldSymbol;
 
                                         // Deconstructor delete:
-                                        AddDeconstructorEdits(semanticEdits, oldPrimaryConstructor, otherConstructor: null, containingTypeKey, oldCompilation, newCompilation, isParameterDelete: true, cancellationToken);
+                                        AddDeconstructorEdits(semanticEdits, oldPrimaryConstructor, otherConstructor: null, containingTypeKey, oldModel.Compilation, newModel.Compilation, isParameterDelete: true, cancellationToken);
 
                                         // Synthesized method updates:
                                         AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newModel.Compilation, newContainingType, cancellationToken);
@@ -2865,7 +2895,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
                         case EditKind.Insert:
                             {
-                                Contract.ThrowIfNull(newModel);
                                 Contract.ThrowIfNull(newSymbol);
                                 Contract.ThrowIfNull(newDeclaration);
 
@@ -2913,7 +2942,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                                         HasEdit(editMap, GetSymbolDeclarationSyntax(newAssociatedMember, cancellationToken), EditKind.Insert);
 
                                     var containingTypeKey = symbolCache.GetKey(newContainingType, cancellationToken);
-                                    oldContainingType = containingTypeKey.Resolve(oldCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol as INamedTypeSymbol;
+                                    oldContainingType = containingTypeKey.Resolve(oldModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol as INamedTypeSymbol;
 
                                     // Check rude edits for each member even if it is inserted into a new type.
                                     if (!hasAssociatedSymbolInsert && IsMember(newSymbol))
@@ -2954,7 +2983,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                                     // (PrintMembers print all properties and fields, Equals and GHC compare all data members, etc.)
                                     if (SymbolPresenceAffectsSynthesizedRecordMembers(newSymbol))
                                     {
-                                        AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newCompilation, newContainingType, cancellationToken);
+                                        AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newModel.Compilation, newContainingType, cancellationToken);
                                     }
 
                                     if (newSymbol is IParameterSymbol newParameter &&
@@ -3015,8 +3044,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                             break;
 
                         case EditKind.Update:
-                            Contract.ThrowIfNull(oldModel);
-                            Contract.ThrowIfNull(newModel);
                             Contract.ThrowIfNull(oldSymbol);
                             Contract.ThrowIfNull(newSymbol);
 
@@ -3024,8 +3051,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                             break;
 
                         case EditKind.Reorder:
-                            Contract.ThrowIfNull(oldModel);
-                            Contract.ThrowIfNull(newModel);
                             Contract.ThrowIfNull(oldSymbol);
                             Contract.ThrowIfNull(newSymbol);
 
@@ -3091,7 +3116,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
                         // The synthesized property replacing the deleted one will be an auto-property.
                         // If the accessor had body or the property changed accessibility then synthesized record members might be affected.
-                        AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newCompilation, newProperty.ContainingType, cancellationToken);
+                        AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newModel.Compilation, newProperty.ContainingType, cancellationToken);
 
                         // When a custom property w/o a backing field is replaced with synthesized in a type with explicit layout,
                         // the synthesized one adds a backing field, which changes the layout of the type.
@@ -3182,7 +3207,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                             {
                                 // The old symbol's declaration syntax may be located in a different document than the old version of the current document.
                                 var oldSyntaxModel = (oldDeclaration != null)
-                                    ? await oldProject.Solution.GetRequiredDocument(oldDeclaration.SyntaxTree).GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false)
+                                    ? new(await oldProject.Solution.GetRequiredDocument(oldDeclaration.SyntaxTree).GetRequiredNullableDisabledSemanticModelAsync(cancellationToken).ConfigureAwait(false))
                                     : oldModel;
 
                                 AnalyzeChangedMemberBody(
@@ -3194,7 +3219,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                                     newModel,
                                     oldSymbol,
                                     newSymbol,
-                                    oldCompilation,
                                     newText,
                                     editScript.Match,
                                     oldActiveStatements,
@@ -3301,9 +3325,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             // Trivia edits are generated for trivia that affect active statement positions.
             foreach (var (oldEditNode, newEditNode, diagnosticSpan) in triviaEdits)
             {
-                Contract.ThrowIfNull(oldModel);
-                Contract.ThrowIfNull(newModel);
-
                 var triviaSymbolEdits = GetSymbolEdits(EditKind.Update, oldEditNode, newEditNode, oldModel, newModel, editScript.Match, editMap, symbolCache, cancellationToken);
                 foreach (var edit in triviaSymbolEdits)
                 {
@@ -3416,7 +3437,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                     instanceConstructorEdits,
                     editScript.Match,
                     oldModel,
-                    oldCompilation,
                     newModel,
                     isStatic: false,
                     semanticEdits,
@@ -3430,7 +3450,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                     staticConstructorEdits,
                     editScript.Match,
                     oldModel,
-                    oldCompilation,
                     newModel,
                     isStatic: true,
                     semanticEdits,
@@ -3442,8 +3461,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             {
                 Contract.ThrowIfFalse(oldSymbol != null || newSymbol != null);
 
-                oldSymbol ??= Resolve(newSymbol!, symbolCache.GetKey(newSymbol!, cancellationToken), oldCompilation, cancellationToken);
-                newSymbol ??= Resolve(oldSymbol!, symbolCache.GetKey(oldSymbol!, cancellationToken), newCompilation, cancellationToken);
+                oldSymbol ??= Resolve(newSymbol!, symbolCache.GetKey(newSymbol!, cancellationToken), oldModel.Compilation, cancellationToken);
+                newSymbol ??= Resolve(oldSymbol!, symbolCache.GetKey(oldSymbol!, cancellationToken), newModel.Compilation, cancellationToken);
 
                 static ISymbol? Resolve(ISymbol symbol, SymbolKey symbolKey, Compilation compilation, CancellationToken cancellationToken)
                 {
@@ -3525,10 +3544,10 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
     protected static bool IsMemberOrDelegate(ISymbol symbol)
         => IsMember(symbol) || symbol is INamedTypeSymbol { TypeKind: TypeKind.Delegate };
 
-    protected static ISymbol? GetSemanticallyMatchingNewSymbol(ISymbol? oldSymbol, ISymbol? newSymbol, SemanticModel newModel, SymbolInfoCache symbolCache, CancellationToken cancellationToken)
+    protected static ISymbol? GetSemanticallyMatchingNewSymbol(ISymbol? oldSymbol, ISymbol? newSymbol, Compilation newCompilation, SymbolInfoCache symbolCache, CancellationToken cancellationToken)
         => oldSymbol != null && IsMember(oldSymbol) &&
            newSymbol != null && IsMember(newSymbol) &&
-           symbolCache.GetKey(oldSymbol, cancellationToken).Resolve(newModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol is { } matchingNewSymbol &&
+           symbolCache.GetKey(oldSymbol, cancellationToken).Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol is { } matchingNewSymbol &&
            !matchingNewSymbol.IsSynthesized() &&
            matchingNewSymbol != newSymbol
            ? matchingNewSymbol
@@ -3846,8 +3865,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
     }
 
     private ImmutableArray<(ISymbol? oldSymbol, ISymbol? newSymbol, EditKind editKind)> GetNamespaceSymbolEdits(
-        SemanticModel oldModel,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         CancellationToken cancellationToken)
     {
         using var _1 = ArrayBuilder<(ISymbol? oldSymbol, ISymbol? newSymbol, EditKind editKind)>.GetInstance(out var builder);
@@ -3866,7 +3885,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         var oldRoot = oldModel.SyntaxTree.GetRoot(cancellationToken);
         foreach (var oldTypeDeclaration in GetTopLevelTypeDeclarations(oldRoot))
         {
-            var oldType = (INamedTypeSymbol)GetRequiredDeclaredSymbol(oldModel, oldTypeDeclaration, cancellationToken);
+            var oldType = (INamedTypeSymbol)GetRequiredDeclaredSymbol(oldModel.RequiredModel, oldTypeDeclaration, cancellationToken);
             if (!processedTypes.Add(oldType))
             {
                 continue;
@@ -3897,7 +3916,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         var newRoot = newModel.SyntaxTree.GetRoot(cancellationToken);
         foreach (var newTypeDeclaration in GetTopLevelTypeDeclarations(newRoot))
         {
-            var newType = (INamedTypeSymbol)GetRequiredDeclaredSymbol(newModel, newTypeDeclaration, cancellationToken);
+            var newType = (INamedTypeSymbol)GetRequiredDeclaredSymbol(newModel.RequiredModel, newTypeDeclaration, cancellationToken);
             if (!processedTypes.Add(newType))
             {
                 continue;
@@ -4523,7 +4542,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
     /// <summary>
     /// Semantic edits of members synthesized based on parameters that have no declaring syntax (<see cref="GetSymbolDeclarationSyntax(ISymbol, CancellationToken)"/> returns null)
-    /// and therefore not produced by <see cref="GetSymbolEdits(EditKind, SyntaxNode?, SyntaxNode?, SemanticModel?, SemanticModel, Match{SyntaxNode}, IReadOnlyDictionary{SyntaxNode, EditKind}, SymbolInfoCache, CancellationToken)"/>
+    /// and therefore not produced by <see cref="GetSymbolEdits(EditKind, SyntaxNode?, SyntaxNode?, DocumentSemanticModel, DocumentSemanticModel, Match{SyntaxNode}, IReadOnlyDictionary{SyntaxNode, EditKind}, SymbolInfoCache, CancellationToken)"/>
     /// </summary>
     private void AddSemanticEditsOriginatingFromParameterUpdate(
         ArrayBuilder<SemanticEditInfo> semanticEdits,
@@ -4897,11 +4916,11 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         ISymbol? oldSymbol,
         ISymbol? newSymbol,
         SyntaxNode? newNode,
-        SemanticModel newModel,
+        DocumentSemanticModel newModel,
         Match<SyntaxNode>? topMatch,
         TextSpan diagnosticSpan)
     {
-        public SemanticModel NewModel => newModel;
+        public DocumentSemanticModel NewModel => newModel;
 
         public ISymbol? OldSymbol
             => oldSymbol;
@@ -5104,7 +5123,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         ISymbol? oldSymbol,
         ISymbol? newSymbol,
         SyntaxNode? newNode,
-        SemanticModel newModel,
+        DocumentSemanticModel newModel,
         Match<SyntaxNode>? topMatch,
         TextSpan diagnosticSpan = default)
         => new(this, diagnostics, oldSymbol, newSymbol, newNode, newModel, topMatch, diagnosticSpan);
@@ -5174,7 +5193,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             && !@event.IsAbstract;
     }
 
-    private static bool HasExplicitOrSequentialLayout(INamedTypeSymbol type, SemanticModel model)
+    private static bool HasExplicitOrSequentialLayout(INamedTypeSymbol type, DocumentSemanticModel model)
     {
         if (type.TypeKind == TypeKind.Struct)
         {
@@ -5305,9 +5324,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
     private void AddConstructorEdits(
         IReadOnlyDictionary<INamedTypeSymbol, MemberInitializationUpdates> updatedTypes,
         Match<SyntaxNode> topMatch,
-        SemanticModel? oldModel,
-        Compilation oldCompilation,
-        SemanticModel newModel,
+        DocumentSemanticModel oldModel,
+        DocumentSemanticModel newModel,
         bool isStatic,
         [Out] ArrayBuilder<SemanticEditInfo> semanticEdits,
         [Out] RudeEditDiagnosticsBuilder diagnostics,
@@ -5384,9 +5402,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
                     if (topMatch.TryGetOldNode(newDeclaration, out oldDeclaration))
                     {
-                        Contract.ThrowIfNull(oldModel);
-
-                        oldCtor = (IMethodSymbol)GetRequiredDeclaredSymbol(oldModel, oldDeclaration, cancellationToken);
+                        oldCtor = (IMethodSymbol)GetRequiredDeclaredSymbol(oldModel.RequiredModel, oldDeclaration, cancellationToken);
                         Contract.ThrowIfFalse(oldCtor is { MethodKind: MethodKind.Constructor or MethodKind.StaticConstructor });
 
                         hasSignatureChanges = !MemberOrDelegateSignaturesEquivalent(oldCtor, newCtor, exact: false);
@@ -5398,7 +5414,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                     }
                     else
                     {
-                        var resolution = newCtorKey.Resolve(oldCompilation, ignoreAssemblyKey: true, cancellationToken);
+                        var resolution = newCtorKey.Resolve(oldModel.Compilation, ignoreAssemblyKey: true, cancellationToken);
 
                         // There may be semantic errors in the compilation that result in multiple candidates.
                         // Pick the first candidate.
@@ -5486,7 +5502,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                         oldCtorIsPrimary != newCtorIsPrimary)
                     {
                         // Deconstructor:
-                        AddDeconstructorEdits(semanticEdits, oldCtor, newCtor, typeKey, oldCompilation, newModel.Compilation, isParameterDelete: newCtorIsPrimary, cancellationToken);
+                        AddDeconstructorEdits(semanticEdits, oldCtor, newCtor, typeKey, oldModel.Compilation, newModel.Compilation, isParameterDelete: newCtorIsPrimary, cancellationToken);
 
                         // Synthesized method updates:
                         AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newModel.Compilation, newCtor.ContainingType, cancellationToken);
@@ -5569,11 +5585,11 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
     #region Lambdas and Closures
 
     private void ReportLambdaAndClosureRudeEdits(
-        SemanticModel? oldModel,
+        DocumentSemanticModel oldModel,
         ISymbol oldMember,
         MemberBody? oldMemberBody,
         SyntaxNode? oldDeclaration,
-        SemanticModel newModel,
+        DocumentSemanticModel newModel,
         ISymbol newMember,
         MemberBody? newMemberBody,
         SyntaxNode? newDeclaration,
@@ -5606,7 +5622,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
                 var lambdaBodyMap = newLambdaInfo.BodyMap;
 
-                Contract.ThrowIfNull(oldModel);
                 Contract.ThrowIfNull(oldDeclaration);
 
                 var oldLambda = oldLambdaBody.GetLambda();
@@ -5615,8 +5630,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                 Debug.Assert(IsNestedFunction(newLambda) == IsNestedFunction(oldLambda));
                 var isNestedFunction = IsNestedFunction(newLambda);
 
-                var oldLambdaSymbol = isNestedFunction ? GetLambdaExpressionSymbol(oldModel, oldLambda, cancellationToken) : null;
-                var newLambdaSymbol = isNestedFunction ? GetLambdaExpressionSymbol(newModel, newLambda, cancellationToken) : null;
+                var oldLambdaSymbol = isNestedFunction ? GetLambdaExpressionSymbol(oldModel.RequiredModel, oldLambda, cancellationToken) : null;
+                var newLambdaSymbol = isNestedFunction ? GetLambdaExpressionSymbol(newModel.RequiredModel, newLambda, cancellationToken) : null;
 
                 var diagnosticContext = CreateDiagnosticContext(diagnostics, oldLambdaSymbol, newLambdaSymbol, newLambda, newModel, topMatch: null);
 
@@ -5670,7 +5685,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                             .Any(oldContainingLambdaBody => activeOrMatchedLambdas.TryGetValue(oldContainingLambdaBody, out var info) && info.HasActiveStatement))
                     {
                         var oldTargetParameter = oldLambda.Parent != null
-                            ? (oldModel.GetOperation(oldLambda.Parent, cancellationToken) as IArgumentOperation)?.Parameter
+                            ? (oldModel.RequiredModel.GetOperation(oldLambda.Parent, cancellationToken) as IArgumentOperation)?.Parameter
                             : null;
 
                         if (oldTargetParameter != null && HasRestartRequiredAttribute(oldTargetParameter))
@@ -5697,9 +5712,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             ArrayBuilder<SyntaxNode>? lazyNewErroneousClauses = null;
             foreach (var (oldQueryClause, newQueryClause) in bodyMap.Forward)
             {
-                Debug.Assert(oldModel != null);
-
-                if (!QueryClauseLambdasTypeEquivalent(oldModel, oldQueryClause, newModel, newQueryClause, cancellationToken))
+                if (!QueryClauseLambdasTypeEquivalent(oldModel.RequiredModel, oldQueryClause, newModel.RequiredModel, newQueryClause, cancellationToken))
                 {
                     lazyNewErroneousClauses ??= ArrayBuilder<SyntaxNode>.GetInstance();
                     lazyNewErroneousClauses.Add(newQueryClause);
@@ -5874,8 +5887,8 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             var isLambdaCachedInField =
                 !inGenericLocalContext &&
                 !isLocalFunction &&
-                (GetAccessedCaptures(newLambdaBody1, newModel, newInLambdaCaptures, newCapturesIndex, newLiftingPrimaryConstructor).Equals(BitVector.Empty) ||
-                    newLambdaBody2 != null && GetAccessedCaptures(newLambdaBody2, newModel, newInLambdaCaptures, newCapturesIndex, newLiftingPrimaryConstructor).Equals(BitVector.Empty));
+                (GetAccessedCaptures(newLambdaBody1, newModel.RequiredModel, newInLambdaCaptures, newCapturesIndex, newLiftingPrimaryConstructor).Equals(BitVector.Empty) ||
+                    newLambdaBody2 != null && GetAccessedCaptures(newLambdaBody2, newModel.RequiredModel, newInLambdaCaptures, newCapturesIndex, newLiftingPrimaryConstructor).Equals(BitVector.Empty));
 
             if (isLambdaCachedInField)
             {
@@ -5980,7 +5993,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
     private void GetCapturedVariables(
         MemberBody? memberBody,
-        SemanticModel? model,
+        DocumentSemanticModel model,
         IMethodSymbol? liftingPrimaryConstructor,
         bool ignorePrimaryParameterCaptures,
         out bool hasLambdaBodies,
@@ -5995,8 +6008,6 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             primaryParametersCapturedViaThis = [];
             return;
         }
-
-        Debug.Assert(model != null);
 
         PooledDictionary<VariableCaptureKey, int>? inLambdaCapturesIndex = null;
         ArrayBuilder<(VariableCaptureKind kind, ISymbol symbol, ArrayBuilder<LambdaBody> capturingLambdas)>? inLambdaCaptures = null;
@@ -6013,7 +6024,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
             void AddCaptures(LambdaBody lambdaBody)
             {
-                var captures = lambdaBody.GetCapturedVariables(model);
+                var captures = lambdaBody.GetCapturedVariables(model.RequiredModel);
                 if (!captures.IsEmpty)
                 {
                     inLambdaCapturesIndex ??= PooledDictionary<VariableCaptureKey, int>.GetInstance();
@@ -6045,7 +6056,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         // only primary constructor parameters can be captured outside of lambda bodies:
         if (liftingPrimaryConstructor != null && !ignorePrimaryParameterCaptures)
         {
-            primaryParametersCapturedViaThis = memberBody.GetCapturedVariables(model).SelectAsArray(
+            primaryParametersCapturedViaThis = memberBody.GetCapturedVariables(model.RequiredModel).SelectAsArray(
                 predicate: (capture, liftingPrimaryConstructor) => capture.ContainingSymbol == liftingPrimaryConstructor,
                 selector: (capture, _) => (IParameterSymbol)capture,
                 liftingPrimaryConstructor);

--- a/src/Features/Core/Portable/EditAndContinue/DocumentSemanticModel.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DocumentSemanticModel.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+internal readonly struct DocumentSemanticModel
+{
+    /// <summary>
+    /// <see cref="SemanticModel"/> for the document, or null if the document has been deleted.
+    /// The <see cref="SyntaxTree"/> is empty in the latter case.
+    /// </summary>
+    public readonly SemanticModel? Model;
+
+    public readonly Compilation Compilation;
+    public readonly SyntaxTree SyntaxTree;
+
+    public DocumentSemanticModel(SemanticModel model)
+    {
+        Model = model;
+        Compilation = model.Compilation;
+        SyntaxTree = model.SyntaxTree;
+    }
+
+    public DocumentSemanticModel(Compilation compilation, SyntaxTree syntaxTree)
+    {
+        Debug.Assert(syntaxTree.GetText().Length == 0);
+
+        Compilation = compilation;
+        SyntaxTree = syntaxTree;
+    }
+
+    /// <summary>
+    /// Semnatic model can only be used if we have a syntax node from the document (the tree is not empty).
+    /// </summary>
+    public SemanticModel RequiredModel
+    {
+        get
+        {
+            Contract.ThrowIfNull(Model);
+            return Model;
+        }
+    }
+}

--- a/src/Features/Core/Portable/EditAndContinue/DocumentWithRudeEdits.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DocumentWithRudeEdits.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+internal readonly struct DocumentWithRudeEdits(DocumentId id, ImmutableArray<RudeEditDiagnostic> rudeEdits)
+{
+    public DocumentId Id { get; } = id;
+    public ImmutableArray<RudeEditDiagnostic> RudeEdits { get; } = rudeEdits;
+}

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
@@ -24,14 +24,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveStatementsMap> baseActiveStatements, AsyncLazy<EditAndContinueCapabilities> capabilities, TraceLog log)
 {
     private readonly object _guard = new();
-    private readonly Dictionary<DocumentId, (AsyncLazy<DocumentAnalysisResults> results, Project baseProject, Document document, ImmutableArray<ActiveStatementLineSpan> activeStatementSpans)> _analyses = [];
+    private readonly Dictionary<DocumentId, (AsyncLazy<DocumentAnalysisResults> results, Project oldProject, Document? newDocument, ImmutableArray<ActiveStatementLineSpan> activeStatementSpans)> _analyses = [];
     private readonly AsyncLazy<ActiveStatementsMap> _baseActiveStatements = baseActiveStatements;
     private readonly AsyncLazy<EditAndContinueCapabilities> _capabilities = capabilities;
     private readonly TraceLog _log = log;
 
     public async ValueTask<ImmutableArray<DocumentAnalysisResults>> GetDocumentAnalysesAsync(
         CommittedSolution oldSolution,
-        IReadOnlyList<(Document? oldDocument, Document newDocument)> documents,
+        Solution newSolution,
+        IReadOnlyList<(Document? oldDocument, Document? newDocument)> documents,
         ActiveStatementSpanProvider activeStatementSpanProvider,
         CancellationToken cancellationToken)
     {
@@ -42,7 +43,7 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
                 return [];
             }
 
-            var tasks = documents.Select(document => Task.Run(() => GetDocumentAnalysisAsync(oldSolution, document.oldDocument, document.newDocument, activeStatementSpanProvider, cancellationToken).AsTask(), cancellationToken));
+            var tasks = documents.Select(document => Task.Run(() => GetDocumentAnalysisAsync(oldSolution, newSolution, document.oldDocument, document.newDocument, activeStatementSpanProvider, cancellationToken).AsTask(), cancellationToken));
             var allResults = await Task.WhenAll(tasks).ConfigureAwait(false);
 
             return [.. allResults];
@@ -61,11 +62,14 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
     /// <param name="activeStatementSpanProvider">Provider of active statement spans tracked by the editor for the solution snapshot of the <paramref name="newDocument"/>.</param>
     public async ValueTask<DocumentAnalysisResults> GetDocumentAnalysisAsync(
         CommittedSolution oldSolution,
+        Solution newSolution,
         Document? oldDocument,
-        Document newDocument,
+        Document? newDocument,
         ActiveStatementSpanProvider activeStatementSpanProvider,
         CancellationToken cancellationToken)
     {
+        Contract.ThrowIfFalse(oldDocument != null || newDocument != null);
+
         try
         {
             var unmappedActiveStatementSpans = await GetLatestUnmappedActiveStatementSpansAsync(oldDocument, newDocument, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
@@ -77,13 +81,14 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
             // but are not up-to-date. These documents do not have impact on the analysis unless we read semantic information
             // from the project compilation. When reading such information we need to be aware of its potential incompleteness
             // and consult the compiler output binary (see https://github.com/dotnet/roslyn/issues/51261).
-            var oldProject = oldDocument?.Project ?? oldSolution.GetRequiredProject(newDocument.Project.Id);
+            var oldProject = oldDocument?.Project ?? oldSolution.GetRequiredProject(newDocument!.Project.Id);
+            var newProject = newDocument?.Project ?? newSolution.GetRequiredProject(oldProject.Id);
 
             AsyncLazy<DocumentAnalysisResults> lazyResults;
 
             lock (_guard)
             {
-                lazyResults = GetDocumentAnalysisNoLock(oldProject, newDocument, unmappedActiveStatementSpans);
+                lazyResults = GetDocumentAnalysisNoLock(oldProject, newProject, oldDocument, newDocument, unmappedActiveStatementSpans);
             }
 
             return await lazyResults.GetValueAsync(cancellationToken).ConfigureAwait(false);
@@ -97,17 +102,23 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
     /// <summary>
     /// Calculates unmapped active statement spans in the <paramref name="newDocument"/> from spans provided by <paramref name="newActiveStatementSpanProvider"/>.
     /// </summary>
-    private async Task<ImmutableArray<ActiveStatementLineSpan>> GetLatestUnmappedActiveStatementSpansAsync(Document? oldDocument, Document newDocument, ActiveStatementSpanProvider newActiveStatementSpanProvider, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<ActiveStatementLineSpan>> GetLatestUnmappedActiveStatementSpansAsync(Document? oldDocument, Document? newDocument, ActiveStatementSpanProvider newActiveStatementSpanProvider, CancellationToken cancellationToken)
     {
-        if (oldDocument == null)
+        if (newDocument == null)
         {
-            // document has been deleted or is out-of-sync
+            // document has been deleted - all active statements have been deleted (rude edits will be reported)
             return [];
         }
 
-        if (newDocument.FilePath == null)
+        if (oldDocument == null)
         {
-            // document has been added, or doesn't have a file path - we do not have tracking spans for it
+            // document has been added - it won't have active statements
+            return [];
+        }
+
+        if (oldDocument.FilePath == null || newDocument.FilePath == null)
+        {
+            // document doesn't have a file path - we do not have tracking spans for it
             return [];
         }
 
@@ -161,8 +172,10 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
         return activeStatementSpansBuilder.ToImmutableAndClear();
     }
 
-    private AsyncLazy<DocumentAnalysisResults> GetDocumentAnalysisNoLock(Project baseProject, Document document, ImmutableArray<ActiveStatementLineSpan> activeStatementSpans)
+    private AsyncLazy<DocumentAnalysisResults> GetDocumentAnalysisNoLock(Project oldProject, Project newProject, Document? oldDocument, Document? newDocument, ImmutableArray<ActiveStatementLineSpan> activeStatementSpans)
     {
+        var documentId = oldDocument?.Id ?? newDocument!.Id;
+
         // Do not reuse an analysis of the document unless its snasphot is exactly the same as was used to calculate the results.
         // Note that comparing document snapshots in effect compares the entire solution snapshots (when another document is changed a new solution snapshot is created
         // that creates new document snapshots for all queried documents).
@@ -174,9 +187,9 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
         // For example, when analyzing a partial class we can record all documents its declaration spans. However, in other cases the analysis
         // checks for absence of a top-level type symbol. Adding a symbol to any document thus invalidates such analysis. It'd be possible
         // to keep track of which type symbols an analysis is conditional upon, if it was worth the extra complexity.
-        if (_analyses.TryGetValue(document.Id, out var analysis) &&
-            analysis.baseProject == baseProject &&
-            analysis.document == document &&
+        if (_analyses.TryGetValue(documentId, out var analysis) &&
+            analysis.oldProject == oldProject &&
+            analysis.newDocument == newDocument &&
             analysis.activeStatementSpans.SequenceEqual(activeStatementSpans))
         {
             return analysis.results;
@@ -187,21 +200,29 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
             {
                 try
                 {
-                    var analyzer = arg.document.Project.Services.GetRequiredService<IEditAndContinueAnalyzer>();
-                    return await analyzer.AnalyzeDocumentAsync(arg.baseProject, arg.self._baseActiveStatements, arg.document, arg.activeStatementSpans, arg.self._capabilities, arg.self._log, cancellationToken).ConfigureAwait(false);
+                    var analyzer = arg.oldProject.Services.GetRequiredService<IEditAndContinueAnalyzer>();
+                    return await analyzer.AnalyzeDocumentAsync(
+                        arg.documentId,
+                        arg.oldProject,
+                        arg.newProject,
+                        arg.self._baseActiveStatements,
+                        arg.activeStatementSpans,
+                        arg.self._capabilities,
+                        arg.self._log,
+                        cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
                 {
                     throw ExceptionUtilities.Unreachable();
                 }
             },
-            arg: (self: this, document, baseProject, activeStatementSpans));
+            arg: (self: this, documentId, newDocument, oldProject, newProject, activeStatementSpans));
 
         // Previous results for this document id are discarded as they are no longer relevant.
         // The only relevant analysis is for the latest base and document snapshots.
         // Note that the base snapshot may evolve if documents are dicovered that were previously
         // out-of-sync with the compiled outputs and are now up-to-date.
-        _analyses[document.Id] = (lazyResults, baseProject, document, activeStatementSpans);
+        _analyses[documentId] = (lazyResults, oldProject, newDocument, activeStatementSpans);
 
         return lazyResults;
     }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
@@ -174,6 +174,9 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
 
     private AsyncLazy<DocumentAnalysisResults> GetDocumentAnalysisNoLock(Project oldProject, Project newProject, Document? oldDocument, Document? newDocument, ImmutableArray<ActiveStatementLineSpan> activeStatementSpans)
     {
+        Debug.Assert(oldDocument == null || oldDocument.Project == oldProject);
+        Debug.Assert(newDocument == null || newDocument.Project == newProject);
+
         var documentId = oldDocument?.Id ?? newDocument!.Id;
 
         // Do not reuse an analysis of the document unless its snasphot is exactly the same as was used to calculate the results.

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -298,7 +298,7 @@ internal sealed class EditSession
             }
 
             var oldProject = oldSolution.GetProject(newProject.Id);
-            if (oldProject == null || await HasChangedOrAddedDocumentsAsync(oldProject, newProject, changedOrAddedDocuments: null, cancellationToken).ConfigureAwait(false))
+            if (oldProject == null || await HasDocumentDifferencesAsync(oldProject, newProject, documentDifferences: null, cancellationToken).ConfigureAwait(false))
             {
                 // project added or has changes
                 return true;
@@ -339,7 +339,7 @@ internal sealed class EditSession
         return oldSource.ContentEquals(newSource);
     }
 
-    internal static async ValueTask<bool> HasChangedOrAddedDocumentsAsync(Project oldProject, Project newProject, ArrayBuilder<Document>? changedOrAddedDocuments, CancellationToken cancellationToken)
+    internal static async ValueTask<bool> HasDocumentDifferencesAsync(Project oldProject, Project newProject, ProjectDocumentDifferences? documentDifferences, CancellationToken cancellationToken)
     {
         if (!newProject.SupportsEditAndContinue())
         {
@@ -364,12 +364,12 @@ internal sealed class EditSession
                 continue;
             }
 
-            if (changedOrAddedDocuments is null)
+            if (!documentDifferences.HasValue)
             {
                 return true;
             }
 
-            changedOrAddedDocuments.Add(document);
+            documentDifferences.Value.ChangedOrAdded.Add(document);
         }
 
         foreach (var documentId in newProject.State.DocumentStates.GetAddedStateIds(oldProject.State.DocumentStates))
@@ -380,18 +380,34 @@ internal sealed class EditSession
                 continue;
             }
 
-            if (changedOrAddedDocuments is null)
+            if (!documentDifferences.HasValue)
             {
                 return true;
             }
 
-            changedOrAddedDocuments.Add(document);
+            documentDifferences.Value.ChangedOrAdded.Add(document);
+        }
+
+        foreach (var documentId in newProject.State.DocumentStates.GetRemovedStateIds(oldProject.State.DocumentStates))
+        {
+            var document = oldProject.GetRequiredDocument(documentId);
+            if (!document.State.SupportsEditAndContinue())
+            {
+                continue;
+            }
+
+            if (!documentDifferences.HasValue)
+            {
+                return true;
+            }
+
+            documentDifferences.Value.Deleted.Add(document);
         }
 
         // Any changes in non-generated document content might affect source generated documents as well,
         // no need to check further in that case.
 
-        if (changedOrAddedDocuments is { Count: > 0 })
+        if (documentDifferences?.Any() == true)
         {
             return true;
         }
@@ -414,9 +430,7 @@ internal sealed class EditSession
             }
         }
 
-        // TODO: should handle removed documents above (detect them as edits) https://github.com/dotnet/roslyn/issues/62848
-        if (newProject.State.DocumentStates.GetRemovedStateIds(oldProject.State.DocumentStates).Any() ||
-            newProject.State.AdditionalDocumentStates.GetRemovedStateIds(oldProject.State.AdditionalDocumentStates).Any() ||
+        if (newProject.State.AdditionalDocumentStates.GetRemovedStateIds(oldProject.State.AdditionalDocumentStates).Any() ||
             newProject.State.AdditionalDocumentStates.GetAddedStateIds(oldProject.State.AdditionalDocumentStates).Any() ||
             newProject.State.AnalyzerConfigDocumentStates.GetRemovedStateIds(oldProject.State.AnalyzerConfigDocumentStates).Any() ||
             newProject.State.AnalyzerConfigDocumentStates.GetAddedStateIds(oldProject.State.AnalyzerConfigDocumentStates).Any())
@@ -427,11 +441,11 @@ internal sealed class EditSession
         return false;
     }
 
-    internal static async Task PopulateChangedAndAddedDocumentsAsync(TraceLog log, Project oldProject, Project newProject, ArrayBuilder<Document> changedOrAddedDocuments, ArrayBuilder<ProjectDiagnostics> diagnostics, CancellationToken cancellationToken)
+    internal static async Task GetDocumentDifferencesAsync(TraceLog log, Project oldProject, Project newProject, ProjectDocumentDifferences documentDifferences, ArrayBuilder<ProjectDiagnostics> diagnostics, CancellationToken cancellationToken)
     {
-        changedOrAddedDocuments.Clear();
+        documentDifferences.Clear();
 
-        if (!await HasChangedOrAddedDocumentsAsync(oldProject, newProject, changedOrAddedDocuments, cancellationToken).ConfigureAwait(false))
+        if (!await HasDocumentDifferencesAsync(oldProject, newProject, documentDifferences, cancellationToken).ConfigureAwait(false))
         {
             return;
         }
@@ -450,7 +464,7 @@ internal sealed class EditSession
                 continue;
             }
 
-            changedOrAddedDocuments.Add(newProject.GetOrCreateSourceGeneratedDocument(newState));
+            documentDifferences.ChangedOrAdded.Add(newProject.GetOrCreateSourceGeneratedDocument(newState));
         }
 
         foreach (var documentId in newSourceGeneratedDocumentStates.GetAddedStateIds(oldSourceGeneratedDocumentStates))
@@ -461,7 +475,18 @@ internal sealed class EditSession
                 continue;
             }
 
-            changedOrAddedDocuments.Add(newProject.GetOrCreateSourceGeneratedDocument(newState));
+            documentDifferences.ChangedOrAdded.Add(newProject.GetOrCreateSourceGeneratedDocument(newState));
+        }
+
+        foreach (var documentId in newSourceGeneratedDocumentStates.GetRemovedStateIds(oldSourceGeneratedDocumentStates))
+        {
+            var oldState = oldSourceGeneratedDocumentStates.GetRequiredState(documentId);
+            if (oldState.Attributes.DesignTimeOnly)
+            {
+                continue;
+            }
+
+            documentDifferences.Deleted.Add(oldProject.GetOrCreateSourceGeneratedDocument(oldState));
         }
     }
 
@@ -533,15 +558,16 @@ internal sealed class EditSession
     }
 
     private async Task<(ImmutableArray<DocumentAnalysisResults> results, ImmutableArray<Diagnostic> diagnostics, bool hasOutOfSyncDocument)> AnalyzeDocumentsAsync(
-        ArrayBuilder<Document> changedOrAddedDocuments,
+        Solution newSolution,
+        ProjectDocumentDifferences documentDifferences,
         ActiveStatementSpanProvider newDocumentActiveStatementSpanProvider,
         CancellationToken cancellationToken)
     {
         using var _1 = ArrayBuilder<Diagnostic>.GetInstance(out var documentDiagnostics);
-        using var _2 = ArrayBuilder<(Document? oldDocument, Document newDocument)>.GetInstance(out var documents);
+        using var _2 = ArrayBuilder<(Document? oldDocument, Document? newDocument)>.GetInstance(out var documents);
         var hasOutOfSyncDocument = false;
 
-        foreach (var newDocument in changedOrAddedDocuments)
+        foreach (var newDocument in documentDifferences.ChangedOrAdded)
         {
             var (oldDocument, oldDocumentState) = await DebuggingSession.LastCommittedSolution.GetDocumentAndStateAsync(newDocument, cancellationToken, reloadOutOfSyncDocument: true).ConfigureAwait(false);
             switch (oldDocumentState)
@@ -573,10 +599,15 @@ internal sealed class EditSession
             }
         }
 
+        foreach (var oldDocument in documentDifferences.Deleted)
+        {
+            documents.Add((oldDocument, newDocument: null));
+        }
+
         // No need to report rude edits if project has any documents that are out of sync. No deltas will be emitted for such project.
         var analyses = hasOutOfSyncDocument
             ? []
-            : await Analyses.GetDocumentAnalysesAsync(DebuggingSession.LastCommittedSolution, documents, newDocumentActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+            : await Analyses.GetDocumentAnalysesAsync(DebuggingSession.LastCommittedSolution, newSolution, documents, newDocumentActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 
         return (analyses, documentDiagnostics.ToImmutable(), hasOutOfSyncDocument);
     }
@@ -824,16 +855,16 @@ internal sealed class EditSession
             using var _2 = ArrayBuilder<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)>.GetInstance(out var nonRemappableRegions);
             using var _3 = ArrayBuilder<ProjectBaseline>.GetInstance(out var newProjectBaselines);
             using var _4 = ArrayBuilder<ProjectDiagnostics>.GetInstance(out var diagnostics);
-            using var _5 = ArrayBuilder<Document>.GetInstance(out var changedOrAddedDocuments);
-            using var _6 = ArrayBuilder<(DocumentId, ImmutableArray<RudeEditDiagnostic>)>.GetInstance(out var documentsWithRudeEdits);
-            using var _7 = ArrayBuilder<ProjectId>.GetInstance(out var projectsToStale);
+            using var _5 = ArrayBuilder<DocumentWithRudeEdits>.GetInstance(out var documentsWithRudeEdits);
+            using var _6 = ArrayBuilder<ProjectId>.GetInstance(out var projectsToStale);
+            using var documentDifferences = new ProjectDocumentDifferences();
 
             // After all projects have been analyzed "true" value indicates changed document that is only included in stale projects.
             var changedDocumentsStaleness = new Dictionary<string, bool>(SolutionState.FilePathComparer);
 
             void UpdateChangedDocumentsStaleness(bool isStale)
             {
-                foreach (var changedDocument in changedOrAddedDocuments)
+                foreach (var changedDocument in documentDifferences.ChangedOrAdded)
                 {
                     var path = changedDocument.FilePath;
 
@@ -868,7 +899,7 @@ internal sealed class EditSession
                 var oldProject = oldSolution.GetProject(newProject.Id);
                 if (oldProject == null)
                 {
-                    Log.Write($"EnC state of {newProject.Name} '{newProject.FilePath}' queried: project not loaded");
+                    Log.Write($"EnC state of {newProject.GetLogDisplay()} queried: project not loaded");
 
                     // TODO (https://github.com/dotnet/roslyn/issues/1204):
                     //
@@ -884,20 +915,20 @@ internal sealed class EditSession
                     continue;
                 }
 
-                await PopulateChangedAndAddedDocumentsAsync(Log, oldProject, newProject, changedOrAddedDocuments, diagnostics, cancellationToken).ConfigureAwait(false);
-                if (changedOrAddedDocuments.IsEmpty)
+                await GetDocumentDifferencesAsync(Log, oldProject, newProject, documentDifferences, diagnostics, cancellationToken).ConfigureAwait(false);
+                if (documentDifferences.IsEmpty)
                 {
                     continue;
                 }
 
-                Log.Write($"Found {changedOrAddedDocuments.Count} potentially changed document(s) in project {newProject.Name} '{newProject.FilePath}'");
+                Log.Write($"Found {documentDifferences.ChangedOrAdded.Count} potentially changed and {documentDifferences.Deleted.Count} deleted document(s) in project {newProject.GetLogDisplay()}");
 
                 var isStaleProject = oldSolution.IsStaleProject(newProject.Id);
 
                 // We don't consider document changes in stale projects until they are rebuilt (removed from stale set).
                 if (isStaleProject)
                 {
-                    Log.Write($"EnC state of {newProject.Name} '{newProject.FilePath}' queried: project is stale");
+                    Log.Write($"EnC state of {newProject.GetLogDisplay()} queried: project is stale");
                     UpdateChangedDocumentsStaleness(isStale: true);
                     continue;
                 }
@@ -938,7 +969,7 @@ internal sealed class EditSession
                 // instead of the true C.M(string).
 
                 var (changedDocumentAnalyses, documentDiagnostics, hasOutOfSyncChangedDocument) =
-                    await AnalyzeDocumentsAsync(changedOrAddedDocuments, solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+                    await AnalyzeDocumentsAsync(solution, documentDifferences, solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 
                 if (documentDiagnostics.Any())
                 {
@@ -1015,7 +1046,7 @@ internal sealed class EditSession
                 {
                     if (!analysis.RudeEdits.IsEmpty)
                     {
-                        documentsWithRudeEdits.Add((analysis.DocumentId, analysis.RudeEdits));
+                        documentsWithRudeEdits.Add(new(analysis.DocumentId, analysis.RudeEdits));
                         Telemetry.LogRudeEditDiagnostics(analysis.RudeEdits, newProject.State.Attributes.TelemetryId);
                     }
                 }

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueAnalyzer.cs
@@ -14,9 +14,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 internal interface IEditAndContinueAnalyzer : ILanguageService
 {
     Task<DocumentAnalysisResults> AnalyzeDocumentAsync(
-        Project baseProject,
+        DocumentId documentId,
+        Project oldProject,
+        Project newProject,
         AsyncLazy<ActiveStatementsMap> lazyBaseActiveStatements,
-        Document document,
         ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         AsyncLazy<EditAndContinueCapabilities> lazyCapabilities,
         TraceLog log,

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueSessionTracker.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueSessionTracker.cs
@@ -20,7 +20,8 @@ internal interface IEditAndContinueSessionTracker
     /// <summary>
     /// Diagnostics reported by the last <see cref="IEditAndContinueService.EmitSolutionUpdateAsync"/> call.
     /// Includes emit errors and issues reported by the debugger when applying changes.
-    /// Does not include rude edits, which are reported by <see cref="IEditAndContinueService.GetDocumentDiagnosticsAsync"/>.
+    /// Does not include rude edits reported for added or changed documents, which are reported by <see cref="IEditAndContinueService.GetDocumentDiagnosticsAsync"/>,
+    /// Incldues rude edits reported for deleted documents.
     /// </summary>
     ImmutableArray<DiagnosticData> ApplyChangesDiagnostics { get; }
 }

--- a/src/Features/Core/Portable/EditAndContinue/ProjectDocumentDifferences.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ProjectDocumentDifferences.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+/// <summary>
+/// Differences between documents of old and new projects.
+/// </summary>
+internal readonly struct ProjectDocumentDifferences() : IDisposable
+{
+    public readonly ArrayBuilder<Document> ChangedOrAdded = ArrayBuilder<Document>.GetInstance();
+    public readonly ArrayBuilder<Document> Deleted = ArrayBuilder<Document>.GetInstance();
+
+    public void Dispose()
+    {
+        ChangedOrAdded.Free();
+        Deleted.Free();
+    }
+
+    public bool IsEmpty
+        => ChangedOrAdded.IsEmpty && Deleted.IsEmpty;
+
+    public bool Any()
+        => !IsEmpty;
+
+    public void Clear()
+    {
+        ChangedOrAdded.Clear();
+        Deleted.Clear();
+    }
+}

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnostic.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnostic.cs
@@ -16,6 +16,9 @@ internal readonly struct RudeEditDiagnostic
     [DataMember(Order = 0)]
     public readonly RudeEditKind Kind;
 
+    /// <summary>
+    /// Span in the new document. May be <c>default</c> if the document (or its entire content) has been deleted.
+    /// </summary>
     [DataMember(Order = 1)]
     public readonly TextSpan Span;
 
@@ -38,10 +41,10 @@ internal readonly struct RudeEditDiagnostic
     {
     }
 
-    internal Diagnostic ToDiagnostic(SyntaxTree tree)
+    internal Diagnostic ToDiagnostic(SyntaxTree? tree)
     {
         var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(Kind);
-        return Diagnostic.Create(descriptor, tree.GetLocation(Span), Arguments);
+        return Diagnostic.Create(descriptor, tree?.GetLocation(Span) ?? Location.None, Arguments);
     }
 }
 

--- a/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
@@ -15,7 +15,7 @@ internal readonly struct SolutionUpdate(
     ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
     ImmutableArray<ProjectBaseline> projectBaselines,
     ImmutableArray<ProjectDiagnostics> diagnostics,
-    ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> documentsWithRudeEdits,
+    ImmutableArray<DocumentWithRudeEdits> documentsWithRudeEdits,
     Diagnostic? syntaxError)
 {
     public readonly ModuleUpdates ModuleUpdates = moduleUpdates;
@@ -23,12 +23,12 @@ internal readonly struct SolutionUpdate(
     public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> NonRemappableRegions = nonRemappableRegions;
     public readonly ImmutableArray<ProjectBaseline> ProjectBaselines = projectBaselines;
     public readonly ImmutableArray<ProjectDiagnostics> Diagnostics = diagnostics;
-    public readonly ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> DocumentsWithRudeEdits = documentsWithRudeEdits;
+    public readonly ImmutableArray<DocumentWithRudeEdits> DocumentsWithRudeEdits = documentsWithRudeEdits;
     public readonly Diagnostic? SyntaxError = syntaxError;
 
     public static SolutionUpdate Empty(
         ImmutableArray<ProjectDiagnostics> diagnostics,
-        ImmutableArray<(DocumentId, ImmutableArray<RudeEditDiagnostic>)> documentsWithRudeEdits,
+        ImmutableArray<DocumentWithRudeEdits> documentsWithRudeEdits,
         Diagnostic? syntaxError,
         ModuleUpdateStatus status)
         => new(
@@ -65,9 +65,9 @@ internal readonly struct SolutionUpdate(
 
         foreach (var documentWithRudeEdits in DocumentsWithRudeEdits)
         {
-            foreach (var rudeEdit in documentWithRudeEdits.Diagnostics)
+            foreach (var rudeEdit in documentWithRudeEdits.RudeEdits)
             {
-                log.Write($"Document {documentWithRudeEdits.DocumentId.DebugName} rude edit: {rudeEdit.Kind} {rudeEdit.SyntaxKind}", LogMessageSeverity.Error);
+                log.Write($"Document {documentWithRudeEdits.Id.DebugName} rude edit: {rudeEdit.Kind} {rudeEdit.SyntaxKind}", LogMessageSeverity.Error);
             }
         }
     }

--- a/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
@@ -44,24 +44,38 @@ internal static partial class Extensions
     {
         if (project.FilePath == null)
         {
-            log?.Write($"Project '{project.Name}' ('{project.Id.DebugName}') doesn't support EnC: no file path");
+            LogReason("no file path");
+            return false;
+        }
+
+        if (!project.SupportsCompilation)
+        {
+            LogReason("no compilation");
             return false;
         }
 
         if (project.Services.GetService<IEditAndContinueAnalyzer>() == null)
         {
-            log?.Write($"Project '{project.FilePath}' doesn't support EnC: no EnC service");
+            LogReason("no EnC service");
             return false;
         }
 
         if (!project.CompilationOutputInfo.HasEffectiveGeneratedFilesOutputDirectory)
         {
-            log?.Write($"Project '{project.FilePath}' doesn't support EnC: no generated files output directory");
+            LogReason("no generated files output directory");
             return false;
         }
 
+        void LogReason(string message)
+            => log?.Write($"Project '{project.GetLogDisplay()}' doesn't support EnC: {message}");
+
         return true;
     }
+
+    public static string GetLogDisplay(this Project project)
+        => project.FilePath != null
+            ? $"'{project.FilePath}' ('{project.State.NameAndFlavor.flavor}')"
+            : $"'{project.Name}' ('{project.Id.DebugName}'";
 
     public static bool SupportsEditAndContinue(this TextDocumentState textDocumentState)
     {

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestVerifier.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestVerifier.cs
@@ -188,7 +188,7 @@ internal abstract class EditAndContinueTestVerifier
             Contract.ThrowIfNull(newModel);
 
             var lazyOldActiveStatementMap = AsyncLazy.Create(expectedResult.ActiveStatements.OldStatementsMap);
-            var result = Analyzer.AnalyzeDocumentAsync(oldProject, lazyOldActiveStatementMap, newDocument, newActiveStatementSpans, lazyCapabilities, log, CancellationToken.None).Result;
+            var result = Analyzer.AnalyzeDocumentAsync(newDocument.Id, oldProject, newProject, lazyOldActiveStatementMap, newActiveStatementSpans, lazyCapabilities, log, CancellationToken.None).Result;
             var oldText = oldDocument.GetTextSynchronously(default);
             var newText = newDocument.GetTextSynchronously(default);
 
@@ -462,19 +462,13 @@ internal abstract class EditAndContinueTestVerifier
 
     private void CreateProjects(EditScriptDescription[] editScripts, AdhocWorkspace workspace, TargetFramework targetFramework, out Project oldProject, out Project newProject)
     {
-        var projectInfo = ProjectInfo.Create(
-            new ProjectInfo.ProjectAttributes(
-                id: ProjectId.CreateNewId(),
-                version: VersionStamp.Create(),
-                name: "project",
-                assemblyName: "project",
-                language: LanguageName,
-                compilationOutputInfo: default,
-                filePath: Path.Combine(TempRoot.Root, "project" + ProjectFileExtension),
-                checksumAlgorithm: SourceHashAlgorithms.Default),
-            parseOptions: ParseOptions);
+        var oldSolution = workspace.CurrentSolution;
+        oldProject = oldSolution.AddTestProject("project", LanguageName, targetFramework, out _);
 
-        oldProject = workspace.AddProject(projectInfo).WithMetadataReferences(TargetFrameworkUtil.GetReferences(targetFramework));
+        oldProject = oldProject
+            .WithParseOptions(ParseOptions)
+            .WithCompilationOptions(oldProject.CompilationOptions!.WithOutputKind(OutputKind.ConsoleApplication));
+
         foreach (var editScript in editScripts)
         {
             var oldRoot = editScript.Match.OldRoot;

--- a/src/Features/TestUtilities/EditAndContinue/Extensions.cs
+++ b/src/Features/TestUtilities/EditAndContinue/Extensions.cs
@@ -113,7 +113,13 @@ internal static class Extensions
                 NoCompilationConstants.LanguageName => null,
                 _ => throw ExceptionUtilities.UnexpectedValue(language)
             },
-            compilationOptions: TestOptions.DebugDll,
+            compilationOptions: language switch
+            {
+                LanguageNames.CSharp => TestOptions.DebugDll,
+                LanguageNames.VisualBasic => VisualBasic.UnitTests.TestOptions.DebugDll,
+                NoCompilationConstants.LanguageName => null,
+                _ => throw ExceptionUtilities.UnexpectedValue(language)
+            },
             filePath: Path.Combine(TempRoot.Root, projectName, projectName + language switch
             {
                 LanguageNames.CSharp => ".csproj",

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -98,21 +98,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return False
         End Function
 
-        Protected Overrides Function GetVariableUseSites(roots As IEnumerable(Of SyntaxNode), localOrParameter As ISymbol, model As SemanticModel, cancellationToken As CancellationToken) As IEnumerable(Of SyntaxNode)
-            Debug.Assert(TypeOf localOrParameter Is IParameterSymbol OrElse TypeOf localOrParameter Is ILocalSymbol OrElse TypeOf localOrParameter Is IRangeVariableSymbol)
-
-            ' Not supported (it's non trivial to find all places where "this" is used):
-            Debug.Assert(Not localOrParameter.IsThisParameter())
-
-            Return From root In roots
-                   From node In root.DescendantNodesAndSelf()
-                   Where node.IsKind(SyntaxKind.IdentifierName)
-                   Let identifier = DirectCast(node, IdentifierNameSyntax)
-                   Where String.Equals(DirectCast(identifier.Identifier.Value, String), localOrParameter.Name, StringComparison.OrdinalIgnoreCase) AndAlso
-                         If(model.GetSymbolInfo(identifier, cancellationToken).Symbol?.Equals(localOrParameter), False)
-                   Select node
-        End Function
-
         Friend Shared Function FindStatementAndPartner(
             span As TextSpan,
             body As SyntaxNode,
@@ -698,15 +683,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             editKind As EditKind,
             oldNode As SyntaxNode,
             newNode As SyntaxNode,
-            oldModel As SemanticModel,
-            newModel As SemanticModel,
+            oldModel As DocumentSemanticModel,
+            newModel As DocumentSemanticModel,
             cancellationToken As CancellationToken) As OneOrMany(Of (oldSymbol As ISymbol, newSymbol As ISymbol))
 
             Dim oldSymbols = OneOrMany(Of ISymbol).Empty
             Dim newSymbols = OneOrMany(Of ISymbol).Empty
 
-            If oldNode IsNot Nothing AndAlso Not TryGetSyntaxNodesForEdit(editKind, oldNode, oldModel, oldSymbols, cancellationToken) OrElse
-               newNode IsNot Nothing AndAlso Not TryGetSyntaxNodesForEdit(editKind, newNode, newModel, newSymbols, cancellationToken) Then
+            If oldNode IsNot Nothing AndAlso Not TryGetSyntaxNodesForEdit(editKind, oldNode, oldModel.RequiredModel, oldSymbols, cancellationToken) OrElse
+               newNode IsNot Nothing AndAlso Not TryGetSyntaxNodesForEdit(editKind, newNode, newModel.RequiredModel, newSymbols, cancellationToken) Then
                 Return OneOrMany(Of (ISymbol, ISymbol)).Empty
             End If
 
@@ -741,8 +726,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             oldSymbol As ISymbol,
             newNode As SyntaxNode,
             newSymbol As ISymbol,
-            oldModel As SemanticModel,
-            newModel As SemanticModel,
+            oldModel As DocumentSemanticModel,
+            newModel As DocumentSemanticModel,
             topMatch As Match(Of SyntaxNode),
             editMap As IReadOnlyDictionary(Of SyntaxNode, EditKind),
             symbolCache As SymbolInfoCache,
@@ -756,10 +741,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                newNode.IsKind(SyntaxKind.ModifiedIdentifier) AndAlso newNode.IsParentKind(SyntaxKind.Parameter) Then
 
                 ' parameter list, member, Or type declaration
-                Dim oldContainingMemberOrType = GetParameterContainingMemberOrType(oldNode, newNode, oldModel, topMatch.ReverseMatches, cancellationToken)
-                Dim newContainingMemberOrType = GetParameterContainingMemberOrType(newNode, oldNode, newModel, topMatch.Matches, cancellationToken)
+                Dim oldContainingMemberOrType = GetParameterContainingMemberOrType(oldNode, newNode, oldModel.RequiredModel, topMatch.ReverseMatches, cancellationToken)
+                Dim newContainingMemberOrType = GetParameterContainingMemberOrType(newNode, oldNode, newModel.RequiredModel, topMatch.Matches, cancellationToken)
 
-                Dim matchingNewContainingMemberOrType = GetSemanticallyMatchingNewSymbol(oldContainingMemberOrType, newContainingMemberOrType, newModel, symbolCache, cancellationToken)
+                Dim matchingNewContainingMemberOrType = GetSemanticallyMatchingNewSymbol(oldContainingMemberOrType, newContainingMemberOrType, newModel.Compilation, symbolCache, cancellationToken)
 
                 ' Any change to a constraint should be analyzed as an update of the type parameter
                 Dim isTypeConstraint = TypeOf oldNode Is TypeParameterConstraintClauseSyntax OrElse
@@ -2289,10 +2274,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                                                                        forwardMap As IReadOnlyDictionary(Of SyntaxNode, SyntaxNode),
                                                                        oldActiveStatement As SyntaxNode,
                                                                        oldBody As DeclarationBody,
-                                                                       oldModel As SemanticModel,
+                                                                       oldModel As DocumentSemanticModel,
                                                                        newActiveStatement As SyntaxNode,
                                                                        newBody As DeclarationBody,
-                                                                       newModel As SemanticModel,
+                                                                       newModel As DocumentSemanticModel,
                                                                        isNonLeaf As Boolean,
                                                                        cancellationToken As CancellationToken)
 
@@ -2327,10 +2312,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                                                                             forwardMap As IReadOnlyDictionary(Of SyntaxNode, SyntaxNode),
                                                                             oldActiveStatement As SyntaxNode,
                                                                             oldEncompassingAncestor As SyntaxNode,
-                                                                            oldModel As SemanticModel,
+                                                                            oldModel As DocumentSemanticModel,
                                                                             newActiveStatement As SyntaxNode,
                                                                             newEncompassingAncestor As SyntaxNode,
-                                                                            newModel As SemanticModel,
+                                                                            newModel As DocumentSemanticModel,
                                                                             cancellationToken As CancellationToken)
 
             ' Rude Edits for Using/SyncLock/With/ForEach statements that are added/updated around an active statement.

--- a/src/Features/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -22,12 +22,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
         End Function
 
         Private Shared Function AddDefaultTestProject(solution As Solution, source As String) As Solution
-
-            Dim pid = ProjectId.CreateNewId()
-
             Return solution.
-                AddProject(ProjectInfo.Create(pid, VersionStamp.Create(), "proj", "proj", LanguageNames.VisualBasic)).GetProject(pid).
-                AddDocument("test.vb", SourceText.From(source, Encoding.UTF8), filePath:=Path.Combine(TempRoot.Root, "test.vb")).Project.Solution
+                AddTestProject("proj", LanguageNames.VisualBasic).
+                AddTestDocument(source, path:=Path.Combine(TempRoot.Root, "test.vb")).Project.Solution
         End Function
 
         Private Shared Sub TestSpans(source As String, hasLabel As Func(Of SyntaxNode, Boolean))
@@ -124,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Dim baseActiveStatements = AsyncLazy.Create(If(activeStatementMap, ActiveStatementsMap.Empty))
             Dim capabilities = AsyncLazy.Create(EditAndContinueTestVerifier.Net5RuntimeCapabilities)
             Dim log = New TraceLog("Test")
-            Return Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray(Of ActiveStatementLineSpan).Empty, capabilities, log, CancellationToken.None)
+            Return Await analyzer.AnalyzeDocumentAsync(newDocument.Id, oldProject, newDocument.Project, baseActiveStatements, ImmutableArray(Of ActiveStatementLineSpan).Empty, capabilities, log, CancellationToken.None)
         End Function
 #End Region
 


### PR DESCRIPTION
Handle deleted document as if its content was changed to empty.

The only difference is that when a document is deleted any rude edits to be reported in that document need to be reported in the project instead. We report such rude edits as workspace diagnostics in LSP diagnostic system.

Fixes https://github.com/dotnet/roslyn/issues/49013
Fixes https://github.com/dotnet/roslyn/issues/41144
