### PR TITLE
Do not set NGenArchitecture to 'All' and let it take defaults.

### DIFF
--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -77,7 +77,6 @@
         <ForceIncludeInVsix>true</ForceIncludeInVsix>
         <Private>true</Private>
         <Ngen Condition="'%(_RuntimeAssetsWithMetadata.Optimization)' == 'true'">true</Ngen>
-        <NgenArchitecture Condition="'%(_RuntimeAssetsWithMetadata.Optimization)' == 'true'">All</NgenArchitecture>
         <NgenPriority Condition="'%(_RuntimeAssetsWithMetadata.Optimization)' == 'true'">3</NgenPriority>
       </VSIXCopyLocalReferenceSourceItem>
 


### PR DESCRIPTION
Based on the following advise:
> If its not loaded in 32-bit process at all, remove the following element entirely which will cause the default to be used (AMD64 on AMD64 or ARM64 on ARM64)
> `<NGenAchitecture>All<NGenArchitecture> (MSBuild)`

Validation run [started](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/639566)