### PR TITLE
Fix embedded language classification inside multi-line string

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/SemanticTokens/AbstractSemanticTokensTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SemanticTokens/AbstractSemanticTokensTests.cs
@@ -35,10 +35,10 @@ public abstract class AbstractSemanticTokensTests : AbstractLanguageServerProtoc
         return result;
     }
 
-    private protected static async Task<LSP.SemanticTokens> RunGetSemanticTokensRangeAsync(TestLspServer testLspServer, LSP.Location caret, LSP.Range range)
+    private protected static async Task<LSP.SemanticTokens> RunGetSemanticTokensRangeAsync(TestLspServer testLspServer, LSP.Location location)
     {
         var result = await testLspServer.ExecuteRequestAsync<LSP.SemanticTokensRangeParams, LSP.SemanticTokens>(LSP.Methods.TextDocumentSemanticTokensRangeName,
-            CreateSemanticTokensRangeParams(caret, range), CancellationToken.None);
+            CreateSemanticTokensRangeParams(location), CancellationToken.None);
         Contract.ThrowIfNull(result);
         return result;
     }
@@ -57,11 +57,11 @@ public abstract class AbstractSemanticTokensTests : AbstractLanguageServerProtoc
             TextDocument = new LSP.TextDocumentIdentifier { DocumentUri = caret.DocumentUri }
         };
 
-    private static LSP.SemanticTokensRangeParams CreateSemanticTokensRangeParams(LSP.Location caret, LSP.Range range)
+    private static LSP.SemanticTokensRangeParams CreateSemanticTokensRangeParams(LSP.Location location)
         => new LSP.SemanticTokensRangeParams
         {
-            TextDocument = new LSP.TextDocumentIdentifier { DocumentUri = caret.DocumentUri },
-            Range = range
+            TextDocument = new LSP.TextDocumentIdentifier { DocumentUri = location.DocumentUri },
+            Range = location.Range
         };
 
     private static SemanticTokensRangesParams CreateSemanticTokensRangesParams(LSP.Location caret, Range[] ranges)

--- a/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -27,15 +27,14 @@ public sealed class SemanticTokensRangeTests(ITestOutputHelper testOutputHelper)
     {
         var markup =
             """
-            {|caret:|}// Comment
-            static class C { }
+            {|range:// Comment
+            static class C { }|}
 
             """;
         await using var testLspServer = await CreateTestLspServerAsync(
             markup, mutatingLspWorkspace, GetCapabilities(isVS));
 
-        var range = new LSP.Range { Start = new Position(0, 0), End = new Position(2, 0) };
-        var results = await RunGetSemanticTokensRangeAsync(testLspServer, testLspServer.GetLocations("caret").First(), range);
+        var results = await RunGetSemanticTokensRangeAsync(testLspServer, testLspServer.GetLocations("range").First());
 
         var expectedResults = new LSP.SemanticTokens();
         var tokenTypeToIndex = GetTokenTypeToIndex(testLspServer);
@@ -604,5 +603,90 @@ public sealed class SemanticTokensRangeTests(ITestOutputHelper testOutputHelper)
             var tokenName = schema.TokenTypeMap[expectedClassificationName];
             Assert.True(schema.AllTokenTypes.Contains(tokenName));
         }
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/74809")]
+    public async Task TestGetSemanticTokensRange_EmbeddedClassificationVerbatimString(bool mutatingLspWorkspace, bool isVS)
+    {
+        var markup =
+            """
+            public class C
+            {
+                public void M()
+                {
+                    {|range:// lang=c#-test
+                    const string Code = @"
+                    class C {
+                        //
+                    }";|}
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup, mutatingLspWorkspace, GetCapabilities(isVS));
+
+        var location = testLspServer.GetLocations("range").Single();
+        var results = await RunGetSemanticTokensRangeAsync(testLspServer, location);
+
+        var expectedResults = new LSP.SemanticTokens();
+        var tokenTypeToIndex = GetTokenTypeToIndex(testLspServer);
+        if (isVS)
+        {
+            expectedResults.Data =
+            [
+                // Line | Char | Len | Token type                        | Modifier
+                4,     8,    15,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
+                1,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
+                0,     6,     6,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
+                0,     7,     4,   tokenTypeToIndex[ClassificationTypeNames.ConstantName],      1,
+                0,     5,     1,   tokenTypeToIndex[SemanticTokenTypes.Operator],               0,
+                0,     2,     2,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
+                1,     0,    17,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
+                0,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
+                0,     5,     1,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
+                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.ClassName],                  0,
+                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
+                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+                1,     0,    12,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
+                0,     0,    14,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
+                0,    12,     2,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
+                1,     0,     8,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
+                0,     0,     9,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
+                0,     8,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
+                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+            ];
+        }
+        else
+        {
+            expectedResults.Data =
+            [
+                // Line | Char | Len | Token type                        | Modifier
+                4,     8,    15,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
+                1,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
+                0,     6,     6,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
+                0,     7,     4,   tokenTypeToIndex[CustomLspSemanticTokenNames.ConstantName],      1,
+                0,     5,     1,   tokenTypeToIndex[SemanticTokenTypes.Operator],               0,
+                0,     2,     2,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
+                1,     0,    17,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
+                0,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
+                0,     5,     1,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
+                0,     1,     1,   tokenTypeToIndex[SemanticTokenTypes.Class],                  0,
+                0,     1,     1,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
+                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+                1,     0,    12,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
+                0,     0,    14,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
+                0,    12,     2,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
+                1,     0,     8,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
+                0,     0,     9,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
+                0,     8,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+                0,     1,     1,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
+                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+            ];
+        }
+
+        await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results.Data).ConfigureAwait(false);
+        AssertEx.Equal(ConvertToReadableFormat(testLspServer.ClientCapabilities, expectedResults.Data), ConvertToReadableFormat(testLspServer.ClientCapabilities, results.Data));
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/74809

![image](https://github.com/user-attachments/assets/f36c3366-f886-4595-8e0a-b004cbfc68fe)
