### PR TITLE
Ensure sln load uses project absolute paths

### DIFF
--- a/src/Workspaces/MSBuild/Core/MSBuild/SolutionFileReader.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/SolutionFileReader.cs
@@ -57,17 +57,17 @@ internal partial class SolutionFileReader
         var builder = ImmutableArray.CreateBuilder<(string ProjectPath, string ProjectGuid)>();
         foreach (var projectModel in solutionModel.SolutionProjects)
         {
+            Contract.ThrowIfFalse(pathResolver.TryGetAbsoluteProjectPath(projectModel.FilePath, baseDirectory, DiagnosticReportingMode.Throw, out var absoluteProjectPath));
             // If we are filtering based on a solution filter, then we need to verify the project is included.
             if (!projectFilter.IsEmpty)
             {
-                Contract.ThrowIfFalse(pathResolver.TryGetAbsoluteProjectPath(projectModel.FilePath, baseDirectory, DiagnosticReportingMode.Throw, out var absoluteProjectPath));
                 if (!projectFilter.Contains(absoluteProjectPath))
                 {
                     continue;
                 }
             }
 
-            builder.Add((projectModel.FilePath, projectModel.Id.ToString()));
+            builder.Add((absoluteProjectPath, projectModel.Id.ToString()));
         }
 
         return builder.ToImmutable();


### PR DESCRIPTION
fixes issue found by integration tests in https://github.com/dotnet/vscode-csharp/pull/8331

```
2025-05-29 20:42:14.888 [info] [Error - 8:42:14 PM] [solution/open] [LSP] System.InvalidOperationException: Unexpected false - file LanguageServerProjectLoader.cs line 195
   at Microsoft.CodeAnalysis.Contract.Fail(String message, Int32 lineNumber, String filePath) in /_/src/Dependencies/Contracts/Contract.cs:line 161
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LanguageServerProjectLoader.ReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken) in /_/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs:line 195
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LanguageServerProjectLoader.<>c.<<ReloadProjectsAsync>b__16_0>d.MoveNext() in /_/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs:line 158
--- End of stack trace from previous location ---
   at Microsoft.CodeAnalysis.Shared.Utilities.ProducerConsumer`1.<>c__DisplayClass11_0`3.<<RunParallelChannelAsync>b__2>d.MoveNext() in /_/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ProducerConsumer.cs:line 256
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.<>c__57`1.<<ForEachAsync>b__57_0>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.CodeAnalysis.Shared.Utilities.ProducerConsumer`1.<>c__14`2.<<RunChannelAsync>b__14_3>d.MoveNext() in /_/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ProducerConsumer.cs:line 385
--- End of stack trace from previous location ---
   at Microsoft.CodeAnalysis.Shared.Utilities.ProducerConsumer`1.PerformActionAndCloseWriterAsync[TArgs](Func`3 action, TArgs args, ChannelWriter`1 writer, CancellationToken cancellationToken) in /_/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ProducerConsumer.cs:line 402
   at Microsoft.CodeAnalysis.Shared.Utilities.ProducerConsumer`1.RunChannelAsync[TArgs,TResult](ProducerConsumerOptions options, Func`4 produceItems, Func`4 consumeItems, TArgs args, CancellationToken cancellationToken) in /_/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ProducerConsumer.cs:line 362
   at Microsoft.CodeAnalysis.Shared.Utilities.ProducerConsumer`1.RunParallelAsync[TSource,TArgs](IAsyncEnumerable`1 source, Func`5 produceItems, TArgs args, CancellationToken cancellationToken) in /_/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ProducerConsumer.cs:line 229
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LanguageServerProjectLoader.ReloadProjectsAsync(ImmutableSegmentedList`1 projectPathsToLoadOrReload, CancellationToken cancellationToken) in /_/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs:line 153
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LanguageServerProjectLoader.ReloadProjectsAsync(ImmutableSegmentedList`1 projectPathsToLoadOrReload, CancellationToken cancellationToken) in /_/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs:line 179
   at Microsoft.CodeAnalysis.Threading.AsyncBatchingWorkQueue`1.<>c__DisplayClass2_0.<<Convert>b__0>d.MoveNext() in /_/src/Dependencies/Threading/AsyncBatchingWorkQueue`1.cs:line 40
--- End of stack trace from previous location ---
   at Microsoft.CodeAnalysis.Threading.AsyncBatchingWorkQueue`2.ProcessNextBatchAsync() in /_/src/Dependencies/Threading/AsyncBatchingWorkQueue`2.cs:line 274
   at Microsoft.CodeAnalysis.Threading.AsyncBatchingWorkQueue`2.<AddWork>g__ContinueAfterDelayAsync|16_1(Task lastTask) in /_/src/Dependencies/Threading/AsyncBatchingWorkQueue`2.cs:line 221
   at Microsoft.CodeAnalysis.Threading.AsyncBatchingWorkQueue`2.WaitUntilCurrentBatchCompletesAsync() in /_/src/Dependencies/Threading/AsyncBatchingWorkQueue`2.cs:line 238
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LanguageServerProjectSystem.OpenSolutionAsync(String solutionFilePath) in /_/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs:line 65
   at Microsoft.CommonLanguageServerProtocol.Framework.QueueItem`1.StartRequestAsync[TRequest,TResponse](TRequest request, TRequestContext context, IMethodHandler handler, String language, CancellationToken cancellationToken) in /_/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs:line 203
```