### PR TITLE
Ensure return local is the correct type for runtime async

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -170,11 +170,24 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         ? LocalSlotConstraints.None
                         : LocalSlotConstraints.ByRef;
 
+                    var returnTypeWithAnnotations = _method.ReturnTypeWithAnnotations;
+                    if (_module.Compilation.IsRuntimeAsyncEnabledIn(_method))
+                    {
+                        // The return type of the method is either Task<T> or ValueTask<T>. The il of the method is
+                        // actually going to appear to return a T, not the wrapper task type. So we need to
+                        // translate the return type to the actual type that will be returned.
+
+                        var returnType = returnTypeWithAnnotations.Type;
+                        Debug.Assert(((InternalSpecialType)returnType.OriginalDefinition.ExtendedSpecialType) is InternalSpecialType.System_Threading_Tasks_ValueTask_T or InternalSpecialType.System_Threading_Tasks_Task_T);
+
+                        returnTypeWithAnnotations = ((NamedTypeSymbol)returnType).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
+                    }
+
                     var bodySyntax = _methodBodySyntaxOpt;
                     if (_ilEmitStyle == ILEmitStyle.Debug && bodySyntax != null)
                     {
                         int syntaxOffset = _method.CalculateLocalSyntaxOffset(LambdaUtilities.GetDeclaratorPosition(bodySyntax), bodySyntax.SyntaxTree);
-                        var localSymbol = new SynthesizedLocal(_method, _method.ReturnTypeWithAnnotations, SynthesizedLocalKind.FunctionReturnValue, bodySyntax);
+                        var localSymbol = new SynthesizedLocal(_method, returnTypeWithAnnotations, SynthesizedLocalKind.FunctionReturnValue, bodySyntax);
 
                         result = _builder.LocalSlotManager.DeclareLocal(
                             type: _module.Translate(localSymbol.Type, bodySyntax, _diagnostics.DiagnosticBag),
@@ -190,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     }
                     else
                     {
-                        result = AllocateTemp(_method.ReturnType, _boundBody.Syntax, slotConstraints);
+                        result = AllocateTemp(returnTypeWithAnnotations.Type, _boundBody.Syntax, slotConstraints);
                     }
 
                     _returnTemp = result;

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         : LocalSlotConstraints.ByRef;
 
                     var returnTypeWithAnnotations = _method.ReturnTypeWithAnnotations;
-                    if (_module.Compilation.IsRuntimeAsyncEnabledIn(_method))
+                    if (_method.IsAsync && _module.Compilation.IsRuntimeAsyncEnabledIn(_method))
                     {
                         // The return type of the method is either Task<T> or ValueTask<T>. The il of the method is
                         // actually going to appear to return a T, not the wrapper task type. So we need to

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -632,7 +632,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return base.CallsAreOmitted(syntaxTree);
         }
 
-        internal sealed override bool GenerateDebugInfo => !IsAsync && !IsIterator;
+        internal sealed override bool GenerateDebugInfo
+        {
+            get
+            {
+                if (IsIterator)
+                {
+                    return false;
+                }
+
+                if (IsAsync)
+                {
+                    // PROTOTYPE: Need more dedicated debug information testing when runtime async is enabled.
+                    return DeclaringCompilation.IsRuntimeAsyncEnabledIn(this);
+                }
+
+                return true;
+            }
+        }
 
 #nullable enable
         protected override void MethodChecks(BindingDiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -8890,15 +8890,14 @@ class Test1
             {
                 ILVerifyMessage = $$"""
                     {{ReturnValueMissing("<Main>$", "0xf")}}
-                    [Handler]: Unexpected type on the stack. { Offset = 0xc, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
-                    [Handler]: Unexpected type on the stack. { Offset = 0x14, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
+                    [Handler]: Unexpected type on the stack. { Offset = 0x18, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
                     """
             });
             verifier.VerifyIL("C.Handler()", """
                 {
                   // Code size       25 (0x19)
                   .maxstack  1
-                  .locals init (System.Threading.Tasks.Task<int> V_0)
+                  .locals init (int V_0)
                   .try
                   {
                     IL_0000:  ldc.i4.s   42
@@ -8923,8 +8922,7 @@ class Test1
             {
                 ILVerifyMessage = $$"""
                     {{ReturnValueMissing("<Main>$", "0x12")}}
-                    [Handler]: Unexpected type on the stack. { Offset = 0x10, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
-                    [Handler]: Unexpected type on the stack. { Offset = 0x1b, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
+                    [Handler]: Unexpected type on the stack. { Offset = 0x1f, Found = Int32, Expected = ref 'System.Threading.Tasks.Task`1<int32>' }
                     """
             });
             verifier.VerifyIL("C.Handler()", """
@@ -8932,7 +8930,7 @@ class Test1
                   // Code size       32 (0x20)
                   .maxstack  1
                   .locals init (int V_0,
-                                System.Threading.Tasks.Task<int> V_1,
+                                int V_1,
                                 IntegerException V_2) //ex
                   IL_0000:  nop
                   .try


### PR DESCRIPTION
The return local created by CodeGenerator did not take runtime async into account, so it made a local of Task<T> or ValueTask<T>, which is very wrong for this scenario. We now do the right thing. Fixes https://github.com/dotnet/roslyn/issues/78529.

Relates to test plan https://github.com/dotnet/roslyn/issues/76130