### PR TITLE
Modify ABWQ.AddWork to take in a ROS instead of an IEnumerable

### DIFF
--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -314,7 +314,7 @@ internal sealed class VisualStudioDesignerAttributeService :
     public ValueTask ReportDesignerAttributeDataAsync(ImmutableArray<DesignerAttributeData> data, CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(_projectSystemNotificationQueue);
-        _projectSystemNotificationQueue.AddWork(data);
+        _projectSystemNotificationQueue.AddWork(data.AsSpan());
         return ValueTaskFactory.CompletedTask;
     }
 }


### PR DESCRIPTION
I'm seeing this enumerator allocation as account for 50 MB (0.9%) in a customer trace for feedback ticket https://developercommunity.visualstudio.com/t/Razor-Development:-30-Second-CPU-Churn-A/10904811

This shows up a bit smaller in the C# editing speedometer test, but does show as 2.3 MB. Test insertion showed allocations were removed.

*** relevant bit from customer trace ***
![image](https://github.com/user-attachments/assets/681eff9c-fdfd-4fa5-b893-bf437dfa7a34)

test insertion with speedometer results: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/638463