### PR TITLE
Unify command handler code for 'go to base/impl' and 'find refs'

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31319.15
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.10623.112 main
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoslynDeployment", "src\Deployment\RoslynDeployment.csproj", "{600AF682-E097-407B-AD85-EE3CED37E680}"
 EndProject
@@ -2207,8 +2207,11 @@ Global
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{57ca988d-f010-4bf2-9a2e-07d6dcd2ff2c}*SharedItemsImports = 5
 		src\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems*{58969243-7f59-4236-93d0-c93b81f569b3}*SharedItemsImports = 13
 		src\Dependencies\Collections\Microsoft.CodeAnalysis.Collections.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
+		src\Dependencies\Contracts\Microsoft.CodeAnalysis.Contracts.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
+		src\Dependencies\Threading\Microsoft.CodeAnalysis.Threading.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
+		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Extensions\Microsoft.CodeAnalysis.Extensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 5
 		src\Analyzers\Core\CodeFixes\CodeFixes.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{5ff1e493-69cc-4d0b-83f2-039f469a04e1}*SharedItemsImports = 5

--- a/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -29,8 +30,10 @@ namespace Microsoft.CodeAnalysis.FindReferences;
 [Export(typeof(ICommandHandler))]
 [ContentType(ContentTypeNames.RoslynContentType)]
 [Name(PredefinedCommandHandlerNames.FindReferences)]
-internal sealed class FindReferencesCommandHandler : ICommandHandler<FindReferencesCommandArgs>
+internal sealed class FindReferencesCommandHandler : AbstractGoToCommandHandler<
+     IFindUsagesService, FindReferencesCommandArgs>
 {
+#if false
     private readonly IStreamingFindUsagesPresenter _streamingPresenter;
     private readonly IGlobalOptionService _globalOptions;
     private readonly IAsynchronousOperationListener _asyncListener;
@@ -156,4 +159,5 @@ internal sealed class FindReferencesCommandHandler : ICommandHandler<FindReferen
         {
         }
     }
+#endif
 }

--- a/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
@@ -2,26 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Host;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
 
@@ -30,134 +23,37 @@ namespace Microsoft.CodeAnalysis.FindReferences;
 [Export(typeof(ICommandHandler))]
 [ContentType(ContentTypeNames.RoslynContentType)]
 [Name(PredefinedCommandHandlerNames.FindReferences)]
-internal sealed class FindReferencesCommandHandler : AbstractGoToCommandHandler<
-     IFindUsagesService, FindReferencesCommandArgs>
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class FindReferencesCommandHandler(
+    IThreadingContext threadingContext,
+    IStreamingFindUsagesPresenter streamingPresenter,
+    IAsynchronousOperationListenerProvider listenerProvider,
+    IGlobalOptionService globalOptions) : AbstractGoOrFindCommandHandler<IFindUsagesService, FindReferencesCommandArgs>(
+        threadingContext,
+        streamingPresenter,
+        listenerProvider.GetListener(FeatureAttribute.FindReferences),
+        globalOptions)
 {
-#if false
-    private readonly IStreamingFindUsagesPresenter _streamingPresenter;
-    private readonly IGlobalOptionService _globalOptions;
-    private readonly IAsynchronousOperationListener _asyncListener;
+    public override string DisplayName => EditorFeaturesResources.Find_References;
 
-    public string DisplayName => EditorFeaturesResources.Find_References;
+    protected override FunctionId FunctionId => FunctionId.CommandHandler_FindAllReference;
 
-    [ImportingConstructor]
-    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-    public FindReferencesCommandHandler(
-        IStreamingFindUsagesPresenter streamingPresenter,
-        IGlobalOptionService globalOptions,
-        IAsynchronousOperationListenerProvider listenerProvider)
-    {
-        Contract.ThrowIfNull(listenerProvider);
+    /// <summary>
+    /// For find-refs, we *always* use the window.  Even if there is only a single result.  This is not a 'go' command 
+    /// which imperatively tries to navigate to the location if possible.  The intent here is to keep the results in view
+    /// so that the user can always refer to them, even as they do other work.
+    /// </summary>
+    protected override bool NavigateToSingleResultIfQuick => false;
 
-        _streamingPresenter = streamingPresenter;
-        _globalOptions = globalOptions;
-        _asyncListener = listenerProvider.GetListener(FeatureAttribute.FindReferences);
-    }
-
-    public CommandState GetCommandState(FindReferencesCommandArgs args)
-    {
-        var (_, service) = GetDocumentAndService(args.SubjectBuffer.CurrentSnapshot);
-        return service != null
-            ? CommandState.Available
-            : CommandState.Unspecified;
-    }
-
-    public bool ExecuteCommand(FindReferencesCommandArgs args, CommandExecutionContext context)
-    {
-        var subjectBuffer = args.SubjectBuffer;
-
-        // Get the selection that user has in our buffer (this also works if there
-        // is no selection and the caret is just at a single position).  If we 
-        // can't get the selection, or there are multiple spans for it (i.e. a 
-        // box selection), then don't do anything.
-        var snapshotSpans = args.TextView.Selection.GetSnapshotSpansOnBuffer(subjectBuffer);
-        if (snapshotSpans.Count == 1)
+    protected override StreamingFindUsagesPresenterOptions GetStreamingPresenterOptions(Document document)
+        => new()
         {
-            var selectedSpan = snapshotSpans[0];
-            var (document, service) = GetDocumentAndService(subjectBuffer.CurrentSnapshot);
-            if (document != null)
-            {
-                // Do a find-refs at the *start* of the selection.  That way if the
-                // user has selected a symbol that has another symbol touching it
-                // on the right (i.e.  Goo++  ), then we'll do the find-refs on the
-                // symbol selected, not the symbol following.
-                if (TryExecuteCommand(selectedSpan.Start, document, service))
-                {
-                    return true;
-                }
-            }
-        }
+            SupportsReferences = true,
+            IncludeContainingTypeAndMemberColumns = document.Project.SupportsCompilation,
+            IncludeKindColumn = document.Project.Language != LanguageNames.FSharp
+        };
 
-        return false;
-    }
-
-    private static (Document, IFindUsagesService) GetDocumentAndService(ITextSnapshot snapshot)
-    {
-        var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
-        return (document, document?.GetLanguageService<IFindUsagesService>());
-    }
-
-    private bool TryExecuteCommand(int caretPosition, Document document, IFindUsagesService findUsagesService)
-    {
-        // See if we're running on a host that can provide streaming results.
-        // We'll both need a FAR service that can stream results to us, and 
-        // a presenter that can accept streamed results.
-        if (findUsagesService != null && _streamingPresenter != null)
-        {
-            // kick this work off in a fire and forget fashion.  Importantly, this means we do
-            // not pass in any ambient cancellation information as the execution of this command
-            // will complete and will have no bearing on the computation of the references we compute.
-            _ = StreamingFindReferencesAsync(document, caretPosition, findUsagesService, _streamingPresenter);
-            return true;
-        }
-
-        return false;
-    }
-
-    private async Task StreamingFindReferencesAsync(
-        Document document,
-        int caretPosition,
-        IFindUsagesService findUsagesService,
-        IStreamingFindUsagesPresenter presenter)
-    {
-        try
-        {
-            using var token = _asyncListener.BeginAsyncOperation(nameof(StreamingFindReferencesAsync));
-            var classificationOptions = _globalOptions.GetClassificationOptionsProvider();
-
-            // Let the presented know we're starting a search.  It will give us back the context object that the FAR
-            // service will push results into. This operation is not externally cancellable.  Instead, the find refs
-            // window will cancel it if another request is made to use it.
-            var (context, cancellationToken) = presenter.StartSearch(
-                EditorFeaturesResources.Find_References,
-                new StreamingFindUsagesPresenterOptions()
-                {
-                    SupportsReferences = true,
-                    IncludeContainingTypeAndMemberColumns = document.Project.SupportsCompilation,
-                    IncludeKindColumn = document.Project.Language != LanguageNames.FSharp
-                });
-
-            using (Logger.LogBlock(
-                FunctionId.CommandHandler_FindAllReference,
-                KeyValueLogMessage.Create(LogType.UserAction, static m => m["type"] = "streaming"),
-                cancellationToken))
-            {
-                try
-                {
-                    await findUsagesService.FindReferencesAsync(context, document, caretPosition, classificationOptions, cancellationToken).ConfigureAwait(false);
-                }
-                finally
-                {
-                    await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (Exception e) when (FatalError.ReportAndCatch(e))
-        {
-        }
-    }
-#endif
+    protected override Task FindActionAsync(IFindUsagesContext context, Document document, IFindUsagesService service, int caretPosition, CancellationToken cancellationToken)
+        => service.FindReferencesAsync(context, document, caretPosition, this.ClassificationOptionsProvider, cancellationToken);
 }

--- a/src/EditorFeatures/Core/FindUsages/BufferedFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/BufferedFindUsagesContext.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Notification;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -28,6 +29,7 @@ internal sealed class BufferedFindUsagesContext : IFindUsagesContext, IStreaming
         public string? InformationalMessage;
         public string? SearchTitle;
         public ImmutableArray<DefinitionItem>.Builder Definitions = ImmutableArray.CreateBuilder<DefinitionItem>();
+        public ImmutableArray<SourceReferenceItem>.Builder References = ImmutableArray.CreateBuilder<SourceReferenceItem>();
     }
 
     /// <summary>
@@ -107,6 +109,8 @@ internal sealed class BufferedFindUsagesContext : IFindUsagesContext, IStreaming
 
         foreach (var definition in _state.Definitions)
             await presenterContext.OnDefinitionFoundAsync(definition, cancellationToken).ConfigureAwait(false);
+
+        await presenterContext.OnReferencesFoundAsync(_state.References.AsAsyncEnumerable(), cancellationToken).ConfigureAwait(false);
 
         // Now swap over to the presenter being the sink for all future callbacks, and clear any buffered data.
         _streamingPresenterContext = presenterContext;
@@ -199,11 +203,18 @@ internal sealed class BufferedFindUsagesContext : IFindUsagesContext, IStreaming
         }
     }
 
-    ValueTask IFindUsagesContext.OnReferencesFoundAsync(IAsyncEnumerable<SourceReferenceItem> references, CancellationToken cancellationToken)
+    async ValueTask IFindUsagesContext.OnReferencesFoundAsync(IAsyncEnumerable<SourceReferenceItem> references, CancellationToken cancellationToken)
     {
-        // Entirely ignored.  These features do not show references.
-        Contract.Fail("GoToImpl/Base should never report a reference.");
-        return ValueTaskFactory.CompletedTask;
+        using var _ = await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false);
+        if (IsSwapped)
+        {
+            await _streamingPresenterContext.OnReferencesFoundAsync(references, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await foreach (var reference in references)
+                _state.References.Add(reference);
+        }
     }
 
     #endregion

--- a/src/EditorFeatures/Core/GoToBase/GoToBaseCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToBase/GoToBaseCommandHandler.cs
@@ -30,7 +30,7 @@ internal sealed class GoToBaseCommandHandler(
     IThreadingContext threadingContext,
     IStreamingFindUsagesPresenter streamingPresenter,
     IAsynchronousOperationListenerProvider listenerProvider,
-    IGlobalOptionService globalOptions) : AbstractGoToCommandHandler<IGoToBaseService, GoToBaseCommandArgs>(
+    IGlobalOptionService globalOptions) : AbstractGoOrFindCommandHandler<IGoToBaseService, GoToBaseCommandArgs>(
         threadingContext,
         streamingPresenter,
         listenerProvider.GetListener(FeatureAttribute.GoToBase),
@@ -39,6 +39,12 @@ internal sealed class GoToBaseCommandHandler(
     public override string DisplayName => EditorFeaturesResources.Go_To_Base;
 
     protected override FunctionId FunctionId => FunctionId.CommandHandler_GoToBase;
+
+    /// <summary>
+    /// If we find a single results quickly enough, we do want to take the user directly to it,
+    /// instead of popping up the FAR window to show it.
+    /// </summary>
+    protected override bool NavigateToSingleResultIfQuick => true;
 
     protected override Task FindActionAsync(IFindUsagesContext context, Document document, IGoToBaseService service, int caretPosition, CancellationToken cancellationToken)
         => service.FindBasesAsync(context, document, caretPosition, ClassificationOptionsProvider, cancellationToken);

--- a/src/EditorFeatures/Core/GoToBase/GoToBaseCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToBase/GoToBaseCommandHandler.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
@@ -30,20 +29,17 @@ namespace Microsoft.CodeAnalysis.GoToBase;
 internal sealed class GoToBaseCommandHandler(
     IThreadingContext threadingContext,
     IStreamingFindUsagesPresenter streamingPresenter,
-    IUIThreadOperationExecutor uiThreadOperationExecutor,
     IAsynchronousOperationListenerProvider listenerProvider,
-    IGlobalOptionService globalOptions) : AbstractGoToCommandHandler<IGoToBaseService, GoToBaseCommandArgs>(threadingContext,
-           streamingPresenter,
-           uiThreadOperationExecutor,
-           listenerProvider.GetListener(FeatureAttribute.GoToBase),
-           globalOptions)
+    IGlobalOptionService globalOptions) : AbstractGoToCommandHandler<IGoToBaseService, GoToBaseCommandArgs>(
+        threadingContext,
+        streamingPresenter,
+        listenerProvider.GetListener(FeatureAttribute.GoToBase),
+        globalOptions)
 {
     public override string DisplayName => EditorFeaturesResources.Go_To_Base;
 
-    protected override string ScopeDescription => EditorFeaturesResources.Locating_bases;
     protected override FunctionId FunctionId => FunctionId.CommandHandler_GoToBase;
 
-    protected override Task FindActionAsync(IFindUsagesContext context, Document document, int caretPosition, CancellationToken cancellationToken)
-        => document.GetRequiredLanguageService<IGoToBaseService>()
-                   .FindBasesAsync(context, document, caretPosition, ClassificationOptionsProvider, cancellationToken);
+    protected override Task FindActionAsync(IFindUsagesContext context, Document document, IGoToBaseService service, int caretPosition, CancellationToken cancellationToken)
+        => service.FindBasesAsync(context, document, caretPosition, ClassificationOptionsProvider, cancellationToken);
 }

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToCommandHandler`2.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToCommandHandler`2.cs
@@ -20,18 +20,17 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Threading;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.GoToDefinition;
 
 internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArgs>(
     IThreadingContext threadingContext,
     IStreamingFindUsagesPresenter streamingPresenter,
-    IUIThreadOperationExecutor uiThreadOperationExecutor,
     IAsynchronousOperationListener listener,
     IGlobalOptionService globalOptions) : ICommandHandler<TCommandArgs>
     where TLanguageService : class, ILanguageService
@@ -39,7 +38,6 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
 {
     private readonly IThreadingContext _threadingContext = threadingContext;
     private readonly IStreamingFindUsagesPresenter _streamingPresenter = streamingPresenter;
-    private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor = uiThreadOperationExecutor;
     private readonly IAsynchronousOperationListener _listener = listener;
 
     public readonly OptionsProvider<ClassificationOptions> ClassificationOptionsProvider = globalOptions.GetClassificationOptionsProvider();
@@ -63,7 +61,7 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
     /// the presenter.  In that case, the presenter will notify us that it has be re-purposed and we will also cancel
     /// this source.
     /// </remarks>
-    private CancellationTokenSource _cancellationTokenSource = new();
+    private readonly CancellationSeries _cancellationSeries = new(threadingContext.DisposalToken);
 
     /// <summary>
     /// This hook allows for stabilizing the asynchronous nature of this command handler for integration testing.
@@ -71,10 +69,9 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
     private Func<CancellationToken, Task>? _delayHook;
 
     public abstract string DisplayName { get; }
-    protected abstract string ScopeDescription { get; }
     protected abstract FunctionId FunctionId { get; }
 
-    protected abstract Task FindActionAsync(IFindUsagesContext context, Document document, int caretPosition, CancellationToken cancellationToken);
+    protected abstract Task FindActionAsync(IFindUsagesContext context, Document document, TLanguageService service, int caretPosition, CancellationToken cancellationToken);
 
     private static (Document?, TLanguageService?) GetDocumentAndService(ITextSnapshot snapshot)
     {
@@ -106,19 +103,19 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
         Contract.ThrowIfNull(document);
 
         // cancel any prior find-refs that might be in progress.
-        _cancellationTokenSource.Cancel();
-        _cancellationTokenSource = new();
+        var cancellationToken = _cancellationSeries.CreateNext();
 
         // we're going to return immediately from ExecuteCommand and kick off our own async work to invoke the
         // operation. Once this returns, the editor will close the threaded wait dialog it created.
-        _inProgressCommand = ExecuteCommandAsync(document, caret.Value.Position, _cancellationTokenSource);
+        _inProgressCommand = ExecuteCommandAsync(document, service, caret.Value.Position, cancellationToken);
         return true;
     }
 
     private async Task ExecuteCommandAsync(
         Document document,
+        TLanguageService service,
         int position,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationToken cancellationToken)
     {
         // This is a fire-and-forget method (nothing guarantees observing it).  As such, we have to handle cancellation
         // and failure ourselves.
@@ -137,7 +134,7 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
             // any failures from it.  Technically this should not be possible as it should be inside this same
             // try/catch. however this code wants to be very resilient to any prior mistakes infecting later operations.
             await _inProgressCommand.NoThrowAwaitable(captureContext: false);
-            await ExecuteCommandWorkerAsync(document, position, cancellationTokenSource).ConfigureAwait(false);
+            await ExecuteCommandWorkerAsync(document, service, position, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -149,8 +146,9 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
 
     private async Task ExecuteCommandWorkerAsync(
         Document document,
+        TLanguageService service,
         int position,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationToken cancellationToken)
     {
         // Switch to the BG immediately so we can keep as much work off the UI thread.
         await TaskScheduler.Default;
@@ -168,9 +166,8 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
         // IStreamingFindUsagesPresenter.
         var findContext = new BufferedFindUsagesContext();
 
-        var cancellationToken = cancellationTokenSource.Token;
         var delayTask = DelayAsync(cancellationToken);
-        var findTask = FindResultsAsync(findContext, document, position, cancellationToken);
+        var findTask = FindResultsAsync(findContext, document, service, position, cancellationToken);
 
         var firstFinishedTask = await Task.WhenAny(delayTask, findTask).ConfigureAwait(false);
         if (cancellationToken.IsCancellationRequested)
@@ -199,7 +196,7 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
         // We either got no results, or 1.5 has passed and we didn't figure out the symbols to navigate to or
         // present.  So pop up the presenter to show the user that we're involved in a longer search, without
         // blocking them.
-        await PresentResultsInStreamingPresenterAsync(findContext, findTask, cancellationTokenSource).ConfigureAwait(false);
+        await PresentResultsInStreamingPresenterAsync(findContext, findTask, cancellationToken).ConfigureAwait(false);
     }
 
     private Task DelayAsync(CancellationToken cancellationToken)
@@ -215,9 +212,8 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
     private async Task PresentResultsInStreamingPresenterAsync(
         BufferedFindUsagesContext findContext,
         Task findTask,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationToken cancellationToken)
     {
-        var cancellationToken = cancellationTokenSource.Token;
         await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
         var (presenterContext, presenterCancellationToken) = _streamingPresenter.StartSearch(DisplayName, StreamingFindUsagesPresenterOptions.Default);
 
@@ -233,7 +229,7 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
             // Hook up the presenter's cancellation token to our overall governing cancellation token.  In other
             // words, if something else decides to present in the presenter (like a find-refs call) we'll hear about
             // that and can cancel all our work.
-            presenterCancellationToken.Register(() => cancellationTokenSource.Cancel());
+            presenterCancellationToken.Register(() => _cancellationSeries.CreateNext());
 
             // now actually wait for the find work to be done.
             await findTask.ConfigureAwait(false);
@@ -248,7 +244,7 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
     }
 
     private async Task FindResultsAsync(
-        IFindUsagesContext findContext, Document document, int position, CancellationToken cancellationToken)
+        IFindUsagesContext findContext, Document document, TLanguageService service, int position, CancellationToken cancellationToken)
     {
         // Ensure that we relinquish the thread so that the caller can proceed with their work.
         await TaskScheduler.Default.SwitchTo(alwaysYield: true);
@@ -259,8 +255,8 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
 
             // Let the user know in the FAR window if results may be inaccurate because this is running prior to the 
             // solution being fully loaded.
-            var service = document.Project.Solution.Services.GetRequiredService<IWorkspaceStatusService>();
-            var isFullyLoaded = await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
+            var statusService = document.Project.Solution.Services.GetRequiredService<IWorkspaceStatusService>();
+            var isFullyLoaded = await statusService.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
             if (!isFullyLoaded)
             {
                 await findContext.ReportMessageAsync(
@@ -269,7 +265,7 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
 
             // We were able to find the doc prior to loading the workspace (or else we would not have the service).
             // So we better be able to find it afterwards.
-            await FindActionAsync(findContext, document, position, cancellationToken).ConfigureAwait(false);
+            await FindActionAsync(findContext, document, service, position, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
@@ -30,7 +30,7 @@ internal sealed class GoToImplementationCommandHandler(
     IThreadingContext threadingContext,
     IStreamingFindUsagesPresenter streamingPresenter,
     IAsynchronousOperationListenerProvider listenerProvider,
-    IGlobalOptionService globalOptions) : AbstractGoToCommandHandler<IFindUsagesService, GoToImplementationCommandArgs>(
+    IGlobalOptionService globalOptions) : AbstractGoOrFindCommandHandler<IFindUsagesService, GoToImplementationCommandArgs>(
         threadingContext,
         streamingPresenter,
         listenerProvider.GetListener(FeatureAttribute.GoToImplementation),
@@ -39,6 +39,12 @@ internal sealed class GoToImplementationCommandHandler(
     public override string DisplayName => EditorFeaturesResources.Go_To_Implementation;
 
     protected override FunctionId FunctionId => FunctionId.CommandHandler_GoToImplementation;
+
+    /// <summary>
+    /// If we find a single results quickly enough, we do want to take the user directly to it,
+    /// instead of popping up the FAR window to show it.
+    /// </summary>
+    protected override bool NavigateToSingleResultIfQuick => true;
 
     protected override Task FindActionAsync(IFindUsagesContext context, Document document, IFindUsagesService service, int caretPosition, CancellationToken cancellationToken)
         => service.FindImplementationsAsync(context, document, caretPosition, ClassificationOptionsProvider, cancellationToken);

--- a/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Utilities;
@@ -30,20 +29,17 @@ namespace Microsoft.CodeAnalysis.GoToImplementation;
 internal sealed class GoToImplementationCommandHandler(
     IThreadingContext threadingContext,
     IStreamingFindUsagesPresenter streamingPresenter,
-    IUIThreadOperationExecutor uiThreadOperationExecutor,
     IAsynchronousOperationListenerProvider listenerProvider,
-    IGlobalOptionService globalOptions) : AbstractGoToCommandHandler<IFindUsagesService, GoToImplementationCommandArgs>(threadingContext,
-           streamingPresenter,
-           uiThreadOperationExecutor,
-           listenerProvider.GetListener(FeatureAttribute.GoToImplementation),
-           globalOptions)
+    IGlobalOptionService globalOptions) : AbstractGoToCommandHandler<IFindUsagesService, GoToImplementationCommandArgs>(
+        threadingContext,
+        streamingPresenter,
+        listenerProvider.GetListener(FeatureAttribute.GoToImplementation),
+        globalOptions)
 {
     public override string DisplayName => EditorFeaturesResources.Go_To_Implementation;
 
-    protected override string ScopeDescription => EditorFeaturesResources.Locating_implementations;
     protected override FunctionId FunctionId => FunctionId.CommandHandler_GoToImplementation;
 
-    protected override Task FindActionAsync(IFindUsagesContext context, Document document, int caretPosition, CancellationToken cancellationToken)
-        => document.GetRequiredLanguageService<IFindUsagesService>()
-                   .FindImplementationsAsync(context, document, caretPosition, ClassificationOptionsProvider, cancellationToken);
+    protected override Task FindActionAsync(IFindUsagesContext context, Document document, IFindUsagesService service, int caretPosition, CancellationToken cancellationToken)
+        => service.FindImplementationsAsync(context, document, caretPosition, ClassificationOptionsProvider, cancellationToken);
 }

--- a/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.FindReferences;
 using Microsoft.CodeAnalysis.FindUsages;
@@ -65,9 +66,10 @@ public sealed class FindReferencesCommandHandlerTests
         var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
 
         var handler = new FindReferencesCommandHandler(
+            workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
             presenter,
-            workspace.GlobalOptions,
-            listenerProvider);
+            listenerProvider,
+            workspace.GlobalOptions);
 
         var textView = workspace.Documents[0].GetTextView();
         textView.Caret.MoveTo(new SnapshotPoint(textView.TextSnapshot, 7));

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
@@ -4,6 +4,7 @@
 
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.FindReferences
 Imports Microsoft.CodeAnalysis.FindUsages
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
@@ -40,9 +41,10 @@ class C
 
                 Dim context = New FindUsagesTestContext()
                 Dim commandHandler = New FindReferencesCommandHandler(
+                    workspace.ExportProvider.GetExportedValue(Of IThreadingContext)(),
                     New MockStreamingFindReferencesPresenter(context),
-                    workspace.GlobalOptions,
-                    listenerProvider)
+                    listenerProvider,
+                    workspace.GlobalOptions)
 
                 Dim document = workspace.CurrentSolution.GetDocument(testDocument.Id)
                 commandHandler.ExecuteCommand(


### PR DESCRIPTION
This is part of the work to get us off progression.  I want to build a unified service for handling these 3 commands.  So they can be hooked up into solution explorer symbols trivially, with unified behavior.