### PR TITLE
Fix checked/unchecked pair matching for extension unary operators during consumption

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2482,25 +2482,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal readonly struct ExtensionGroupingKey : IEquatable<ExtensionGroupingKey>
         {
-            public readonly int ExtensionArity;
-            public readonly TypeSymbol ReceiverType;
+            public readonly NamedTypeSymbol NormalizedExtension;
 
             public ExtensionGroupingKey(NamedTypeSymbol extension)
             {
-                ExtensionArity = extension.Arity;
-
                 if (extension.Arity != 0)
                 {
                     extension = extension.Construct(IndexedTypeParameterSymbol.Take(extension.Arity));
                 }
 
-                if (extension.ExtensionParameter is { } receiverParameter)
+                NormalizedExtension = extension;
+            }
+
+            private readonly int ExtensionArity
+            {
+                get
                 {
-                    ReceiverType = receiverParameter.Type;
+                    return NormalizedExtension.Arity;
                 }
-                else
+            }
+
+            private readonly TypeSymbol ReceiverType
+            {
+                get
                 {
-                    ReceiverType = ErrorTypeSymbol.UnknownResultType;
+                    if (NormalizedExtension.ExtensionParameter is { } receiverParameter)
+                    {
+                        return receiverParameter.Type;
+                    }
+                    else
+                    {
+                        return ErrorTypeSymbol.UnknownResultType;
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionOperatorsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionOperatorsTests.cs
@@ -1770,6 +1770,51 @@ class Program
                 );
         }
 
+        [Fact]
+        public void Unary_034_Consumption_Checked_Generic()
+        {
+            var src = $$$"""
+public static class Extensions1
+{
+    extension<T1>(C1<T1>)
+    {
+        public static C1<T1> operator -(C1<T1> x)
+        {
+            System.Console.Write("regular");
+            return x;
+        }
+    }
+    extension<T2>(C1<T2>)
+    {
+        public static C1<T2> operator checked -(C1<T2> x)
+        {
+            System.Console.Write("checked");
+            return x;
+        }
+    }
+}
+
+public class C1<T>;
+
+class Program
+{
+    static void Main()
+    {
+        var c1 = new C1<int>();
+        _ = -c1;
+
+        checked
+        {
+            _ = -c1;
+        }
+    }
+}
+""";
+
+            var comp = CreateCompilation(src, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "regularchecked").VerifyDiagnostics();
+        }
+
         [Theory]
         [CombinatorialData]
         public void Increment_001_Declaration([CombinatorialValues("++", "--")] string op)


### PR DESCRIPTION
Relates to test plan https://github.com/dotnet/roslyn/issues/76130