### PR TITLE
Remove EditorFeaturesWpf TestComposition

### DIFF
--- a/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
@@ -375,7 +375,7 @@ class C{i}
             </Workspace>
             """),
             workspaceKind: WorkspaceKind.Interactive,
-            composition: EditorTestCompositions.EditorFeaturesWpf);
+            composition: EditorTestCompositions.EditorFeatures);
         // Force initialization.
         workspace.GetOpenDocumentIds().Select(id => workspace.GetTestDocument(id).GetTextView()).ToList();
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateType/GenerateTypeTests.cs
@@ -34,7 +34,7 @@ public sealed partial class GenerateTypeTests(ITestOutputHelper logger)
 
     // TODO: Requires WPF due to IInlineRenameService dependency (https://github.com/dotnet/roslyn/issues/46153)
     protected override TestComposition GetComposition()
-        => EditorTestCompositions.EditorFeaturesWpf;
+        => EditorTestCompositions.EditorFeatures;
 
     #region Generate Class
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/PreviewTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/PreviewTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 
 public sealed partial class PreviewTests : AbstractCSharpCodeActionTest
 {
-    private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeaturesWpf
+    private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeatures
         .AddParts(
             typeof(MockPreviewPaneService));
 

--- a/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ArgumentProviderOrderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ArgumentProviderOrderTests.cs
@@ -24,7 +24,7 @@ public sealed class ArgumentProviderOrderTests
     [Fact]
     public void TestArgumentProviderOrder()
     {
-        var exportProvider = EditorTestCompositions.EditorFeaturesWpf.ExportProviderFactory.CreateExportProvider();
+        var exportProvider = EditorTestCompositions.EditorFeatures.ExportProviderFactory.CreateExportProvider();
         var argumentProviderExports = exportProvider.GetExports<ArgumentProvider, CompletionProviderMetadata>();
         var orderedCSharpArgumentProviders = ExtensionOrderer.Order(argumentProviderExports.Where(export => export.Metadata.Language == LanguageNames.CSharp));
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CompletionProviderOrderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CompletionProviderOrderTests.cs
@@ -25,7 +25,7 @@ public sealed class CompletionProviderOrderTests
     [Fact]
     public void TestCompletionProviderOrder()
     {
-        var exportProvider = EditorTestCompositions.EditorFeaturesWpf.ExportProviderFactory.CreateExportProvider();
+        var exportProvider = EditorTestCompositions.EditorFeatures.ExportProviderFactory.CreateExportProvider();
         var completionProviderExports = exportProvider.GetExports<CompletionProvider, CompletionProviderMetadata>();
         var orderedCSharpCompletionProviders = ExtensionOrderer.Order(completionProviderExports.Where(export => export.Metadata.Language == LanguageNames.CSharp));
 

--- a/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertNamespaceCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertNamespaceCommandHandlerTests.cs
@@ -18,7 +18,7 @@ public sealed class ConvertNamespaceCommandHandlerTests
 {
     internal sealed class ConvertNamespaceTestState : AbstractCommandHandlerTestState
     {
-        private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeaturesWpf.AddParts(
+        private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeatures.AddParts(
             typeof(ConvertNamespaceCommandHandler));
 
         private readonly ConvertNamespaceCommandHandler _commandHandler;

--- a/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.cs
@@ -202,7 +202,7 @@ public sealed class EncapsulateFieldCommandHandlerTests
             </Workspace>
             """),
             workspaceKind: WorkspaceKind.Interactive,
-            composition: EditorTestCompositions.EditorFeaturesWpf);
+            composition: EditorTestCompositions.EditorFeatures);
         // Force initialization.
         workspace.GetOpenDocumentIds().Select(id => workspace.GetTestDocument(id).GetTextView()).ToList();
 

--- a/src/EditorFeatures/CSharpTest/EventHookup/EventHookupTestState.cs
+++ b/src/EditorFeatures/CSharpTest/EventHookup/EventHookupTestState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EventHookup;
 
 internal sealed class EventHookupTestState : AbstractCommandHandlerTestState
 {
-    private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeaturesWpf.AddParts(
+    private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeatures.AddParts(
         typeof(EventHookupCommandHandler),
         typeof(EventHookupSessionManager));
 

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -1449,7 +1449,7 @@ public sealed class ExtractInterfaceTests : AbstractExtractInterfaceTests
             </Workspace>
             """),
             workspaceKind: WorkspaceKind.Interactive,
-            composition: EditorTestCompositions.EditorFeaturesWpf);
+            composition: EditorTestCompositions.EditorFeatures);
         // Force initialization.
         workspace.GetOpenDocumentIds().Select(id => workspace.GetTestDocument(id)!.GetTextView()).ToList();
 

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodMiscellaneousTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodMiscellaneousTests.cs
@@ -131,7 +131,7 @@ public sealed class ExtractMethodMiscellaneousTests
 
     private static async Task TestCommandHandler(string markupCode, string? result, bool expectNotification)
     {
-        using var workspace = EditorTestWorkspace.CreateCSharp(markupCode, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateCSharp(markupCode, composition: EditorTestCompositions.EditorFeatures);
         var testDocument = workspace.Documents.Single();
 
         var view = testDocument.GetTextView();

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -11504,7 +11504,7 @@ public sealed partial class ExtractMethodTests : ExtractMethodBase
             </Workspace>
             """),
             workspaceKind: WorkspaceKind.Interactive,
-            composition: EditorTestCompositions.EditorFeaturesWpf);
+            composition: EditorTestCompositions.EditorFeatures);
         // Force initialization.
         workspace.GetOpenDocumentIds().Select(id => workspace.GetTestDocument(id)!.GetTextView()).ToList();
 

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -782,7 +782,7 @@ public sealed partial class CodeCleanupTests
         where TCodefix : CodeFixProvider, new()
     {
 
-        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf.AddParts(typeof(TCodefix)));
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeatures.AddParts(typeof(TCodefix)));
 
         var project = workspace.CurrentSolution.Projects.Single();
         var analyzer = (DiagnosticAnalyzer)new TAnalyzer();
@@ -833,12 +833,12 @@ public sealed partial class CodeCleanupTests
         {
             if (language == LanguageNames.CSharp)
             {
-                return EditorTestWorkspace.CreateCSharp(string.Empty, composition: EditorTestCompositions.EditorFeaturesWpf);
+                return EditorTestWorkspace.CreateCSharp(string.Empty, composition: EditorTestCompositions.EditorFeatures);
             }
 
             if (language == LanguageNames.VisualBasic)
             {
-                return EditorTestWorkspace.CreateVisualBasic(string.Empty, composition: EditorTestCompositions.EditorFeaturesWpf);
+                return EditorTestWorkspace.CreateVisualBasic(string.Empty, composition: EditorTestCompositions.EditorFeatures);
             }
 
             return null;
@@ -871,7 +871,7 @@ public sealed partial class CodeCleanupTests
     /// <returns>The <see cref="Task"/> to test code cleanup.</returns>
     private static async Task AssertCodeCleanupResult(string expected, string code, CodeStyleOption2<AddImportPlacement> preferredImportPlacement, bool systemUsingsFirst = true, bool separateUsingGroups = false, Func<string, bool> enabledFixIdsFilter = null, (string, DiagnosticSeverity)[] diagnosticIdsWithSeverity = null)
     {
-        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeatures);
 
         // must set global options since incremental analyzer infra reads from global options
         workspace.SetAnalyzerFallbackAndGlobalOptions(new OptionsCollection(LanguageNames.CSharp)

--- a/src/EditorFeatures/CSharpTest/Organizing/OrganizeTypeDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Organizing/OrganizeTypeDeclarationTests.cs
@@ -1175,7 +1175,7 @@ $@"{typeKind} Program
             </Workspace>
             """),
             workspaceKind: WorkspaceKind.Interactive,
-            composition: EditorTestCompositions.EditorFeaturesWpf);
+            composition: EditorTestCompositions.EditorFeatures);
         // Force initialization.
         workspace.GetOpenDocumentIds().Select(id => workspace.GetTestDocument(id).GetTextView()).ToList();
 

--- a/src/EditorFeatures/CSharpTest/RawStringLiteral/RawStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/RawStringLiteral/RawStringLiteralCommandHandlerTests.cs
@@ -19,7 +19,7 @@ public sealed class RawStringLiteralCommandHandlerTests
 {
     internal sealed class RawStringLiteralTestState : AbstractCommandHandlerTestState
     {
-        private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeaturesWpf.AddParts(
+        private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeatures.AddParts(
             typeof(RawStringLiteralCommandHandler));
 
         private readonly RawStringLiteralCommandHandler _commandHandler;

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/StringCopyPasteCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/StringCopyPasteCommandHandlerTests.cs
@@ -29,11 +29,11 @@ public abstract class StringCopyPasteCommandHandlerTests
     internal sealed class StringCopyPasteTestState : AbstractCommandHandlerTestState
     {
         private static readonly TestComposition s_composition =
-            EditorTestCompositions.EditorFeaturesWpf
+            EditorTestCompositions.EditorFeatures
                 .AddParts(typeof(StringCopyPasteCommandHandler));
 
         private static readonly TestComposition s_compositionWithMockCopyPasteService =
-            EditorTestCompositions.EditorFeaturesWpf
+            EditorTestCompositions.EditorFeatures
                 .RemoveExcludedPartTypes(typeof(WpfStringCopyPasteService))
                 .AddParts(typeof(TestStringCopyPasteService))
                 .AddParts(typeof(StringCopyPasteCommandHandler));

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_GenerateTypeDialog.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_GenerateTypeDialog.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
 public abstract partial class AbstractUserDiagnosticTest
 {
     // TODO: IInlineRenameService requires WPF (https://github.com/dotnet/roslyn/issues/46153)
-    private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeaturesWpf
+    private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeatures
         .AddParts(
             typeof(TestGenerateTypeOptionsService),
             typeof(TestProjectManagementService));

--- a/src/EditorFeatures/DiagnosticsTestUtilities/MoveType/AbstractMoveTypeTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/MoveType/AbstractMoveTypeTest.cs
@@ -30,7 +30,7 @@ public abstract class AbstractMoveTypeTest : AbstractCodeActionTest
 
     // TODO: Requires WPF due to IInlineRenameService dependency (https://github.com/dotnet/roslyn/issues/46153)
     protected override TestComposition GetComposition()
-        => EditorTestCompositions.EditorFeaturesWpf;
+        => EditorTestCompositions.EditorFeatures;
 
     protected override CodeRefactoringProvider CreateCodeRefactoringProvider(EditorTestWorkspace workspace, TestParameters parameters)
         => new MoveTypeCodeRefactoringProvider();

--- a/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
+++ b/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
@@ -52,7 +52,7 @@ public sealed class LinkedFileDiffMergingEditorTests : AbstractCodeActionTest
     public async Task TestCodeActionPreviewAndApply()
     {
         // TODO: WPF required due to https://github.com/dotnet/roslyn/issues/46153
-        using var workspace = EditorTestWorkspace.Create(WorkspaceXml, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.Create(WorkspaceXml, composition: EditorTestCompositions.EditorFeatures);
         var codeIssueOrRefactoring = await GetCodeRefactoringAsync(workspace, new TestParameters());
 
         await TestActionOnLinkedFiles(

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -128,7 +128,7 @@ internal sealed class RenameTrackingTestState : IDisposable
 
     private static EditorTestWorkspace CreateTestWorkspace(string xml)
     {
-        return EditorTestWorkspace.Create(xml, composition: EditorTestCompositions.EditorFeaturesWpf);
+        return EditorTestWorkspace.Create(xml, composition: EditorTestCompositions.EditorFeatures);
     }
 
     public void SendEscape()

--- a/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
+++ b/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
@@ -52,7 +52,7 @@ namespace MyNamespace
 #endregion
 }";
 
-        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeatures);
         var globalOptions = workspace.GlobalOptions;
 
         globalOptions.SetGlobalOption(BlockStructureOptionsStorage.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.CSharp, collapseRegionsWhenCollapsingToDefinitions);
@@ -119,7 +119,7 @@ public class Bar
 }
 ";
 
-        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeatures);
         var globalOptions = workspace.GlobalOptions;
 
         globalOptions.SetGlobalOption(BlockStructureOptionsStorage.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.CSharp, collapseRegionsWhenCollapsingToDefinitions);
@@ -164,7 +164,7 @@ public class Bar
 }
 ";
 
-        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeatures);
         var globalOptions = workspace.GlobalOptions;
 
         globalOptions.SetGlobalOption(BlockStructureOptionsStorage.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.CSharp, collapseRegionsWhenCollapsingToDefinitions);
@@ -209,7 +209,7 @@ namespace Foo
 }
 ";
 
-        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeatures);
         var globalOptions = workspace.GlobalOptions;
 
         globalOptions.SetGlobalOption(BlockStructureOptionsStorage.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.CSharp, collapseRegionsWhenCollapsingToDefinitions);
@@ -261,7 +261,7 @@ Namespace MyNamespace
 #End Region
 End Namespace";
 
-        using var workspace = EditorTestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeatures);
         var globalOptions = workspace.GlobalOptions;
 
         globalOptions.SetGlobalOption(BlockStructureOptionsStorage.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.VisualBasic, collapseRegionsWhenCollapsingToDefinitions);
@@ -317,7 +317,7 @@ End Namespace";
     End Sub
 End Module";
 
-        using var workspace = EditorTestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeatures);
         var tags = await GetTagsFromWorkspaceAsync(workspace);
 
         var hints = tags.Select(x => x.GetCollapsedHintForm()).Cast<ViewHostingControl>().ToArray();
@@ -339,7 +339,7 @@ Module Program
     End Sub
 End Module";
 
-        using var workspace = EditorTestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeatures);
         var tags = await GetTagsFromWorkspaceAsync(workspace);
         Assert.Collection(tags, programTag =>
         {
@@ -371,7 +371,7 @@ End Module";
             }
             """;
 
-        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeatures);
         var tags = await GetTagsFromWorkspaceAsync(workspace);
 
         Assert.Collection(tags, programTag =>

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -99,7 +99,7 @@ public sealed class AsynchronousTaggerTests
             class Program {
 
             }
-            """, composition: EditorTestCompositions.EditorFeaturesWpf);
+            """, composition: EditorTestCompositions.EditorFeatures);
         WpfTestRunner.RequireWpfFact($"{nameof(AsynchronousTaggerTests)}.{nameof(TestNotSynchronousOutlining)} creates asynchronous taggers");
 
         var tagProvider = workspace.ExportProvider.GetExportedValue<AbstractStructureTaggerProvider>();
@@ -125,7 +125,7 @@ public sealed class AsynchronousTaggerTests
             }
 
             #endregion
-            """, composition: EditorTestCompositions.EditorFeaturesWpf);
+            """, composition: EditorTestCompositions.EditorFeatures);
         WpfTestRunner.RequireWpfFact($"{nameof(AsynchronousTaggerTests)}.{nameof(TestSynchronousOutlining)} creates asynchronous taggers");
 
         var tagProvider = workspace.ExportProvider.GetExportedValue<AbstractStructureTaggerProvider>();

--- a/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
                             <Document/>
                         </Project>
                     </Workspace>,
-                    composition:=EditorTestCompositions.EditorFeaturesWpf)
+                    composition:=EditorTestCompositions.EditorFeatures)
 
                 Dim textView = workspace.Documents.Single().GetTextView()
 
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
                             <Document/>
                         </Project>
                     </Workspace>,
-                    composition:=EditorTestCompositions.EditorFeaturesWpf)
+                    composition:=EditorTestCompositions.EditorFeatures)
 
                 Dim textView = workspace.Documents.Single().GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
@@ -104,7 +104,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
                             <Document/>
                         </Project>
                     </Workspace>,
-                    composition:=EditorTestCompositions.EditorFeaturesWpf)
+                    composition:=EditorTestCompositions.EditorFeatures)
 
                 Dim textView = workspace.Documents.Single().GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
                             <Document/>
                         </Project>
                     </Workspace>,
-                    composition:=EditorTestCompositions.EditorFeaturesWpf)
+                    composition:=EditorTestCompositions.EditorFeatures)
 
                 Dim textView = workspace.Documents.Single().GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
                             <Document/>
                         </Project>
                     </Workspace>,
-                    composition:=EditorTestCompositions.EditorFeaturesWpf)
+                    composition:=EditorTestCompositions.EditorFeatures)
 
                 Dim textView = workspace.Documents.Single().GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)

--- a/src/EditorFeatures/Test2/Peek/PeekTests.vb
+++ b/src/EditorFeatures/Test2/Peek/PeekTests.vb
@@ -289,7 +289,7 @@ public partial class D
         End Sub
 
         Private Shared Function CreateTestWorkspace(element As XElement) As EditorTestWorkspace
-            Return EditorTestWorkspace.Create(element, composition:=EditorTestCompositions.EditorFeaturesWpf)
+            Return EditorTestWorkspace.Create(element, composition:=EditorTestCompositions.EditorFeatures)
         End Function
 
         Private Shared Function GetPeekResultCollection(element As XElement) As PeekResultCollection

--- a/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                     </Submission>
                 </Workspace>,
                 workspaceKind:=WorkspaceKind.Interactive,
-                composition:=EditorTestCompositions.EditorFeaturesWpf)
+                composition:=EditorTestCompositions.EditorFeatures)
 
                 ' Force initialization.
                 workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -20,7 +20,7 @@ Imports Microsoft.VisualStudio.Text.Tagging
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     Friend Module RenameTestHelpers
-        Private ReadOnly s_composition As TestComposition = EditorTestCompositions.EditorFeaturesWpf.AddParts(
+        Private ReadOnly s_composition As TestComposition = EditorTestCompositions.EditorFeatures.AddParts(
             GetType(MockDocumentNavigationServiceFactory),
             GetType(MockPreviewDialogService),
             GetType(TestWorkspaceConfigurationService))

--- a/src/EditorFeatures/Test2/Workspaces/WpfTextBufferVisibilityTrackerTests.vb
+++ b/src/EditorFeatures/Test2/Workspaces/WpfTextBufferVisibilityTrackerTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     Public Class WpfTextBufferVisibilityTrackerTests
         <WpfFact>
         Public Sub TestMutationInCallback()
-            Using workspace = EditorTestWorkspace.CreateCSharp("", composition:=EditorTestCompositions.EditorFeaturesWpf)
+            Using workspace = EditorTestWorkspace.CreateCSharp("", composition:=EditorTestCompositions.EditorFeatures)
                 Dim visibilityTracker = DirectCast(workspace.ExportProvider.GetExportedValue(Of ITextBufferVisibilityTracker), WpfTextBufferVisibilityTracker)
 
                 Dim buffer = workspace.Documents.Single().GetTextBuffer()

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
@@ -70,7 +70,7 @@ public abstract class AbstractAutomaticLineEnderTests
         var markupCode = code[0..position] + "$$" + code[position..];
 
         // WPF is required for some reason: https://github.com/dotnet/roslyn/issues/46286
-        using var workspace = EditorTestWorkspace.Create(Language, compilationOptions: null, parseOptions: null, [markupCode], composition: EditorTestCompositions.EditorFeaturesWpf);
+        using var workspace = EditorTestWorkspace.Create(Language, compilationOptions: null, parseOptions: null, [markupCode], composition: EditorTestCompositions.EditorFeatures);
 
         var view = workspace.Documents.Single().GetTextView();
         var buffer = workspace.Documents.Single().GetTextBuffer();

--- a/src/EditorFeatures/TestUtilities/EditorTestCompositions.cs
+++ b/src/EditorFeatures/TestUtilities/EditorTestCompositions.cs
@@ -66,11 +66,7 @@ public static class EditorTestCompositions
             typeof(VisualBasic.VBEditorResources).Assembly,
             typeof(LanguageServerProtocolResources).Assembly);
 
-    public static readonly TestComposition EditorFeaturesWpf = EditorFeatures
-        .AddAssemblies(
-            typeof(EditorFeaturesWpfResources).Assembly);
-
-    public static readonly TestComposition InteractiveWindow = EditorFeaturesWpf
+    public static readonly TestComposition InteractiveWindow = EditorFeatures
         .AddAssemblies(
             typeof(IInteractiveWindow).Assembly)
         .AddParts(

--- a/src/EditorFeatures/TestUtilities/Squiggles/SquiggleUtilities.cs
+++ b/src/EditorFeatures/TestUtilities/Squiggles/SquiggleUtilities.cs
@@ -23,7 +23,7 @@ public static class SquiggleUtilities
     internal static TestComposition CompositionWithSolutionCrawler = EditorTestCompositions.EditorFeatures
         .RemoveParts(typeof(MockWorkspaceEventListenerProvider));
 
-    internal static TestComposition WpfCompositionWithSolutionCrawler = EditorTestCompositions.EditorFeaturesWpf
+    internal static TestComposition WpfCompositionWithSolutionCrawler = EditorTestCompositions.EditorFeatures
         .RemoveParts(typeof(MockWorkspaceEventListenerProvider));
 
     internal static async Task<ImmutableArray<TagSpan<TTag>>> GetTagSpansAsync<TProvider, TTag>(

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Protected ReadOnly CompleteStatementCommandHandler As CompleteStatementCommandHandler
         Private ReadOnly FormatCommandHandler As FormatCommandHandler
 
-        Public Shared ReadOnly CompositionWithoutCompletionTestParts As TestComposition = EditorTestCompositions.EditorFeaturesWpf.
+        Public Shared ReadOnly CompositionWithoutCompletionTestParts As TestComposition = EditorTestCompositions.EditorFeatures.
             AddExcludedPartTypes(
                 GetType(IIntelliSensePresenter(Of ISignatureHelpPresenterSession, ISignatureHelpSession)),
                 GetType(FormatCommandHandler)).

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/RemoveParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/RemoveParametersTests.vb
@@ -107,7 +107,7 @@ End Module
                     </Submission>
                 </Workspace>,
                 workspaceKind:=WorkspaceKind.Interactive,
-                composition:=EditorTestCompositions.EditorFeaturesWpf)
+                composition:=EditorTestCompositions.EditorFeatures)
 
                 ' Force initialization.
                 workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateType/GenerateTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateType/GenerateTypeTests.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
 
         ' TODO Requires Wpf due to IInlineRenameService dependency (https: //github.com/dotnet/roslyn/issues/46153)
         Protected Overrides Function GetComposition() As TestComposition
-            Return EditorTestCompositions.EditorFeaturesWpf
+            Return EditorTestCompositions.EditorFeatures
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
     Public Class PreviewTests
         Inherits AbstractVisualBasicCodeActionTest
 
-        Private Shared ReadOnly s_composition As TestComposition = EditorTestCompositions.EditorFeaturesWpf _
+        Private Shared ReadOnly s_composition As TestComposition = EditorTestCompositions.EditorFeatures _
             .AddParts(
                 GetType(MockPreviewPaneService))
 

--- a/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.vb
@@ -145,7 +145,7 @@ End Class
                     </Submission>
                 </Workspace>,
                 workspaceKind:=WorkspaceKind.Interactive,
-                composition:=EditorTestCompositions.EditorFeaturesWpf)
+                composition:=EditorTestCompositions.EditorFeatures)
 
                 ' Force initialization.
                 workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()

--- a/src/EditorFeatures/VisualBasicTest/ExtractInterface/ExtractInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractInterface/ExtractInterfaceTests.vb
@@ -1279,7 +1279,7 @@ End Namespace
                     </Submission>
                 </Workspace>,
                 workspaceKind:=WorkspaceKind.Interactive,
-                composition:=EditorTestCompositions.EditorFeaturesWpf)
+                composition:=EditorTestCompositions.EditorFeatures)
 
                 ' Force initialization.
                 workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
@@ -3352,7 +3352,7 @@ End Namespace"
                         </Submission>
                     </Workspace>,
                     workspaceKind:=WorkspaceKind.Interactive,
-                    composition:=EditorTestCompositions.EditorFeaturesWpf)
+                    composition:=EditorTestCompositions.EditorFeatures)
 
                     ' Force initialization.
                     workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()

--- a/src/EditorFeatures/VisualBasicTest/Formatting/CodeCleanUpTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/CodeCleanUpTests.vb
@@ -509,7 +509,7 @@ End Class
         End Function
 
         Private Shared Async Function TestThirdPartyCodeFixer(Of TCodefix As {CodeFixProvider, New}, TAnalyzer As {DiagnosticAnalyzer, New})(expected As String, code As String, Optional severity As DiagnosticSeverity = DiagnosticSeverity.Warning) As Task
-            Using workspace = TestWorkspace.CreateVisualBasic(code, composition:=EditorTestCompositions.EditorFeaturesWpf.AddParts(GetType(TCodefix)))
+            Using workspace = TestWorkspace.CreateVisualBasic(code, composition:=EditorTestCompositions.EditorFeatures.AddParts(GetType(TCodefix)))
                 Dim project = workspace.CurrentSolution.Projects.Single()
                 Dim map = New Dictionary(Of String, ImmutableArray(Of DiagnosticAnalyzer)) From
                     {
@@ -559,7 +559,7 @@ End Class
                                                                              code As String,
                                                                              Optional systemImportsFirst As Boolean = True,
                                                                              Optional separateImportsGroups As Boolean = False) As Task
-            Using workspace = TestWorkspace.CreateVisualBasic(code, composition:=EditorTestCompositions.EditorFeaturesWpf)
+            Using workspace = TestWorkspace.CreateVisualBasic(code, composition:=EditorTestCompositions.EditorFeatures)
 
                 workspace.SetAnalyzerFallbackOptions(New OptionsCollection(LanguageNames.VisualBasic) From {
                     {GenerationOptions.SeparateImportDirectiveGroups, separateImportsGroups},

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
         Private ReadOnly _inlineRenameService As InlineRenameServiceMock
 
         Public Shared Function Create(test As XElement) As CommitTestData
-            Dim workspace = EditorTestWorkspace.Create(test, composition:=EditorTestCompositions.EditorFeaturesWpf)
+            Dim workspace = EditorTestWorkspace.Create(test, composition:=EditorTestCompositions.EditorFeatures)
             Return New CommitTestData(workspace)
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeTypeDeclarationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeTypeDeclarationTests.vb
@@ -935,7 +935,7 @@ End Namespace</element>
                     </Submission>
                 </Workspace>,
                 workspaceKind:=WorkspaceKind.Interactive,
-                composition:=EditorTestCompositions.EditorFeaturesWpf)
+                composition:=EditorTestCompositions.EditorFeatures)
 
                 ' Force initialization.
                 workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_GenerateTypeDialog.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_GenerateTypeDialog.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
     public abstract partial class AbstractUserDiagnosticTest_NoEditor
     {
         // TODO: IInlineRenameService requires WPF (https://github.com/dotnet/roslyn/issues/46153)
-        private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeaturesWpf
+        private static readonly TestComposition s_composition = EditorTestCompositions.EditorFeatures
             .AddExcludedPartTypes(typeof(IDiagnosticUpdateSourceRegistrationService))
             .AddParts(
                 typeof(MockDiagnosticUpdateSourceRegistrationService),

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -49,7 +49,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         '        GetType(MockDiagnosticUpdateSourceRegistrationService),
         '        GetType(MockWorkspaceEventListenerProvider))
 
-        Private Shared ReadOnly s_composition As TestComposition = EditorTestCompositions.EditorFeaturesWpf _
+        Private Shared ReadOnly s_composition As TestComposition = EditorTestCompositions.EditorFeatures _
             .AddParts(
                 GetType(FileChangeWatcherProvider),
                 GetType(MockVisualStudioWorkspace),

--- a/src/VisualStudio/TestUtilities2/VisualStudioTestCompositions.vb
+++ b/src/VisualStudio/TestUtilities2/VisualStudioTestCompositions.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         Private Sub New()
         End Sub
 
-        Public Shared ReadOnly LanguageServices As TestComposition = EditorTestCompositions.EditorFeaturesWpf.
+        Public Shared ReadOnly LanguageServices As TestComposition = EditorTestCompositions.EditorFeatures.
             AddAssemblies(
                 GetType(ServicesVSResources).Assembly,
                 GetType(CSharpVSResources).Assembly,


### PR DESCRIPTION
After the EditorFeatures.WPF => EditorFeatures refactoring, this TestComposition became equivalent to the EditorFeatures one, so just removing the WPF one.