### PR TITLE
Fixed crash in `CSharpConvertToRecordRefactoringProvider`

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertToRecord/ConvertToRecordEngine.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertToRecord/ConvertToRecordEngine.cs
@@ -218,24 +218,28 @@ internal static class ConvertToRecordEngine
 
         foreach (var method in typeDeclaration.Members.OfType<MethodDeclarationSyntax>())
         {
-            var methodSymbol = (IMethodSymbol)semanticModel.GetRequiredDeclaredSymbol(method, cancellationToken);
-            var operation = (IMethodBodyOperation)semanticModel.GetRequiredOperation(method, cancellationToken);
+            var methodSymbol = semanticModel.GetRequiredDeclaredSymbol(method, cancellationToken);
 
             if (methodSymbol.Name == "Clone")
             {
                 // remove clone method as clone is a reserved method name in records
                 documentEditor.RemoveNode(method);
             }
-            else if (ConvertToRecordHelpers.IsSimpleHashCodeMethod(
-                semanticModel.Compilation, methodSymbol, operation, expectedFields))
+            else if (method is { Body: not null })
             {
-                documentEditor.RemoveNode(method);
-            }
-            else if (ConvertToRecordHelpers.IsSimpleEqualsMethod(
-                semanticModel.Compilation, methodSymbol, operation, expectedFields))
-            {
-                // the Equals method implementation is fundamentally equivalent to the generated one
-                documentEditor.RemoveNode(method);
+                var operation = (IMethodBodyOperation)semanticModel.GetRequiredOperation(method, cancellationToken);
+
+                if (ConvertToRecordHelpers.IsSimpleHashCodeMethod(
+                    semanticModel.Compilation, methodSymbol, operation, expectedFields))
+                {
+                    documentEditor.RemoveNode(method);
+                }
+                else if (ConvertToRecordHelpers.IsSimpleEqualsMethod(
+                    semanticModel.Compilation, methodSymbol, operation, expectedFields))
+                {
+                    // the Equals method implementation is fundamentally equivalent to the generated one
+                    documentEditor.RemoveNode(method);
+                }
             }
         }
 

--- a/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
@@ -4515,6 +4515,55 @@ public sealed class ConvertToRecordCodeRefactoringTests
         }.RunAsync();
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78664")]
+    public async Task TestDoesNotCrashOnAbstractMethod()
+    {
+        var initialMarkup = """
+            namespace N
+            {
+                public abstract class [|C|]
+                {
+                    public string? S { get; set; }
+
+                    public abstract System.Guid F();
+                }
+            }
+            """;
+        var changedMarkup = """
+            namespace N
+            {
+                public abstract record C(string? S)
+                {
+                    public abstract System.Guid F();
+                }
+            }
+            """;
+        await TestRefactoringAsync(initialMarkup, changedMarkup).ConfigureAwait(false);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78664")]
+    public async Task TestDoesNotCrashOnAbstractCloneMethod()
+    {
+        var initialMarkup = """
+            namespace N
+            {
+                public abstract class [|C|]
+                {
+                    public string? S { get; set; }
+
+                    public abstract object Clone();
+                }
+            }
+            """;
+        var changedMarkup = """
+            namespace N
+            {
+                public abstract record C(string? S);
+            }
+            """;
+        await TestRefactoringAsync(initialMarkup, changedMarkup).ConfigureAwait(false);
+    }
+
 #pragma warning disable RS1042 // Do not implement
     private sealed class ConvertToRecordTestGenerator : ISourceGenerator
 #pragma warning restore RS1042 // Do not implement

--- a/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
@@ -4538,7 +4538,7 @@ public sealed class ConvertToRecordCodeRefactoringTests
                 }
             }
             """;
-        await TestRefactoringAsync(initialMarkup, changedMarkup).ConfigureAwait(false);
+        await TestRefactoringAsync(initialMarkup, changedMarkup);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78664")]
@@ -4561,7 +4561,7 @@ public sealed class ConvertToRecordCodeRefactoringTests
                 public abstract record C(string? S);
             }
             """;
-        await TestRefactoringAsync(initialMarkup, changedMarkup).ConfigureAwait(false);
+        await TestRefactoringAsync(initialMarkup, changedMarkup);
     }
 
 #pragma warning disable RS1042 // Do not implement


### PR DESCRIPTION
This PR fixes the crash in `CSharpConvertToRecordRefactoringProvider` described in #78664 while maintaining the behaviors for `Clone`, `GetHashCode`, and `Equals`.