### PR TITLE
EnC: Partial solution updates

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -458,9 +458,9 @@ internal sealed class CommittedSolution
         }
     }
 
-    public void CommitChanges(Solution solution, ImmutableArray<ProjectId> projectsToStale, ImmutableArray<ProjectId> projectsToUnstale)
+    public void CommitChanges(Solution solution, ImmutableArray<ProjectId> projectsToStale, IReadOnlyCollection<ProjectId> projectsToUnstale)
     {
-        Contract.ThrowIfFalse(projectsToStale is [] || projectsToUnstale is []);
+        Debug.Assert(projectsToStale.Intersect(projectsToUnstale).IsEmpty());
 
         lock (_guard)
         {

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -82,7 +82,7 @@ internal sealed class DebuggingSession : IDisposable
     /// read lock is acquired before every operation that may access a baseline module/symbol reader 
     /// and write lock when the baseline readers are being disposed.
     /// </summary>
-    private readonly ReaderWriterLockSlim _baselineAccessLock = new();
+    private readonly ReaderWriterLockSlim _baselineContentAccessLock = new();
     private bool _isDisposed;
 
     internal EditSession EditSession { get; private set; }
@@ -168,7 +168,7 @@ internal sealed class DebuggingSession : IDisposable
         _cancellationSource.Dispose();
 
         // Wait for all operations on baseline to finish before we dispose the readers.
-        _baselineAccessLock.EnterWriteLock();
+        _baselineContentAccessLock.EnterWriteLock();
 
         lock (_projectEmitBaselinesGuard)
         {
@@ -179,8 +179,8 @@ internal sealed class DebuggingSession : IDisposable
             }
         }
 
-        _baselineAccessLock.ExitWriteLock();
-        _baselineAccessLock.Dispose();
+        _baselineContentAccessLock.ExitWriteLock();
+        _baselineContentAccessLock.Dispose();
 
         if (Interlocked.Exchange(ref _pendingUpdate, null) != null)
         {
@@ -312,7 +312,7 @@ internal sealed class DebuggingSession : IDisposable
         ArrayBuilder<Diagnostic> diagnostics,
         out ReaderWriterLockSlim baselineAccessLock)
     {
-        baselineAccessLock = _baselineAccessLock;
+        baselineAccessLock = _baselineContentAccessLock;
 
         ImmutableList<ProjectBaseline>? existingBaselines;
         lock (_projectEmitBaselinesGuard)
@@ -523,17 +523,31 @@ internal sealed class DebuggingSession : IDisposable
 
         var solutionUpdate = await EditSession.EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, updateId, cancellationToken).ConfigureAwait(false);
 
+        var allowPartialUpdates = runningProjects.Any(p => p.Value.AllowPartialUpdate);
+
+        EmitSolutionUpdateResults.GetProjectsToRebuildAndRestart(
+            solution,
+            solutionUpdate.ModuleUpdates,
+            solutionUpdate.Diagnostics,
+            runningProjects,
+            out var projectsToRestart,
+            out var projectsToRebuild);
+
         solutionUpdate.Log(SessionLog, updateId);
         _lastModuleUpdatesLog = solutionUpdate.ModuleUpdates.Updates;
 
         switch (solutionUpdate.ModuleUpdates.Status)
         {
+            case ModuleUpdateStatus.RestartRequired when allowPartialUpdates:
             case ModuleUpdateStatus.Ready:
-                // We have updates to be applied. The debugger will call Commit/Discard on the solution
+                Contract.ThrowIfTrue(solutionUpdate.ModuleUpdates.Updates.IsEmpty && projectsToRebuild.IsEmpty);
+
+                // We have updates to be applied or processes to restart. The debugger will call Commit/Discard on the solution
                 // based on whether the updates will be applied successfully or not.
                 StorePendingUpdate(new PendingSolutionUpdate(
                     solution,
                     solutionUpdate.ProjectsToStale,
+                    allowPartialUpdates ? projectsToRebuild : [],
                     solutionUpdate.ProjectBaselines,
                     solutionUpdate.ModuleUpdates.Updates,
                     solutionUpdate.NonRemappableRegions));
@@ -544,19 +558,15 @@ internal sealed class DebuggingSession : IDisposable
                 Contract.ThrowIfFalse(solutionUpdate.ModuleUpdates.Updates.IsEmpty);
                 Contract.ThrowIfFalse(solutionUpdate.NonRemappableRegions.IsEmpty);
 
+                // Insignificant changes should not cause rebuilds/restarts:
+                Contract.ThrowIfFalse(projectsToRestart.IsEmpty);
+                Contract.ThrowIfFalse(projectsToRebuild.IsEmpty);
+
                 // No significant changes have been made.
                 // Commit the solution to apply any insignificant changes that do not generate updates.
                 LastCommittedSolution.CommitChanges(solution, projectsToStale: solutionUpdate.ProjectsToStale, projectsToUnstale: []);
                 break;
         }
-
-        EmitSolutionUpdateResults.GetProjectsToRebuildAndRestart(
-            solution,
-            solutionUpdate.ModuleUpdates,
-            solutionUpdate.Diagnostics,
-            runningProjects,
-            out var projectsToRestart,
-            out var projectsToRebuild);
 
         // Note that we may return empty deltas if all updates have been deferred.
         // The debugger will still call commit or discard on the update batch.
@@ -576,6 +586,7 @@ internal sealed class DebuggingSession : IDisposable
         ThrowIfDisposed();
 
         ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>? newNonRemappableRegions = null;
+        using var _ = PooledHashSet<ProjectId>.GetInstance(out var projectsToRebuildTransitive);
 
         var pendingUpdate = RetrievePendingUpdate();
         if (pendingUpdate is PendingSolutionUpdate pendingSolutionUpdate)
@@ -591,17 +602,43 @@ internal sealed class DebuggingSession : IDisposable
             if (newNonRemappableRegions.IsEmpty)
                 newNonRemappableRegions = null;
 
-            LastCommittedSolution.CommitChanges(pendingSolutionUpdate.Solution, projectsToStale: pendingSolutionUpdate.ProjectsToStale, projectsToUnstale: []);
+            var solution = pendingSolutionUpdate.Solution;
+
+            // Once the project is rebuilt all its dependencies are going to be up-to-date.
+            var dependencyGraph = solution.GetProjectDependencyGraph();
+            foreach (var projectId in pendingSolutionUpdate.ProjectsToRebuild)
+            {
+                projectsToRebuildTransitive.Add(projectId);
+                projectsToRebuildTransitive.AddRange(dependencyGraph.GetProjectsThatThisProjectTransitivelyDependsOn(projectId));
+            }
+
+            // Unstale all projects that will be up-to-date after rebuild.
+            LastCommittedSolution.CommitChanges(solution, projectsToStale: pendingSolutionUpdate.ProjectsToStale, projectsToUnstale: projectsToRebuildTransitive);
+
+            foreach (var projectId in projectsToRebuildTransitive)
+            {
+                _editSessionTelemetry.LogUpdatedBaseline(solution.GetRequiredProject(projectId).State.ProjectInfo.Attributes.TelemetryId);
+            }
         }
 
         // update baselines:
+
+        // Wait for all operations on baseline content to finish before we dispose the readers.
+        _baselineContentAccessLock.EnterWriteLock();
+
         lock (_projectEmitBaselinesGuard)
         {
             foreach (var updatedBaseline in pendingUpdate.ProjectBaselines)
             {
                 _projectBaselines[updatedBaseline.ProjectId] = [.. _projectBaselines[updatedBaseline.ProjectId].Select(existingBaseline => existingBaseline.ModuleId == updatedBaseline.ModuleId ? updatedBaseline : existingBaseline)];
             }
+
+            // Discard any open baseline readers for projects that need to be rebuilt,
+            // so that the build can overwrite the underlying files.
+            DiscardProjectBaselinesNoLock(projectsToRebuildTransitive);
         }
+
+        _baselineContentAccessLock.ExitWriteLock();
 
         _editSessionTelemetry.LogCommitted();
 
@@ -615,6 +652,28 @@ internal sealed class DebuggingSession : IDisposable
         _ = RetrievePendingUpdate();
     }
 
+    private void DiscardProjectBaselinesNoLock(IEnumerable<ProjectId> projects)
+    {
+        foreach (var projectId in projects)
+        {
+            if (_projectBaselines.TryGetValue(projectId, out var projectBaselines))
+            {
+                // remove all versions of modules associated with the project:
+                _projectBaselines.Remove(projectId);
+
+                foreach (var projectBaseline in projectBaselines)
+                {
+                    var (metadata, pdb) = _initialBaselineModuleReaders[projectBaseline.ModuleId];
+                    metadata.Dispose();
+                    pdb.Dispose();
+
+                    _initialBaselineModuleReaders.Remove(projectBaseline.ModuleId);
+                }
+            }
+        }
+    }
+
+    // TODO: remove once the debugger implements https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2459003
     public void UpdateBaselines(Solution solution, ImmutableArray<ProjectId> rebuiltProjects)
     {
         ThrowIfDisposed();
@@ -625,30 +684,15 @@ internal sealed class DebuggingSession : IDisposable
         LastCommittedSolution.CommitChanges(solution, projectsToStale: [], projectsToUnstale: rebuiltProjects);
 
         // Wait for all operations on baseline to finish before we dispose the readers.
-        _baselineAccessLock.EnterWriteLock();
+
+        _baselineContentAccessLock.EnterWriteLock();
 
         lock (_projectEmitBaselinesGuard)
         {
-            foreach (var projectId in rebuiltProjects)
-            {
-                if (_projectBaselines.TryGetValue(projectId, out var projectBaselines))
-                {
-                    // remove all versions of modules associated with the project:
-                    _projectBaselines.Remove(projectId);
-
-                    foreach (var projectBaseline in projectBaselines)
-                    {
-                        var (metadata, pdb) = _initialBaselineModuleReaders[projectBaseline.ModuleId];
-                        metadata.Dispose();
-                        pdb.Dispose();
-
-                        _initialBaselineModuleReaders.Remove(projectBaseline.ModuleId);
-                    }
-                }
-            }
+            DiscardProjectBaselinesNoLock(rebuiltProjects);
         }
 
-        _baselineAccessLock.ExitWriteLock();
+        _baselineContentAccessLock.ExitWriteLock();
 
         foreach (var projectId in rebuiltProjects)
         {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -72,6 +72,27 @@ internal readonly struct EmitSolutionUpdateResults
 
             return builder.ToImmutableAndClear();
         }
+
+        public static Data CreateFromInternalError(Solution solution, string errorMessage, ImmutableDictionary<ProjectId, RunningProjectInfo> runningProjects)
+        {
+            ImmutableArray<DiagnosticData> diagnostics = [];
+            var firstProject = solution.GetProject(runningProjects.FirstOrDefault().Key) ?? solution.Projects.First();
+            var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.CannotApplyChangesUnexpectedError);
+
+            var diagnostic = Diagnostic.Create(
+                descriptor,
+                Location.None,
+                string.Format(descriptor.MessageFormat.ToString(), "", errorMessage));
+
+            return new()
+            {
+                ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.Ready, []),
+                Diagnostics = [DiagnosticData.Create(diagnostic, firstProject)],
+                SyntaxError = null,
+                ProjectsToRebuild = [.. runningProjects.Keys],
+                ProjectsToRestart = runningProjects.Keys.ToImmutableDictionary(keySelector: static p => p, elementSelector: static p => ImmutableArray.Create(p))
+            };
+        }
     }
 
     public static readonly EmitSolutionUpdateResults Empty = new()
@@ -160,7 +181,7 @@ internal readonly struct EmitSolutionUpdateResults
     /// </param>
     internal static void GetProjectsToRebuildAndRestart(
         Solution solution,
-        ModuleUpdates moduleUpdates,
+        ImmutableArray<ManagedHotReloadUpdate> moduleUpdates,
         ImmutableArray<ProjectDiagnostics> diagnostics,
         ImmutableDictionary<ProjectId, RunningProjectInfo> runningProjects,
         out ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> projectsToRestart,
@@ -173,7 +194,7 @@ internal readonly struct EmitSolutionUpdateResults
         Debug.Assert(diagnostics
             .Where(r => r.Diagnostics.Any(static d => d.Severity == DiagnosticSeverity.Error))
             .Select(r => r.ProjectId)
-            .Intersect(moduleUpdates.Updates.Select(u => u.ProjectId))
+            .Intersect(moduleUpdates.Select(u => u.ProjectId))
             .IsEmpty());
 
         var graph = solution.GetProjectDependencyGraph();
@@ -234,7 +255,7 @@ internal readonly struct EmitSolutionUpdateResults
             // Partial solution update not supported.
             if (projectsToRestartBuilder.Any())
             {
-                foreach (var update in moduleUpdates.Updates)
+                foreach (var update in moduleUpdates)
                 {
                     AddImpactedRunningProjects(impactedRunningProjects, update.ProjectId, isBlocking: true);
 
@@ -247,7 +268,7 @@ internal readonly struct EmitSolutionUpdateResults
                 }
             }
         }
-        else if (!moduleUpdates.Updates.IsEmpty && projectsToRestartBuilder.Count > 0)
+        else if (!moduleUpdates.IsEmpty && projectsToRestartBuilder.Count > 0)
         {
             // The set of updated projects is usually much smaller than the number of all projects in the solution.
             // We iterate over this set updating the reset set until no new project is added to the reset set.
@@ -261,7 +282,7 @@ internal readonly struct EmitSolutionUpdateResults
             using var _7 = ArrayBuilder<ProjectId>.GetInstance(out var updatedProjectsToRemove);
             using var _8 = PooledHashSet<ProjectId>.GetInstance(out var projectsThatCausedRestart);
 
-            updatedProjects.AddRange(moduleUpdates.Updates.Select(static u => u.ProjectId));
+            updatedProjects.AddRange(moduleUpdates.Select(static u => u.ProjectId));
 
             while (true)
             {

--- a/src/Features/Core/Portable/EditAndContinue/ModuleUpdateStatus.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ModuleUpdateStatus.cs
@@ -15,18 +15,13 @@ internal enum ModuleUpdateStatus
     None = 0,
 
     /// <summary>
-    /// All changes are valid, can be applied.
+    /// Changes can be applied (project might need rebuild in presence of transient errors).
     /// </summary>
     Ready = 1,
-
-    /// <summary>
-    /// Changes require restarting the application in order to be applied.
-    /// </summary>
-    RestartRequired = 2,
 
     /// <summary>
     /// Some changes are errors that block rebuild of the module.
     /// This means that the code is in a broken state that cannot be resolved by restarting the application.
     /// </summary>
-    Blocked = 3
+    Blocked = 2
 }

--- a/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
@@ -19,11 +19,13 @@ internal abstract class PendingUpdate(
 internal sealed class PendingSolutionUpdate(
     Solution solution,
     ImmutableArray<ProjectId> projectsToStale,
+    ImmutableArray<ProjectId> projectsToRebuild,
     ImmutableArray<ProjectBaseline> projectBaselines,
     ImmutableArray<ManagedHotReloadUpdate> deltas,
     ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions) : PendingUpdate(projectBaselines, deltas)
 {
     public readonly Solution Solution = solution;
     public readonly ImmutableArray<ProjectId> ProjectsToStale = projectsToStale;
+    public readonly ImmutableArray<ProjectId> ProjectsToRebuild = projectsToRebuild;
     public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)> Regions)> NonRemappableRegions = nonRemappableRegions;
 }

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
@@ -74,38 +74,13 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
                 callbackTarget: new ActiveStatementSpanProviderCallback(activeStatementSpanProvider),
                 cancellationToken).ConfigureAwait(false);
 
-            return result.HasValue ? result.Value : new EmitSolutionUpdateResults.Data()
-            {
-                ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.RestartRequired, []),
-                Diagnostics = [],
-                SyntaxError = null,
-                ProjectsToRebuild = [],
-                ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
-            };
+            return result.HasValue
+                ? result.Value
+                : EmitSolutionUpdateResults.Data.CreateFromInternalError(solution, errorMessage: "Unexpected RPC failure", runningProjects); // user friendly error already reported by OOP infra
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
         {
-            return new EmitSolutionUpdateResults.Data()
-            {
-                ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.RestartRequired, []),
-                Diagnostics = GetInternalErrorDiagnosticData(e.Message),
-                SyntaxError = null,
-                ProjectsToRebuild = [],
-                ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
-            };
-        }
-
-        ImmutableArray<DiagnosticData> GetInternalErrorDiagnosticData(string message)
-        {
-            var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(RudeEditKind.InternalError);
-
-            var firstProject = solution.GetProject(runningProjects.FirstOrDefault().Key) ?? solution.Projects.First();
-            var diagnostic = Diagnostic.Create(
-                descriptor,
-                Location.None,
-                string.Format(descriptor.MessageFormat.ToString(), "", message));
-
-            return [DiagnosticData.Create(diagnostic, firstProject)];
+            return EmitSolutionUpdateResults.Data.CreateFromInternalError(solution, e.Message, runningProjects);
         }
     }
 

--- a/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
@@ -15,7 +15,9 @@ internal readonly struct SolutionUpdate(
     ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
     ImmutableArray<ProjectBaseline> projectBaselines,
     ImmutableArray<ProjectDiagnostics> diagnostics,
-    Diagnostic? syntaxError)
+    Diagnostic? syntaxError,
+    ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> projectsToRestart,
+    ImmutableArray<ProjectId> projectsToRebuild)
 {
     public readonly ModuleUpdates ModuleUpdates = moduleUpdates;
     public readonly ImmutableArray<ProjectId> ProjectsToStale = projectsToStale;
@@ -25,6 +27,8 @@ internal readonly struct SolutionUpdate(
     // Diagnostics for projects, unique entries per project.
     public readonly ImmutableArray<ProjectDiagnostics> Diagnostics = diagnostics;
     public readonly Diagnostic? SyntaxError = syntaxError;
+    public readonly ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> ProjectsToRestart = projectsToRestart;
+    public readonly ImmutableArray<ProjectId> ProjectsToRebuild = projectsToRebuild;
 
     public static SolutionUpdate Empty(
         ImmutableArray<ProjectDiagnostics> diagnostics,
@@ -36,7 +40,9 @@ internal readonly struct SolutionUpdate(
             nonRemappableRegions: [],
             projectBaselines: [],
             diagnostics,
-            syntaxError);
+            syntaxError,
+            projectsToRestart: ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
+            projectsToRebuild: []);
 
     internal void Log(TraceLog log, UpdateId updateId)
     {

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
@@ -98,7 +98,7 @@ internal sealed class UnitTestingHotReloadService(HostWorkspaceServices services
             .EmitSolutionUpdateAsync(sessionId, solution, runningProjects: ImmutableDictionary<ProjectId, RunningProjectInfo>.Empty, s_solutionActiveStatementSpanProvider, cancellationToken)
             .ConfigureAwait(false);
 
-        if (results.ModuleUpdates.Status == ModuleUpdateStatus.Ready)
+        if (!results.ModuleUpdates.Updates.IsEmpty)
         {
             if (commitUpdates)
             {

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -241,7 +241,7 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
         var runningProjectsImpl = runningProjects.ToImmutableDictionary(keySelector: p => p, elementSelector: _ => new EditAndContinue.RunningProjectInfo()
         {
             RestartWhenChangesHaveNoEffect = false,
-            AllowPartialUpdate = false
+            AllowPartialUpdate = true
         });
 
         var results = await _encService.EmitSolutionUpdateAsync(sessionId, solution, runningProjectsImpl, s_solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -216,7 +216,7 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
 
         // If the changes fail to apply dotnet-watch fails.
         // We don't support discarding the changes and letting the user retry.
-        if (!RequireCommit && results.ModuleUpdates.Status is ModuleUpdateStatus.Ready or ModuleUpdateStatus.RestartRequired)
+        if (!RequireCommit && results.ModuleUpdates.Status is ModuleUpdateStatus.Ready)
         {
             _encService.CommitSolutionUpdate(sessionId);
         }
@@ -226,7 +226,7 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
             Status = results.ModuleUpdates.Status switch
             {
                 ModuleUpdateStatus.None => Status.NoChangesToApply,
-                ModuleUpdateStatus.Ready or ModuleUpdateStatus.RestartRequired => Status.ReadyToApply,
+                ModuleUpdateStatus.Ready => Status.ReadyToApply,
                 ModuleUpdateStatus.Blocked => Status.Blocked,
                 _ => throw ExceptionUtilities.UnexpectedValue(results.ModuleUpdates.Status)
             },

--- a/src/Features/Test/EditAndContinue/EmitSolutionUpdateResultsTests.cs
+++ b/src/Features/Test/EditAndContinue/EmitSolutionUpdateResultsTests.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -46,8 +45,8 @@ public sealed class EmitSolutionUpdateResultsTests
             activeStatements: [],
             exceptionRegions: []);
 
-    private static ModuleUpdates CreateValidUpdates(params IEnumerable<ProjectId> projectIds)
-        => new(ModuleUpdateStatus.Blocked, [.. projectIds.Select(CreateMockUpdate)]);
+    private static ImmutableArray<ManagedHotReloadUpdate> CreateValidUpdates(params IEnumerable<ProjectId> projectIds)
+        => [.. projectIds.Select(CreateMockUpdate)];
 
     private static ImmutableArray<ProjectDiagnostics> CreateProjectRudeEdits(IEnumerable<ProjectId> blocking, IEnumerable<ProjectId> noEffect)
         => [.. blocking.Select(id => (id, kind: RudeEditKind.InternalError)).Concat(noEffect.Select(id => (id, kind: RudeEditKind.UpdateMightNotHaveAnyEffect)))

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -240,6 +240,9 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase, IDisposable
     internal static IEnumerable<string> InspectDiagnosticIds(ImmutableArray<DiagnosticData> actual)
         => actual.Select(d => d.Id);
 
+    internal static IEnumerable<string> InspectDiagnosticIds(IEnumerable<Diagnostic> actual)
+        => actual.Select(d => d.Id);
+
     internal static Guid ReadModuleVersionId(Stream stream)
     {
         using var peReader = new PEReader(stream);

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -224,8 +224,38 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase, IDisposable
         Solution solution,
         ActiveStatementSpanProvider? activeStatementSpanProvider = null)
     {
-        var result = await session.EmitSolutionUpdateAsync(solution, runningProjects: ImmutableDictionary<ProjectId, RunningProjectInfo>.Empty, activeStatementSpanProvider ?? s_noActiveSpans, CancellationToken.None);
+        var runningProjects = solution.ProjectIds.ToImmutableDictionary(
+            keySelector: id => id,
+            elementSelector: id => new RunningProjectInfo() { AllowPartialUpdate = false, RestartWhenChangesHaveNoEffect = false });
+
+        var result = await session.EmitSolutionUpdateAsync(solution, runningProjects, activeStatementSpanProvider ?? s_noActiveSpans, CancellationToken.None);
         return (result.ModuleUpdates, result.Diagnostics.OrderBy(d => d.ProjectId.DebugName).ToImmutableArray().ToDiagnosticData(solution));
+    }
+
+    internal static async ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(
+        DebuggingSession session,
+        Solution solution,
+        bool allowPartialUpdate,
+        ActiveStatementSpanProvider? activeStatementSpanProvider = null)
+    {
+        var runningProjects = solution.ProjectIds.ToImmutableDictionary(
+            keySelector: id => id,
+            elementSelector: id => new RunningProjectInfo() { AllowPartialUpdate = allowPartialUpdate, RestartWhenChangesHaveNoEffect = false });
+
+        var results = await session.EmitSolutionUpdateAsync(solution, runningProjects, activeStatementSpanProvider ?? s_noActiveSpans, CancellationToken.None);
+
+        var hasTransientError = results.Diagnostics.SelectMany(pd => pd.Diagnostics).Any(d => d.IsEncDiagnostic() && d.Severity == DiagnosticSeverity.Error);
+
+        Assert.Equal(hasTransientError, results.ProjectsToRestart.Any());
+        Assert.Equal(hasTransientError, results.ProjectsToRebuild.Any());
+
+        if (!allowPartialUpdate)
+        {
+            // No updates should be produced if transient error is reported:
+            Assert.True(!hasTransientError || results.ModuleUpdates.Updates.IsEmpty);
+        }
+
+        return results;
     }
 
     internal static IEnumerable<string> InspectDiagnostics(ImmutableArray<DiagnosticData> actual)
@@ -234,11 +264,23 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase, IDisposable
     internal static string InspectDiagnostic(DiagnosticData diagnostic)
         => $"{(string.IsNullOrWhiteSpace(diagnostic.DataLocation.MappedFileSpan.Path) ? diagnostic.ProjectId.ToString() : diagnostic.DataLocation.MappedFileSpan.ToString())}: {diagnostic.Severity} {diagnostic.Id}: {diagnostic.Message}";
 
+    internal static IEnumerable<string> InspectDiagnostics(ImmutableArray<ProjectDiagnostics> actual)
+        => actual.SelectMany(pd => pd.Diagnostics.Select(d => $"{pd.ProjectId.DebugName}: {InspectDiagnostic(d)}"));
+
+    internal static string InspectDiagnostic(Diagnostic actual)
+        => $"{Inspect(actual.Location)}: {actual.Severity} {actual.Id}: {actual.GetMessage()}";
+
+    internal static string Inspect(Location actual)
+        => actual.GetLineSpan() is { IsValid: true } span ? span.ToString() : "<no location>";
+
     internal static IEnumerable<string> InspectDiagnostics(ImmutableArray<Diagnostic> actual)
-        => actual.Select(d => $"{d.Id}: {d.Severity}: {d.GetMessage()}");
+        => actual.Select(InspectDiagnostic);
 
     internal static IEnumerable<string> InspectDiagnosticIds(ImmutableArray<DiagnosticData> actual)
         => actual.Select(d => d.Id);
+
+    internal static IEnumerable<string> InspectDiagnosticIds(ImmutableArray<ProjectDiagnostics> actual)
+        => InspectDiagnosticIds(actual.SelectMany(pd => pd.Diagnostics));
 
     internal static IEnumerable<string> InspectDiagnosticIds(IEnumerable<Diagnostic> actual)
         => actual.Select(d => d.Id);

--- a/src/Workspaces/Remote/Core/EditAndContinue/ManagedHotReloadLanguageService.cs
+++ b/src/Workspaces/Remote/Core/EditAndContinue/ManagedHotReloadLanguageService.cs
@@ -301,22 +301,7 @@ internal sealed partial class ManagedHotReloadLanguageService(
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
-                var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(RudeEditKind.InternalError);
-
-                var diagnostic = Diagnostic.Create(
-                    descriptor,
-                    Location.None,
-                    string.Format(descriptor.MessageFormat.ToString(), "", e.Message));
-
-                var firstProject = designTimeSolution.GetProject(runningProjectInfos.FirstOrDefault().Key) ?? designTimeSolution.Projects.First();
-                results = new EmitSolutionUpdateResults.Data()
-                {
-                    Diagnostics = [DiagnosticData.Create(diagnostic, firstProject)],
-                    ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.RestartRequired, []),
-                    SyntaxError = null,
-                    ProjectsToRebuild = [],
-                    ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
-                };
+                results = EmitSolutionUpdateResults.Data.CreateFromInternalError(solution, e.Message, runningProjectInfos);
             }
 
             // Only store the solution if we have any changes to apply, otherwise CommitUpdatesAsync/DiscardUpdatesAsync won't be called.

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -154,23 +154,9 @@ internal sealed class RemoteEditAndContinueService : BrokeredServiceBase, IRemot
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
-                return new EmitSolutionUpdateResults.Data()
-                {
-                    ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.Blocked, []),
-                    Diagnostics = GetUnexpectedUpdateError(solution.GetProject(runningProjects.FirstOrDefault().Key) ?? solution.Projects.First(), e.Message),
-                    SyntaxError = null,
-                    ProjectsToRebuild = [],
-                    ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
-                };
+                return EmitSolutionUpdateResults.Data.CreateFromInternalError(solution, e.Message, runningProjects);
             }
         }, cancellationToken);
-
-        static ImmutableArray<DiagnosticData> GetUnexpectedUpdateError(Project project, string message)
-        {
-            var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.CannotApplyChangesUnexpectedError);
-            var diagnostic = Diagnostic.Create(descriptor, Location.None, [message]);
-            return [DiagnosticData.Create(diagnostic, project)];
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Implements https://github.com/dotnet/roslyn/issues/78244 while keeping the current debugger-Roslyn protocol working (allowPartialSolutionUpdate == false).

Previously we treated project rebuilds/restarts as separate steps from solution update.
With this change we integrate project restart/rebuild into solution update. A solution update is now comprised of deltas to be applied and projects to be rebuilt/restarted. The entire update must be applied atomically. Once it is the debugger calls CommitUpdate and we transition to the new solution snapshot.
