### PR TITLE
Convert operand of `true`/`false` operator invoked as part of `&&`/`||`operator evaluation

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -1156,17 +1156,36 @@ namespace Microsoft.CodeAnalysis.CSharp
                             CheckConstraintLanguageVersionAndRuntimeSupportForOperator(node, kind == BinaryOperatorKind.LogicalAnd ? falseOperator : trueOperator,
                                 isUnsignedRightShift: false, signature.ConstrainedToTypeOpt, diagnostics);
 
+                        var operandPlaceholder = new BoundValuePlaceholder(resultLeft.Syntax, resultLeft.Type).MakeCompilerGenerated();
+                        var trueFalseParameterType = (resultKind.Operator() == BinaryOperatorKind.And ? falseOperator : trueOperator).Parameters[0].Type;
+                        CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+                        var conversion = this.Conversions.ClassifyConversionFromType(resultLeft.Type, trueFalseParameterType, isChecked: CheckOverflowAtRuntime, ref useSiteInfo);
+                        Debug.Assert(conversion.IsImplicit);
+
+                        BoundExpression operandConversion = CreateConversion(
+                            resultLeft.Syntax,
+                            operandPlaceholder,
+                            conversion,
+                            isCast: false,
+                            conversionGroupOpt: null,
+                            trueFalseParameterType,
+                            diagnostics);
+
+                        diagnostics.Add(operandConversion.Syntax, useSiteInfo);
+
                         return new BoundUserDefinedConditionalLogicalOperator(
                             node,
                             resultKind,
-                            resultLeft,
-                            resultRight,
                             signature.Method,
                             trueOperator,
                             falseOperator,
+                            operandPlaceholder,
+                            operandConversion,
                             signature.ConstrainedToTypeOpt,
                             lookupResult,
                             originalUserDefinedOperators,
+                            resultLeft,
+                            resultRight,
                             signature.ReturnType);
                     }
                     else
@@ -1234,8 +1253,35 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
+            // Strictly speaking, we probably should be digging through nullable type here to look for an operator
+            // declared by the underlying type. However, it doesn't look like dynamic binder is able to deal with
+            // nullable types while evaluating logical binary operators. Exceptions that it throws look like:
+            //
+            // Microsoft.CSharp.RuntimeBinder.RuntimeBinderException : The type ('S1?') must contain declarations of operator true and operator false
+            // Stack Trace:
+            //     at CallSite.Target(Closure, CallSite, Object, Object)
+            //     at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
+            //
+            // Microsoft.CSharp.RuntimeBinder.RuntimeBinderException : Operator '&&' cannot be applied to operands of type 'S1' and 'S1?'
+            // Stack Trace:
+            //     at CallSite.Target(Closure, CallSite, Object, Nullable`1)
+            //     at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
             var namedType = type as NamedTypeSymbol;
             var result = HasApplicableBooleanOperator(namedType, isNegative ? WellKnownMemberNames.FalseOperatorName : WellKnownMemberNames.TrueOperatorName, type, ref useSiteInfo, out userDefinedOperator);
+
+            if (result)
+            {
+                Debug.Assert(userDefinedOperator is not null);
+
+                var operandPlaceholder = new BoundValuePlaceholder(left.Syntax, left.Type).MakeCompilerGenerated();
+                TypeSymbol parameterType = userDefinedOperator.Parameters[0].Type;
+
+                implicitConversion = this.Conversions.ClassifyConversionFromType(operandPlaceholder.Type, parameterType, isChecked: CheckOverflowAtRuntime, ref useSiteInfo);
+                Debug.Assert(implicitConversion.IsImplicit);
+
+                CreateConversion(left.Syntax, operandPlaceholder, implicitConversion, isCast: false, conversionGroupOpt: null, parameterType, diagnostics);
+            }
+
             diagnostics.Add(left.Syntax, useSiteInfo);
 
             return result;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -501,6 +501,15 @@
     <Field Name="LogicalOperator" Type="MethodSymbol"/>
     <Field Name="TrueOperator" Type="MethodSymbol"/>
     <Field Name="FalseOperator" Type="MethodSymbol"/>
+
+    <!-- Used as an operand to bind TrueFalseOperandConversion -->
+    <Field Name="TrueFalseOperandPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
+    <!--
+    Could be a BoundConversion or, in some cases of an identity conversion, the OperandPlaceholder, or null for no conversion case
+    If the node survives lowering, this property in it must be null.
+    -->
+    <Field Name="TrueFalseOperandConversion" Type="BoundExpression?" SkipInVisitor="true" Null="allow"/>
+
     <Field Name="ConstrainedToTypeOpt" Type="TypeSymbol?" Null="allow"/>
     <Field Name="ResultKind" PropertyOverrides="true" Type="LookupResultKind"/>
     <!--The set of method symbols from which this operator's method was chosen.

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -454,39 +454,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundUserDefinedConditionalLogicalOperator
-    {
-        public BoundUserDefinedConditionalLogicalOperator(
-            SyntaxNode syntax,
-            BinaryOperatorKind operatorKind,
-            BoundExpression left,
-            BoundExpression right,
-            MethodSymbol logicalOperator,
-            MethodSymbol trueOperator,
-            MethodSymbol falseOperator,
-            TypeSymbol? constrainedToTypeOpt,
-            LookupResultKind resultKind,
-            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt,
-            TypeSymbol type,
-            bool hasErrors = false)
-            : this(
-                syntax,
-                operatorKind,
-                logicalOperator,
-                trueOperator,
-                falseOperator,
-                constrainedToTypeOpt,
-                resultKind,
-                originalUserDefinedOperatorsOpt,
-                left,
-                right,
-                type,
-                hasErrors)
-        {
-            Debug.Assert(operatorKind.IsUserDefined() && operatorKind.IsLogical());
-        }
-    }
-
     internal sealed partial class BoundParameter
     {
         public BoundParameter(SyntaxNode syntax, ParameterSymbol parameterSymbol, bool hasErrors = false)

--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         right,
                         type!),
                     // https://github.com/dotnet/roslyn/issues/35031: We'll need to update logical.LogicalOperator
-                    BoundUserDefinedConditionalLogicalOperator logical => logical.Update(logical.OperatorKind, logical.LogicalOperator, logical.TrueOperator, logical.FalseOperator, logical.ConstrainedToTypeOpt, logical.ResultKind, logical.OriginalUserDefinedOperatorsOpt, leftChild, right, type!),
+                    BoundUserDefinedConditionalLogicalOperator logical => logical.Update(logical.OperatorKind, logical.LogicalOperator, logical.TrueOperator, logical.FalseOperator, logical.TrueFalseOperandPlaceholder, logical.TrueFalseOperandConversion, logical.ConstrainedToTypeOpt, logical.ResultKind, logical.OriginalUserDefinedOperatorsOpt, leftChild, right, type!),
                     _ => throw ExceptionUtilities.UnexpectedValue(currentBinary.Kind),
                 };
 

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -1730,8 +1730,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundUserDefinedConditionalLogicalOperator : BoundBinaryOperatorBase
     {
-        public BoundUserDefinedConditionalLogicalOperator(SyntaxNode syntax, BinaryOperatorKind operatorKind, MethodSymbol logicalOperator, MethodSymbol trueOperator, MethodSymbol falseOperator, TypeSymbol? constrainedToTypeOpt, LookupResultKind resultKind, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt, BoundExpression left, BoundExpression right, TypeSymbol type, bool hasErrors = false)
-            : base(BoundKind.UserDefinedConditionalLogicalOperator, syntax, left, right, type, hasErrors || left.HasErrors() || right.HasErrors())
+        public BoundUserDefinedConditionalLogicalOperator(SyntaxNode syntax, BinaryOperatorKind operatorKind, MethodSymbol logicalOperator, MethodSymbol trueOperator, MethodSymbol falseOperator, BoundValuePlaceholder? trueFalseOperandPlaceholder, BoundExpression? trueFalseOperandConversion, TypeSymbol? constrainedToTypeOpt, LookupResultKind resultKind, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt, BoundExpression left, BoundExpression right, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.UserDefinedConditionalLogicalOperator, syntax, left, right, type, hasErrors || trueFalseOperandPlaceholder.HasErrors() || trueFalseOperandConversion.HasErrors() || left.HasErrors() || right.HasErrors())
         {
 
             RoslynDebug.Assert(logicalOperator is object, "Field 'logicalOperator' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
@@ -1745,6 +1745,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.LogicalOperator = logicalOperator;
             this.TrueOperator = trueOperator;
             this.FalseOperator = falseOperator;
+            this.TrueFalseOperandPlaceholder = trueFalseOperandPlaceholder;
+            this.TrueFalseOperandConversion = trueFalseOperandConversion;
             this.ConstrainedToTypeOpt = constrainedToTypeOpt;
             this.ResultKind = resultKind;
             this.OriginalUserDefinedOperatorsOpt = originalUserDefinedOperatorsOpt;
@@ -1754,6 +1756,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public MethodSymbol LogicalOperator { get; }
         public MethodSymbol TrueOperator { get; }
         public MethodSymbol FalseOperator { get; }
+        public BoundValuePlaceholder? TrueFalseOperandPlaceholder { get; }
+        public BoundExpression? TrueFalseOperandConversion { get; }
         public TypeSymbol? ConstrainedToTypeOpt { get; }
         public override LookupResultKind ResultKind { get; }
         public ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt { get; }
@@ -1761,11 +1765,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitUserDefinedConditionalLogicalOperator(this);
 
-        public BoundUserDefinedConditionalLogicalOperator Update(BinaryOperatorKind operatorKind, MethodSymbol logicalOperator, MethodSymbol trueOperator, MethodSymbol falseOperator, TypeSymbol? constrainedToTypeOpt, LookupResultKind resultKind, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt, BoundExpression left, BoundExpression right, TypeSymbol type)
+        public BoundUserDefinedConditionalLogicalOperator Update(BinaryOperatorKind operatorKind, MethodSymbol logicalOperator, MethodSymbol trueOperator, MethodSymbol falseOperator, BoundValuePlaceholder? trueFalseOperandPlaceholder, BoundExpression? trueFalseOperandConversion, TypeSymbol? constrainedToTypeOpt, LookupResultKind resultKind, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt, BoundExpression left, BoundExpression right, TypeSymbol type)
         {
-            if (operatorKind != this.OperatorKind || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(logicalOperator, this.LogicalOperator) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(trueOperator, this.TrueOperator) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(falseOperator, this.FalseOperator) || !TypeSymbol.Equals(constrainedToTypeOpt, this.ConstrainedToTypeOpt, TypeCompareKind.ConsiderEverything) || resultKind != this.ResultKind || originalUserDefinedOperatorsOpt != this.OriginalUserDefinedOperatorsOpt || left != this.Left || right != this.Right || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (operatorKind != this.OperatorKind || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(logicalOperator, this.LogicalOperator) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(trueOperator, this.TrueOperator) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(falseOperator, this.FalseOperator) || trueFalseOperandPlaceholder != this.TrueFalseOperandPlaceholder || trueFalseOperandConversion != this.TrueFalseOperandConversion || !TypeSymbol.Equals(constrainedToTypeOpt, this.ConstrainedToTypeOpt, TypeCompareKind.ConsiderEverything) || resultKind != this.ResultKind || originalUserDefinedOperatorsOpt != this.OriginalUserDefinedOperatorsOpt || left != this.Left || right != this.Right || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundUserDefinedConditionalLogicalOperator(this.Syntax, operatorKind, logicalOperator, trueOperator, falseOperator, constrainedToTypeOpt, resultKind, originalUserDefinedOperatorsOpt, left, right, type, this.HasErrors);
+                var result = new BoundUserDefinedConditionalLogicalOperator(this.Syntax, operatorKind, logicalOperator, trueOperator, falseOperator, trueFalseOperandPlaceholder, trueFalseOperandConversion, constrainedToTypeOpt, resultKind, originalUserDefinedOperatorsOpt, left, right, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -11087,11 +11091,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol trueOperator = this.VisitMethodSymbol(node.TrueOperator);
             MethodSymbol falseOperator = this.VisitMethodSymbol(node.FalseOperator);
             ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = this.VisitSymbols<MethodSymbol>(node.OriginalUserDefinedOperatorsOpt);
+            BoundValuePlaceholder? trueFalseOperandPlaceholder = node.TrueFalseOperandPlaceholder;
+            BoundExpression? trueFalseOperandConversion = node.TrueFalseOperandConversion;
             BoundExpression left = (BoundExpression)this.Visit(node.Left);
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             TypeSymbol? constrainedToTypeOpt = this.VisitType(node.ConstrainedToTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.OperatorKind, logicalOperator, trueOperator, falseOperator, constrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt, left, right, type);
+            return node.Update(node.OperatorKind, logicalOperator, trueOperator, falseOperator, trueFalseOperandPlaceholder, trueFalseOperandConversion, constrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt, left, right, type);
         }
         public override BoundNode? VisitCompoundAssignmentOperator(BoundCompoundAssignmentOperator node)
         {
@@ -15496,6 +15502,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("logicalOperator", node.LogicalOperator, null),
             new TreeDumperNode("trueOperator", node.TrueOperator, null),
             new TreeDumperNode("falseOperator", node.FalseOperator, null),
+            new TreeDumperNode("trueFalseOperandPlaceholder", null, new TreeDumperNode[] { Visit(node.TrueFalseOperandPlaceholder, null) }),
+            new TreeDumperNode("trueFalseOperandConversion", null, new TreeDumperNode[] { Visit(node.TrueFalseOperandConversion, null) }),
             new TreeDumperNode("constrainedToTypeOpt", node.ConstrainedToTypeOpt, null),
             new TreeDumperNode("resultKind", node.ResultKind, null),
             new TreeDumperNode("originalUserDefinedOperatorsOpt", node.OriginalUserDefinedOperatorsOpt, null),

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_inExpressionLambda)
             {
-                return node.Update(operatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, node.ConstrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt: default, loweredLeft, loweredRight, type);
+                return node.Update(operatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, trueFalseOperandPlaceholder: null, trueFalseOperandConversion: null, node.ConstrainedToTypeOpt, node.ResultKind, originalUserDefinedOperatorsOpt: default, loweredLeft, loweredRight, type);
             }
 
             BoundAssignmentOperator tempAssignment;
@@ -86,7 +86,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // T.false(temp)
             var falseOperatorCall = BoundCall.Synthesized(syntax, receiverOpt: node.ConstrainedToTypeOpt is null ? null : new BoundTypeExpression(syntax, aliasOpt: null, node.ConstrainedToTypeOpt),
                                                           initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
-                                                          operatorKind.Operator() == BinaryOperatorKind.And ? node.FalseOperator : node.TrueOperator, boundTemp);
+                                                          operatorKind.Operator() == BinaryOperatorKind.And ? node.FalseOperator : node.TrueOperator,
+                                                          ApplyConversionIfNotIdentity(node.TrueFalseOperandConversion, node.TrueFalseOperandPlaceholder, boundTemp));
 
             // T.&(temp, y)
             var andOperatorCall = LowerUserDefinedBinaryOperator(syntax, operatorKind & ~BinaryOperatorKind.Logical, boundTemp, loweredRight, type, node.LogicalOperator, node.ConstrainedToTypeOpt);
@@ -683,7 +684,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = _dynamicFactory.MakeDynamicUnaryOperator(testOperator, op, boolean).ToExpression();
                 if (!leftTestIsConstantFalse)
                 {
-                    BoundExpression leftTest = MakeTruthTestForDynamicLogicalOperator(syntax, loweredLeft, boolean, leftTruthOperator, constrainedToTypeOpt, negative: isAnd);
+                    BoundExpression leftTest = MakeTruthTestForDynamicLogicalOperator(syntax, operatorKind, loweredLeft, boolean, leftTruthOperator, constrainedToTypeOpt, negative: isAnd);
                     result = _factory.Binary(BinaryOperatorKind.LogicalOr, boolean, leftTest, result);
                 }
             }
@@ -699,7 +700,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // We might need to box.
-                    BoundExpression leftTest = MakeTruthTestForDynamicLogicalOperator(syntax, loweredLeft, boolean, leftTruthOperator, constrainedToTypeOpt, negative: isAnd);
+                    BoundExpression leftTest = MakeTruthTestForDynamicLogicalOperator(syntax, operatorKind, loweredLeft, boolean, leftTruthOperator, constrainedToTypeOpt, negative: isAnd);
                     var convertedLeft = MakeConversionNode(loweredLeft, type, @checked: false);
                     result = _factory.Conditional(leftTest, convertedLeft, op, type);
                 }
@@ -728,7 +729,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private BoundExpression MakeTruthTestForDynamicLogicalOperator(SyntaxNode syntax, BoundExpression loweredLeft, TypeSymbol boolean, MethodSymbol? leftTruthOperator, TypeSymbol? constrainedToTypeOpt, bool negative)
+        private BoundExpression MakeTruthTestForDynamicLogicalOperator(SyntaxNode syntax, BinaryOperatorKind operatorKind, BoundExpression loweredLeft, TypeSymbol boolean, MethodSymbol? leftTruthOperator, TypeSymbol? constrainedToTypeOpt, bool negative)
         {
             if (loweredLeft.HasDynamicType())
             {
@@ -742,10 +743,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo();
             var conversion = _compilation.Conversions.ClassifyConversionFromExpression(loweredLeft, boolean, isChecked: false, ref useSiteInfo);
-            _diagnostics.Add(loweredLeft.Syntax, useSiteInfo);
+
             if (conversion.IsImplicit)
             {
                 Debug.Assert(leftTruthOperator == null);
+
+                _diagnostics.Add(loweredLeft.Syntax, useSiteInfo);
 
                 var converted = MakeConversionNode(loweredLeft, boolean, @checked: false, markAsChecked: true); // The conversion was checked in binding
                 if (negative)
@@ -762,6 +765,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert(leftTruthOperator != null);
+
+            var parameterType = leftTruthOperator.Parameters[0].Type;
+            conversion = _compilation.Conversions.ClassifyConversionFromType(loweredLeft.Type, parameterType, isChecked: operatorKind.IsChecked(), ref useSiteInfo);
+            Debug.Assert(conversion.IsImplicit);
+
+            loweredLeft = MakeConversionNode(loweredLeft, parameterType, @checked: operatorKind.IsChecked(), markAsChecked: true); // The conversion was checked in binding
+
+            _diagnostics.Add(loweredLeft.Syntax, useSiteInfo);
+
             return BoundCall.Synthesized(
                 syntax,
                 receiverOpt: constrainedToTypeOpt is null ? null : new BoundTypeExpression(syntax, aliasOpt: null, constrainedToTypeOpt),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -8969,6 +8969,646 @@ class P
                 Diagnostic(ErrorCode.ERR_MustHaveOpTF, "x || y").WithArguments("A<object>.operator |(A<object>, A<object>)", "A<object>").WithLocation(21, 13));
         }
 
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_01([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        Test1(s1);
+        Test2(s1);
+    }
+
+    static S1 Test1(S1 s1) => s1 {{{op}}} s1;
+
+    static void Test2(S1 s1)
+    {
+        System.Linq.Expressions.Expression<System.Func<S1>> ex;
+        
+        try
+        {
+            ex = () => s1 {{{op}}} s1;
+        }
+        catch (System.ArgumentException) // https://github.com/dotnet/runtime/issues/115674 The user-defined operator method 'op_BitwiseOr' for operator 'OrElse' must have associated boolean True and False operators.
+        {
+            System.Console.Write("exception");
+            return;
+        }
+
+        ex.Compile()();
+    }
+
+    static void Test3(S1 s1)
+    {
+        if (s1)
+        {
+            s1 = default;
+        }
+    }
+}
+""";
+
+            var comp = CreateCompilation(src, options: TestOptions.DebugExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "operator2operator1exception").VerifyDiagnostics();
+
+            verifier.VerifyIL("Program.Test1",
+@"
+{
+  // Code size       26 (0x1a)
+  .maxstack  2
+  .locals init (S1 V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  newobj     ""S1?..ctor(S1)""
+  IL_0008:  call       ""bool S1." + (op == "&&" ? "op_False" : "op_True") + @"(S1?)""
+  IL_000d:  brtrue.s   IL_0018
+  IL_000f:  ldloc.0
+  IL_0010:  ldarg.0
+  IL_0011:  call       ""S1 S1." + (op == "&&" ? "op_BitwiseAnd" : "op_BitwiseOr") + @"(S1, S1)""
+  IL_0016:  br.s       IL_0019
+  IL_0018:  ldloc.0
+  IL_0019:  ret
+}
+");
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_02([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        Test1(s1);
+        Test2(s1);
+    }
+
+    static S1? Test1(S1? s1) => s1 {{{op}}} s1;
+
+    static void Test2(S1? s1)
+    {
+        System.Linq.Expressions.Expression<System.Func<S1?>> ex;
+        
+        try
+        {
+            ex = () => s1 {{{op}}} s1;
+        }
+        catch (System.ArgumentException) // https://github.com/dotnet/runtime/issues/115674 The user-defined operator method 'op_BitwiseOr' for operator 'OrElse' must have associated boolean True and False operators.
+        {
+            System.Console.Write("exception");
+            return;
+        }
+
+        ex.Compile()();
+    }
+
+    static void Test3(S1? s1)
+    {
+        if (s1)
+        {
+            s1 = default;
+        }
+    }
+}
+""";
+
+            var comp = CreateCompilation(src, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2operator1exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_03([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1? operator {{{op[0]}}}(S1? x, S1? y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        Test1(s1);
+        Test2(s1);
+    }
+
+    static S1? Test1(S1? s1) => s1 {{{op}}} s1;
+
+    static void Test2(S1? s1)
+    {
+        System.Linq.Expressions.Expression<System.Func<S1?>> ex;
+        
+        try
+        {
+            ex = () => s1 {{{op}}} s1;
+        }
+        catch (System.ArgumentException) // https://github.com/dotnet/runtime/issues/115674 The user-defined operator method 'op_BitwiseOr' for operator 'OrElse' must have associated boolean True and False operators.
+        {
+            System.Console.Write("exception");
+            return;
+        }
+
+        ex.Compile()();
+    }
+}
+""";
+
+            var comp = CreateCompilation(src, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2operator1exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_04_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        try
+        {
+            Test1(s1);
+        }
+        catch (System.ArgumentException) // https://github.com/dotnet/runtime/issues/115674 The user-defined operator method 'op_BitwiseOr' for operator 'OrElse' must have associated boolean True and False operators.
+        {
+            System.Console.Write("exception");
+        }
+    }
+
+    static dynamic Test1(S1 s1) => s1 {{{op}}} (dynamic)s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_05_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        Test1(s1);
+    }
+
+    static dynamic Test1(S1? s1) => s1 {{{op}}} (dynamic)s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (27,37): error CS7083: Expression must be implicitly convertible to Boolean or its type 'S1?' must define operator 'false'.
+                //     static dynamic Test1(S1? s1) => s1 && (dynamic)s1;
+                Diagnostic(ErrorCode.ERR_InvalidDynamicCondition, "s1").WithArguments("S1?", (op == "&&" ? "false" : "true")).WithLocation(27, 37)
+                );
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_06_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1? operator {{{op[0]}}}(S1? x, S1? y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        Test1(s1);
+    }
+
+    static dynamic Test1(S1? s1) => s1 {{{op}}} (dynamic)s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (27,37): error CS7083: Expression must be implicitly convertible to Boolean or its type 'S1?' must define operator 'false'.
+                //     static dynamic Test1(S1? s1) => s1 && (dynamic)s1;
+                Diagnostic(ErrorCode.ERR_InvalidDynamicCondition, "s1").WithArguments("S1?", (op == "&&" ? "false" : "true")).WithLocation(27, 37)
+                );
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_07_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        try
+        {
+            Test1(s1);
+        }
+        catch (System.ArgumentException) // https://github.com/dotnet/runtime/issues/115674 The user-defined operator method 'op_BitwiseOr' for operator 'OrElse' must have associated boolean True and False operators.
+        {
+            System.Console.Write("exception");
+        }
+    }
+
+    static dynamic Test1(S1 s1) => (dynamic)s1 {{{op}}} (dynamic)s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_08_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        try
+        {
+            Test1(s1);
+        }
+        catch (System.ArgumentException) // https://github.com/dotnet/runtime/issues/115674 The user-defined operator method 'op_BitwiseOr' for operator 'OrElse' must have associated boolean True and False operators.
+        {
+            System.Console.Write("exception");
+        }
+    }
+
+    static dynamic Test1(S1? s1) => (dynamic)s1 {{{op}}} (dynamic)s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_09_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1? operator {{{op[0]}}}(S1? x, S1? y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        try
+        {
+            Test1(s1);
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // The type ('S1?') must contain declarations of operator true and operator false
+        {
+            System.Console.Write("exception");
+        }
+    }
+
+    static dynamic Test1(S1? s1) => (dynamic)s1 {{{op}}} (dynamic)s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_10_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        try
+        {
+            Test1(s1);
+        }
+        catch (System.ArgumentException) // https://github.com/dotnet/runtime/issues/115674 The user-defined operator method 'op_BitwiseOr' for operator 'OrElse' must have associated boolean True and False operators.
+        {
+            System.Console.Write("exception");
+        }
+    }
+
+    static dynamic Test1(S1 s1) => (dynamic)s1 {{{op}}} s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_11_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1 operator {{{op[0]}}}(S1 x, S1 y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        try
+        {
+            Test1(s1);
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // Operator '&&' cannot be applied to operands of type 'S1' and 'S1?'
+        {
+            System.Console.Write("exception");
+        }
+    }
+
+    static dynamic Test1(S1? s1) => (dynamic)s1 {{{op}}} s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2exception").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/78609")]
+        [WorkItem("https://github.com/dotnet/runtime/issues/115674")]
+        [CombinatorialData]
+        public void UserDefinedShortCircuitingOperators_TrueFalseArgumentConversion_12_Dynamic([CombinatorialValues("&&", "||")] string op)
+        {
+            var src = $$$"""
+public struct S1
+{
+    public static S1? operator {{{op[0]}}}(S1? x, S1? y)
+    {
+        System.Console.Write("operator1");
+        return x;
+    }
+
+    public static bool operator {{{(op == "&&" ? "false" : "true")}}}(S1? x)
+    {
+        System.Console.Write("operator2");
+        return false;
+    }
+
+    public static bool operator {{{(op == "&&" ? "true" : "false")}}}(S1? x) => throw null;
+}
+
+class Program
+{
+    static void Main()
+    {
+        S1 s1 = new S1();
+
+        try
+        {
+            Test1(s1);
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // The type ('S1?') must contain declarations of operator true and operator false
+        {
+            System.Console.Write("exception");
+        }
+    }
+
+    static dynamic Test1(S1? s1) => (dynamic)s1 {{{op}}} s1;
+}
+""";
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.StandardAndCSharp, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "operator2exception").VerifyDiagnostics();
+        }
+
         private sealed class EmptyRewriter : BoundTreeRewriter
         {
             protected override BoundNode VisitExpressionOrPatternWithoutStackGuard(BoundNode node)


### PR DESCRIPTION
Fixes #78609.