### PR TITLE
Extensions: nullability analysis for property access

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -2207,11 +2207,8 @@ Global
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{57ca988d-f010-4bf2-9a2e-07d6dcd2ff2c}*SharedItemsImports = 5
 		src\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems*{58969243-7f59-4236-93d0-c93b81f569b3}*SharedItemsImports = 13
 		src\Dependencies\Collections\Microsoft.CodeAnalysis.Collections.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
-		src\Dependencies\Contracts\Microsoft.CodeAnalysis.Contracts.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
-		src\Dependencies\Threading\Microsoft.CodeAnalysis.Threading.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
-		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Extensions\Microsoft.CodeAnalysis.Extensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Analyzers\Core\CodeFixes\CodeFixes.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3831,7 +3831,7 @@ outerDefault:
         }
 
         internal static void GetEffectiveParameterTypes(
-            MethodSymbol method,
+            Symbol member,
             int argumentCount,
             ImmutableArray<int> argToParamMap,
             ArrayBuilder<RefKind> argumentRefKinds,
@@ -3847,8 +3847,8 @@ outerDefault:
                               (allowRefOmittedArguments ? Options.AllowRefOmittedArguments : Options.None);
 
             EffectiveParameters effectiveParameters = expanded ?
-                GetEffectiveParametersInExpandedForm(method, argumentCount, argToParamMap, argumentRefKinds, options, binder, out hasAnyRefOmittedArgument) :
-                GetEffectiveParametersInNormalForm(method, argumentCount, argToParamMap, argumentRefKinds, options, binder, out hasAnyRefOmittedArgument);
+                GetEffectiveParametersInExpandedForm(member, argumentCount, argToParamMap, argumentRefKinds, options, binder, out hasAnyRefOmittedArgument) :
+                GetEffectiveParametersInNormalForm(member, argumentCount, argToParamMap, argumentRefKinds, options, binder, out hasAnyRefOmittedArgument);
             parameterTypes = effectiveParameters.ParameterTypes;
             parameterRefKinds = effectiveParameters.ParameterRefKinds;
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/MostCommonNullableValueBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/MostCommonNullableValueBuilder.cs
@@ -12,8 +12,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal struct MostCommonNullableValueBuilder
     {
+        /// <see cref="NullableAnnotationExtensions.ObliviousAttributeValue"/>
         private int _value0;
+
+        /// <see cref="NullableAnnotationExtensions.NotAnnotatedAttributeValue"/>
         private int _value1;
+
+        /// <see cref="NullableAnnotationExtensions.AnnotatedAttributeValue"/>
         private int _value2;
 
         internal byte? MostCommonValue

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7151,7 +7151,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if (tryShortCircuitTargetTypedExpression(argument, argumentNoConversion))
                             {
-                                Debug.Assert(member is ErrorMethodSymbol);
+                                Debug.Assert(method is ErrorMethodSymbol);
                             }
                             continue;
                         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7121,9 +7121,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                             CheckMethodConstraints(syntaxForConstraintCheck, reinferredMethod);
                         }
                     }
-                    else if (member.GetIsNewExtensionMember() && member.ContainingType is { } extension && ConstraintsHelper.RequiresChecking(extension))
+                    else if (member.GetIsNewExtensionMember())
                     {
-                        CheckExtensionConstraints(syntaxForConstraintCheck, extension);
+                        if (member.ContainingType is { } extension && ConstraintsHelper.RequiresChecking(extension))
+                        {
+                            CheckExtensionConstraints(syntaxForConstraintCheck, extension);
+                        }
+                    }
+                    else
+                    {
+                        throw ExceptionUtilities.UnexpectedValue(member);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case BoundDagPropertyEvaluation e:
                                     {
                                         Debug.Assert(inputSlot > 0);
-                                        var property = (PropertySymbol)AsMemberOfType(inputType, e.Property);
+                                        var property = (PropertySymbol)AsMemberOfType(inputType, e.Property); // Tracked by https://github.com/dotnet/roslyn/issues/76130 : this needs to handle extension properties
                                         var type = property.TypeWithAnnotations;
                                         var output = new BoundDagTemp(e.Syntax, type.Type, e);
                                         int outputSlot = GetOrCreateSlot(property, inputSlot, forceSlotEvenIfEmpty: true);

--- a/src/Compilers/CSharp/Portable/Lowering/ExtensionMethodReferenceRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ExtensionMethodReferenceRewriter.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     invokedAsExtensionMethod = true;
 
-                    Debug.Assert(receiverOpt.Type!.Equals(method.Parameters[0].Type, TypeCompareKind.ConsiderEverything));
+                    Debug.Assert(receiverOpt.Type!.Equals(method.Parameters[0].Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
 
                     arguments = arguments.Insert(0, receiverOpt);
                     receiverOpt = null;

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -14,6 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed class SourceExtensionImplementationMethodSymbol : RewrittenMethodSymbol // Tracked by https://github.com/dotnet/roslyn/issues/76130 : Do we need to implement ISynthesizedMethodBodyImplementationSymbol?
     {
         private string? lazyDocComment;
+        private StrongBox<byte?>? lazyNullableContext;
 
         public SourceExtensionImplementationMethodSymbol(MethodSymbol sourceMethod)
             : base(sourceMethod, TypeMap.Empty, sourceMethod.ContainingType.TypeParameters.Concat(sourceMethod.TypeParameters))
@@ -67,6 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
+            // Copy ORPA from the property onto the implementation accessors
             if (_originalMethod is SourcePropertyAccessorSymbol { AssociatedSymbol: SourcePropertySymbolBase extensionProperty })
             {
                 foreach (CSharpAttributeData attr in extensionProperty.GetAttributes())
@@ -78,8 +81,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
             SourceMethodSymbol.AddSynthesizedAttributes(this, moduleBuilder, ref attributes);
+        }
+
+        internal override void AddSynthesizedReturnTypeAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
+        {
+            // Copy NotNull/MaybeNull attribute from the property onto the implementation getter
+            if (_originalMethod is SourcePropertyAccessorSymbol { MethodKind: MethodKind.PropertyGet, AssociatedSymbol: SourcePropertySymbolBase extensionProperty })
+            {
+                foreach (CSharpAttributeData attr in extensionProperty.GetAttributes())
+                {
+                    if (attr.IsTargetAttribute(AttributeDescription.NotNullAttribute)
+                        || attr.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
+                    {
+                        AddSynthesizedAttribute(ref attributes, attr);
+                    }
+                }
+            }
+
+            base.AddSynthesizedReturnTypeAttributes(moduleBuilder, ref attributes);
+        }
+
+        internal override byte? GetLocalNullableContextValue()
+        {
+            if (lazyNullableContext is null)
+            {
+                byte? nullableContext = SourceMemberMethodSymbol.ComputeNullableContextValue(this);
+                Interlocked.CompareExchange(ref lazyNullableContext, new StrongBox<byte?>(nullableContext), comparand: null);
+            }
+
+            return lazyNullableContext.Value;
         }
 
         public override bool IsStatic => true;
@@ -174,6 +205,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     return ordinal + 1;
                 }
+            }
+
+            internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
+            {
+                // Copy AllowNull/DisallowNull from the property onto the implementation setter's `value` parameter
+                if (this._underlyingParameter is SynthesizedAccessorValueParameterSymbol
+                    && this._underlyingParameter.ContainingSymbol is SourcePropertyAccessorSymbol { MethodKind: MethodKind.PropertySet, AssociatedSymbol: SourcePropertySymbolBase extensionProperty })
+                {
+                    foreach (CSharpAttributeData attr in extensionProperty.GetAttributes())
+                    {
+                        if (attr.IsTargetAttribute(AttributeDescription.AllowNullAttribute)
+                            || attr.IsTargetAttribute(AttributeDescription.DisallowNullAttribute))
+                        {
+                            AddSynthesizedAttribute(ref attributes, attr);
+                        }
+                    }
+                }
+
+                // Synthesized nullability attributes are context-dependent, so we intentionally do not call base.AddSynthesizedAttributes here
+                // as that would delegate to underlying parameter symbol
+                SourceParameterSymbolBase.AddSynthesizedAttributes(this, moduleBuilder, ref attributes);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
@@ -86,9 +86,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override void AddSynthesizedReturnTypeAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
-            if (_originalMethod is SourcePropertyAccessorSymbol { AssociatedSymbol: SourcePropertySymbolBase extensionProperty })
+            if (_originalMethod is SourcePropertyAccessorSymbol accessor)
             {
-                SourcePropertyAccessorSymbol.AddSynthesizedReturnTypeFlowAnalysisAttributes(_originalMethod, extensionProperty, ref attributes);
+                accessor.AddSynthesizedReturnTypeFlowAnalysisAttributes(ref attributes);
             }
 
             base.AddSynthesizedReturnTypeAttributes(moduleBuilder, ref attributes);
@@ -201,9 +201,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
             {
-                if (this is { _underlyingParameter: SynthesizedAccessorValueParameterSymbol { ContainingSymbol: SourcePropertyAccessorSymbol { AssociatedSymbol: SourcePropertySymbolBase extensionProperty } } })
+                if (_underlyingParameter is SynthesizedAccessorValueParameterSymbol valueParameter)
                 {
-                    SynthesizedAccessorValueParameterSymbol.AddSynthesizedFlowAnalysisAttributes(this, extensionProperty, ref attributes);
+                    valueParameter.AddSynthesizedFlowAnalysisAttributes(ref attributes);
                 }
 
                 // Synthesized nullability attributes are context-dependent, so we intentionally do not call base.AddSynthesizedAttributes here

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1000,27 +1000,27 @@ done:
             byte? value;
             if (!flags.TryGetNullableContext(out value))
             {
-                value = ComputeNullableContextValue();
+                value = ComputeNullableContextValue(this);
                 flags.SetNullableContext(value);
             }
             return value;
         }
 
-        private byte? ComputeNullableContextValue()
+        internal static byte? ComputeNullableContextValue(MethodSymbol method)
         {
-            var compilation = DeclaringCompilation;
-            if (!compilation.ShouldEmitNullableAttributes(this))
+            var compilation = method.DeclaringCompilation;
+            if (!compilation.ShouldEmitNullableAttributes(method))
             {
                 return null;
             }
 
             var builder = new MostCommonNullableValueBuilder();
-            foreach (var typeParameter in TypeParameters)
+            foreach (var typeParameter in method.TypeParameters)
             {
                 typeParameter.GetCommonNullableValues(compilation, ref builder);
             }
-            builder.AddValue(ReturnTypeWithAnnotations);
-            foreach (var parameter in Parameters)
+            builder.AddValue(method.ReturnTypeWithAnnotations);
+            foreach (var parameter in method.Parameters)
             {
                 parameter.GetCommonNullableValues(compilation, ref builder);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -945,7 +945,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(arguments.AttributeSyntaxOpt is object);
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
-            if (MethodKind != MethodKind.Ordinary)
+            if (MethodKind != MethodKind.Ordinary || this.GetIsNewExtensionMember())
             {
                 diagnostics.Add(ErrorCode.ERR_ModuleInitializerMethodMustBeOrdinary, arguments.AttributeSyntaxOpt.Location);
                 return;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
@@ -69,42 +69,47 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+            AddSynthesizedAttributes(this, moduleBuilder, ref attributes);
+        }
 
-            var compilation = this.DeclaringCompilation;
+        internal static void AddSynthesizedAttributes(ParameterSymbol parameter, PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
+        {
+            var compilation = parameter.DeclaringCompilation;
 
-            if (this.IsParamsArray)
+            if (parameter.IsParamsArray)
             {
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_ParamArrayAttribute__ctor));
             }
-            else if (this.IsParamsCollection)
+            else if (parameter.IsParamsCollection)
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeParamCollectionAttribute(this));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeParamCollectionAttribute(parameter));
             }
 
             // Synthesize DecimalConstantAttribute if we don't have an explicit custom attribute already:
-            var defaultValue = this.ExplicitDefaultConstantValue;
+            var defaultValue = parameter.ExplicitDefaultConstantValue;
             if (defaultValue != ConstantValue.NotAvailable &&
                 defaultValue.SpecialType == SpecialType.System_Decimal &&
-                DefaultValueFromAttributes == ConstantValue.NotAvailable)
+                parameter is SourceParameterSymbolBase sourceParameter &&
+                sourceParameter.DefaultValueFromAttributes == ConstantValue.NotAvailable)
             {
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDecimalConstantAttribute(defaultValue.DecimalValue));
             }
 
-            var type = this.TypeWithAnnotations;
+            var type = parameter.TypeWithAnnotations;
 
             if (type.Type.ContainsDynamic())
             {
-                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length + this.RefCustomModifiers.Length, this.RefKind));
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length + parameter.RefCustomModifiers.Length, parameter.RefKind));
             }
 
             if (compilation.ShouldEmitNativeIntegerAttributes(type.Type))
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(parameter, type.Type));
             }
 
-            if (ParameterHelpers.RequiresScopedRefAttribute(this))
+            if (ParameterHelpers.RequiresScopedRefAttribute(parameter))
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeScopedRefAttribute(this, EffectiveScope));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeScopedRefAttribute(parameter, parameter.EffectiveScope));
             }
 
             if (type.Type.ContainsTupleNames())
@@ -113,19 +118,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     compilation.SynthesizeTupleNamesAttribute(type.Type));
             }
 
-            switch (this.RefKind)
+            switch (parameter.RefKind)
             {
                 case RefKind.In:
-                    AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeIsReadOnlyAttribute(this));
+                    AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeIsReadOnlyAttribute(parameter));
                     break;
                 case RefKind.RefReadOnlyParameter:
-                    AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeRequiresLocationAttribute(this));
+                    AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeRequiresLocationAttribute(parameter));
                     break;
             }
 
-            if (compilation.ShouldEmitNullableAttributes(this))
+            if (compilation.ShouldEmitNullableAttributes(parameter))
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNullableAttributeIfNecessary(this, GetNullableContextValue(), type));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNullableAttributeIfNecessary(parameter, parameter.GetNullableContextValue(), type));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -741,7 +741,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case SyntaxKind.InitAccessorDeclaration:
                     case SyntaxKind.ArrowExpressionClause:
                         return false;
-                };
+                }
 
                 return true;
             }
@@ -796,19 +796,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override void AddSynthesizedReturnTypeAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
             base.AddSynthesizedReturnTypeAttributes(moduleBuilder, ref attributes);
-            AddSynthesizedReturnTypeFlowAnalysisAttributes(this, _property, ref attributes);
+            AddSynthesizedReturnTypeFlowAnalysisAttributes(ref attributes);
         }
 
-        internal static void AddSynthesizedReturnTypeFlowAnalysisAttributes(MethodSymbol accessor, SourcePropertySymbolBase property, ref ArrayBuilder<CSharpAttributeData> attributes)
+        internal void AddSynthesizedReturnTypeFlowAnalysisAttributes(ref ArrayBuilder<CSharpAttributeData> attributes)
         {
-            var annotations = accessor.ReturnTypeFlowAnalysisAnnotations;
+            var annotations = ReturnTypeFlowAnalysisAnnotations;
             if ((annotations & FlowAnalysisAnnotations.MaybeNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.MaybeNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.MaybeNullAttributeIfExists));
             }
             if ((annotations & FlowAnalysisAnnotations.NotNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.NotNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.NotNullAttributeIfExists));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -796,15 +796,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override void AddSynthesizedReturnTypeAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
             base.AddSynthesizedReturnTypeAttributes(moduleBuilder, ref attributes);
+            AddSynthesizedReturnTypeFlowAnalysisAttributes(this, _property, ref attributes);
+        }
 
-            var annotations = ReturnTypeFlowAnalysisAnnotations;
+        internal static void AddSynthesizedReturnTypeFlowAnalysisAttributes(MethodSymbol accessor, SourcePropertySymbolBase property, ref ArrayBuilder<CSharpAttributeData> attributes)
+        {
+            var annotations = accessor.ReturnTypeFlowAnalysisAnnotations;
             if ((annotations & FlowAnalysisAnnotations.MaybeNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.MaybeNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.MaybeNullAttributeIfExists));
             }
             if ((annotations & FlowAnalysisAnnotations.NotNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.NotNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.NotNullAttributeIfExists));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
@@ -80,22 +80,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
-            if (this.ContainingSymbol is SourcePropertyAccessorSymbol { AssociatedSymbol: SourcePropertySymbolBase property })
-            {
-                AddSynthesizedFlowAnalysisAttributes(this, property, ref attributes);
-            }
+            AddSynthesizedFlowAnalysisAttributes(ref attributes);
         }
 
-        internal static void AddSynthesizedFlowAnalysisAttributes(ParameterSymbol valueParameter, SourcePropertySymbolBase property, ref ArrayBuilder<CSharpAttributeData> attributes)
+        internal void AddSynthesizedFlowAnalysisAttributes(ref ArrayBuilder<CSharpAttributeData> attributes)
         {
-            var annotations = valueParameter.FlowAnalysisAnnotations;
-            if ((annotations & FlowAnalysisAnnotations.DisallowNull) != 0)
+            if (ContainingSymbol is SourcePropertyAccessorSymbol { AssociatedSymbol: SourcePropertySymbolBase property })
             {
-                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.DisallowNullAttributeIfExists));
-            }
-            if ((annotations & FlowAnalysisAnnotations.AllowNull) != 0)
-            {
-                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.AllowNullAttributeIfExists));
+                var annotations = FlowAnalysisAnnotations;
+                if ((annotations & FlowAnalysisAnnotations.DisallowNull) != 0)
+                {
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.DisallowNullAttributeIfExists));
+                }
+                if ((annotations & FlowAnalysisAnnotations.AllowNull) != 0)
+                {
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.AllowNullAttributeIfExists));
+                }
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
@@ -80,18 +80,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<CSharpAttributeData> attributes)
         {
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
-
-            if (ContainingSymbol is SourcePropertyAccessorSymbol propertyAccessor && propertyAccessor.AssociatedSymbol is SourcePropertySymbolBase property)
+            if (this.ContainingSymbol is SourcePropertyAccessorSymbol { AssociatedSymbol: SourcePropertySymbolBase property })
             {
-                var annotations = FlowAnalysisAnnotations;
-                if ((annotations & FlowAnalysisAnnotations.DisallowNull) != 0)
-                {
-                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.DisallowNullAttributeIfExists));
-                }
-                if ((annotations & FlowAnalysisAnnotations.AllowNull) != 0)
-                {
-                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.AllowNullAttributeIfExists));
-                }
+                AddSynthesizedFlowAnalysisAttributes(this, property, ref attributes);
+            }
+        }
+
+        internal static void AddSynthesizedFlowAnalysisAttributes(ParameterSymbol valueParameter, SourcePropertySymbolBase property, ref ArrayBuilder<CSharpAttributeData> attributes)
+        {
+            var annotations = valueParameter.FlowAnalysisAnnotations;
+            if ((annotations & FlowAnalysisAnnotations.DisallowNull) != 0)
+            {
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.DisallowNullAttributeIfExists));
+            }
+            if ((annotations & FlowAnalysisAnnotations.AllowNull) != 0)
+            {
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.AllowNullAttributeIfExists));
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -36316,6 +36316,8 @@ oNull.M(); // 1
 object? oNotNull = new object();
 oNotNull.M();
 
+oNotNull?.M(); // 2
+
 object? oNull2 = null;
 oNull2!.M();
 
@@ -36346,6 +36348,8 @@ oNull.M().ToString();
 
 object? oNotNull = new object();
 oNotNull.M().ToString();
+
+oNotNull?.M().ToString();
 
 static class E
 {

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -28996,7 +28996,7 @@ static class E
     }
 
     [Fact]
-    public void PropertyAccess_ReceiverConversion()
+    public void PropertyAccess_ReceiverConversion_01()
     {
         var src = """
 _  = 42.P;
@@ -29017,6 +29017,26 @@ static class E
         var literal = GetSyntax<LiteralExpressionSyntax>(tree, "42");
         Assert.Equal("System.Int32", model.GetTypeInfo(literal).Type.ToTestDisplayString());
         Assert.Equal("System.Object", model.GetTypeInfo(literal).ConvertedType.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void PropertyAccess_ReceiverConversion_02()
+    {
+        // tuple names mismatch
+        var src = """
+(int a, int b) t = (1, 2);
+_ = t.P;
+
+static class E
+{
+    extension((int c, int d) t)
+    {
+        public int P { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -36361,8 +36381,11 @@ oNull.M().ToString();
 
 object? oNotNull = new object();
 oNotNull.M().ToString();
+""";
+        var libSrc = """
+#nullable enable
 
-static class E
+public static class E
 {
     extension<T>(T t) where T : notnull
     {
@@ -36370,14 +36393,21 @@ static class E
     }
 }
 """;
-        var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics(
+        DiagnosticDescription[] expected = [
             // (4,1): warning CS8714: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'E.extension<T>(T)'. Nullability of type argument 'object?' doesn't match 'notnull' constraint.
             // oNull.M().ToString();
             Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "oNull.M").WithArguments("E.extension<T>(T)", "T", "object?").WithLocation(4, 1),
             // (4,1): warning CS8602: Dereference of a possibly null reference.
             // oNull.M().ToString();
-            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "oNull.M()").WithLocation(4, 1));
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "oNull.M()").WithLocation(4, 1)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -36563,6 +36593,99 @@ static class E
             // (6,1): warning CS8602: Dereference of a possibly null reference.
             // oNull.M().M().ToString();
             Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "oNull.M().M()").WithLocation(6, 1));
+    }
+
+    [Fact]
+    public void Nullability_Invocation_10()
+    {
+        // nullability check on the return value
+        var src = """
+#nullable enable
+
+object.M().ToString(); // 1
+E.M().ToString(); // 2
+
+object.M2().ToString();
+E.M2().ToString();
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        public static object? M() => throw null!;
+        public static object M2() => throw null!;
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (3,1): warning CS8602: Dereference of a possibly null reference.
+            // object.M().ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "object.M()").WithLocation(3, 1),
+            // (4,1): warning CS8602: Dereference of a possibly null reference.
+            // E.M().ToString(); // 2
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E.M()").WithLocation(4, 1)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_Invocation_11()
+    {
+        // nullability annotation in constraints
+        var src = """
+#nullable enable
+
+I? iNull = null;
+iNull.M(); // 1
+
+I? iNull2 = null;
+iNull2.M2();
+
+I iNotNull = getI();
+iNotNull.M();
+iNotNull.M2();
+
+I getI() => throw null!;
+""";
+        var libSrc = """
+#nullable enable
+
+public interface I { }
+
+public static class E
+{
+    extension<T>(T t) where T : I
+    {
+        public T M() => t;
+    }
+
+    extension<T>(T t) where T : I?
+    {
+        public T M2() => t;
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (4,1): warning CS8631: The type 'I?' cannot be used as type parameter 'T' in the generic type or method 'E.extension<T>(T)'. Nullability of type argument 'I?' doesn't match constraint type 'I'.
+            // iNull.M(); // 1
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "iNull.M").WithArguments("E.extension<T>(T)", "I", "T", "I?").WithLocation(4, 1)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
     }
 
     [Fact]
@@ -37516,11 +37639,32 @@ static class E
         var src = """
 #nullable enable
 
-static class E
+object? o = null;
+o.M();
+
+object? o2 = null;
+E.M(o2);
+
+object o3 = new object();
+o3.M2(); // 1
+
+object o4 = new object();
+E.M2(o4); // 2
+
+object o5 = new object();
+o5.M();
+E.M(o5);
+o5.M2();
+E.M(o5);
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
 {
     extension(object? o)
     {
-        public void M() { o.ToString(); }
+        public void M() { o.ToString(); } // 3
     }
     extension(object o)
     {
@@ -37528,11 +37672,15 @@ static class E
     }
 }
 """;
-        var comp = CreateCompilation(src);
+        var comp = CreateCompilation([src, libSrc]);
         comp.VerifyEmitDiagnostics(
             // (7,27): warning CS8602: Dereference of a possibly null reference.
             //         public void M() { o.ToString(); }
             Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(7, 27));
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -37581,7 +37729,16 @@ if (o2.Try2())
     o2.ToString();
 }
 
-static class E
+object? o3 = null;
+if (E.Try(o3))
+{
+    o3.ToString();
+}
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
 {
     extension([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? o)
     {
@@ -37608,8 +37765,12 @@ static class E
 }
 """;
         // Note: the enforcement within body only kicks in for ref/out parameters
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
         comp.VerifyEmitDiagnostics();
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -38224,7 +38385,6 @@ static class E
     }
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : there should be no error on nameof
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
         comp.VerifyEmitDiagnostics(
             // (5,5): warning CS8602: Dereference of a possibly null reference.
@@ -38256,7 +38416,16 @@ static class E
         public object? P => null;
     }
 }
+
+class C
+{
+    [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(C.P))]
+    public bool M() => throw null!;
+
+    public object? P => null;
+}
 """;
+        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : we shouldn't care about static/instance mismatch in nameof
         comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
         comp.VerifyEmitDiagnostics(
             // (5,5): warning CS8602: Dereference of a possibly null reference.
@@ -38300,6 +38469,64 @@ static class E
             // (13,73): error CS8082: Sub-expression cannot be used in an argument to nameof.
             //         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(new object().P))]
             Diagnostic(ErrorCode.ERR_SubexpressionNotInNameof, "new object()").WithLocation(13, 73));
+
+        src = """
+class E
+{
+    [My(nameof(E.P))]
+    public bool M() => throw null!;
+
+    public object P => null;
+}
+
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string s) { }
+}
+""";
+        comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Nullability_Attribute_15_Static()
+    {
+        var src = """
+#nullable enable
+
+static class E
+{
+    extension(object o)
+    {
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(P))]
+        public static bool M() => throw null!;
+
+        public static object? P => null;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (7,73): error CS0103: The name 'P' does not exist in the current context
+            //         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(P))]
+            Diagnostic(ErrorCode.ERR_NameNotInContext, "P").WithArguments("P").WithLocation(7, 73));
+
+        src = """
+#nullable enable
+
+static class E
+{
+    extension(object o)
+    {
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(object.P))]
+        public static bool M() => throw null!;
+
+        public static object? P => null;
+    }
+}
+""";
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -38529,6 +38756,125 @@ static class E
     }
 
     [Fact]
+    public void Nullability_Attribute_23()
+    {
+        var src = """
+#nullable enable
+
+bool b = true;
+if (b)
+{
+    object? o = null;
+    int.Throws();
+    o.ToString();
+}
+else
+{
+    object? o2 = null;
+    E.Throws();
+    o2.ToString();
+}
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(int)
+    {
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void Throws() => throw null!;
+    }
+}
+""";
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics();
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Nullability_Attributes_24()
+    {
+        // NotNullIfNotNull should be enforced in getter body
+        var src = """
+#nullable enable
+
+public static class E
+{
+    extension(object? o)
+    {
+        [property: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(o))]
+        public object? P 
+        { 
+            get
+            {
+                if (o is null)
+                    return null;
+                else
+                    return null; // 1
+            }
+            set { }
+        }
+
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(o))]
+        public object? M()
+        {
+            if (o is null)
+                return null;
+            else
+                return null; // 2
+        }
+    }
+
+    [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(o))]
+    public static object? M2(object? o)
+    {
+        if (o is null)
+            return null;
+        else
+            return null; // 3
+    }
+}
+""";
+        // Tracked by https://github.com/dotnet/roslyn/issues/37238 : need to track and enforce NotNullIfNotNull on properties/indexers
+
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (26,17): warning CS8825: Return value must be non-null because parameter 'o' is non-null.
+            //                 return null; // 2
+            Diagnostic(ErrorCode.WRN_ReturnNotNullIfNotNull, "return null;").WithArguments("o").WithLocation(26, 17),
+            // (36,13): warning CS8825: Return value must be non-null because parameter 'o' is non-null.
+            //             return null; // 3
+            Diagnostic(ErrorCode.WRN_ReturnNotNullIfNotNull, "return null;").WithArguments("o").WithLocation(36, 13));
+
+        src = """
+#nullable enable
+
+class C
+{
+    [property: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(o))]
+    public object? this[object? o]
+    {
+        get
+        {
+            if (o is null)
+                return null;
+            else
+                return null; // 1
+        }
+        set { }
+    }
+}
+""";
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        // Tracked by https://github.com/dotnet/roslyn/issues/37238 : indexers lack support for NotNullIfNotNull
+        comp.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
     public void Nullability_ForEach_01()
     {
         var src = """
@@ -38746,6 +39092,41 @@ static class E
     }
 
     [Fact]
+    public void Nullability_ObjectInitializer_03()
+    {
+        var src = """
+#nullable enable
+
+object? oNull = null;
+_ = new object() { Property = oNull };
+
+object oNotNull = new object();
+_ = new object() { Property = oNotNull };
+
+static class E
+{
+    extension<T>(T t)
+    {
+        public T Property { set { } }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : incorrect nullability analysis for object initializer scenario with extension property
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var assignment = GetSyntax<AssignmentExpressionSyntax>(tree, "Property = oNull");
+        Assert.Equal("System.Object E.extension<System.Object>(System.Object).Property { set; }",
+            model.GetSymbolInfo(assignment.Left).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+        assignment = GetSyntax<AssignmentExpressionSyntax>(tree, "Property = oNotNull");
+        Assert.Equal("System.Object E.extension<System.Object>(System.Object).Property { set; }",
+            model.GetSymbolInfo(assignment.Left).Symbol.ToTestDisplayString(includeNonNullable: true));
+    }
+
+    [Fact]
     public void Nullability_With_01()
     {
         var src = """
@@ -38828,7 +39209,7 @@ static class E
 }
 """;
 
-        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : unexpected nullability warning
+        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : incorrect nullability analysis for with-expression with extension property (unexpected warning)
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
             // (4,5): warning CS8602: Dereference of a possibly null reference.
@@ -39278,7 +39659,7 @@ _ = 42.P2;
     }
 
     [Fact]
-    public void SkipLocalsInit_01()
+    public void WellKnownAttribute_SkipLocalsInit_01()
     {
         string source = """
 static unsafe class E
@@ -39307,7 +39688,7 @@ static unsafe class E
     }
 
     [Fact]
-    public void SkipLocalsInit_02()
+    public void WellKnownAttribute_SkipLocalsInit_02()
     {
         string source = """
 static unsafe class E

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -726,7 +726,7 @@ public static class E
         {
             var module = (PEModuleSymbol)m;
             var parameterSymbol = (PEParameterSymbol)m.GlobalNamespace.GetMember<MethodSymbol>("E.M").Parameters[1];
-            AssertEx.SetEqual(["System.Runtime.CompilerServices.ParamCollectionAttribute"], module.GetCustomAttributesForToken(parameterSymbol.Handle).ToStrings());
+            Assert.True(module.Module.HasParamCollectionAttribute(parameterSymbol.Handle));
         }
     }
 
@@ -836,10 +836,10 @@ public static class E
         {
             var module = (PEModuleSymbol)m;
             var parameterSymbol = (PEParameterSymbol)m.GlobalNamespace.GetMember<MethodSymbol>("E.get_P").Parameters[0];
-            AssertEx.SetEqual(["System.Runtime.CompilerServices.IsReadOnlyAttribute"], module.GetCustomAttributesForToken(parameterSymbol.Handle).ToStrings());
+            Assert.True(module.Module.HasIsReadOnlyAttribute(parameterSymbol.Handle));
 
             parameterSymbol = (PEParameterSymbol)m.GlobalNamespace.GetMember<MethodSymbol>("E.get_P2").Parameters[0];
-            Assert.Empty(module.GetCustomAttributesForToken(parameterSymbol.Handle).ToStrings());
+            Assert.False(module.Module.HasIsReadOnlyAttribute(parameterSymbol.Handle));
         }
     }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -1594,7 +1594,6 @@ public static class E
         var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
         comp2.VerifyEmitDiagnostics(expected);
 
-
         CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.Skipped);
 
         static void validate(ModuleSymbol m)

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -4,6 +4,9 @@
 #nullable disable
 
 using System;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -631,6 +634,1499 @@ public static class E
             // (2,7): error CS0656: Missing compiler required member 'System.Threading.Lock+Scope.Dispose'
             // lock (x) { }
             Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x").WithArguments("System.Threading.Lock+Scope", "Dispose").WithLocation(2, 7));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_01()
+    {
+        // nullability check on the receiver, annotated extension parameter
+        var src = """
+#nullable enable
+
+object? oNull = null;
+_ = oNull.P;
+
+object? oNull2 = null;
+E.get_P(oNull2);
+
+object? oNotNull = new object();
+_ = oNotNull.P;
+
+E.get_P(oNotNull);
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object? o)
+    {
+        public int P { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics();
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void SynthesizedAttributeOnParameters_Params_01()
+    {
+        var src = """
+new object().M(1, 2, 3);
+E.M(new object(), 1, 2, 3);
+""";
+        var libSrc = """
+public static class E
+{
+    extension(object o)
+    {
+        public void M(params int[] i) { System.Console.Write((i[0], i[1], i[2])); }
+    }
+}
+""";
+        var comp = CreateCompilation([src, libSrc]);
+        CompileAndVerify(comp, expectedOutput: "(1, 2, 3)(1, 2, 3)").VerifyDiagnostics();
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        CompileAndVerify(comp2, expectedOutput: "(1, 2, 3)(1, 2, 3)").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void SynthesizedAttributeOnParameters_Params_02()
+    {
+        var src = """
+new object().M(1, 2, 3);
+E.M(new object(), 1, 2, 3);
+""";
+        var libSrc = """
+using System.Linq;
+public static class E
+{
+    extension(object o)
+    {
+        public void M(params System.Collections.Generic.IEnumerable<int> i) { int[] i2 = i.ToArray(); System.Console.Write((i2[0], i2[1], i2[2])); }
+    }
+}
+""";
+        var comp = CreateCompilation([src, libSrc]);
+        CompileAndVerify(comp, expectedOutput: "(1, 2, 3)(1, 2, 3)").VerifyDiagnostics();
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        CompileAndVerify(comp, expectedOutput: "(1, 2, 3)(1, 2, 3)").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void SynthesizedAttributeOnParameters_Dynamic_01()
+    {
+        var src = """
+public static class E
+{
+    extension(object o)
+    {
+        public void M(dynamic d) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.Skipped);
+
+        static void validate(ModuleSymbol m)
+        {
+            AssertEx.SetEqual(m is SourceModuleSymbol ? new string[] { } : ["System.Runtime.CompilerServices.DynamicAttribute"],
+                m.GlobalNamespace.GetMember<MethodSymbol>("E.M").Parameters[1].GetAttributes().ToStrings());
+        }
+    }
+
+    [Fact]
+    public void SynthesizedAttributeOnParameters_Dynamic_02()
+    {
+        var src = """
+public class C<T> { }
+
+public static class E
+{
+    extension(C<dynamic> d)
+    {
+        public void M() { }
+        public int Property => 42;
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate);
+
+        static void validate(ModuleSymbol m)
+        {
+            AssertEx.SetEqual(m is SourceModuleSymbol ? new string[] { } : ["System.Runtime.CompilerServices.DynamicAttribute({false, true})"],
+                m.GlobalNamespace.GetMember<MethodSymbol>("E.M").Parameters[0].GetAttributes().ToStrings());
+
+            AssertEx.SetEqual(m is SourceModuleSymbol ? new string[] { } : ["System.Runtime.CompilerServices.DynamicAttribute({false, true})"],
+                m.GlobalNamespace.GetMember<MethodSymbol>("E.get_Property").Parameters[0].GetAttributes().ToStrings());
+        }
+    }
+
+    [Fact]
+    public void SynthesizedAttributeOnParameters_In_01()
+    {
+        var src = """
+class C
+{
+    void M(in int i)
+    {
+        _ = i.P;
+        _ = E.get_P(i);
+
+        _ = i.P2;
+        _ = E.get_P2(ref i);
+    }
+}
+""";
+        var libSrc = """
+public static class E
+{
+    extension(in int i)
+    {
+        public int P => throw null!;
+    }
+
+    extension(ref int i)
+    {
+        public int P2 => throw null!;
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (8,13): error CS8329: Cannot use variable 'i' as a ref or out value because it is a readonly variable
+            //         _ = i.P2;
+            Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "i").WithArguments("variable", "i").WithLocation(8, 13),
+            // (9,26): error CS8329: Cannot use variable 'i' as a ref or out value because it is a readonly variable
+            //         _ = E.get_P2(ref i);
+            Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "i").WithArguments("variable", "i").WithLocation(9, 26)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void SynthesizedAttributeOnParameters_In_02()
+    {
+        var src = """
+class C
+{
+    void M(in int i)
+    {
+        i.M();
+        E.M(i);
+
+        i.M2();
+        E.M2(ref i);
+    }
+}
+""";
+        var libSrc = """
+public static class E
+{
+    extension(in int i)
+    {
+        public void M() => throw null!;
+    }
+
+    extension(ref int i)
+    {
+        public void M2() => throw null!;
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (8,9): error CS8329: Cannot use variable 'i' as a ref or out value because it is a readonly variable
+            //         i.M2();
+            Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "i").WithArguments("variable", "i").WithLocation(8, 9),
+            // (9,18): error CS8329: Cannot use variable 'i' as a ref or out value because it is a readonly variable
+            //         E.M2(ref i);
+            Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "i").WithArguments("variable", "i").WithLocation(9, 18)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void SynthesizedAttributeOnReturn_Dynamic_01()
+    {
+        var src = """
+new object().P.Dynamic();
+E.get_P(new object()).Dynamic();
+""";
+        var libSrc = """
+public static class E
+{
+    extension(object o)
+    {
+        public dynamic P => throw null!;
+    }
+}
+""";
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics();
+
+        CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.Skipped);
+
+        static void validate(ModuleSymbol m)
+        {
+            AssertEx.SetEqual(m is SourceModuleSymbol ? new string[] { } : ["System.Runtime.CompilerServices.DynamicAttribute"],
+                m.GlobalNamespace.GetMember<MethodSymbol>("E.get_P").GetReturnTypeAttributes().ToStrings());
+        }
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_02()
+    {
+        // nullability check on the receiver, un-annotated extension parameter
+        var src = """
+#nullable enable
+
+object? oNull = null;
+_ = oNull.P;
+
+object? oNull2 = null;
+E.get_P(oNull2);
+
+object? oNotNull = new object();
+_ = oNotNull.P;
+
+E.get_P(oNotNull);
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object o)
+    {
+        public int P { get => throw null!; }
+    }
+    public static void M(object here) { }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (4,5): warning CS8604: Possible null reference argument for parameter 'o' in 'extension(object)'.
+            // _ = oNull.P;
+            Diagnostic(ErrorCode.WRN_NullReferenceArgument, "oNull").WithArguments("o", "extension(object)").WithLocation(4, 5),
+            // (7,9): warning CS8604: Possible null reference argument for parameter 'o' in 'int E.get_P(object o)'.
+            // E.get_P(oNull2);
+            Diagnostic(ErrorCode.WRN_NullReferenceArgument, "oNull2").WithArguments("o", "int E.get_P(object o)").WithLocation(7, 9)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_03()
+    {
+        // nullability check on the return value
+        var src = """
+#nullable enable
+
+object o1 = object.P; // 1
+object? o2 = object.P;
+
+object o3 = E.get_P(); // 2
+object? o4 = E.get_P();
+
+object o5 = object.P2;
+object? o6 = object.P2;
+
+object o7 = E.get_P2();
+object? o8 = E.get_P2();
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        public static object? P { get => throw null!; }
+        public static object P2 { get => throw null!; }
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (3,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+            // object o1 = object.P; // 1
+            Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "object.P").WithLocation(3, 13),
+            // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+            // object o3 = E.get_P(); // 2
+            Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E.get_P()").WithLocation(6, 13)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_04()
+    {
+        // nullability check on the set value
+        var src = """
+#nullable enable
+
+object.P = null;
+object.P = new object();
+
+E.set_P(null);
+E.set_P(new object());
+
+object.P2 = null; // 1
+object.P2 = new object();
+
+E.set_P2(null); // 2
+E.set_P2(new object());
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        public static object? P { set => throw null!; }
+        public static object P2 { set => throw null!; }
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (9,13): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // object.P2 = null; // 1
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 13),
+            // (12,10): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // E.set_P2(null); // 2
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 10)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_05()
+    {
+        // nullability check on compound assignment
+        var src = """
+#nullable enable
+
+object.P ??= null;
+object.P ??= new object();
+
+object.P2 ??= null; // 1
+object.P2 ??= new object();
+
+static class E
+{
+    extension(object)
+    {
+        public static object? P { get => throw null!; set => throw null!; }
+        public static object P2 { get => throw null!; set => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (6,15): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // object.P2 ??= null; // 1
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 15));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_06()
+    {
+        // generic extension parameter, property read access
+        var src = """
+#nullable enable
+
+object? oNull = null;
+oNull.P.ToString();
+
+object? oNotNull = new object();
+oNotNull.P.ToString();
+
+static class E
+{
+    extension<T>(T t)
+    {
+        public T P { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (4,1): warning CS8602: Dereference of a possibly null reference.
+            // oNull.P.ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "oNull.P").WithLocation(4, 1));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var propertyAccess1 = GetSyntax<MemberAccessExpressionSyntax>(tree, "oNull.P");
+        AssertEx.Equal("System.Object? E.extension<System.Object?>(System.Object?).P { get; }", model.GetSymbolInfo(propertyAccess1).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+        var propertyAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "oNotNull.P");
+        AssertEx.Equal("System.Object! E.extension<System.Object!>(System.Object!).P { get; }", model.GetSymbolInfo(propertyAccess2).Symbol.ToTestDisplayString(includeNonNullable: true));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_07()
+    {
+        // generic extension parameter, instance member, property write access
+        var src = """
+#nullable enable
+
+object? oNull = null;
+oNull.P = null;
+
+object? oNull2 = null;
+oNull2.P = new object();
+
+object? oNotNull = new object();
+oNotNull.P = null; // 1
+
+object? oNotNull2 = new object();
+oNotNull2.P = new object();
+
+static class E
+{
+    extension<T>(T t)
+    {
+        public T P { set => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (10,14): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // oNotNull.P = null; // 1
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 14));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_08()
+    {
+        // generic extension parameter, static member
+        var src = """
+#nullable enable
+
+C<object>.P = new C<object?>(); // 1
+C<object>.P = new C<object>();
+
+C<object?>.P = new C<object?>();
+C<object?>.P = new C<object>(); // 2
+
+class C<T> { }
+
+static class E
+{
+    extension<T>(T)
+    {
+        public static T P { set => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (3,15): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
+            // C<object>.P = new C<object?>(); // 1
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new C<object?>()").WithArguments("C<object?>", "C<object>").WithLocation(3, 15),
+            // (7,16): warning CS8619: Nullability of reference types in value of type 'C<object>' doesn't match target type 'C<object?>'.
+            // C<object?>.P = new C<object>(); // 2
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new C<object>()").WithArguments("C<object>", "C<object?>").WithLocation(7, 16));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var propertyAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "C<object?>.P").First();
+        AssertEx.Equal("C<System.Object?>! E.extension<C<System.Object?>!>(C<System.Object?>!).P { set; }", model.GetSymbolInfo(propertyAccess).Symbol.ToTestDisplayString(includeNonNullable: true));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_09()
+    {
+        // notnull constraint
+        var src = """
+#nullable enable
+
+object? oNull = null;
+_ = oNull.P;
+
+object? oNotNull = new object();
+_ = oNotNull.P;
+
+static class E
+{
+    extension<T>(T t) where T : notnull
+    {
+        public T P { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (4,5): warning CS8714: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'E.extension<T>(T)'. Nullability of type argument 'object?' doesn't match 'notnull' constraint.
+            // _ = oNull.P;
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "oNull.P").WithArguments("E.extension<T>(T)", "T", "object?").WithLocation(4, 5));
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var propertyAccess1 = GetSyntax<MemberAccessExpressionSyntax>(tree, "oNull.P");
+        AssertEx.Equal("System.Object? E.extension<System.Object?>(System.Object?).P { get; }", model.GetSymbolInfo(propertyAccess1).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+        var propertyAccess2 = GetSyntax<MemberAccessExpressionSyntax>(tree, "oNotNull.P");
+        AssertEx.Equal("System.Object! E.extension<System.Object!>(System.Object!).P { get; }", model.GetSymbolInfo(propertyAccess2).Symbol.ToTestDisplayString(includeNonNullable: true));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_10()
+    {
+        // notnull constraint, in tuple
+        var src = """
+#nullable enable
+
+object? oNull = null;
+_ = (1, oNull.P);
+
+static class E
+{
+    extension<T>(T t) where T : notnull
+    {
+        public T P { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (4,9): warning CS8714: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'E.extension<T>(T)'. Nullability of type argument 'object?' doesn't match 'notnull' constraint.
+            // _ = (1, oNull.P);
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "oNull.P").WithArguments("E.extension<T>(T)", "T", "object?").WithLocation(4, 9));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_11()
+    {
+        // implicit reference conversion on the receiver
+        var src = """
+#nullable enable
+
+string? sNull = null;
+_ = sNull.P;
+
+string? sNotNull = "";
+_ = sNotNull.P;
+
+static class E
+{
+    extension(object? o)
+    {
+        public int P { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_12()
+    {
+        // implicit reference conversion on the receiver
+        var src = """
+#nullable enable
+
+string? sNull = null;
+_ = sNull.P;
+
+string? sNotNull = "";
+_ = sNotNull.P;
+
+static class E
+{
+    extension(object o)
+    {
+        public int P { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (4,5): warning CS8604: Possible null reference argument for parameter 'o' in 'extension(object)'.
+            // _ = sNull.P;
+            Diagnostic(ErrorCode.WRN_NullReferenceArgument, "sNull").WithArguments("o", "extension(object)").WithLocation(4, 5));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_13()
+    {
+        // `ref` extension parameter
+        var src = """
+#nullable enable
+
+S<object?> s1 = default;
+_ = s1.P;
+
+S<object> s2 = default;
+_ = s2.P; // 1
+
+S<object?> s3 = default;
+_ = s3.P2; // 2
+
+S<object> s4 = default;
+_ = s4.P2;
+
+struct S<T> { }
+
+static class E
+{
+    extension(ref S<object?> o)
+    {
+        public int P { get => throw null!; }
+    }
+    extension(ref S<object> o)
+    {
+        public int P2 { get => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (7,5): warning CS8620: Argument of type 'S<object>' cannot be used for parameter 'o' of type 'S<object?>' in 'extension(ref S<object?>)' due to differences in the nullability of reference types.
+            // _ = s2.P; // 1
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s2").WithArguments("S<object>", "S<object?>", "o", "extension(ref S<object?>)").WithLocation(7, 5),
+            // (10,5): warning CS8620: Argument of type 'S<object?>' cannot be used for parameter 'o' of type 'S<object>' in 'extension(ref S<object>)' due to differences in the nullability of reference types.
+            // _ = s3.P2; // 2
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s3").WithArguments("S<object?>", "S<object>", "o", "extension(ref S<object>)").WithLocation(10, 5));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_14()
+    {
+        // `in` extension parameter
+        var src = """
+#nullable enable
+
+S<object?> s1 = default;
+_ = s1.P;
+
+S<object> s2 = default;
+_ = s2.P; // 1
+
+S<object?> s3 = default;
+_ = s3.P2; // 2
+
+S<object> s4 = default;
+_ = s4.P2;
+""";
+        var libSrc = """
+#nullable enable
+
+public struct S<T> { }
+
+public static class E
+{
+    extension(in S<object?> o)
+    {
+        public int P { get => throw null!; }
+    }
+    extension(in S<object> o)
+    {
+        public int P2 { get => throw null!; }
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (7,5): warning CS8620: Argument of type 'S<object>' cannot be used for parameter 'o' of type 'S<object?>' in 'extension(in S<object?>)' due to differences in the nullability of reference types.
+            // _ = s2.P; // 1
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s2").WithArguments("S<object>", "S<object?>", "o", "extension(in S<object?>)").WithLocation(7, 5),
+            // (10,5): warning CS8620: Argument of type 'S<object?>' cannot be used for parameter 'o' of type 'S<object>' in 'extension(in S<object>)' due to differences in the nullability of reference types.
+            // _ = s3.P2; // 2
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s3").WithArguments("S<object?>", "S<object>", "o", "extension(in S<object>)").WithLocation(10, 5)
+            ];
+
+        var comp = CreateCompilation([src, libSrc]);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_15()
+    {
+        // NotNullIfNotNull
+        var src = """
+#nullable enable
+
+object? oNull = null;
+oNull.P.ToString(); // 1
+
+object? oNull2 = null;
+E.get_P(oNull2).ToString(); // 2
+
+object oNotNull = new object();
+oNotNull.P.ToString();
+
+E.get_P(oNotNull).ToString();
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object? o)
+    {
+        [property: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(o))]
+        public object? P { get => throw null!; }
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (4,1): warning CS8602: Dereference of a possibly null reference.
+            // oNull.P.ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "oNull.P").WithLocation(4, 1),
+            // (7,1): warning CS8602: Dereference of a possibly null reference.
+            // E.get_P(oNull2).ToString(); // 2
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E.get_P(oNull2)").WithLocation(7, 1),
+
+            // Tracked by https://github.com/dotnet/roslyn/issues/37238 : NotNullIfNotNull not yet supported on indexers. The last two warnings are spurious
+
+            // (10,1): warning CS8602: Dereference of a possibly null reference.
+            // oNotNull.P.ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "oNotNull.P").WithLocation(10, 1),
+            // (12,1): warning CS8602: Dereference of a possibly null reference.
+            // E.get_P(oNotNull).ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E.get_P(oNotNull)").WithLocation(12, 1)
+            ];
+
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics(expected);
+
+        src = """
+#nullable enable
+
+object? oNull = null;
+new C()[oNull].ToString();
+
+object oNotNull = new object();
+new C()[oNotNull].ToString();
+
+class C
+{
+    [property: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(o))]
+    public object? this[object? o] { get => throw null!; }
+}
+""";
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        // Tracked by https://github.com/dotnet/roslyn/issues/37238 : NotNullIfNotNull not yet supported on indexers. 
+        comp.VerifyEmitDiagnostics(
+            // (4,1): warning CS8602: Dereference of a possibly null reference.
+            // new C()[oNull].ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new C()[oNull]").WithLocation(4, 1),
+            // (7,1): warning CS8602: Dereference of a possibly null reference.
+            // new C()[oNotNull].ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new C()[oNotNull]").WithLocation(7, 1));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_16()
+    {
+        // NotNull
+        var src = """
+#nullable enable
+
+object.P.ToString();
+object.P = null;
+
+E.get_P().ToString();
+E.set_P(null);
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        [property: System.Diagnostics.CodeAnalysis.NotNull]
+        public static object? P { get => throw null!; set => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics();
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics();
+
+        CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.Skipped);
+
+        static void validate(ModuleSymbol m)
+        {
+            AssertEx.SetEqual(m is SourceModuleSymbol ? new string[] { } : ["System.Diagnostics.CodeAnalysis.NotNullAttribute"],
+                m.GlobalNamespace.GetMember<MethodSymbol>("E.get_P").GetReturnTypeAttributes().ToStrings());
+
+            Assert.Empty(m.GlobalNamespace.GetMember<MethodSymbol>("E.set_P").GetReturnTypeAttributes());
+            Assert.Empty(m.GlobalNamespace.GetMember<MethodSymbol>("E.set_P").Parameters[0].GetAttributes());
+        }
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_17()
+    {
+        // MaybeNull
+        var src = """
+#nullable enable
+
+object.P.ToString(); // 1
+object.P = null; // 2
+object.P = "";
+
+E.get_P().ToString(); // 3
+E.set_P(null); // 4
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        [property: System.Diagnostics.CodeAnalysis.MaybeNull]
+        public static object P { get => throw null!; set => throw null!; }
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (3,1): warning CS8602: Dereference of a possibly null reference.
+            // object.P.ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "object.P").WithLocation(3, 1),
+            // (4,12): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // object.P = null; // 2
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(4, 12),
+            // (7,1): warning CS8602: Dereference of a possibly null reference.
+            // E.get_P().ToString(); // 3
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E.get_P()").WithLocation(7, 1),
+            // (8,9): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // E.set_P(null); // 4
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 9)
+            ];
+
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_18()
+    {
+        // AllowNull
+        var src = """
+#nullable enable
+
+object.P.ToString();
+object.P = null;
+
+E.get_P().ToString();
+E.set_P(null);
+""";
+        var libSrc = """
+public static class E
+{
+    extension(object)
+    {
+        [property: System.Diagnostics.CodeAnalysis.AllowNull]
+        public static object P { get => throw null!; set => throw null!; }
+    }
+}
+""";
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics();
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics();
+
+        CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.Skipped);
+
+        static void validate(ModuleSymbol m)
+        {
+            AssertEx.SetEqual(m is SourceModuleSymbol ? new string[] { } : ["System.Diagnostics.CodeAnalysis.AllowNullAttribute"],
+                m.GlobalNamespace.GetMember<MethodSymbol>("E.set_P").Parameters[0].GetAttributes().ToStrings());
+        }
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_19()
+    {
+        // DisallowNull
+        var src = """
+#nullable enable
+
+object.P.ToString();
+object.P = null;
+
+E.get_P().ToString();
+E.set_P(null);
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        [property: System.Diagnostics.CodeAnalysis.DisallowNull]
+        public static object? P { get => throw null!; set => throw null!; }
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (3,1): warning CS8602: Dereference of a possibly null reference.
+            // object.P.ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "object.P").WithLocation(3, 1),
+            // (4,12): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // object.P = null;
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(4, 12),
+            // (6,1): warning CS8602: Dereference of a possibly null reference.
+            // E.get_P().ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E.get_P()").WithLocation(6, 1),
+            // (7,9): warning CS8625: Cannot convert null literal to non-nullable reference type.
+            // E.set_P(null);
+            Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 9)
+            ];
+
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics(expected);
+
+        CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.Skipped);
+
+        static void validate(ModuleSymbol m)
+        {
+            AssertEx.SetEqual(m is SourceModuleSymbol ? new string[] { } : ["System.Diagnostics.CodeAnalysis.DisallowNullAttribute"],
+                m.GlobalNamespace.GetMember<MethodSymbol>("E.set_P").Parameters[0].GetAttributes().ToStrings());
+        }
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_20()
+    {
+        // DoesNotReturn
+        var src = """
+#nullable enable
+
+bool b = false;
+object? o = null;
+
+if (b)
+{
+    _ = object.P;
+    o.ToString(); // incorrect
+}
+
+if (b)
+{
+    object.P = 0;
+    o.ToString(); // incorrect
+}
+
+if (b)
+{
+    E.get_P();
+    o.ToString();
+}
+
+if (b)
+{
+    E.set_P(0);
+    o.ToString();
+}
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        public static int P
+        {
+            [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+            get => throw null!;
+            [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+            set => throw null!;
+        }
+    }
+}
+""";
+        // Tracked by https://github.com/dotnet/roslyn/issues/50018 : DoesNotReturn not yet supported on indexers.
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // incorrect
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(9, 5),
+            // (15,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // incorrect
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(15, 5));
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics(
+            // (9,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // incorrect
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(9, 5),
+            // (15,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // incorrect
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(15, 5));
+
+        src = """
+#nullable enable
+
+bool b = false;
+object? o = null;
+
+if (b)
+{
+    _ = object.P;
+    o.ToString(); // incorrect
+}
+
+if (b)
+{
+    object.P = 0;
+    o.ToString(); // incorrect
+}
+
+public static class E
+{
+    extension(object)
+    {
+        public static int P
+        {
+            [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+            get => throw null!;
+            [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+            set => throw null!;
+        }
+    }
+}
+""";
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // incorrect
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(9, 5),
+            // (15,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // incorrect
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(15, 5));
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_21()
+    {
+        // NotNullWhen
+        var src = """
+#nullable enable
+
+object? o = null;
+if (o.P)
+    o.ToString();
+else
+    o.ToString(); // 1
+
+object? o2 = null;
+if (E.get_P(o2))
+    o2.ToString();
+else
+    o2.ToString(); // 2
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? o)
+    {
+        public bool P => throw null!;
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (7,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(7, 5),
+            // (13,5): warning CS8602: Dereference of a possibly null reference.
+            //     o2.ToString(); // 2
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o2").WithLocation(13, 5)
+            ];
+
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_22()
+    {
+        // MaybeNullWhen
+        var src = """
+#nullable enable
+
+object o = new object();
+if (o.P)
+    o.ToString(); // 1
+else
+    o.ToString();
+
+object o2 = new object();
+if (E.get_P(o2))
+    o2.ToString(); // 2
+else
+    o2.ToString();
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension([System.Diagnostics.CodeAnalysis.MaybeNullWhen(true)] object? o)
+    {
+        public bool P => throw null!;
+    }
+}
+""";
+        DiagnosticDescription[] expected = [
+            // (5,5): warning CS8602: Dereference of a possibly null reference.
+            //     o.ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(5, 5),
+            // (11,5): warning CS8602: Dereference of a possibly null reference.
+            //     o2.ToString(); // 2
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o2").WithLocation(11, 5)
+            ];
+
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyAccess_23()
+    {
+        // MemberNotNull
+        var src = """
+#nullable enable
+
+if (object.P)
+    object.P2.ToString(); // 1
+else
+    object.P2.ToString();
+
+if (E.get_P())
+    E.get_P2().ToString(); // 2
+else
+    E.get_P2().ToString();
+
+""";
+        var libSrc = """
+#nullable enable
+
+public static class E
+{
+    extension(object)
+    {
+        [System.Diagnostics.CodeAnalysis.MemberNotNull("P2")]
+        public static bool P => throw null!;
+
+        public static object? P2 => throw null!;
+    }
+}
+""";
+        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : should we extend member post-conditions to work with extension members?
+        DiagnosticDescription[] expected = [
+            // (4,5): warning CS8602: Dereference of a possibly null reference.
+            //     object.P2.ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "object.P2").WithLocation(4, 5),
+            // (6,5): warning CS8602: Dereference of a possibly null reference.
+            //     object.P2.ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "object.P2").WithLocation(6, 5),
+            // (9,5): warning CS8602: Dereference of a possibly null reference.
+            //     E.get_P2().ToString(); // 2
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E.get_P2()").WithLocation(9, 5),
+            // (11,5): warning CS8602: Dereference of a possibly null reference.
+            //     E.get_P2().ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E.get_P2()").WithLocation(11, 5)
+            ];
+
+        var comp = CreateCompilation([src, libSrc], targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(expected);
+
+        var libComp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net90);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()], targetFramework: TargetFramework.Net90);
+        comp2.VerifyEmitDiagnostics(expected);
+    }
+
+    [Fact]
+    public void Nullability_PropertyPattern_01()
+    {
+        // return type of property
+        var src = """
+#nullable enable
+
+if (new object() is { P: var x })
+    x.ToString(); // 1
+
+if (new object() is { P2: var x2 })
+    x2.ToString();
+
+#nullable enable
+
+public static class E
+{
+    extension(object o)
+    {
+        public object? P => throw null!;
+        public object P2 => throw null!;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (4,5): warning CS8602: Dereference of a possibly null reference.
+            //     x.ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(4, 5));
+    }
+
+    [Fact]
+    public void Nullability_PropertyPattern_02()
+    {
+        // nullability of extension parameter
+        var src = """
+#nullable enable
+
+object? oNull = null;
+_ = oNull is { P: 0 };
+
+object? oNull2 = null;
+_ = oNull2 is { P2: 0 };
+
+#nullable enable
+
+public static class E
+{
+    extension(object o)
+    {
+        public int P => throw null!;
+    }
+    extension(object? o)
+    {
+        public int P2 => throw null!;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Nullability_PropertyPattern_03()
+    {
+        // NotNull
+        var src = """
+#nullable enable
+
+if (new object() is { P: var x })
+    x.ToString();
+
+if (new object() is { P2: var x2 })
+    x2.ToString(); // 1
+
+if (new C() is { P3: var x3 })
+    x3.ToString();
+
+public static class E
+{
+    extension(object o)
+    {
+        [property: System.Diagnostics.CodeAnalysis.NotNull]
+        public object? P => throw null!;
+
+        public object? P2 => throw null!;
+    }
+}
+
+class C
+{
+    [property: System.Diagnostics.CodeAnalysis.NotNull]
+    public object? P3 => throw null!;
+}
+""";
+        // Tracked by https://github.com/dotnet/roslyn/issues/76130 : incorrect nullability analysis for property pattern with extension property (unexpected warning)
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (4,5): warning CS8602: Dereference of a possibly null reference.
+            //     x.ToString();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(4, 5),
+            // (7,5): warning CS8602: Dereference of a possibly null reference.
+            //     x2.ToString(); // 1
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(7, 5));
+    }
+
+    [Fact]
+    public void WellKnownAttribute_Conditional()
+    {
+        var src = """
+object.M();
+E.M();
+""";
+        var libSrc = """
+public static class E
+{
+    extension(object)
+    {
+        [System.Diagnostics.Conditional("CONDITION")]
+        public static void M() { System.Console.Write("ran "); }
+    }
+}
+""";
+
+        var comp = CreateCompilation([src, libSrc]);
+        CompileAndVerify(comp, expectedOutput: "").VerifyDiagnostics();
+
+        var libComp = CreateCompilation(libSrc);
+        var comp2 = CreateCompilation(src, references: [libComp.EmitToImageReference()]);
+        CompileAndVerify(comp2, expectedOutput: "").VerifyDiagnostics();
+
+        var src2 = """
+#define CONDITION
+
+object.M();
+E.M();
+""";
+
+        comp = CreateCompilation([src2, libSrc]);
+        CompileAndVerify(comp, expectedOutput: "ran ran").VerifyDiagnostics();
+
+        libComp = CreateCompilation(libSrc);
+        comp2 = CreateCompilation(src2, references: [libComp.EmitToImageReference()]);
+        CompileAndVerify(comp2, expectedOutput: "ran ran").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void WellKnownAttribute_ModuleInitializer()
+    {
+        var src = """
+System.Console.Write("");
+
+public static class E
+{
+    extension(object)
+    {
+        [System.Runtime.CompilerServices.ModuleInitializer] // 1
+        public static void M() => throw null;
+
+        public static int P
+        {
+            [System.Runtime.CompilerServices.ModuleInitializer] // 2
+            get => throw null;
+        }
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (7,10): error CS8813: A module initializer must be an ordinary member method
+            //         [System.Runtime.CompilerServices.ModuleInitializer] // 1
+            Diagnostic(ErrorCode.ERR_ModuleInitializerMethodMustBeOrdinary, "System.Runtime.CompilerServices.ModuleInitializer").WithLocation(7, 10),
+            // (12,14): error CS8813: A module initializer must be an ordinary member method
+            //             [System.Runtime.CompilerServices.ModuleInitializer] // 2
+            Diagnostic(ErrorCode.ERR_ModuleInitializerMethodMustBeOrdinary, "System.Runtime.CompilerServices.ModuleInitializer").WithLocation(12, 14));
+    }
+
+    [Fact]
+    public void WellKnownAttribute_UnscopedRef_01()
+    {
+        var src = """
+public static class E
+{
+    extension<T>(System.Span<T> span)
+    {
+        [System.Diagnostics.CodeAnalysis.UnscopedRef]
+        public ref T GetFirst() => throw null;
+
+        [System.Diagnostics.CodeAnalysis.UnscopedRef]
+        public ref T First => throw null;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics(
+            // (5,10): error CS9101: UnscopedRefAttribute can only be applied to struct or virtual interface instance methods and properties, and cannot be applied to constructors or init-only members.
+            //         [System.Diagnostics.CodeAnalysis.UnscopedRef]
+            Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedMemberTarget, "System.Diagnostics.CodeAnalysis.UnscopedRef").WithLocation(5, 10),
+            // (8,10): error CS9101: UnscopedRefAttribute can only be applied to struct or virtual interface instance methods and properties, and cannot be applied to constructors or init-only members.
+            //         [System.Diagnostics.CodeAnalysis.UnscopedRef]
+            Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedMemberTarget, "System.Diagnostics.CodeAnalysis.UnscopedRef").WithLocation(8, 10));
     }
 }
 


### PR DESCRIPTION
This PR includes:
- Nullability analysis of property access and invocation of the implementation accessors (changes in `NullableWalker`)
- Adjusting attributes emitted (changes in `SourceExtensionImplementationMethodSymbol`):
  We were missing synthesized attributes on implementation method (NullableContext for method, Nullable for implementation parameter) 
  We need to synthesize some nullability attributes onto return of getter implementation or value parameter of setter implementation
- Relaxing an assertion in `ExtensionMethodReferenceRewriter`
- Some tests related to well-known attributes (disallows `ModuleInitializer` attribute in extensions)

Ran into a couple of existing/known issues:
- NotNullIfNotNull not supported on indexers: https://github.com/dotnet/roslyn/issues/37238
- DoesNotReturn not yet supported on indexers: https://github.com/dotnet/roslyn/issues/50018

Relates to test plan https://github.com/dotnet/roslyn/issues/76130