### PR TITLE
Update AnalyzerConfig.cs s_propertyMatcherPattern regex key refactorization

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -64,22 +64,16 @@ my_prop = my_val
             var config = ParseConfigFile(@"
 [*.cs]
 
+#
+;
 =
-a
-a#
-a#b
-a##
-a#b#
-a;
-a;b
-a;;
-a;b;
-a#;
-a;#
-a 
- a
- a 
-Valid lines below
+ =
+==
+:
+ :
+::
+=:
+:=
 ");
 
             var namedSections = config.NamedSections;
@@ -92,33 +86,23 @@ Valid lines below
         {
             var config = ParseConfigFile(@"
 a=
-b=#
-c=#b
-d=##
-e=#b#
-f=;
-g=;b
-h=;;
-i=;b;
-j=#;
-k=;#
-l =
- m=
- n =
-o:
-p:#
-q:#b
-r:##
-s:#b#
-t:;
-u:;b
-v:;;
-w:;b;
-x:#;
-y:;#
-z :
- 0:
- 1 :
+b= 
+c=#
+d= #
+e=;
+f= ;
+g =
+ h=
+ i =
+j:
+k: 
+l:#
+m: #
+n:;
+o: ;
+p :
+ q:
+ r :
 ");
 
             var properties = config.GlobalSection.Properties;
@@ -140,17 +124,7 @@ z :
                         KeyValuePair.Create("o", ""),
                         KeyValuePair.Create("p", ""),
                         KeyValuePair.Create("q", ""),
-                        KeyValuePair.Create("r", ""),
-                        KeyValuePair.Create("s", ""),
-                        KeyValuePair.Create("t", ""),
-                        KeyValuePair.Create("u", ""),
-                        KeyValuePair.Create("v", ""),
-                        KeyValuePair.Create("w", ""),
-                        KeyValuePair.Create("x", ""),
-                        KeyValuePair.Create("y", ""),
-                        KeyValuePair.Create("z", ""),
-                        KeyValuePair.Create("0", ""),
-                        KeyValuePair.Create("1", "") },
+                        KeyValuePair.Create("r", "") },
                 properties);
         }
 
@@ -159,27 +133,11 @@ z :
         {
             var config = ParseConfigFile(@"
 a=b
-b=b#
-c=b#c
-d=b##
-e=b#c#
-f=b;
-g=b;c
-h=b;;
-i=b;c;
-j=b#;
-k=b;#
-l:b
-m:b#
-n:b#c
-o:b##
-p:b#c#
-q:b;
-r:b;c
-s:b;;
-t:b;c;
-u:b#;
-v:b;#
+ b = b #
+ c = b ;
+d:b
+ e : b #
+ f : b ;
 ");
 
             var properties = config.GlobalSection.Properties;
@@ -189,23 +147,7 @@ v:b;#
                         KeyValuePair.Create("c", "b"),
                         KeyValuePair.Create("d", "b"),
                         KeyValuePair.Create("e", "b"),
-                        KeyValuePair.Create("f", "b"),
-                        KeyValuePair.Create("g", "b"),
-                        KeyValuePair.Create("h", "b"),
-                        KeyValuePair.Create("i", "b"),
-                        KeyValuePair.Create("j", "b"),
-                        KeyValuePair.Create("k", "b"),
-                        KeyValuePair.Create("l", "b"),
-                        KeyValuePair.Create("m", "b"),
-                        KeyValuePair.Create("n", "b"),
-                        KeyValuePair.Create("o", "b"),
-                        KeyValuePair.Create("p", "b"),
-                        KeyValuePair.Create("q", "b"),
-                        KeyValuePair.Create("r", "b"),
-                        KeyValuePair.Create("s", "b"),
-                        KeyValuePair.Create("t", "b"),
-                        KeyValuePair.Create("u", "b"),
-                        KeyValuePair.Create("v", "b") },
+                        KeyValuePair.Create("f", "b") },
                 properties);
         }
 
@@ -215,92 +157,28 @@ v:b;#
             var config = ParseConfigFile(@"
 a=b=
 b=b=#
-c=b=#c
-d=b=##
-e=b=#c#
-f=b=;
-g=b=;c
-h=b=;;
-i=b=;c;
-j=b=#;
-k=b=;#
-l=b=c
-m=b=c#
-n=b=c#d
-o=b=c##
-p=b=c#d#
-q=b=c;
-r=b=c;d
-s=b=c;;
-t=b=c;d;
-u=b=c#;
-v=b=c;#
-w=b:
-x=b:#
-y=b:#c
-z=b:##
-0=b:#c#
-1=b:;
-2=b:;c
-3=b:;;
-4=b:;c;
-5=b:#;
-6=b:;#
-7=b:c
-8=b:c#
-9=b:c#d
-aa=b:c##
-ab=b:c#d#
-ac=b:c;
-ad=b:c;d
-ae=b:c;;
-af=b:c;d;
-ag=b:c#;
-ah=b:c;#
-ai:b=
-aj:b=#
-ak:b=#c
-al:b=##
-am:b=#c#
-an:b=;
-ao:b=;c
-ap:b=;;
-aq:b=;c;
-ar:b=#;
-as:b=;#
-at:b=c
-au:b=c#
-av:b=c#d
-aw:b=c##
-ax:b=c#d#
-ay:b=c;
-az:b=c;d
-a0:b=c;;
-a1:b=c;d;
-a2:b=c#;
-a3:b=c;#
-a4:b:
-a5:b:#
-a6:b:#c
-a7:b:##
-a8:b:#c#
-a9:b:;
-ba:b:;c
-ca:b:;;
-da:b:;c;
-ea:b:#;
-fa:b:;#
-ga:b:c
-ha:b:c#
-ia:b:c#d
-ja:b:c##
-ka:b:c#d#
-la:b:c;
-ma:b:c;d
-na:b:c;;
-oa:b:c;d;
-pa:b:c#;
-qa:b:c;#
+c=b=;
+d=b=c
+e=b=c#
+f=b=c;
+g=b:
+h=b:#
+i=b:;
+j=b:c
+k=b:c#
+l=b:c;
+m:b=
+n:b=#
+o:b=;
+p:b=c
+q:b=c#
+r:b=c;
+s:b:
+t:b:#
+u:b:;
+v:b:c
+w:b:c#
+x:b:c;
 ");
 
             var properties = config.GlobalSection.Properties;
@@ -308,91 +186,27 @@ qa:b:c;#
                 new[] { KeyValuePair.Create("a", "b="),
                         KeyValuePair.Create("b", "b="),
                         KeyValuePair.Create("c", "b="),
-                        KeyValuePair.Create("d", "b="),
-                        KeyValuePair.Create("e", "b="),
-                        KeyValuePair.Create("f", "b="),
-                        KeyValuePair.Create("g", "b="),
-                        KeyValuePair.Create("h", "b="),
-                        KeyValuePair.Create("i", "b="),
-                        KeyValuePair.Create("j", "b="),
-                        KeyValuePair.Create("k", "b="),
-                        KeyValuePair.Create("l", "b=c"),
-                        KeyValuePair.Create("m", "b=c"),
-                        KeyValuePair.Create("n", "b=c"),
-                        KeyValuePair.Create("o", "b=c"),
+                        KeyValuePair.Create("d", "b=c"),
+                        KeyValuePair.Create("e", "b=c"),
+                        KeyValuePair.Create("f", "b=c"),
+                        KeyValuePair.Create("g", "b:"),
+                        KeyValuePair.Create("h", "b:"),
+                        KeyValuePair.Create("i", "b:"),
+                        KeyValuePair.Create("j", "b:c"),
+                        KeyValuePair.Create("k", "b:c"),
+                        KeyValuePair.Create("l", "b:c"),
+                        KeyValuePair.Create("m", "b="),
+                        KeyValuePair.Create("n", "b="),
+                        KeyValuePair.Create("o", "b="),
                         KeyValuePair.Create("p", "b=c"),
                         KeyValuePair.Create("q", "b=c"),
                         KeyValuePair.Create("r", "b=c"),
-                        KeyValuePair.Create("s", "b=c"),
-                        KeyValuePair.Create("t", "b=c"),
-                        KeyValuePair.Create("u", "b=c"),
-                        KeyValuePair.Create("v", "b=c"),
-                        KeyValuePair.Create("w", "b:"),
-                        KeyValuePair.Create("x", "b:"),
-                        KeyValuePair.Create("y", "b:"),
-                        KeyValuePair.Create("z", "b:"),
-                        KeyValuePair.Create("0", "b:"),
-                        KeyValuePair.Create("1", "b:"),
-                        KeyValuePair.Create("2", "b:"),
-                        KeyValuePair.Create("3", "b:"),
-                        KeyValuePair.Create("4", "b:"),
-                        KeyValuePair.Create("5", "b:"),
-                        KeyValuePair.Create("6", "b:"),
-                        KeyValuePair.Create("7", "b:c"),
-                        KeyValuePair.Create("8", "b:c"),
-                        KeyValuePair.Create("9", "b:c"),
-                        KeyValuePair.Create("aa", "b:c"),
-                        KeyValuePair.Create("ab", "b:c"),
-                        KeyValuePair.Create("ac", "b:c"),
-                        KeyValuePair.Create("ad", "b:c"),
-                        KeyValuePair.Create("ae", "b:c"),
-                        KeyValuePair.Create("af", "b:c"),
-                        KeyValuePair.Create("ag", "b:c"),
-                        KeyValuePair.Create("ah", "b:c"),
-                        KeyValuePair.Create("ai", "b="),
-                        KeyValuePair.Create("aj", "b="),
-                        KeyValuePair.Create("ak", "b="),
-                        KeyValuePair.Create("al", "b="),
-                        KeyValuePair.Create("am", "b="),
-                        KeyValuePair.Create("an", "b="),
-                        KeyValuePair.Create("ao", "b="),
-                        KeyValuePair.Create("ap", "b="),
-                        KeyValuePair.Create("aq", "b="),
-                        KeyValuePair.Create("ar", "b="),
-                        KeyValuePair.Create("as", "b="),
-                        KeyValuePair.Create("at", "b=c"),
-                        KeyValuePair.Create("au", "b=c"),
-                        KeyValuePair.Create("av", "b=c"),
-                        KeyValuePair.Create("aw", "b=c"),
-                        KeyValuePair.Create("ax", "b=c"),
-                        KeyValuePair.Create("ay", "b=c"),
-                        KeyValuePair.Create("az", "b=c"),
-                        KeyValuePair.Create("a0", "b=c"),
-                        KeyValuePair.Create("a1", "b=c"),
-                        KeyValuePair.Create("a2", "b=c"),
-                        KeyValuePair.Create("a3", "b=c"),
-                        KeyValuePair.Create("a4", "b:"),
-                        KeyValuePair.Create("a5", "b:"),
-                        KeyValuePair.Create("a6", "b:"),
-                        KeyValuePair.Create("a7", "b:"),
-                        KeyValuePair.Create("a8", "b:"),
-                        KeyValuePair.Create("a9", "b:"),
-                        KeyValuePair.Create("ba", "b:"),
-                        KeyValuePair.Create("ca", "b:"),
-                        KeyValuePair.Create("da", "b:"),
-                        KeyValuePair.Create("ea", "b:"),
-                        KeyValuePair.Create("fa", "b:"),
-                        KeyValuePair.Create("ga", "b:c"),
-                        KeyValuePair.Create("ha", "b:c"),
-                        KeyValuePair.Create("ia", "b:c"),
-                        KeyValuePair.Create("ja", "b:c"),
-                        KeyValuePair.Create("ka", "b:c"),
-                        KeyValuePair.Create("la", "b:c"),
-                        KeyValuePair.Create("ma", "b:c"),
-                        KeyValuePair.Create("na", "b:c"),
-                        KeyValuePair.Create("oa", "b:c"),
-                        KeyValuePair.Create("pa", "b:c"),
-                        KeyValuePair.Create("qa", "b:c") },
+                        KeyValuePair.Create("s", "b:"),
+                        KeyValuePair.Create("t", "b:"),
+                        KeyValuePair.Create("u", "b:"),
+                        KeyValuePair.Create("v", "b:c"),
+                        KeyValuePair.Create("w", "b:c"),
+                        KeyValuePair.Create("x", "b:c") },
                 properties);
         }
 
@@ -419,71 +233,30 @@ qa:b:c;#
         public void LimitTestCase()
         {
             var config = ParseConfigFile(@"
-a =:
+a=:
 b:=
-c=:=
-d:=:
-.
-.=
--
--=
-_
-_=
-e.
-f.=
-.g=
-.-
-.-=
--.
--.=
--_
--_=
-_-
-_-=
-h 
-i .
-j .=
-. k
-. l=
-m  =
-  n=
-  o  =
-p=b c
-q=b c#d
-r=b c#d;e
-s b=c
- t . b = c # d ; e
+ c b = 
+d  =
+  e=
+  f  =
+g=b c
+h b=c
+ i . b = c # d ; e
 dotnet_analyzer_diagnostic.category-Minor Code Smell.severity = suggestion
 dotnet_analyzer_diagnostic.category-Minor\x2020Code\x2020Smell.severity = error
 ");
-
-            Assert.Equal(0, config.NamedSections.Length);
 
             var properties = config.GlobalSection.Properties;
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("a", ":"),
                         KeyValuePair.Create("b", "="),
-                        KeyValuePair.Create("c", ":="),
-                        KeyValuePair.Create("d", "=:"),
-                        KeyValuePair.Create(".", ""),
-                        KeyValuePair.Create("-", ""),
-                        KeyValuePair.Create("_", ""),
-                        KeyValuePair.Create("f.", ""),
-                        KeyValuePair.Create(".g", ""),
-                        KeyValuePair.Create(".-", ""),
-                        KeyValuePair.Create("-.", ""),
-                        KeyValuePair.Create("-_", ""),
-                        KeyValuePair.Create("_-", ""),
-                        KeyValuePair.Create("j .", ""),
-                        KeyValuePair.Create(". l", ""),
-                        KeyValuePair.Create("m", ""),
-                        KeyValuePair.Create("n", ""),
-                        KeyValuePair.Create("o", ""),
-                        KeyValuePair.Create("p", "b c"),
-                        KeyValuePair.Create("q", "b c"),
-                        KeyValuePair.Create("r", "b c"),
-                        KeyValuePair.Create("s b", "c"),
-                        KeyValuePair.Create("t . b", "c"),
+                        KeyValuePair.Create("c b", ""),
+                        KeyValuePair.Create("d", ""),
+                        KeyValuePair.Create("e", ""),
+                        KeyValuePair.Create("f", ""),
+                        KeyValuePair.Create("g", "b c"),
+                        KeyValuePair.Create("h b", "c"),
+                        KeyValuePair.Create("i . b", "c"),
                         KeyValuePair.Create("dotnet_analyzer_diagnostic.category-minor code smell.severity", "suggestion"),
                         KeyValuePair.Create(@"dotnet_analyzer_diagnostic.category-minor\x2020code\x2020smell.severity", "error") },
                 properties);

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -21,25 +21,15 @@ namespace Microsoft.CodeAnalysis
         // Matches EditorConfig section header such as "[*.{js,py}]", see https://editorconfig.org for details
         private const string s_sectionMatcherPattern = @"^\s*\[(([^#;]|\\#|\\;)+)\]\s*([#;].*)?$";
 
-        // Matches EditorConfig property such as "indent_style = space", see https://editorconfig.org for details
-        private const string s_propertyMatcherPattern = @"^[^\S\r\n]*((?:[^=:\s]+[^\S\r\n]*?)+?)[^\S\r\n]*[=:][^\S\r\n]*(.*?)[^\S\r\n]*([#;].*)?$";
-
 #if NET
 
         [GeneratedRegex(s_sectionMatcherPattern)]
         private static partial Regex GetSectionMatcherRegex();
 
-        [GeneratedRegex(s_propertyMatcherPattern)]
-        private static partial Regex GetPropertyMatcherRegex();
-
 #else
         private static readonly Regex s_sectionMatcher = new Regex(s_sectionMatcherPattern, RegexOptions.Compiled);
 
-        private static readonly Regex s_propertyMatcher = new Regex(s_propertyMatcherPattern, RegexOptions.Compiled);
-
         private static Regex GetSectionMatcherRegex() => s_sectionMatcher;
-
-        private static Regex GetPropertyMatcherRegex() => s_propertyMatcher;
 
 #endif
 
@@ -218,6 +208,7 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
+                // Section matching
                 var sectionMatches = GetSectionMatcherRegex().Matches(line);
                 if (sectionMatches.Count > 0 && sectionMatches[0].Groups.Count > 0)
                 {
@@ -232,23 +223,9 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
-                var propMatches = GetPropertyMatcherRegex().Matches(line);
-                if (propMatches.Count > 0 && propMatches[0].Groups.Count > 1)
+                // property matching
+                if (ExtractKeyValue(line, activeSectionProperties, out var _))
                 {
-                    var key = propMatches[0].Groups[1].Value;
-                    var value = propMatches[0].Groups[2].Value;
-
-                    Debug.Assert(!string.IsNullOrEmpty(key));
-                    Debug.Assert(key == key.Trim());
-                    Debug.Assert(value == value?.Trim());
-
-                    key = CaseInsensitiveComparison.ToLower(key);
-                    if (ReservedKeys.Contains(key) || ReservedValues.Contains(value))
-                    {
-                        value = CaseInsensitiveComparison.ToLower(value);
-                    }
-
-                    activeSectionProperties[key] = value ?? "";
                     continue;
                 }
             }
@@ -279,6 +256,62 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <summary>
+        /// Extracts a key-value pair from the given line. The line content will be trimmed
+        /// </summary>
+        /// <param name="line">Line to extract key/value from as an expected form of key{:|=}[value[{#|;}inline comment]]</param>
+        /// <param name="activeSectionProperties">Property collection builder</param>
+        /// <param name="key">Optional key found; default is "" because nullability is flagged by return</param>
+        /// <returns>Actual key found flag</returns>
+        private static bool ExtractKeyValue(string line, ImmutableDictionary<string, string>.Builder activeSectionProperties, out string key)
+        {
+            // Look for a key-value pair
+            var trimmedLine = line.TrimStart(); // remove leading whitespace for the key part
+            string keyPart;
+
+            // Look for a non-empty key part
+            var keyStart = trimmedLine.IndexOfAny(['=', ':']);
+            if (keyStart <= 0 || (keyPart = trimmedLine[..keyStart].TrimEnd()).Length == 0) // remove trailing whitespace for the key part, and ensure keyPart has a non-trimmable content (it can't have a content if keyStart is below second character)
+            {
+                key = "";
+                return false;
+            }
+
+            key = keyPart.ToLower(); // lower casing the key part
+            var valueComment = trimmedLine[(keyStart + 1)..].TrimStart(); // remove leading whitespace for the value part
+            string valuePart;
+
+            // Look for an inline comment in the value part
+            var commentStart = valueComment.IndexOfAny(['#', ';']);
+            if (commentStart > -1)
+            {
+                // Remove inline comment from the value part
+                valuePart = valueComment[..commentStart];
+            }
+            else
+            {
+                valuePart = valueComment;
+            }
+
+            string value;
+            if (ReservedKeys.Contains(key) || ReservedValues.Contains(valuePart))
+            {
+                // Lower case the value part if the key is reserved
+                value = valuePart.ToLower();
+            }
+            else
+            {
+                value = valuePart;
+            }
+
+            // Add the key-value pair to the dictionary
+            activeSectionProperties[key] = value.TrimEnd(); // remove trailing whitespace for the value part, allowing for "" values
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if the line is a comment. A line is considered a comment if its first non-space character is either # or ;
+        /// </summary>
         private static bool IsComment(string line)
         {
             foreach (char c in line)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EditorConfig/Parsing/EditorConfigParser.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EditorConfig/Parsing/EditorConfigParser.cs
@@ -14,8 +14,6 @@ internal static class EditorConfigParser
 {
     // Matches EditorConfig section header such as "[*.{js,py}]", see https://editorconfig.org for details
     private static readonly Regex s_sectionMatcher = new(@"^\s*\[(([^#;]|\\#|\\;)+)\]\s*([#;].*)?$", RegexOptions.Compiled);
-    // Matches EditorConfig property such as "indent_style = space", see https://editorconfig.org for details
-    private static readonly Regex s_propertyMatcher = new(@"^[^\S\r\n]*((?:[^=:\s]+[^\S\r\n]*?)+?)[^\S\r\n]*[=:][^\S\r\n]*(.*?)[^\S\r\n]*([#;].*)?$", RegexOptions.Compiled);
 
     private static ImmutableHashSet<string> ReservedKeys { get; }
         = ImmutableHashSet.CreateRange(AnalyzerConfigOptions.KeyComparer, [
@@ -82,23 +80,8 @@ internal static class EditorConfigParser
             }
 
             // property matching
-            var propMatches = s_propertyMatcher.Matches(line);
-            if (propMatches is [{ Groups.Count: > 1 }, ..])
+            if (ExtractKeyValue(line, activeSectionValues, out var key))
             {
-                var key = propMatches[0].Groups[1].Value;
-                var value = propMatches[0].Groups[2].Value;
-
-                Debug.Assert(!string.IsNullOrEmpty(key));
-                Debug.Assert(key == key.Trim());
-                Debug.Assert(value == value.Trim());
-
-                key = CaseInsensitiveComparison.ToLower(key);
-                if (ReservedKeys.Contains(key) || ReservedValues.Contains(value))
-                {
-                    value = CaseInsensitiveComparison.ToLower(value);
-                }
-
-                activeSectionValues[key] = value;
                 activeSectionLines[key] = textLine;
                 activeSectionEnd = textLine.End;
 
@@ -120,6 +103,7 @@ internal static class EditorConfigParser
             accumulator.ProcessSection(previousSection, activeSectionValues, activeSectionLines);
         }
 
+        // Check if the line is a comment. A line is considered a comment if its first non-space character is either # or ;
         static bool IsComment(string line)
         {
             foreach (var c in line)
@@ -132,5 +116,58 @@ internal static class EditorConfigParser
 
             return false;
         }
+    }
+
+    /// <summary>
+    /// Extracts a key-value pair from the given line. The line content will be trimmed
+    /// </summary>
+    /// <param name="line">Line to extract key/value from as an expected form of key{:|=}[value[{#|;}inline comment]]</param>
+    /// <param name="activeSectionProperties">Property collection builder</param>
+    /// <param name="key">Optional key found; default is "" because nullability is flagged by return</param>
+    /// <returns>Actual key found flag</returns>
+    private static bool ExtractKeyValue(string line, ImmutableDictionary<string, string>.Builder activeSectionProperties, out string key)
+    {
+        // Look for a key-value pair
+        var trimmedLine = line.TrimStart(); // remove leading whitespace for the key part
+        string keyPart;
+
+        // Look for a non-empty key part
+        var keyStart = trimmedLine.IndexOfAny(['=', ':']);
+        if (keyStart <= 0 || (keyPart = trimmedLine[..keyStart].TrimEnd()).Length == 0) // remove trailing whitespace for the key part, and ensure keyPart has a non-trimmable content (it can't have a content if keyStart is below second character)
+        {
+            key = "";
+            return false;
+        }
+
+        key = keyPart.ToLower(); // lower casing the key part
+        var valueComment = trimmedLine[(keyStart + 1)..].TrimStart(); // remove leading whitespace for the value part
+        string valuePart;
+
+        // Look for an inline comment in the value part
+        var commentStart = valueComment.IndexOfAny(['#', ';']);
+        if (commentStart > -1)
+        {
+            // Remove inline comment from the value part
+            valuePart = valueComment[..commentStart];
+        }
+        else
+        {
+            valuePart = valueComment;
+        }
+
+        string value;
+        if (ReservedKeys.Contains(key) || ReservedValues.Contains(valuePart))
+        {
+            // Lower case the value part if the key is reserved
+            value = valuePart.ToLower();
+        }
+        else
+        {
+            value = valuePart;
+        }
+
+        // Add the key-value pair to the dictionary
+        activeSectionProperties[key] = value.TrimEnd(); // remove trailing whitespace for the value part, allowing for "" values
+        return true;
     }
 }


### PR DESCRIPTION
Per request from @CyrusNajmabadi in https://github.com/dotnet/roslyn/pull/78459#issuecomment-2859946093, refactorization of `s_propertyMatcherPattern` as an expanded scope.

Closes https://github.com/dotnet/roslyn/issues/55431
Relates to https://github.com/dotnet/roslyn/pull/78459:
> Allowed any character in the key name as per [specification](https://spec.editorconfig.org/#file-format), including spaces, excluding `:` and `=` characters.
> Changed `\s*` to `[^\S\r\n]` to account for multiline context
> 
> Regex testings: https://regex101.com/r/l0FeUH/9
> 
> PR related to issue https://github.com/dotnet/roslyn/issues/55431#issuecomment-2839580612
> 
> Notes:
> - To NOT break [current](https://github.com/dotnet/roslyn/blob/1e14d8a2f9eb04b0c9b4076fdc8a7f02d5d53ab1/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs#L25) implementation parsing, inline comments are still available. Removing the trailing `([#;].*)?` part would solve the issue.
> - Multiline parsing is enabled as part of easy regex testings, eventho it's a single-line evaluation process implementation.

@dotnet-policy-service agree