### PR TITLE
Extensions: ignore static/instance mismatches for properties inside nameof

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8808,7 +8808,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 OverloadResolutionResult<PropertySymbol> overloadResolutionResult = OverloadResolutionResult<PropertySymbol>.GetInstance();
 
                 binder.OverloadResolution.PropertyOverloadResolution(properties, left, actualReceiverArguments, overloadResolutionResult,
-                    allowRefOmittedArguments: binder.AllowRefOmittedArguments(left), dynamicResolution: actualReceiverArguments.HasDynamicArgument, ref useSiteInfo);
+                    allowRefOmittedArguments: binder.AllowRefOmittedArguments(left), dynamicResolution: actualReceiverArguments.HasDynamicArgument,
+                    ignoreStaticInstanceMismatches: binder.IsInsideNameof, ref useSiteInfo);
 
                 properties.Free();
                 return overloadResolutionResult;
@@ -10127,6 +10128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.OverloadResolution.PropertyOverloadResolution(propertyGroup, receiver, analyzedArguments, overloadResolutionResult,
                 allowRefOmittedArguments: allowRefOmittedArguments,
                 dynamicResolution: analyzedArguments.HasDynamicArgument,
+                ignoreStaticInstanceMismatches: false,
                 ref useSiteInfo);
             diagnostics.Add(syntax, useSiteInfo);
 


### PR DESCRIPTION
Closes https://github.com/dotnet/csharplang/issues/9654

This matches the [behavior](https://lab.razor.fyi/#41rByMUVUJSfXpSYq5dcLDSTkSvat1IjLzE3NT9Nw1kvoCi_ILWopFJTM5YrOSexuFjBmauaS0FBQaGgNCknM1khM69EAaZIwdZOwcTImquWCyoJ0eFb6VhSUpSZVFqSqmClEFxZXJKaqwcXQjUOSa1GcUlRZl66QrGmQrVCLVetF3NRaV4CIwA) of instance members:
```
[My(nameof(C.Property))]
class C
{
    public int Property => 42;
}
public class MyAttribute : System.Attribute
{
    public MyAttribute(string s) { }
}
```

Some existing/relevant tests: `PropertyAccess_RemoveStaticInstanceMismatches_*` for static/instance mismatches outside of `nameof`.
