### PR TITLE
Update persistence version

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -23,7 +23,7 @@ internal abstract partial class AbstractSyntaxIndex<TIndex>
     /// that we will not try to read previously cached data from a prior version of roslyn with a different format and
     /// will instead regenerate all the indices with the new format.
     /// </summary>
-    private static readonly Checksum s_serializationFormatChecksum = CodeAnalysis.Checksum.Create("46");
+    private static readonly Checksum s_serializationFormatChecksum = CodeAnalysis.Checksum.Create("47");
 
     /// <summary>
     /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/78717

That PR changed the values of some enums we store in our DB.  As such we need to rev our persistence version so that indices are recreated.