### PR TITLE
Switch MethodImplAttributes.Async to 0x2000

### DIFF
--- a/docs/compilers/CSharp/Runtime Async Design.md
+++ b/docs/compilers/CSharp/Runtime Async Design.md
@@ -57,7 +57,7 @@ namespace System.Runtime.CompilerServices;
 
 public enum MethodImplOptions
 {
-    Async = 1024
+    Async = 0x2000
 }
 ```
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -1762,7 +1762,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // PROTOTYPE: Use real value from MethodImplAttributes when available
                     // When a method is emitted using runtime async, we add MethodImplAttributes.Async to indicate to the 
                     // runtime to generate the state machine
-                    result |= (System.Reflection.MethodImplAttributes)1024;
+                    result |= (System.Reflection.MethodImplAttributes)0x2000;
                 }
 
                 return result;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class CodeGenAsyncTests : EmitMetadataTestBase
     {
         // PROTOTYPE: Use the real value when possible
-        private const MethodImplAttributes MethodImplOptionsAsync = (MethodImplAttributes)1024;
+        private const MethodImplAttributes MethodImplOptionsAsync = (MethodImplAttributes)0x2000;
         private static CSharpParseOptions WithRuntimeAsync(CSharpParseOptions options) => options.WithFeature("runtime-async", "on");
 
         internal static string ExpectedOutput(string output, bool isRuntimeAsync = false)


### PR DESCRIPTION
It was changed in https://github.com/dotnet/runtime/issues/114310 as 0x400 is a thing in framework.

Relates to test plan https://github.com/dotnet/roslyn/issues/75960
