### PR TITLE
Add IsNull property to IAsyncToken

### DIFF
--- a/src/Dependencies/Threading/TestHooks/IAsyncToken.cs
+++ b/src/Dependencies/Threading/TestHooks/IAsyncToken.cs
@@ -10,4 +10,5 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks;
 
 internal interface IAsyncToken : IDisposable
 {
+    bool IsNull { get; }
 }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener+AsyncToken.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener+AsyncToken.cs
@@ -22,6 +22,9 @@ internal sealed partial class AsynchronousOperationListener
 
         public AsynchronousOperationListener Listener { get; }
 
+        public bool IsNull
+            => false;
+
         public void Dispose()
         {
             using (Listener._gate.DisposableWait(CancellationToken.None))

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/EmptyAsyncToken.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/EmptyAsyncToken.cs
@@ -8,6 +8,8 @@ internal sealed class EmptyAsyncToken : IAsyncToken
 {
     public static IAsyncToken Instance { get; } = new EmptyAsyncToken();
 
+    public bool IsNull => true;
+
     private EmptyAsyncToken()
     {
     }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/TaskExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/TaskExtensions.cs
@@ -29,7 +29,7 @@ internal static partial class TaskExtensions
     [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "This is a Task wrapper, not an asynchronous method.")]
     public static Task CompletesTrackingOperation(this Task task, IDisposable token)
     {
-        if (token == null || token == EmptyAsyncToken.Instance)
+        if (token is IAsyncToken { IsNull: true })
         {
             return task;
         }


### PR DESCRIPTION
Use it instead of checking for a singleton EmptyAsyncToken.Instance token.

This allows to define other empty tokens. Useful when consuming the source via Threading source package.