### PR TITLE
Fix ILBuilder visualization

### DIFF
--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -1277,11 +1277,11 @@ tryAgain:
         private string GetDebuggerDisplay()
         {
 #if DEBUG
-            var visType = Type.GetType("Roslyn.Test.Utilities.ILBuilderVisualizer, Roslyn.Test.Utilities", false);
+            var visType = Type.GetType("Roslyn.Test.Utilities.ILBuilderVisualizer, Microsoft.CodeAnalysis.Test.Utilities", false);
             if (visType != null)
             {
                 var method = visType.GetTypeInfo().GetDeclaredMethod("ILBuilderToString");
-                return (string)method!.Invoke(null, [this, null, null])!;
+                return (string)method!.Invoke(null, [this, null, null, null])!;
             }
 #endif
 


### PR DESCRIPTION
Turns out that we do have visualization of in-progress IL building, but it's been broken since 2020, when we renamed Roslyn.Test.Utilities to Microsoft.CodeAnalysis.Test.Utilities. It was then further broken by the change a few months ago to pass IL visualization formats along. This gets the debugger display working again.
