### PR TITLE
Source packages nullable

### DIFF
--- a/src/Dependencies/.editorconfig
+++ b/src/Dependencies/.editorconfig
@@ -1,0 +1,6 @@
+[*.cs]
+
+# IDE0240: Remove redundant nullable directive
+# The directive needs to be included since all sources in a source package are considered generated code
+# when referenced from a project via package reference.
+dotnet_diagnostic.IDE0240.severity = none

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoConstants.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoConstants.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Debugging
 {
     /// <summary>

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoEncoder.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoEncoder.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Debugging
         public readonly int RecordCount => _recordCount;
 
         /// <exception cref="InvalidOperationException">More than <see cref="byte.MaxValue"/> records added.</exception>
-        public readonly byte[] ToArray()
+        public readonly byte[]? ToArray()
         {
             if (_recordCount == 0)
             {
@@ -54,8 +54,6 @@ namespace Microsoft.CodeAnalysis.Debugging
 
         public void AddStateMachineTypeName(string typeName)
         {
-            Debug.Assert(typeName != null);
-
             AddRecord(
                 CustomDebugInfoKind.StateMachineTypeName,
                 typeName,
@@ -142,8 +140,6 @@ namespace Microsoft.CodeAnalysis.Debugging
 
         public void AddDynamicLocals(IReadOnlyCollection<(string LocalName, byte[] Flags, int Count, int SlotIndex)> dynamicLocals)
         {
-            Debug.Assert(dynamicLocals != null);
-
             AddRecord(
                 CustomDebugInfoKind.DynamicLocals,
                 dynamicLocals,
@@ -168,8 +164,6 @@ namespace Microsoft.CodeAnalysis.Debugging
 
         public void AddTupleElementNames(IReadOnlyCollection<(string LocalName, int SlotIndex, int ScopeStart, int ScopeEnd, ImmutableArray<string> Names)> tupleLocals)
         {
-            Debug.Assert(tupleLocals != null);
-
             AddRecord(
                 CustomDebugInfoKind.TupleElementNames,
                 tupleLocals,

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoEncoder.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoEncoder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #nullable disable
 
 using System;

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoEncoder.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoEncoder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #nullable disable
 
 using System;

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoKind.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoKind.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+#nullable enable
 
 namespace Microsoft.CodeAnalysis.Debugging
 {

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoKind.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoKind.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #nullable disable
 
 namespace Microsoft.CodeAnalysis.Debugging

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoKind.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #nullable disable
 
 namespace Microsoft.CodeAnalysis.Debugging

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -313,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Debugging
         private static TupleElementNamesInfo DecodeTupleElementNamesInfo(ImmutableArray<byte> bytes, ref int offset)
         {
             var n = ReadInt32(bytes, ref offset);
-            var builder = ArrayBuilder<string>.GetInstance(n);
+            var builder = ArrayBuilder<string?>.GetInstance(n);
             for (var i = 0; i < n; i++)
             {
                 var value = ReadUtf8String(bytes, ref offset);
@@ -337,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Debugging
         public static ImmutableArray<ImmutableArray<string>> GetCSharpGroupedImportStrings<TArg>(
             int methodToken,
             TArg arg,
-            Func<int, TArg, byte[]> getMethodCustomDebugInfo,
+            Func<int, TArg, byte[]?> getMethodCustomDebugInfo,
             Func<int, TArg, ImmutableArray<string>> getMethodImportStrings,
             out ImmutableArray<string> externAliasStrings)
         {
@@ -572,7 +573,7 @@ RETRY:
         ///  "TSystem.Math" -> <type name="System.Math" />
         /// ]]>
         /// </remarks>
-        public static bool TryParseCSharpImportString(string import, out string alias, out string externAlias, out string target, out ImportTargetKind kind)
+        public static bool TryParseCSharpImportString(string import, out string? alias, out string? externAlias, out string? target, out ImportTargetKind kind)
         {
             alias = null;
             externAlias = null;
@@ -673,7 +674,7 @@ RETRY:
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="import"/> is null.</exception>
         /// <exception cref="ArgumentException">Format of <paramref name="import"/> is not valid.</exception>
-        public static bool TryParseVisualBasicImportString(string import, out string alias, out string target, out ImportTargetKind kind, out VBImportScopeKind scope)
+        public static bool TryParseVisualBasicImportString(string import, out string? alias, out string? target, out ImportTargetKind kind, out VBImportScopeKind scope)
         {
             alias = null;
             target = null;
@@ -820,7 +821,7 @@ RETRY:
             }
         }
 
-        private static bool TrySplit(string input, int offset, char separator, out string before, out string after)
+        private static bool TrySplit(string input, int offset, char separator, [NotNullWhen(true)] out string? before, [NotNullWhen(true)] out string? after)
         {
             var separatorPos = input.IndexOf(separator, offset);
 

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #nullable disable
 
 using System;

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #nullable disable
 
 using System;

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoRecord.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoRecord.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+#nullable enable
 
 using System.Collections.Immutable;
 

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoRecord.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoRecord.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #nullable disable
 
 using System.Collections.Immutable;

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoRecord.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoRecord.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #nullable disable
 
 using System.Collections.Immutable;

--- a/src/Dependencies/CodeAnalysis.Debugging/DynamicLocalInfo.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/DynamicLocalInfo.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+#nullable enable
 
 using System.Collections.Immutable;
 

--- a/src/Dependencies/CodeAnalysis.Debugging/DynamicLocalInfo.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/DynamicLocalInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #nullable disable
 
 using System.Collections.Immutable;

--- a/src/Dependencies/CodeAnalysis.Debugging/DynamicLocalInfo.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/DynamicLocalInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 #nullable disable
 
 using System.Collections.Immutable;

--- a/src/Dependencies/CodeAnalysis.Debugging/ImportTargetKind.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/ImportTargetKind.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Debugging
 {
     internal enum ImportTargetKind

--- a/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
+++ b/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
@@ -24,4 +24,5 @@
     <PackageReference Include="System.ValueTuple" />
     <ProjectReference Include="..\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.Package.csproj" />
   </ItemGroup>
+  <Import Project="..\Contracts\Microsoft.CodeAnalysis.Contracts.projitems" Label="Shared" />
 </Project>

--- a/src/Dependencies/CodeAnalysis.Debugging/PortableCustomDebugInfoKinds.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/PortableCustomDebugInfoKinds.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis.Debugging

--- a/src/Dependencies/CodeAnalysis.Debugging/StateMachineHoistedLocalScope.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/StateMachineHoistedLocalScope.cs
@@ -4,8 +4,6 @@
 
 #nullable enable
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Debugging

--- a/src/Dependencies/CodeAnalysis.Debugging/StateMachineHoistedLocalScope.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/StateMachineHoistedLocalScope.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #nullable disable
 
 using System.Diagnostics;

--- a/src/Dependencies/CodeAnalysis.Debugging/TupleElementNamesInfo.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/TupleElementNamesInfo.cs
@@ -4,8 +4,6 @@
 
 #nullable enable
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/src/Dependencies/CodeAnalysis.Debugging/TupleElementNamesInfo.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/TupleElementNamesInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #nullable disable
 
 using System.Collections.Immutable;

--- a/src/Dependencies/CodeAnalysis.Debugging/TupleElementNamesInfo.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/TupleElementNamesInfo.cs
@@ -11,13 +11,13 @@ namespace Microsoft.CodeAnalysis.Debugging
 {
     internal readonly struct TupleElementNamesInfo
     {
-        internal readonly ImmutableArray<string> ElementNames;
+        internal readonly ImmutableArray<string?> ElementNames;
         internal readonly int SlotIndex; // Locals only
         internal readonly string LocalName;
         internal readonly int ScopeStart; // Constants only
         internal readonly int ScopeEnd; // Constants only
 
-        internal TupleElementNamesInfo(ImmutableArray<string> elementNames, int slotIndex, string localName, int scopeStart, int scopeEnd)
+        internal TupleElementNamesInfo(ImmutableArray<string?> elementNames, int slotIndex, string localName, int scopeStart, int scopeEnd)
         {
             Debug.Assert(!elementNames.IsDefault);
 

--- a/src/Dependencies/CodeAnalysis.Debugging/VBImportScopeKind.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/VBImportScopeKind.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Debugging
 {
     internal enum VBImportScopeKind

--- a/src/Dependencies/Collections/Extensions/ICollectionExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/ICollectionExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Extensions/IEnumerableExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/IEnumerableExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Internal/ArraySortHelper.cs
+++ b/src/Dependencies/Collections/Internal/ArraySortHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
 //

--- a/src/Dependencies/Collections/Internal/BitHelper.cs
+++ b/src/Dependencies/Collections/Internal/BitHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/Common/src/System/Collections/Generic/BitHelper.cs
 //

--- a/src/Dependencies/Collections/Internal/HashHelpers.cs
+++ b/src/Dependencies/Collections/Internal/HashHelpers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
 //

--- a/src/Dependencies/Collections/Internal/ICollectionCalls.cs
+++ b/src/Dependencies/Collections/Internal/ICollectionCalls.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 

--- a/src/Dependencies/Collections/Internal/ICollectionCalls`1.cs
+++ b/src/Dependencies/Collections/Internal/ICollectionCalls`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Collections.Internal

--- a/src/Dependencies/Collections/Internal/ICollectionDebugView`1.cs
+++ b/src/Dependencies/Collections/Internal/ICollectionDebugView`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ICollectionDebugView.cs
 //

--- a/src/Dependencies/Collections/Internal/IDictionaryCalls.cs
+++ b/src/Dependencies/Collections/Internal/IDictionaryCalls.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 

--- a/src/Dependencies/Collections/Internal/IDictionaryDebugView`2.cs
+++ b/src/Dependencies/Collections/Internal/IDictionaryDebugView`2.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IDictionaryDebugView.cs
 //

--- a/src/Dependencies/Collections/Internal/IEnumerableCalls.cs
+++ b/src/Dependencies/Collections/Internal/IEnumerableCalls.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 
 namespace Microsoft.CodeAnalysis.Collections.Internal

--- a/src/Dependencies/Collections/Internal/IEnumerableCalls`1.cs
+++ b/src/Dependencies/Collections/Internal/IEnumerableCalls`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Collections.Internal

--- a/src/Dependencies/Collections/Internal/IListCalls.cs
+++ b/src/Dependencies/Collections/Internal/IListCalls.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 
 namespace Microsoft.CodeAnalysis.Collections.Internal

--- a/src/Dependencies/Collections/Internal/InsertionBehavior.cs
+++ b/src/Dependencies/Collections/Internal/InsertionBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/InsertionBehavior.cs
 //

--- a/src/Dependencies/Collections/Internal/RoslynUnsafe.cs
+++ b/src/Dependencies/Collections/Internal/RoslynUnsafe.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis.Collections.Internal

--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Collections/Internal/SegmentedArraySegment`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArraySegment`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Collections.Internal
 {
     internal readonly struct SegmentedArraySegment<T>

--- a/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSetEqualityComparer.cs
 //

--- a/src/Dependencies/Collections/Internal/ThrowHelper.cs
+++ b/src/Dependencies/Collections/Internal/ThrowHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // This file defines an internal class used to throw exceptions in BCL code.
 // The main purpose is to reduce code size.
 //

--- a/src/Dependencies/Collections/OneOrMany.cs
+++ b/src/Dependencies/Collections/OneOrMany.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/RoslynEnumerable.cs
+++ b/src/Dependencies/Collections/RoslynEnumerable.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Collections.Internal;

--- a/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
+++ b/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder+KeyCollection.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder+KeyCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder+PrivateMarshal.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder+PrivateMarshal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Collections;
 
 internal readonly partial struct ImmutableSegmentedDictionary<TKey, TValue>

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder+ValueCollection.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder+ValueCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Builder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Enumerator.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+Enumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+KeyCollection+Enumerator.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+KeyCollection+Enumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+KeyCollection.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+KeyCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+PrivateMarshal.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+PrivateMarshal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 using System.Threading;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+ValueBuilder.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+ValueBuilder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+ValueCollection+Enumerator.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+ValueCollection+Enumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+ValueCollection.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2+ValueCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedDictionary`2.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+Builder.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+Builder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+Enumerator.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+Enumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+PrivateMarshal.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+PrivateMarshal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 using System.Threading;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+ValueBuilder.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1+ValueBuilder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedHashSet`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedList.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedListExtensions.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedListExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Collections;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+Builder.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+Builder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+Enumerator.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+Enumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+PrivateMarshal.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+PrivateMarshal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 using System.Threading;
 

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+ValueBuilder.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1+ValueBuilder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1.cs
+++ b/src/Dependencies/Collections/Segmented/ImmutableSegmentedList`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/SegmentedArray.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedArray.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Dependencies/Collections/Segmented/SegmentedArray`1+PrivateMarshal.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedArray`1+PrivateMarshal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Collections;
 
 internal readonly partial struct SegmentedArray<T>

--- a/src/Dependencies/Collections/Segmented/SegmentedArray`1.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedArray`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Segmented/SegmentedCollectionsMarshal.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedCollectionsMarshal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.Collections;

--- a/src/Dependencies/Collections/Segmented/SegmentedDictionary`2+PrivateMarshal.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedDictionary`2+PrivateMarshal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Collections;
 
 internal sealed partial class SegmentedDictionary<TKey, TValue>

--- a/src/Dependencies/Collections/Segmented/SegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedDictionary`2.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
 //

--- a/src/Dependencies/Collections/Segmented/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedHashSet`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
 //

--- a/src/Dependencies/Collections/Segmented/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/Segmented/SegmentedList`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
 //

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Collection.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Collection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Dictionary.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Dictionary.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Enumerable.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Enumerable.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Roslyn.Utilities

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Enumerator.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Enumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Enumerator`1.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Enumerator`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.List.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.List.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Set.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.Set.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Empty.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Roslyn.Utilities
 {
     internal partial class SpecializedCollections

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Collection.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Collection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Enumerable`1.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Enumerable`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 
 namespace Roslyn.Utilities

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Enumerable`2.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Enumerable`2.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Roslyn.Utilities

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Set.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.ReadOnly.Set.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Singleton.Collection`1.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Singleton.Collection`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.Singleton.Enumerator`1.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.Singleton.Enumerator`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/Dependencies/Collections/Specialized/SpecializedCollections.cs
+++ b/src/Dependencies/Collections/Specialized/SpecializedCollections.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Roslyn.Utilities

--- a/src/Dependencies/Collections/TemporaryArrayExtensions.cs
+++ b/src/Dependencies/Collections/TemporaryArrayExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Collections/TemporaryArray`1.cs
+++ b/src/Dependencies/Collections/TemporaryArray`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/Contracts/CollectionBuilderAttribute.cs
+++ b/src/Dependencies/Contracts/CollectionBuilderAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if !NET8_0_OR_GREATER
 
 namespace System.Runtime.CompilerServices

--- a/src/Dependencies/Contracts/CompilerFeatureRequiredAttribute.cs
+++ b/src/Dependencies/Contracts/CompilerFeatureRequiredAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // Copied from:
 // https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
 

--- a/src/Dependencies/Contracts/Contract.InterpolatedStringHandlers.cs
+++ b/src/Dependencies/Contracts/Contract.InterpolatedStringHandlers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if !MICROSOFT_CODEANALYSIS_CONTRACTS_NO_CONTRACT
 
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Contracts/Contract.cs
+++ b/src/Dependencies/Contracts/Contract.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if !MICROSOFT_CODEANALYSIS_CONTRACTS_NO_CONTRACT
 
 using System;

--- a/src/Dependencies/Contracts/ExceptionUtilities.cs
+++ b/src/Dependencies/Contracts/ExceptionUtilities.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Contracts/ExperimentalAttribute.cs
+++ b/src/Dependencies/Contracts/ExperimentalAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // This was copied from https://github.com/dotnet/runtime/blob/815953a12c822847095a843d69c610a9f895ae3f/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/ExperimentalAttribute.cs
 // and updated to have the scope of the attributes be internal.
 

--- a/src/Dependencies/Contracts/IReadOnlySet.cs
+++ b/src/Dependencies/Contracts/IReadOnlySet.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if NET6_0_OR_GREATER
 
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Contracts/Index.cs
+++ b/src/Dependencies/Contracts/Index.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if NET
 
 #pragma warning disable RS0016 // Add public types and members to the declared API (this is a supporting forwarder for an internal polyfill API)

--- a/src/Dependencies/Contracts/InterpolatedStringHandlerArgumentAttribute.cs
+++ b/src/Dependencies/Contracts/InterpolatedStringHandlerArgumentAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if NET6_0_OR_GREATER
 
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Contracts/InterpolatedStringHandlerArgumentAttribute.cs
+++ b/src/Dependencies/Contracts/InterpolatedStringHandlerArgumentAttribute.cs
@@ -12,6 +12,8 @@ using System.Runtime.CompilerServices;
 
 #else
 
+#pragma warning disable CA1019 // Add a public read-only property accessor for positional argument argument of Attribute
+
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Indicates which arguments to a method involving an interpolated string handler should be passed to that handler.</summary>

--- a/src/Dependencies/Contracts/InterpolatedStringHandlerAttribute.cs
+++ b/src/Dependencies/Contracts/InterpolatedStringHandlerAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if NET6_0_OR_GREATER
 
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Contracts/IsExternalInit.cs
+++ b/src/Dependencies/Contracts/IsExternalInit.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // Copied from:
 // https://github.com/dotnet/runtime/blob/218ef0f7776c2c20f6c594e3475b80f1fe2d7d08/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsExternalInit.cs
 

--- a/src/Dependencies/Contracts/NonCopyableAttribute.cs
+++ b/src/Dependencies/Contracts/NonCopyableAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis;

--- a/src/Dependencies/Contracts/NonDefaultableAttribute.cs
+++ b/src/Dependencies/Contracts/NonDefaultableAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis;

--- a/src/Dependencies/Contracts/NullableAttributes.cs
+++ b/src/Dependencies/Contracts/NullableAttributes.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // This was copied from https://github.com/dotnet/runtime/blob/39b9607807f29e48cae4652cd74735182b31182e/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 // and updated to have the scope of the attributes be internal.
 

--- a/src/Dependencies/Contracts/NullableAttributes.cs
+++ b/src/Dependencies/Contracts/NullableAttributes.cs
@@ -4,6 +4,7 @@
 
 // This was copied from https://github.com/dotnet/runtime/blob/39b9607807f29e48cae4652cd74735182b31182e/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 // and updated to have the scope of the attributes be internal.
+
 namespace System.Diagnostics.CodeAnalysis
 {
 #if !NETCOREAPP

--- a/src/Dependencies/Contracts/Range.cs
+++ b/src/Dependencies/Contracts/Range.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if NET
 
 #pragma warning disable RS0016 // Add public types and members to the declared API (this is a supporting forwarder for an internal polyfill API)

--- a/src/Dependencies/Contracts/RequiredMemberAttribute.cs
+++ b/src/Dependencies/Contracts/RequiredMemberAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // Copied from:
 // https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
 

--- a/src/Dependencies/Contracts/SetsRequiredMembersAttribute.cs
+++ b/src/Dependencies/Contracts/SetsRequiredMembersAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // Copied from:
 // https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
 

--- a/src/Dependencies/Directory.Build.targets
+++ b/src/Dependencies/Directory.Build.targets
@@ -1,0 +1,17 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+  
+  <!--
+    Include SourcePackage.editorconfig in all source packages.
+  -->
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddEditorConfigToSourcePackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="_AddEditorConfigToSourcePackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)SourcePackage.editorconfig" PackagePath="contentFiles/cs/$(TargetFramework)/.editorconfig" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Dependencies/PooledObjects/ArrayBuilder.Enumerator.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.Enumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     internal partial class ArrayBuilder<T>

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Dependencies/PooledObjects/ArrayBuilderExtensions.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilderExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Dependencies/PooledObjects/IPooled.cs
+++ b/src/Dependencies/PooledObjects/IPooled.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.PooledObjects;
 
 internal interface IPooled

--- a/src/Dependencies/PooledObjects/ObjectPool`1.cs
+++ b/src/Dependencies/PooledObjects/ObjectPool`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // define TRACE_LEAKS to get additional diagnostics that can lead to the leak sources. note: it will
 // make everything about 2-3x slower
 // 

--- a/src/Dependencies/PooledObjects/PooledDelegates.cs
+++ b/src/Dependencies/PooledObjects/PooledDelegates.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 

--- a/src/Dependencies/PooledObjects/PooledDictionary.cs
+++ b/src/Dependencies/PooledObjects/PooledDictionary.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Dependencies/PooledObjects/PooledDisposer.cs
+++ b/src/Dependencies/PooledObjects/PooledDisposer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if !MICROSOFT_CODEANALYSIS_POOLEDOBJECTS_NO_POOLED_DISPOSER
 using System;
 

--- a/src/Dependencies/PooledObjects/PooledHashSet.cs
+++ b/src/Dependencies/PooledObjects/PooledHashSet.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Text;
 

--- a/src/Dependencies/SourcePackage.editorconfig
+++ b/src/Dependencies/SourcePackage.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+generated_code = true

--- a/src/Dependencies/Threading/AsyncBatchingWorkQueue`0.cs
+++ b/src/Dependencies/Threading/AsyncBatchingWorkQueue`0.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Dependencies/Threading/AsyncBatchingWorkQueue`1.cs
+++ b/src/Dependencies/Threading/AsyncBatchingWorkQueue`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Dependencies/Threading/AsyncBatchingWorkQueue`2.cs
+++ b/src/Dependencies/Threading/AsyncBatchingWorkQueue`2.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Threading;
 /// cref="CancellationToken.IsCancellationRequested"/>.
 /// </para>
 /// </summary>
-internal class AsyncBatchingWorkQueue<TItem, TResult>
+internal class AsyncBatchingWorkQueue<TItem, TResult> : IDisposable
 {
     /// <summary>
     /// Delay we wait after finishing the processing of one batch and starting up on then.
@@ -119,6 +119,11 @@ internal class AsyncBatchingWorkQueue<TItem, TResult>
         // Combine with the queue cancellation token so that any batch is controlled by that token as well.
         _cancellationSeries = new CancellationSeries(_entireQueueCancellationToken);
         CancelExistingWork();
+    }
+
+    public void Dispose()
+    {
+        _cancellationSeries.Dispose();
     }
 
     /// <summary>

--- a/src/Dependencies/Threading/AsyncBatchingWorkQueue`2.cs
+++ b/src/Dependencies/Threading/AsyncBatchingWorkQueue`2.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Dependencies/Threading/CancellationSeries.cs
+++ b/src/Dependencies/Threading/CancellationSeries.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 // NOTE: This code is derived from an implementation originally in dotnet/project-system:
 // https://github.com/dotnet/project-system/blob/bdf69d5420ec8d894f5bf4c3d4692900b7f2479c/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
 //

--- a/src/Dependencies/Threading/ConfiguredYieldAwaitable.cs
+++ b/src/Dependencies/Threading/ConfiguredYieldAwaitable.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/src/Dependencies/Threading/TaskExtensions.cs
+++ b/src/Dependencies/Threading/TaskExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;

--- a/src/Dependencies/Threading/TestHooks/IAsyncToken.cs
+++ b/src/Dependencies/Threading/TestHooks/IAsyncToken.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis.Shared.TestHooks;

--- a/src/Dependencies/Threading/TestHooks/IAsynchronousOperationListener.cs
+++ b/src/Dependencies/Threading/TestHooks/IAsynchronousOperationListener.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis.Shared.TestHooks;

--- a/src/Dependencies/Threading/TestHooks/IAsynchronousOperationListenerProvider.cs
+++ b/src/Dependencies/Threading/TestHooks/IAsynchronousOperationListenerProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Shared.TestHooks;
 
 /// <summary>

--- a/src/Dependencies/Threading/TestHooks/IExpeditableDelaySource.cs
+++ b/src/Dependencies/Threading/TestHooks/IExpeditableDelaySource.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;

--- a/src/Dependencies/Threading/ValueTaskExtensions.cs
+++ b/src/Dependencies/Threading/ValueTaskExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;

--- a/src/Dependencies/Threading/VoidResult.cs
+++ b/src/Dependencies/Threading/VoidResult.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis.Threading;

--- a/src/Dependencies/Threading/YieldAwaitableExtensions.cs
+++ b/src/Dependencies/Threading/YieldAwaitableExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
@@ -358,6 +358,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 ITypeSymbolInternal? type = null;
                 if (targetKind == ImportTargetKind.Type)
                 {
+                    RoslynDebug.Assert(targetString != null);
                     type = symbolProvider.GetTypeSymbolForSerializedType(targetString);
                     targetString = null;
                 }
@@ -599,10 +600,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         private static bool TryCreateImportRecordFromVisualBasicImportString(string importString, out ImportRecord record, out VBImportScopeKind scope)
         {
-            ImportTargetKind targetKind;
-            string alias;
-            string targetString;
-            if (CustomDebugInfoReader.TryParseVisualBasicImportString(importString, out alias, out targetString, out targetKind, out scope))
+            if (CustomDebugInfoReader.TryParseVisualBasicImportString(importString, out var alias, out var targetString, out var targetKind, out scope))
             {
                 record = new ImportRecord(
                     targetKind: targetKind,


### PR DESCRIPTION
Subset of https://github.com/dotnet/roslyn/pull/77187 that is not blocked by TypeScript usage of internal apis

Include editorconfig file in all source packages that designates all source files in the package generated. This allows the consuming project to use different naming conventions.

Add #nullable enable to all source files in source packages. Generated source files are required to declare nullability rules.