### PR TITLE
Add a test to verify that behavior is expected and bug no longer occurs

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
@@ -452,4 +452,41 @@ public {typeKind} A
             """;
         await RunReferenceTest(input);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67956")]
+    public async Task TestConstructorReferencesInOtherProject()
+    {
+        const string input = """
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Document FilePath="Class1.cs"><![CDATA[
+            namespace ClassLibrary1
+            {
+                public class Class1
+                {
+                    {|2:public Class1()|}
+                    {
+                    }
+                }
+            }]]>
+                    </Document>
+                </Project>
+                <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2">
+                    <ProjectReference>ClassLibrary1</ProjectReference>
+                    <Document FilePath="Class2.cs"><![CDATA[
+            using ClassLibrary1;
+
+            namespace ClassLibrary2;
+
+            public class Class2
+            {
+                static Class1 x = new Class1();
+                static Class1 y = new();
+            }]]>
+                    </Document>
+                </Project>
+            </Workspace>
+            """;
+        await RunReferenceTest(input);
+    }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/67956

To be extra safe I also verified behavior in the VS manually and everything works as expected there as well