### PR TITLE
StaticLogMessage isn't pooling correctly

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/LogMessage.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/LogMessage.cs
@@ -60,10 +60,13 @@ internal abstract class LogMessage
     {
         private static readonly ObjectPool<StaticLogMessage> s_pool = SharedPools.Default<StaticLogMessage>();
 
+        private bool _isConstructed;
+
         public static LogMessage Construct(string message, LogLevel logLevel)
         {
             var logMessage = s_pool.Allocate();
             logMessage._message = message;
+            logMessage._isConstructed = true;
             logMessage.LogLevel = logLevel;
 
             return logMessage;
@@ -74,11 +77,12 @@ internal abstract class LogMessage
 
         protected override void FreeCore()
         {
-            if (_message == null)
+            if (!_isConstructed)
             {
                 return;
             }
 
+            _isConstructed = false;
             _message = null;
             s_pool.Free(this);
         }


### PR DESCRIPTION
Noticed this when looking at a profile and was curious why there were 3 MB of allocations of the StaticLogMessage type.

LogMessage.Free sets _message to null before calling FreeCore, thus StaticLogMessage.FreeCore was never adding items back to it's pool. The ordering of LogMessage setting _message to null and calling FreeCore is important, so that can't be changed. Instead, add a flag to StaticLogMessage to indicate whether it's in a constructed state or not.

![image](https://github.com/user-attachments/assets/de113a29-fa39-489c-8a9f-54fc1de53534)