### PR TITLE
Mini Allocation-Reduction: avoid not needed compilationUnit clone

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -515,7 +515,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 compilationUnit,
                 parser.Directives,
                 diagnosticOptions: diagnosticOptions,
-                cloneRoot: true);
+                cloneRoot: false);
+            Debug.Assert(compilationUnit._syntaxTree == null);
+            compilationUnit._syntaxTree = tree;
             tree.VerifySource();
             return tree;
         }


### PR DESCRIPTION
This is a mini performance improvement. Currently a red node is created, directly copied and thrown away in CSharpSyntaxTree.ParseText....