### PR TITLE
Fix information logs getting logged as debug in VSCode

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
@@ -106,7 +106,7 @@ internal sealed class RestoreHandler(DotnetCliHelper dotnetCliHelper) : ILspServ
             .Distinct()
             .ToImmutableArray();
 
-        context.TraceInformation($"Found {projects.Length} restorable projects from {solution.Projects.Count()} projects in solution");
+        context.TraceDebug($"Found {projects.Length} restorable projects from {solution.Projects.Count()} projects in solution");
         return projects;
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspServiceLogger.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspServiceLogger.cs
@@ -35,7 +35,7 @@ internal sealed class LspServiceLogger : AbstractLspLogger, ILspService
     /// <summary>
     /// TODO - Switch this to call LogInformation once appropriate callers have been changed to LogDebug.
     /// </summary>
-    public override void LogInformation(string message, params object[] @params) => _hostLogger.LogDebug(message, @params);
+    public override void LogInformation(string message, params object[] @params) => _hostLogger.LogInformation(message, @params);
 
     public override void LogWarning(string message, params object[] @params) => _hostLogger.LogWarning(message, @params);
 }

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -181,7 +181,7 @@ internal abstract class AbstractLanguageServer<TRequestContext>
 
     public virtual bool TryGetLanguageForRequest(string methodName, object? serializedRequest, [NotNullWhen(true)] out string? language)
     {
-        Logger.LogInformation($"Using default language handler for {methodName}");
+        Logger.LogDebug($"Using default language handler for {methodName}");
         language = LanguageServerConstants.DefaultLanguageName;
         return true;
     }

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs
@@ -223,7 +223,7 @@ internal sealed class QueueItem<TRequestContext> : IQueueItem<TRequestContext>
         {
             // Record logs + metrics on cancellation.
             _requestTelemetryScope?.RecordCancellation();
-            _logger.LogInformation($"Request was cancelled.");
+            _logger.LogDebug($"Request was cancelled.");
 
             _completionSource.TrySetCanceled(ex.CancellationToken);
         }

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -492,7 +492,7 @@ internal static partial class ProtocolConversions
 
         if (uri == null)
         {
-            context?.TraceInformation($"Could not convert '{mappedSpan.FilePath}' to uri");
+            context?.TraceDebug($"Could not convert '{mappedSpan.FilePath}' to uri");
             return null;
         }
 

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -492,7 +492,7 @@ internal static partial class ProtocolConversions
 
         if (uri == null)
         {
-            context?.TraceDebug($"Could not convert '{mappedSpan.FilePath}' to uri");
+            context?.TraceWarning($"Could not convert '{mappedSpan.FilePath}' to uri");
             return null;
         }
 

--- a/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHelper.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHelper.cs
@@ -30,7 +30,7 @@ internal sealed class CodeActionResolveHelper
             data,
             operations,
             context.GetRequiredClientCapabilities().Workspace?.WorkspaceEdit?.ResourceOperations ?? [],
-            context.TraceInformation,
+            context.TraceDebug,
             cancellationToken);
     }
 

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -51,7 +51,7 @@ internal sealed class CompletionResolveHandler : ILspServiceRequestHandler<LSP.C
         if (!completionListCache.TryGetCompletionListCacheEntry(completionItem, out var cacheEntry))
         {
             // Don't have a cache associated with this completion item, cannot resolve.
-            context.TraceInformation("No cache entry found for the provided completion item at resolve time.");
+            context.TraceWarning("No cache entry found for the provided completion item at resolve time.");
             return Task.FromResult(completionItem);
         }
 

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractDocumentPullDiagnosticHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractDocumentPullDiagnosticHandler.cs
@@ -37,7 +37,7 @@ internal abstract class AbstractDocumentPullDiagnosticHandler<TDiagnosticsParams
         var textDocument = context.TextDocument;
         if (textDocument is null)
         {
-            context.TraceInformation("Ignoring diagnostics request because no text document was provided");
+            context.TraceDebug("Ignoring diagnostics request because no text document was provided");
             return new([]);
         }
 

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -107,7 +107,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
         // noise.  It is not exposed to the user.
         if (!this.GlobalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
         {
-            context.TraceInformation($"{this.GetType()}. Skipping due to {nameof(SolutionCrawlerRegistrationService.EnableSolutionCrawler)}={false}");
+            context.TraceDebug($"{this.GetType()}. Skipping due to {nameof(SolutionCrawlerRegistrationService.EnableSolutionCrawler)}={false}");
         }
         else
         {
@@ -116,7 +116,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
             var clientCapabilities = context.GetRequiredClientCapabilities();
             var category = GetRequestDiagnosticCategory(diagnosticsParams);
             var handlerName = $"{this.GetType().Name}(category: {category})";
-            context.TraceInformation($"{handlerName} started getting diagnostics");
+            context.TraceDebug($"{handlerName} started getting diagnostics");
 
             var versionedCache = _categoryToVersionedCache.GetOrAdd(
                 handlerName, static (handlerName, globalOptions) => new(globalOptions, handlerName), GlobalOptions);
@@ -124,7 +124,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
             // Get the set of results the request said were previously reported.  We can use this to determine both
             // what to skip, and what files we have to tell the client have been removed.
             var previousResults = GetPreviousResults(diagnosticsParams) ?? [];
-            context.TraceInformation($"previousResults.Length={previousResults.Length}");
+            context.TraceDebug($"previousResults.Length={previousResults.Length}");
 
             // Create a mapping from documents to the previous results the client says it has for them.  That way as we
             // process documents we know if we should tell the client it should stay the same, or we can tell it what
@@ -142,7 +142,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
             var orderedSources = await GetOrderedDiagnosticSourcesAsync(
                 diagnosticsParams, category, context, cancellationToken).ConfigureAwait(false);
 
-            context.TraceInformation($"Processing {orderedSources.Length} documents");
+            context.TraceDebug($"Processing {orderedSources.Length} documents");
 
             // Keep track of what diagnostic sources we see this time around.  For any we do not see this time
             // around, we'll notify the client that the diagnostics for it have been removed.
@@ -169,7 +169,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
                 }
                 else
                 {
-                    context.TraceInformation($"Diagnostics were unchanged for {diagnosticSource.ToDisplayString()}");
+                    context.TraceDebug($"Diagnostics were unchanged for {diagnosticSource.ToDisplayString()}");
 
                     // Nothing changed between the last request and this one.  Report a (null-diagnostics,
                     // same-result-id) response to the client as that means they should just preserve the current
@@ -212,7 +212,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
 
             // If we had a progress object, then we will have been reporting to that.  Otherwise, take what we've been
             // collecting and return that.
-            context.TraceInformation($"{this.GetType()} finished getting diagnostics");
+            context.TraceDebug($"{this.GetType()} finished getting diagnostics");
         }
 
         return CreateReturn(progress);
@@ -297,7 +297,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
     {
         foreach (var removedResult in removedPreviousResults)
         {
-            context.TraceInformation($"Clearing diagnostics for removed document: {removedResult.TextDocument.DocumentUri}");
+            context.TraceDebug($"Clearing diagnostics for removed document: {removedResult.TextDocument.DocumentUri}");
 
             // Client is asking server about a document that no longer exists (i.e. was removed/deleted from
             // the workspace). Report a (null-diagnostics, null-result-id) response to the client as that

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
@@ -114,7 +114,7 @@ internal abstract class AbstractWorkspacePullDiagnosticsHandler<TDiagnosticsPara
         }
 
         // We've hit a change, so we close the current request to allow the client to open a new one.
-        context.TraceInformation($"Closing workspace/diagnostics request for {category}");
+        context.TraceDebug($"Closing workspace/diagnostics request for {category}");
         return;
 
         bool HasChanged()

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSourceProviders/WorkspaceDiagnosticSourceHelpers.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSourceProviders/WorkspaceDiagnosticSourceHelpers.cs
@@ -45,7 +45,7 @@ internal static class WorkspaceDiagnosticSourceHelpers
         // Each handler treats those as separate worlds that they are responsible for.
         if (context.IsTracking(document.GetURI()))
         {
-            context.TraceInformation($"Skipping tracked document: {document.GetURI()}");
+            context.TraceDebug($"Skipping tracked document: {document.GetURI()}");
             return true;
         }
 

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticsPullCache.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticsPullCache.cs
@@ -47,7 +47,7 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
         public override async Task<ImmutableArray<DiagnosticData>> ComputeDataAsync(DiagnosticsRequestState state, CancellationToken cancellationToken)
         {
             var diagnostics = await state.DiagnosticSource.GetDiagnosticsAsync(state.Context, cancellationToken).ConfigureAwait(false);
-            state.Context.TraceInformation($"Found {diagnostics.Length} diagnostics for {state.DiagnosticSource.ToDisplayString()}");
+            state.Context.TraceDebug($"Found {diagnostics.Length} diagnostics for {state.DiagnosticSource.ToDisplayString()}");
             return diagnostics;
         }
 

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
@@ -31,7 +31,7 @@ internal class DidCloseHandler : ILspServiceNotificationHandler<LSP.DidCloseText
     public async Task HandleNotificationAsync(LSP.DidCloseTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
     {
         // GetTextDocumentIdentifier returns null to avoid creating the solution, so the queue is not able to log the uri.
-        context.TraceInformation($"didClose for {request.TextDocument.DocumentUri}");
+        context.TraceDebug($"didClose for {request.TextDocument.DocumentUri}");
 
         await context.StopTrackingAsync(request.TextDocument.DocumentUri, cancellationToken).ConfigureAwait(false);
     }

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -32,7 +32,7 @@ internal class DidOpenHandler : ILspServiceNotificationHandler<LSP.DidOpenTextDo
     public async Task HandleNotificationAsync(LSP.DidOpenTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
     {
         // GetTextDocumentIdentifier returns null to avoid creating the solution, so the queue is not able to log the uri.
-        context.TraceInformation($"didOpen for {request.TextDocument.DocumentUri}");
+        context.TraceDebug($"didOpen for {request.TextDocument.DocumentUri}");
 
         // Add the document and ensure the text we have matches whats on the client
         // TODO (https://github.com/dotnet/roslyn/issues/63583):

--- a/src/LanguageServer/Protocol/Handler/InlineCompletions/XmlSnippetParser.cs
+++ b/src/LanguageServer/Protocol/Handler/InlineCompletions/XmlSnippetParser.cs
@@ -47,7 +47,7 @@ internal sealed partial class XmlSnippetParser
         ParsedXmlSnippet? parsedSnippet = null;
         try
         {
-            logger.LogInformation($"Reading snippet for {matchingSnippetInfo.Title} with path {matchingSnippetInfo.Path}");
+            logger.LogDebug($"Reading snippet for {matchingSnippetInfo.Title} with path {matchingSnippetInfo.Path}");
             parsedSnippet = GetAndParseSnippetFromFile(matchingSnippetInfo);
         }
         catch (Exception ex) when (FatalError.ReportAndCatch(ex, ErrorSeverity.General))

--- a/src/LanguageServer/Protocol/Handler/MapCode/MapCodeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/MapCode/MapCodeHandler.cs
@@ -102,7 +102,7 @@ internal sealed class MapCodeHandler : ILspServiceRequestHandler<VSInternalMapCo
 
             if (textChanges is null)
             {
-                context.TraceInformation($"mapCode sub-request for {textDocument.DocumentUri} failed: 'IMapCodeService.MapCodeAsync' returns null.");
+                context.TraceDebug($"mapCode sub-request for {textDocument.DocumentUri} failed: 'IMapCodeService.MapCodeAsync' returns null.");
                 return null;
             }
 
@@ -127,7 +127,7 @@ internal sealed class MapCodeHandler : ILspServiceRequestHandler<VSInternalMapCo
                     // Ignore anything not in target document, which current code mapper doesn't handle anyway
                     if (!location.DocumentUri.Equals(textDocumentIdentifier.DocumentUri))
                     {
-                        context.TraceInformation($"A focus location in '{textDocumentIdentifier.DocumentUri}' is skipped, only locations in corresponding MapCodeMapping.TextDocument is currently considered.");
+                        context.TraceDebug($"A focus location in '{textDocumentIdentifier.DocumentUri}' is skipped, only locations in corresponding MapCodeMapping.TextDocument is currently considered.");
                         continue;
                     }
 

--- a/src/LanguageServer/Protocol/Handler/RelatedDocuments/RelatedDocumentsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/RelatedDocuments/RelatedDocumentsHandler.cs
@@ -41,19 +41,19 @@ internal sealed class RelatedDocumentsHandler
     public async Task<VSInternalRelatedDocumentReport[]?> HandleRequestAsync(
         VSInternalRelatedDocumentParams requestParams, RequestContext context, CancellationToken cancellationToken)
     {
-        context.TraceInformation($"{this.GetType()} started getting related documents");
+        context.TraceDebug($"{this.GetType()} started getting related documents");
 
         var solution = context.Solution;
         var document = context.Document;
         Contract.ThrowIfNull(solution);
         Contract.ThrowIfNull(document);
 
-        context.TraceInformation($"Processing: {document.FilePath}");
+        context.TraceDebug($"Processing: {document.FilePath}");
 
         var relatedDocumentsService = document.GetLanguageService<IRelatedDocumentsService>();
         if (relatedDocumentsService == null)
         {
-            context.TraceInformation($"Ignoring document '{document.FilePath}' because it does not support related documents");
+            context.TraceDebug($"Ignoring document '{document.FilePath}' because it does not support related documents");
             return [];
         }
 
@@ -85,7 +85,7 @@ internal sealed class RelatedDocumentsHandler
 
         // If we had a progress object, then we will have been reporting to that.  Otherwise, take what we've been
         // collecting and return that.
-        context.TraceInformation($"{this.GetType()} finished getting related documents");
+        context.TraceDebug($"{this.GetType()} finished getting related documents");
         return progress.GetFlattenedValues();
     }
 }

--- a/src/LanguageServer/Protocol/Handler/RelatedDocuments/RelatedDocumentsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/RelatedDocuments/RelatedDocumentsHandler.cs
@@ -41,8 +41,6 @@ internal sealed class RelatedDocumentsHandler
     public async Task<VSInternalRelatedDocumentReport[]?> HandleRequestAsync(
         VSInternalRelatedDocumentParams requestParams, RequestContext context, CancellationToken cancellationToken)
     {
-        context.TraceDebug($"{this.GetType()} started getting related documents");
-
         var solution = context.Solution;
         var document = context.Document;
         Contract.ThrowIfNull(solution);
@@ -85,7 +83,6 @@ internal sealed class RelatedDocumentsHandler
 
         // If we had a progress object, then we will have been reporting to that.  Otherwise, take what we've been
         // collecting and return that.
-        context.TraceDebug($"{this.GetType()} finished getting related documents");
         return progress.GetFlattenedValues();
     }
 }

--- a/src/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -330,13 +330,13 @@ internal readonly struct RequestContext
         // handler treats those as separate worlds that they are responsible for.
         if (TextDocument is not TDocument document)
         {
-            TraceInformation($"Ignoring diagnostics request because no {typeof(TDocument).Name} was provided");
+            TraceDebug($"Ignoring diagnostics request because no {typeof(TDocument).Name} was provided");
             return null;
         }
 
         if (!IsTracking(document.GetURI()))
         {
-            TraceWarning($"Ignoring diagnostics request for untracked document: {document.GetURI()}");
+            TraceDebug($"Ignoring diagnostics request for untracked document: {document.GetURI()}");
             return null;
         }
 
@@ -360,6 +360,9 @@ internal readonly struct RequestContext
 
         _lspSolution.Value = default;
     }
+
+    public void TraceDebug(string message)
+        => _logger.LogDebug(message);
 
     /// <summary>
     /// Logs an informational message.

--- a/src/LanguageServer/Protocol/Handler/SpellCheck/AbstractSpellCheckingHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/SpellCheck/AbstractSpellCheckingHandler.cs
@@ -62,7 +62,7 @@ internal abstract class AbstractSpellCheckHandler<TParams, TReport>
     public async Task<TReport[]?> HandleRequestAsync(
         TParams requestParams, RequestContext context, CancellationToken cancellationToken)
     {
-        context.TraceInformation($"{this.GetType()} started getting spell checking spans");
+        context.TraceDebug($"{this.GetType()} started getting spell checking spans");
 
         // The progress object we will stream reports to.
         using var progress = BufferedProgress.Create(requestParams.PartialResultToken);
@@ -70,7 +70,7 @@ internal abstract class AbstractSpellCheckHandler<TParams, TReport>
         // Get the set of results the request said were previously reported.  We can use this to determine both
         // what to skip, and what files we have to tell the client have been removed.
         var previousResults = GetPreviousResults(requestParams) ?? [];
-        context.TraceInformation($"previousResults.Length={previousResults.Length}");
+        context.TraceDebug($"previousResults.Length={previousResults.Length}");
 
         // First, let the client know if any workspace documents have gone away.  That way it can remove those for
         // the user from squiggles or error-list.
@@ -84,16 +84,16 @@ internal abstract class AbstractSpellCheckHandler<TParams, TReport>
         // Next process each file in priority order. Determine if spans are changed or unchanged since the
         // last time we notified the client.  Report back either to the client so they can update accordingly.
         var orderedDocuments = GetOrderedDocuments(context, cancellationToken);
-        context.TraceInformation($"Processing {orderedDocuments.Length} documents");
+        context.TraceDebug($"Processing {orderedDocuments.Length} documents");
 
         foreach (var document in orderedDocuments)
         {
-            context.TraceInformation($"Processing: {document.FilePath}");
+            context.TraceDebug($"Processing: {document.FilePath}");
 
             var languageService = document.GetLanguageService<ISpellCheckSpanService>();
             if (languageService == null)
             {
-                context.TraceInformation($"Ignoring document '{document.FilePath}' because it does not support spell checking");
+                context.TraceDebug($"Ignoring document '{document.FilePath}' because it does not support spell checking");
                 continue;
             }
 
@@ -107,7 +107,7 @@ internal abstract class AbstractSpellCheckHandler<TParams, TReport>
             if (newResult != null)
             {
                 var (newResultId, spans) = newResult.Value;
-                context.TraceInformation($"Spans were changed for document: {document.FilePath}");
+                context.TraceDebug($"Spans were changed for document: {document.FilePath}");
                 foreach (var report in ReportCurrentSpans(
                     document, spans, newResultId))
                 {
@@ -116,7 +116,7 @@ internal abstract class AbstractSpellCheckHandler<TParams, TReport>
             }
             else
             {
-                context.TraceInformation($"Spans were unchanged for document: {document.FilePath}");
+                context.TraceDebug($"Spans were unchanged for document: {document.FilePath}");
 
                 // Nothing changed between the last request and this one.  Report a (null-spans, same-result-id)
                 // response to the client as that means they should just preserve the current spans they have for
@@ -128,7 +128,7 @@ internal abstract class AbstractSpellCheckHandler<TParams, TReport>
 
         // If we had a progress object, then we will have been reporting to that.  Otherwise, take what we've been
         // collecting and return that.
-        context.TraceInformation($"{this.GetType()} finished getting spans");
+        context.TraceDebug($"{this.GetType()} finished getting spans");
         return progress.GetFlattenedValues();
     }
 
@@ -212,7 +212,7 @@ internal abstract class AbstractSpellCheckHandler<TParams, TReport>
                 var document = await context.Solution.GetTextDocumentAsync(textDocument, cancellationToken).ConfigureAwait(false);
                 if (document == null)
                 {
-                    context.TraceInformation($"Clearing spans for removed document: {textDocument.DocumentUri}");
+                    context.TraceDebug($"Clearing spans for removed document: {textDocument.DocumentUri}");
 
                     // Client is asking server about a document that no longer exists (i.e. was removed/deleted from
                     // the workspace). Report a (null-spans, null-result-id) response to the client as that means

--- a/src/LanguageServer/Protocol/Handler/SpellCheck/DocumentSpellCheckHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/SpellCheck/DocumentSpellCheckHandler.cs
@@ -47,13 +47,13 @@ internal sealed class DocumentSpellCheckHandler : AbstractSpellCheckHandler<VSIn
         // handler treats those as separate worlds that they are responsible for.
         if (context.Document == null)
         {
-            context.TraceInformation("Ignoring spell check request because no document was provided");
+            context.TraceDebug("Ignoring spell check request because no document was provided");
             return [];
         }
 
         if (!context.IsTracking(context.Document.GetURI()))
         {
-            context.TraceInformation($"Ignoring spell check request for untracked document: {context.Document.GetURI()}");
+            context.TraceDebug($"Ignoring spell check request for untracked document: {context.Document.GetURI()}");
             return [];
         }
 

--- a/src/LanguageServer/Protocol/Handler/SpellCheck/WorkspaceSpellCheckHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/SpellCheck/WorkspaceSpellCheckHandler.cs
@@ -79,7 +79,7 @@ internal sealed class WorkspaceSpellCheckHandler : AbstractSpellCheckHandler<VSI
                 // Each handler treats those as separate worlds that they are responsible for.
                 if (context.IsTracking(document.GetURI()))
                 {
-                    context.TraceInformation($"Skipping tracked document: {document.GetURI()}");
+                    context.TraceDebug($"Skipping tracked document: {document.GetURI()}");
                     continue;
                 }
 

--- a/src/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -167,7 +167,7 @@ internal sealed class RoslynLanguageServer : SystemTextJsonLanguageServer<Reques
     {
         if (serializedParameters == null)
         {
-            Logger.LogInformation("No request parameters given, using default language handler");
+            Logger.LogDebug("No request parameters given, using default language handler");
             language = LanguageServerConstants.DefaultLanguageName;
             return true;
         }
@@ -212,7 +212,7 @@ internal sealed class RoslynLanguageServer : SystemTextJsonLanguageServer<Reques
         if (uri == null)
         {
             // This request is not for a textDocument and is not a resolve request.
-            Logger.LogInformation("Request did not contain a textDocument, using default language handler");
+            Logger.LogDebug("Request did not contain a textDocument, using default language handler");
             language = LanguageServerConstants.DefaultLanguageName;
             return true;
         }

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -247,7 +247,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 var workspaceKind = document.Project.Solution.WorkspaceKind;
                 _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: true, workspaceKind);
                 _requestTelemetryLogger.UpdateUsedForkedSolutionCounter(isForked);
-                _logger.LogInformation($"{document.FilePath} found in workspace {workspaceKind}");
+                _logger.LogDebug($"{document.FilePath} found in workspace {workspaceKind}");
 
                 // As we found the document in a non-misc workspace, also attempt to remove it from the misc workspace
                 // if it happens to be in there as well.
@@ -264,7 +264,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         // We didn't find the document in any workspace, record a telemetry notification that we did not find it.
         // Depending on the host, this can be entirely normal (e.g. opening a loose file)
         var searchedWorkspaceKinds = string.Join(";", lspSolutions.SelectAsArray(lspSolution => lspSolution.Solution.Workspace.Kind));
-        _logger.LogInformation($"Could not find '{textDocumentIdentifier.DocumentUri}'.  Searched {searchedWorkspaceKinds}");
+        _logger.LogDebug($"Could not find '{textDocumentIdentifier.DocumentUri}'.  Searched {searchedWorkspaceKinds}");
         _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
 
         // Add the document to our loose files workspace (if we have one) if it is open.

--- a/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLogHubLoggerFactory.cs
+++ b/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLogHubLoggerFactory.cs
@@ -50,7 +50,7 @@ internal sealed class VisualStudioLogHubLoggerFactory : ILspServiceLoggerFactory
         // Register the default log level as information.
         // Loghub will take care of cleaning up older logs from past sessions / current session
         // if it decides the log file sizes are too large.
-        var loggingLevel = SourceLevels.ActivityTracing | SourceLevels.Information;
+        var loggingLevel = SourceLevels.ActivityTracing | SourceLevels.Verbose;
 
         var logOptions = new RpcContracts.Logging.LoggerOptions(new LoggingLevelSettings(loggingLevel));
         var traceSource = await configuration.RegisterLogSourceAsync(logId, logOptions, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Updates LSP logging to log using debug more appropriately, and fixes LSP server logging to not downgrade information logs to debug.