### PR TITLE
Fix nullable crash for field keyword in partial property

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -170,11 +170,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return NullableAnnotation.Annotated;
             }
 
+            getAccessor = (SourcePropertyAccessorSymbol?)getAccessor.PartialImplementationPart ?? getAccessor;
             // If the get accessor is auto-implemented, the property is not null-resilient.
             if (getAccessor.IsAutoPropertyAccessor)
                 return NullableAnnotation.NotAnnotated;
 
-            getAccessor = (SourcePropertyAccessorSymbol?)getAccessor.PartialImplementationPart ?? getAccessor;
             var binder = getAccessor.TryGetBodyBinder() ?? throw ExceptionUtilities.UnexpectedValue(getAccessor);
             var boundGetAccessor = binder.BindMethodBody(getAccessor.SyntaxNode, BindingDiagnosticBag.Discarded);
 

--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -12638,5 +12638,78 @@ class C<T>
                 //         Prop.ToString(); // unexpected warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(14, 9));
         }
+
+        [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/78592")]
+        [InlineData(""" = "a";""", "")]
+        [InlineData("", """ = "a";""")]
+        public void PartialProperty_AutoImplGetter_PropertyInitializer(string defInitializer, string implInitializer)
+        {
+            var source = $$"""
+                #nullable enable
+
+                partial class C
+                {
+                    public partial string Prop { get; set; }{{defInitializer}}
+                }
+
+                partial class C
+                {
+                    public partial string Prop { get; set => Set(ref field, value); }{{implInitializer}}
+
+                    private void Set(ref string dest, string value)
+                    {
+                        dest = value;
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78592")]
+        public void Repro_78592()
+        {
+            var source1 = """
+                #nullable enable
+
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+
+                namespace TestLibrary
+                {
+                    public partial class Class1
+                    {
+                        public partial int P1 { get; set; } = -1;
+
+                        protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+                        {
+                            if (EqualityComparer<T>.Default.Equals(storage, value))
+                            {
+                                return false;
+                            }
+
+                            storage = value;
+
+                            return true;
+                        }
+                    }
+
+                }
+                """;
+
+
+            var source2 = """
+                namespace TestLibrary
+                {
+                    public partial class Class1
+                    {
+                        public partial int P1 { get; set => SetProperty(ref field, value); }
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation([source1, source2]);
+            comp.VerifyEmitDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Closes #78592 

2 factors interacting to cause a crash here:
1) Putting a property initializer on the def part actually changes the symbol model--the def part now needs its own backing field symbol to serve as the target of the assignment, in its particular context. (This happens independently of any determination that the property actually is field-backed, e.g. usage of `field` in the impl part.)
2) Only the implementation part answers for whether the accessor is auto-implemented, just as only the implementation part supplies a body binder (when it has a body).

When the two factors are combined, when we dig thru the symbol model for the `field` usage in the setter, we get a definition part accessor, and we need to make sure we dig out its impl part before asking `IsAutoPropertyAccessor`.