### PR TITLE
Revert "Update XAML EA to use DocumentUri instead of System.Uri (#78555)"

### DIFF
--- a/src/Tools/ExternalAccess/Xaml/External/ConversionHelpers.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/ConversionHelpers.cs
@@ -7,15 +7,14 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.QuickInfo;
-using Roslyn.LanguageServer.Protocol;
 using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
 
 internal static class ConversionHelpers
 {
-    public static DocumentUri CreateAbsoluteDocumentUri(string absolutePath)
-        => ProtocolConversions.CreateAbsoluteDocumentUri(absolutePath);
+    public static Uri CreateAbsoluteUri(string absolutePath)
+        => ProtocolConversions.CreateAbsoluteUri(absolutePath);
 
     public static (string content, bool isMarkdown) CreateMarkdownContent(TextDocument document, QuickInfoItem info, XamlRequestContext context)
     {

--- a/src/Tools/ExternalAccess/Xaml/External/IResolveCachedDataService.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/IResolveCachedDataService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
 
@@ -15,6 +14,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
 /// </remarks>
 internal interface IResolveCachedDataService
 {
-    object ToResolveData(object data, DocumentUri uri);
-    (object? data, DocumentUri? uri) FromResolveData(object? resolveData);
+    object ToResolveData(object data, Uri uri);
+    (object? data, Uri? uri) FromResolveData(object? resolveData);
 }

--- a/src/Tools/ExternalAccess/Xaml/External/ResolveDataConversions.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/ResolveDataConversions.cs
@@ -17,24 +17,24 @@ internal static class ResolveDataConversions
     private record DataResolveData(object Data, LSP.TextDocumentIdentifier Document) : DocumentResolveData(Document);
     private record DataIdResolveData(long DataId, LSP.TextDocumentIdentifier Document) : DocumentResolveData(Document);
 
-    public static object ToResolveData(object data, DocumentUri uri)
-        => new DataResolveData(data, new LSP.TextDocumentIdentifier { DocumentUri = uri });
+    public static object ToResolveData(object data, Uri uri)
+        => new DataResolveData(data, new LSP.TextDocumentIdentifier { DocumentUri = new(uri) });
 
-    public static (object? data, DocumentUri? uri) FromResolveData(object? requestData)
+    public static (object? data, Uri? uri) FromResolveData(object? requestData)
     {
         Contract.ThrowIfNull(requestData);
         var resolveData = JsonSerializer.Deserialize<DataResolveData>((JsonElement)requestData);
-        return (resolveData?.Data, resolveData?.Document.DocumentUri);
+        return (resolveData?.Data, resolveData?.Document.DocumentUri.GetRequiredParsedUri());
     }
 
-    internal static object ToCachedResolveData(object data, DocumentUri uri, ResolveDataCache resolveDataCache)
+    internal static object ToCachedResolveData(object data, Uri uri, ResolveDataCache resolveDataCache)
     {
         var dataId = resolveDataCache.UpdateCache(data);
 
-        return new DataIdResolveData(dataId, new LSP.TextDocumentIdentifier { DocumentUri = uri });
+        return new DataIdResolveData(dataId, new LSP.TextDocumentIdentifier { DocumentUri = new(uri) });
     }
 
-    internal static (object? data, DocumentUri? uri) FromCachedResolveData(object? lspData, ResolveDataCache resolveDataCache)
+    internal static (object? data, Uri? uri) FromCachedResolveData(object? lspData, ResolveDataCache resolveDataCache)
     {
         DataIdResolveData? resolveData;
         if (lspData is JsonElement token)
@@ -50,6 +50,6 @@ internal static class ResolveDataConversions
         var data = resolveDataCache.GetCachedEntry(resolveData.DataId);
         var document = resolveData.Document;
 
-        return (data, document.DocumentUri);
+        return (data, document.DocumentUri.GetRequiredParsedUri());
     }
 }

--- a/src/Tools/ExternalAccess/Xaml/External/XamlRequestContext.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/XamlRequestContext.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Roslyn.LanguageServer.Protocol;
 using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
@@ -28,14 +27,14 @@ internal struct XamlRequestContext
     [Obsolete("Use ClientCapabilities instead.")]
     public readonly IClientCapabilityProvider ClientCapabilityProvider => new ClientCapabilityProvider(_context.GetRequiredClientCapabilities());
 
-    public object ToCachedResolveData(object data, DocumentUri uri)
+    public object ToCachedResolveData(object data, Uri uri)
     {
         var resolveDataCache = _context.GetRequiredLspService<ResolveDataCache>();
 
         return ResolveDataConversions.ToCachedResolveData(data, uri, resolveDataCache);
     }
 
-    public (object? data, DocumentUri? uri) FromCachedResolveData(object? lspData)
+    public (object? data, Uri? uri) FromCachedResolveData(object? lspData)
     {
         var resolveDataCache = _context.GetRequiredLspService<ResolveDataCache>();
 

--- a/src/Tools/ExternalAccess/Xaml/External/XamlRequestHandlerBase.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/XamlRequestHandlerBase.cs
@@ -25,9 +25,9 @@ internal abstract class XamlRequestHandlerBase<TRequest, TResponse> : ILspServic
     public bool RequiresLSPSolution => true;
 
     public LSP.TextDocumentIdentifier GetTextDocumentIdentifier(TRequest request)
-        => new() { DocumentUri = GetTextDocumentUri(request) };
+        => new() { DocumentUri = new(GetTextDocumentUri(request)) };
 
-    public abstract DocumentUri GetTextDocumentUri(TRequest request);
+    public abstract Uri GetTextDocumentUri(TRequest request);
 
     public Task<TResponse> HandleRequestAsync(TRequest request, RequestContext context, CancellationToken cancellationToken)
         => _xamlRequestHandler?.HandleRequestAsync(request, XamlRequestContext.FromRequestContext(context), cancellationToken) ?? throw new NotImplementedException();

--- a/src/Tools/ExternalAccess/Xaml/External/XamlRequestHandlerFactoryBase.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/XamlRequestHandlerFactoryBase.cs
@@ -5,7 +5,6 @@
 using System;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
 
@@ -37,10 +36,10 @@ internal abstract class XamlRequestHandlerFactoryBase<TRequest, TResponse> : ILs
             _resolveDataCache = resolveDataCache ?? throw new ArgumentNullException(nameof(resolveDataCache));
         }
 
-        public object ToResolveData(object data, DocumentUri uri)
+        public object ToResolveData(object data, Uri uri)
             => ResolveDataConversions.ToCachedResolveData(data, uri, _resolveDataCache);
 
-        public (object? data, DocumentUri? uri) FromResolveData(object? lspData)
+        public (object? data, Uri? uri) FromResolveData(object? lspData)
             => ResolveDataConversions.FromCachedResolveData(lspData, _resolveDataCache);
     }
 }

--- a/src/Tools/ExternalAccess/Xaml/InternalAPI.Unshipped.txt
+++ b/src/Tools/ExternalAccess/Xaml/InternalAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-abstract Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TResponse>.GetTextDocumentUri(TRequest request) -> Roslyn.LanguageServer.Protocol.DocumentUri!
+abstract Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TResponse>.GetTextDocumentUri(TRequest request) -> System.Uri!
 abstract Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerFactoryBase<TRequest, TResponse>.CreateHandler(Microsoft.CodeAnalysis.ExternalAccess.Xaml.IXamlRequestHandler<TRequest, TResponse>? xamlRequestHandler, Microsoft.CodeAnalysis.ExternalAccess.Xaml.IResolveCachedDataService! resolveDataService) -> Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TResponse>!
 const Microsoft.CodeAnalysis.ExternalAccess.Xaml.Constants.DiagnosticSourceProviderName = "XamlDiagnostics" -> string!
 const Microsoft.CodeAnalysis.ExternalAccess.Xaml.StringConstants.FactoryMethodMessage = "This factory method only provides services for the MEF export provider." -> string!
@@ -40,8 +40,8 @@ Microsoft.CodeAnalysis.ExternalAccess.Xaml.ILocationService.GetSymbolLocationsAs
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.IOnInitializedService
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.IOnInitializedService.OnInitializedAsync(Microsoft.CodeAnalysis.ExternalAccess.Xaml.IClientRequestManager! clientRequestManager, Roslyn.LanguageServer.Protocol.ClientCapabilities! clientCapabilities, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.IResolveCachedDataService
-Microsoft.CodeAnalysis.ExternalAccess.Xaml.IResolveCachedDataService.FromResolveData(object? resolveData) -> (object? data, Roslyn.LanguageServer.Protocol.DocumentUri? uri)
-Microsoft.CodeAnalysis.ExternalAccess.Xaml.IResolveCachedDataService.ToResolveData(object! data, Roslyn.LanguageServer.Protocol.DocumentUri! uri) -> object!
+Microsoft.CodeAnalysis.ExternalAccess.Xaml.IResolveCachedDataService.FromResolveData(object? resolveData) -> (object? data, System.Uri? uri)
+Microsoft.CodeAnalysis.ExternalAccess.Xaml.IResolveCachedDataService.ToResolveData(object! data, System.Uri! uri) -> object!
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.IXamlDiagnosticSource
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.IXamlDiagnosticSource.GetDiagnosticsAsync(Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic!>>!
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.IXamlRequestHandler<TRequest, TResponse>
@@ -67,9 +67,9 @@ Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlMethodAttribute.XamlMethodAttribu
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.ClientCapabilities.get -> Roslyn.LanguageServer.Protocol.ClientCapabilities!
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.ClientCapabilityProvider.get -> Microsoft.CodeAnalysis.ExternalAccess.Xaml.IClientCapabilityProvider!
-Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.FromCachedResolveData(object? lspData) -> (object? data, Roslyn.LanguageServer.Protocol.DocumentUri? uri)
+Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.FromCachedResolveData(object? lspData) -> (object? data, System.Uri? uri)
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.TextDocument.get -> Microsoft.CodeAnalysis.TextDocument?
-Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.ToCachedResolveData(object! data, Roslyn.LanguageServer.Protocol.DocumentUri! uri) -> object!
+Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.ToCachedResolveData(object! data, System.Uri! uri) -> object!
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.XamlRequestContext() -> void
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TResponse>
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TResponse>.GetTextDocumentIdentifier(TRequest request) -> Roslyn.LanguageServer.Protocol.TextDocumentIdentifier!
@@ -80,10 +80,11 @@ Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TRes
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerFactoryBase<TRequest, TResponse>
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerFactoryBase<TRequest, TResponse>.CreateILspService(Microsoft.CodeAnalysis.LanguageServer.LspServices! lspServices, Microsoft.CodeAnalysis.LanguageServer.WellKnownLspServerKinds serverKind) -> Microsoft.CodeAnalysis.LanguageServer.ILspService!
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerFactoryBase<TRequest, TResponse>.XamlRequestHandlerFactoryBase(Microsoft.CodeAnalysis.ExternalAccess.Xaml.IXamlRequestHandler<TRequest, TResponse>? xamlRequestHandler) -> void
-static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ConversionHelpers.CreateAbsoluteDocumentUri(string! absolutePath) -> Roslyn.LanguageServer.Protocol.DocumentUri!
+static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ConversionHelpers.CreateAbsoluteUri(string! absolutePath) -> System.Uri!
+static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ConversionHelpers.CreateHoverResultAsync(Microsoft.CodeAnalysis.TextDocument! document, Microsoft.CodeAnalysis.QuickInfo.QuickInfoItem! info, Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Roslyn.LanguageServer.Protocol.Hover!>!
 static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ConversionHelpers.CreateMarkdownContent(Microsoft.CodeAnalysis.TextDocument! document, Microsoft.CodeAnalysis.QuickInfo.QuickInfoItem! info, Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext context) -> (string! content, bool isMarkdown)
-static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.FromCachedResolveData(object? lspData, Microsoft.CodeAnalysis.LanguageServer.Handler.ResolveDataCache! resolveDataCache) -> (object? data, Roslyn.LanguageServer.Protocol.DocumentUri? uri)
-static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.FromResolveData(object? requestData) -> (object? data, Roslyn.LanguageServer.Protocol.DocumentUri? uri)
-static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.ToCachedResolveData(object! data, Roslyn.LanguageServer.Protocol.DocumentUri! uri, Microsoft.CodeAnalysis.LanguageServer.Handler.ResolveDataCache! resolveDataCache) -> object!
-static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.ToResolveData(object! data, Roslyn.LanguageServer.Protocol.DocumentUri! uri) -> object!
+static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.FromCachedResolveData(object? lspData, Microsoft.CodeAnalysis.LanguageServer.Handler.ResolveDataCache! resolveDataCache) -> (object? data, System.Uri? uri)
+static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.FromResolveData(object? requestData) -> (object? data, System.Uri? uri)
+static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.ToCachedResolveData(object! data, System.Uri! uri, Microsoft.CodeAnalysis.LanguageServer.Handler.ResolveDataCache! resolveDataCache) -> object!
+static Microsoft.CodeAnalysis.ExternalAccess.Xaml.ResolveDataConversions.ToResolveData(object! data, System.Uri! uri) -> object!
 static Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext.FromRequestContext(Microsoft.CodeAnalysis.LanguageServer.Handler.RequestContext context) -> Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestContext


### PR DESCRIPTION
This was fine in VS, but broke VSCode (until xaml updates).

This reverts commit 2611c9a910e5eed00e67f7615377ed5f23a94fe5, reversing changes made to f4e69647dc4320e1aefddd752ab7939e2610d6f3.