### PR TITLE
Move off of a linear walk in solution-explorer symbol tree updates.

### DIFF
--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemCollectionSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemCollectionSource.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
@@ -49,6 +48,10 @@ internal sealed partial class RootSymbolTreeItemSourceProvider
         {
             _rootProvider.ThreadingContext.ThrowIfNotOnUIThread();
             _childCollection.ResetToUncomputedState(GetHasItemsDefaultValue(_hierarchyItem));
+
+            // Note: we intentionally do not touch _hasEverBeenExpanded.  The platform only ever calls "Items"
+            // at most once (even if we notify that it changed). So if we reset _hasEverBeenExpanded to 0, then
+            // it will never leave that state from that point on, and we'll be stuck in an invalid state.
         }
 
         public async Task UpdateIfEverExpandedAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemCollectionSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemCollectionSource.cs
@@ -48,7 +48,6 @@ internal sealed partial class RootSymbolTreeItemSourceProvider
         public void Reset()
         {
             _rootProvider.ThreadingContext.ThrowIfNotOnUIThread();
-            _hasEverBeenExpanded = 0;
             _childCollection.ResetToUncomputedState(GetHasItemsDefaultValue(_hierarchyItem));
         }
 

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemSourceProvider.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemSourceProvider.cs
@@ -3,9 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Threading;

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/SymbolTreeChildCollection.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/SymbolTreeChildCollection.cs
@@ -137,5 +137,6 @@ internal sealed class SymbolTreeChildCollection(
 
         // Notify any listenerrs that our items have changed.
         this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasItems)));
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Items)));
     }
 }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/SymbolTreeChildCollection.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/SymbolTreeChildCollection.cs
@@ -137,6 +137,5 @@ internal sealed class SymbolTreeChildCollection(
 
         // Notify any listenerrs that our items have changed.
         this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasItems)));
-        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Items)));
     }
 }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/78754.
Updates our core structure to be a dictionary keyed off of the IVsHierarchyItem's CanonicalName instead.  