### PR TITLE
Remove most remaining uses of WorkspaceChanged off the UI thread

### DIFF
--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DocumentActiveContextChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DocumentActiveContextChangedEventSource.cs
@@ -13,9 +13,8 @@ internal partial class TaggerEventSources
     {
         private WorkspaceEventRegistration? _documentActiveContextChangedDisposer;
 
-        // Require main thread on the callback as RaiseChanged implementors may have main thread dependencies.
         protected override void ConnectToWorkspace(Workspace workspace)
-            => _documentActiveContextChangedDisposer = workspace.RegisterDocumentActiveContextChangedHandler(OnDocumentActiveContextChanged, WorkspaceEventOptions.RequiresMainThreadOptions);
+            => _documentActiveContextChangedDisposer = workspace.RegisterDocumentActiveContextChangedHandler(OnDocumentActiveContextChanged);
 
         protected override void DisconnectFromWorkspace(Workspace workspace)
             => _documentActiveContextChangedDisposer?.Dispose();

--- a/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
@@ -41,7 +41,7 @@ internal interface ITaggerEventSource
 
     /// <summary>
     /// An event has happened on the thing the tagger is attached to.  The tagger should
-    /// recompute tags.
+    /// recompute tags. May be raised on any thread.
     /// </summary>
     event EventHandler<TaggerEventArgs> Changed;
 }

--- a/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
@@ -49,9 +49,7 @@ internal sealed class CodeAnalysisDiagnosticAnalyzerServiceFactory() : IWorkspac
             _workspace = workspace;
             _diagnosticAnalyzerService = _workspace.Services.GetRequiredService<IDiagnosticAnalyzerService>();
 
-            // Main thread as OnWorkspaceChanged's call to IDiagnosticAnalyzerService.RequestDiagnosticRefresh isn't clear on
-            // threading requirements
-            _ = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged, WorkspaceEventOptions.RequiresMainThreadOptions);
+            _ = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
         }
 
         private void OnWorkspaceChanged(WorkspaceChangeEventArgs e)

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -22,6 +22,9 @@ internal interface IDiagnosticAnalyzerService : IWorkspaceService
     /// <summary>
     /// Re-analyze all projects and documents.  This will cause an LSP diagnostic refresh request to be sent.
     /// </summary>
+    /// <remarks>
+    /// This implementation must be safe to call on any thread.
+    /// </remarks>
     void RequestDiagnosticRefresh();
 
     /// <summary>

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
@@ -39,9 +39,7 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
             m["WorkspacePartialSemanticsEnabled"] = workspace.PartialSemanticsEnabled;
         }, workspace));
 
-        // Forward workspace change events for all registered LSP workspaces. Requires main thread as it
-        // fires LspSolutionChanged which hasn't been guaranteed to be thread safe.
-        var workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnLspWorkspaceChanged, WorkspaceEventOptions.RequiresMainThreadOptions);
+        var workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnLspWorkspaceChanged);
 
         lock (_gate)
         {
@@ -94,9 +92,7 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
     }
 
     /// <summary>
-    /// Indicates whether the LSP solution has changed in a non-tracked document context.
-    /// 
-    /// <b>IMPORTANT:</b> Implementations of this event handler should do as little synchronous work as possible since this will block.
+    /// Indicates whether the LSP solution has changed in a non-tracked document context. May be raised on any thread.
     /// </summary>
     public EventHandler<WorkspaceChangeEventArgs>? LspSolutionChanged;
 }

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerViewModel.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerViewModel.cs
@@ -53,9 +53,6 @@ internal sealed class StackTraceExplorerViewModel : ViewModelBase
         _threadingContext = threadingContext;
         _workspace = workspace;
 
-        // Main thread dependency as Workspace_WorkspaceChanged modifies an ObservableCollection
-        _ = workspace.RegisterWorkspaceChangedHandler(Workspace_WorkspaceChanged, WorkspaceEventOptions.RequiresMainThreadOptions);
-
         _classificationTypeMap = classificationTypeMap;
         _formatMap = formatMap;
 
@@ -104,15 +101,6 @@ internal sealed class StackTraceExplorerViewModel : ViewModelBase
     {
         NotifyPropertyChanged(nameof(IsListVisible));
         NotifyPropertyChanged(nameof(IsInstructionTextVisible));
-    }
-
-    private void Workspace_WorkspaceChanged(WorkspaceChangeEventArgs e)
-    {
-        if (e.Kind == WorkspaceChangeKind.SolutionChanged)
-        {
-            Selection = null;
-            Frames.Clear();
-        }
     }
 
     private FrameViewModel GetViewModel(ParsedFrame frame)

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSource.cs
@@ -19,6 +19,7 @@ internal sealed partial class CpsDiagnosticItemSource : BaseDiagnosticAndGenerat
 {
     private readonly IVsHierarchyItem _item;
     private readonly string _projectDirectoryPath;
+    private readonly string? _analyzerFilePath;
 
     private WorkspaceEventRegistration? _workspaceChangedDisposer;
 
@@ -37,6 +38,8 @@ internal sealed partial class CpsDiagnosticItemSource : BaseDiagnosticAndGenerat
         _item = item;
         _projectDirectoryPath = Path.GetDirectoryName(projectPath);
 
+        _analyzerFilePath = CpsUtilities.ExtractAnalyzerFilePath(_projectDirectoryPath, _item.CanonicalName);
+
         this.AnalyzerReference = TryGetAnalyzerReference(Workspace.CurrentSolution);
         if (this.AnalyzerReference == null)
         {
@@ -47,9 +50,7 @@ internal sealed partial class CpsDiagnosticItemSource : BaseDiagnosticAndGenerat
             // then connect to it.
             if (workspace.CurrentSolution.ContainsProject(projectId))
             {
-                // Main thread dependency as OnWorkspaceChangedLookForAnalyzer accesses the IVsHierarchy
-                // and fires the PropertyChanged event 
-                _workspaceChangedDisposer = Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChangedLookForAnalyzer, WorkspaceEventOptions.RequiresMainThreadOptions);
+                _workspaceChangedDisposer = Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChangedLookForAnalyzer);
                 item.PropertyChanged += IVsHierarchyItem_PropertyChanged;
 
                 // Now that we've subscribed, check once more in case we missed the event
@@ -118,14 +119,11 @@ internal sealed partial class CpsDiagnosticItemSource : BaseDiagnosticAndGenerat
             return null;
         }
 
-        var canonicalName = _item.CanonicalName;
-        var analyzerFilePath = CpsUtilities.ExtractAnalyzerFilePath(_projectDirectoryPath, canonicalName);
-
-        if (string.IsNullOrEmpty(analyzerFilePath))
+        if (string.IsNullOrEmpty(_analyzerFilePath))
         {
             return null;
         }
 
-        return project.AnalyzerReferences.FirstOrDefault(r => string.Equals(r.FullPath, analyzerFilePath, StringComparison.OrdinalIgnoreCase));
+        return project.AnalyzerReferences.FirstOrDefault(r => string.Equals(r.FullPath, _analyzerFilePath, StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
Commit-at-a-time is recommended, since each use gets its own commit with further analysis there.

The remaining uses of eventing that hit the UI thread (of any kind of workspace event) are:

1. Inline rename subscribes when there is an active rename to cancel on changes it doesn't know about. Since this is only active during the session, it doesn't seem worth it change it.
2. MiscellanousFilesWorkspace subscribes to workspace _registration_ changed, which is when a document is opened/closed, and that's not urgent to fix and restricted to just registration events.
3. XamlProjectService subscribes to document _closed_. This only happens if XAML is loaded in the first place, and then is only raised on the close path. I looked at making a small change to move it off but the code is generally quite scary and since it's document close only that's not chatty.