### PR TITLE
Shorten log category name

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
@@ -68,7 +68,7 @@ public abstract class AbstractLanguageServerHostTests : IDisposable
             var typeRefResolver = new ExtensionTypeRefResolver(assemblyLoader, loggerFactory);
 
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
-            LanguageServerHost = new LanguageServerHost(serverStream, serverStream, exportProvider, loggerFactory.CreateLogger<LanguageServerHost>(), typeRefResolver);
+            LanguageServerHost = new LanguageServerHost(serverStream, serverStream, exportProvider, loggerFactory, typeRefResolver);
 
             var messageFormatter = RoslynLanguageServer.CreateJsonMessageFormatter();
             _clientRpc = new JsonRpc(new HeaderDelimitedMessageHandler(clientStream, clientStream, messageFormatter))

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
@@ -26,7 +26,7 @@ internal sealed class LanguageServerHost
     private readonly AbstractLanguageServer<RequestContext> _roslynLanguageServer;
     private readonly JsonRpc _jsonRpc;
 
-    public LanguageServerHost(Stream inputStream, Stream outputStream, ExportProvider exportProvider, ILogger logger, AbstractTypeRefResolver typeRefResolver)
+    public LanguageServerHost(Stream inputStream, Stream outputStream, ExportProvider exportProvider, ILoggerFactory loggerFactory, AbstractTypeRefResolver typeRefResolver)
     {
         var messageFormatter = RoslynLanguageServer.CreateJsonMessageFormatter();
 
@@ -41,7 +41,7 @@ internal sealed class LanguageServerHost
         var roslynLspFactory = exportProvider.GetExportedValue<ILanguageServerFactory>();
         var capabilitiesProvider = new ServerCapabilitiesProvider(exportProvider.GetExportedValue<ExperimentalCapabilitiesProvider>());
 
-        _logger = logger;
+        _logger = loggerFactory.CreateLogger("LSP");
         var lspLogger = new LspServiceLogger(_logger);
 
         var hostServices = exportProvider.GetExportedValue<HostServicesProvider>().HostServices;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -122,12 +122,10 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     // TODO: Remove, the path should match exactly. Workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1830914.
     Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueMethodDebugInfoReader.IgnoreCaseWhenComparingDocumentNames = Path.DirectorySeparatorChar == '\\';
 
-    var languageServerLogger = loggerFactory.CreateLogger(nameof(LanguageServerHost));
-
     LanguageServerHost? server = null;
     if (serverConfiguration.UseStdIo)
     {
-        server = new LanguageServerHost(Console.OpenStandardInput(), Console.OpenStandardOutput(), exportProvider, languageServerLogger, typeRefResolver);
+        server = new LanguageServerHost(Console.OpenStandardInput(), Console.OpenStandardOutput(), exportProvider, loggerFactory, typeRefResolver);
     }
     else
     {
@@ -147,7 +145,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
         // Wait for connection from client
         await pipeServer.WaitForConnectionAsync(cancellationToken);
 
-        server = new LanguageServerHost(pipeServer, pipeServer, exportProvider, languageServerLogger, typeRefResolver);
+        server = new LanguageServerHost(pipeServer, pipeServer, exportProvider, loggerFactory, typeRefResolver);
     }
 
     server.Start();


### PR DESCRIPTION
Noticed while investigating logs.  Replaces `LanguageServerHost` with `LSP` which is a bit more readable.

![image](https://github.com/user-attachments/assets/d285f699-bd09-4a30-bf1b-92372309a9d3)
