### PR TITLE
Fix angle brackets in generics in hover

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -41,7 +41,7 @@ internal static partial class ProtocolConversions
 
     private static readonly char[] s_dirSeparators = [PathUtilities.DirectorySeparatorChar, PathUtilities.AltDirectorySeparatorChar];
 
-    private static readonly Regex s_markdownEscapeRegex = new(@"([\\`\*_\{\}\[\]\(\)#+\-\.!])", RegexOptions.Compiled);
+    private static readonly Regex s_markdownEscapeRegex = new(@"([\\`\*_\{\}\[\]\(\)#+\-\.!<>])", RegexOptions.Compiled);
 
     // NOTE: While the spec allows it, don't use Function and Method, as both VS and VS Code display them the same
     // way which can confuse users

--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -527,6 +527,7 @@ class C
             expectedLocation).ConfigureAwait(false);
         Assert.Equal(expectedMarkdown, results.Contents.Fourth.Value);
     }
+
     [Theory, CombinatorialData]
     public async Task TestGetHoverAsync_UsesNonBreakingSpaceForSupportedPlatforms(bool mutatingLspWorkspace)
     {
@@ -584,6 +585,47 @@ class C
 
         AssertEx.NotNull(result);
         Assert.Equal(expectedMarkdown, result.Contents.Fourth.Value);
+    }
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/6577")]
+    public async Task TestGetHoverAsync_EscapesAngleBracketsInGenerics(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            using System.Collections.Generic;
+            using System.Collections.Immutable;
+            using System.Threading.Tasks;
+            class C
+            {
+                private async Task<IDictionary<string, ImmutableArray<int>>> GetData()
+                {
+                    {|caret:var|} d = await GetData();
+                    return null;
+                }
+            }
+            """;
+        var clientCapabilities = new LSP.ClientCapabilities
+        {
+            TextDocument = new LSP.TextDocumentClientCapabilities { Hover = new LSP.HoverSetting { ContentFormat = [LSP.MarkupKind.Markdown] } }
+        };
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, clientCapabilities);
+        var expectedLocation = testLspServer.GetLocations("caret").Single();
+
+        var expectedMarkdown = """
+            ```csharp
+            interface System.Collections.Generic.IDictionary<TKey, TValue>
+            ```
+              
+              
+            TKey&nbsp;is&nbsp;string  
+            TValue&nbsp;is&nbsp;ImmutableArray\<int\>  
+            
+            """;
+
+        var results = await RunGetHoverAsync(
+            testLspServer,
+            expectedLocation).ConfigureAwait(false);
+        Assert.Equal(expectedMarkdown, results.Contents.Fourth.Value);
     }
 
     private static async Task<LSP.Hover> RunGetHoverAsync(


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/77233

Angle brackets can be used as html elements in markdown, and so sometimes need to be escaped (there is no issue if we always escape them).