### PR TITLE
Add operator == and != for DocumentUri

### DIFF
--- a/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
+++ b/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
@@ -138,14 +138,12 @@ internal sealed class DocumentUri : IEquatable<DocumentUri>
     }
 
     public static bool operator ==(DocumentUri? uri1, DocumentUri? uri2)
-    {
-        if (uri1 is null)
-            return uri2 is null;
-        else if (uri2 is null)
-            return false;
-
-        return uri1.Equals(uri2);
-    }
+        => (uri1, uri2) switch
+        {
+            (null, null) => true,
+            (null, _) or (_, null) => false,
+            _ => uri1.Equals(uri2)
+        };
 
     public static bool operator !=(DocumentUri? uri1, DocumentUri? uri2)
         => !(uri1 == uri2);

--- a/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
+++ b/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
@@ -136,4 +136,17 @@ internal sealed class DocumentUri : IEquatable<DocumentUri>
             return this.ParsedUri.GetHashCode();
         }
     }
+
+    public static bool operator ==(DocumentUri? uri1, DocumentUri? uri2)
+    {
+        if (uri1 is null)
+            return uri2 is null;
+        else if (uri2 is null)
+            return false;
+
+        return uri1.Equals(uri2);
+    }
+
+    public static bool operator !=(DocumentUri? uri1, DocumentUri? uri2)
+        => !(uri1 == uri2);
 }

--- a/src/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -352,6 +352,23 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
         Assert.Equal("hello", (await document!.GetTextAsync()).ToString());
     }
 
+    [Theory]
+    [InlineData(true, null, null)]
+    [InlineData(false, "file://c:\\valid", null)]
+    [InlineData(false, null, "file://c:\\valid")]
+    [InlineData(true, "file://c:\\valid", "file://c:\\valid")]
+    [InlineData(true, "file://c:\\valid", "file:///c:/valid")]
+    [InlineData(true, "file://c:\\valid", "file://c:\\VALID")]
+    [InlineData(false, "file://c:\\valid", "file://c:\\valid2")]
+    public void TestUriEquality(bool areEqual, string? uriString1, string? uriString2)
+    {
+        var documentUri1 = uriString1 != null ? new DocumentUri(uriString1) : null;
+        var documentUri2 = uriString2 != null ? new DocumentUri(uriString2) : null;
+
+        Assert.True(areEqual == (documentUri1 == documentUri2));
+        Assert.True(areEqual != (documentUri1 != documentUri2));
+    }
+
     private sealed record class ResolvedDocumentInfo(string WorkspaceKind, string ProjectLanguage);
     private sealed record class CustomResolveParams([property: JsonPropertyName("textDocument")] LSP.TextDocumentIdentifier TextDocument);
 


### PR DESCRIPTION
Razor uses these operators on Uri and will expect the same behavior on DocumentUri when it switches to using that. 