### PR TITLE
Use VerifyDiagnostics format to report CompileAndVerify diagnostics

### DIFF
--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
@@ -515,7 +515,43 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             // write out the actual results as method calls (copy/paste this to update baseline)
             assertText.AppendLine("Actual:");
-            var e = actual.GetEnumerator();
+            bool isNonEmpty = GetPrettyDiagnostics(assertText, actual, includeDiagnosticMessagesAsComments, indentDepth, includeDefaultSeverity, includeEffectiveSeverity);
+            if (isNonEmpty)
+            {
+                assertText.AppendLine();
+            }
+
+            assertText.AppendLine("Diff:");
+
+            var unmatchedExpectedText = ArrayBuilder<string>.GetInstance();
+            foreach (var d in unmatchedExpected)
+            {
+                unmatchedExpectedText.Add(GetDiagnosticDescription(d, indentDepth));
+            }
+
+            var unmatchedActualText = ArrayBuilder<string>.GetInstance();
+            IEnumerator<Diagnostic> e = unmatchedActual.GetEnumerator();
+            for (i = 0; e.MoveNext(); i++)
+            {
+                Diagnostic d = e.Current;
+                var diffDescription = new DiagnosticDescription(d, errorCodeOnly: false, includeDefaultSeverity, includeEffectiveSeverity);
+                unmatchedActualText.Add(GetDiagnosticDescription(diffDescription, indentDepth));
+            }
+
+            assertText.Append(DiffUtil.DiffReport(unmatchedExpectedText, unmatchedActualText, separator: Environment.NewLine));
+
+            unmatchedExpectedText.Free();
+            unmatchedActualText.Free();
+
+            expectedText.Free();
+
+            return assertText.ToString();
+        }
+
+        internal static bool GetPrettyDiagnostics(StringBuilder assertText, IEnumerable<Diagnostic> diagnostics, bool includeDiagnosticMessagesAsComments, int indentDepth, bool includeDefaultSeverity, bool includeEffectiveSeverity)
+        {
+            IEnumerator<Diagnostic> e = diagnostics.GetEnumerator();
+            int i = 0;
             for (i = 0; e.MoveNext(); i++)
             {
                 Diagnostic d = e.Current;
@@ -547,36 +583,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 var description = new DiagnosticDescription(d, errorCodeOnly: false, includeDefaultSeverity, includeEffectiveSeverity);
                 assertText.Append(GetDiagnosticDescription(description, indentDepth));
             }
-            if (i > 0)
-            {
-                assertText.AppendLine();
-            }
 
-            assertText.AppendLine("Diff:");
-
-            var unmatchedExpectedText = ArrayBuilder<string>.GetInstance();
-            foreach (var d in unmatchedExpected)
-            {
-                unmatchedExpectedText.Add(GetDiagnosticDescription(d, indentDepth));
-            }
-
-            var unmatchedActualText = ArrayBuilder<string>.GetInstance();
-            e = unmatchedActual.GetEnumerator();
-            for (i = 0; e.MoveNext(); i++)
-            {
-                Diagnostic d = e.Current;
-                var diffDescription = new DiagnosticDescription(d, errorCodeOnly: false, includeDefaultSeverity, includeEffectiveSeverity);
-                unmatchedActualText.Add(GetDiagnosticDescription(diffDescription, indentDepth));
-            }
-
-            assertText.Append(DiffUtil.DiffReport(unmatchedExpectedText, unmatchedActualText, separator: Environment.NewLine));
-
-            unmatchedExpectedText.Free();
-            unmatchedActualText.Free();
-
-            expectedText.Free();
-
-            return assertText.ToString();
+            return i > 0;
         }
 
         private static IEnumerable<Diagnostic> Sort(IEnumerable<Diagnostic> diagnostics)

--- a/src/Compilers/Test/Core/ExceptionHelper.cs
+++ b/src/Compilers/Test/Core/ExceptionHelper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Utilities;
 
 namespace Roslyn.Test.Utilities
 {
@@ -19,10 +20,13 @@ namespace Roslyn.Test.Utilities
                 sb.AppendLine("Emit Failed, binaries saved to: ");
                 sb.AppendLine(directory);
             }
-            foreach (var d in diagnostics)
+            else
             {
-                sb.AppendLine(d.ToString());
+                sb.AppendLine();
             }
+
+            DiagnosticDescription.GetPrettyDiagnostics(sb, diagnostics, includeDiagnosticMessagesAsComments: true, indentDepth: 0, includeDefaultSeverity: false, includeEffectiveSeverity: false);
+
             return sb.ToString();
         }
 


### PR DESCRIPTION
This helps in two ways:
1. it adds useful information to the error output of `CompileAndVerify`
2. it makes it easier to convert a test from `CompileAndVerify` to `VerifyDiagnostics` (saves one test run just to get the properly formatted output)

Before:
```
  Message: 
Microsoft.CodeAnalysis.Test.Utilities.CompilationVerifier+EmitException : (2,12): error CS9286: 'string[]' does not contain a definition for 'Property' and no accessible extension member 'Property' for receiver of type 'string[]' could be found (are you missing a using directive or an assembly reference?)
(3,1): error CS1929: 'string[]' does not contain a definition for 'M' and the best extension method overload 'E.M(Span<object>)' requires a receiver of type 'System.Span<object>'
```

After:
```
  Message: 
Microsoft.CodeAnalysis.Test.Utilities.CompilationVerifier+EmitException : 
// (2,12): error CS9286: 'string[]' does not contain a definition for 'Property' and no accessible extension member 'Property' for receiver of type 'string[]' could be found (are you missing a using directive or an assembly reference?)
// _ = i is { Property: 42 };
Diagnostic(ErrorCode.ERR_ExtensionResolutionFailed, "Property").WithArguments("string[]", "Property").WithLocation(2, 12),
// (3,1): error CS1929: 'string[]' does not contain a definition for 'M' and the best extension method overload 'E.M(Span<object>)' requires a receiver of type 'System.Span<object>'
// i.M();
Diagnostic(ErrorCode.ERR_BadInstanceArgType, "i").WithArguments("string[]", "M", "E.M(System.Span<object>)", "System.Span<object>").WithLocation(3, 1)
```