### PR TITLE
LSP: Fix batch builds for file-based programs and fix `"dotnet.projects.binaryLogPath"` throwing an exception

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -235,7 +235,7 @@ internal sealed class ProjectBuildManager
             ? [_msbuildLogger]
             : ImmutableArray<MSB.Framework.ILogger>.Empty;
 
-        // https://github.com/dotnet/msbuild/issues/11867: workaround LoggerException when passing binary logger to both evaluation and build
+        // Pass empty loggers array to workaround LoggerException when passing binary logger to both evaluation and build. See https://github.com/dotnet/msbuild/issues/11867
         _batchBuildProjectCollection = new MSB.Evaluation.ProjectCollection(allProperties, loggers: [], MSB.Evaluation.ToolsetDefinitionLocations.Default);
 
         var buildParameters = new MSB.Execution.BuildParameters(_batchBuildProjectCollection)

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -152,7 +152,7 @@ internal sealed class ProjectBuildManager
         {
             var projectCollection = new MSB.Evaluation.ProjectCollection(
                 AllGlobalProperties,
-                _msbuildLogger != null ? [_msbuildLogger] : ImmutableArray<MSB.Framework.ILogger>.Empty,
+                loggers: [],
                 MSB.Evaluation.ToolsetDefinitionLocations.Default);
             try
             {
@@ -179,7 +179,7 @@ internal sealed class ProjectBuildManager
             {
                 var projectCollection = new MSB.Evaluation.ProjectCollection(
                     AllGlobalProperties,
-                    _msbuildLogger != null ? [_msbuildLogger] : ImmutableArray<MSB.Framework.ILogger>.Empty,
+                    loggers: [],
                     MSB.Evaluation.ToolsetDefinitionLocations.Default);
                 try
                 {

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -152,6 +152,7 @@ internal sealed class ProjectBuildManager
         {
             var projectCollection = new MSB.Evaluation.ProjectCollection(
                 AllGlobalProperties,
+                // https://github.com/dotnet/msbuild/issues/11867: workaround LoggerException when passing binary logger to both evaluation and build
                 loggers: [],
                 MSB.Evaluation.ToolsetDefinitionLocations.Default);
             try
@@ -179,6 +180,7 @@ internal sealed class ProjectBuildManager
             {
                 var projectCollection = new MSB.Evaluation.ProjectCollection(
                     AllGlobalProperties,
+                    // https://github.com/dotnet/msbuild/issues/11867: workaround LoggerException when passing binary logger to both evaluation and build
                     loggers: [],
                     MSB.Evaluation.ToolsetDefinitionLocations.Default);
                 try


### PR DESCRIPTION
Closes #78591
Works around issue dotnet/msbuild#11867 by not passing loggers to the evaluation step.