### PR TITLE
Directly create virtual project when dotnet run-api is missing for now

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -135,8 +135,10 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         var content = await _projectXmlProvider.GetVirtualProjectContentAsync(documentPath, cancellationToken);
         if (content is not var (virtualProjectContent, diagnostics))
         {
-            // 'GetVirtualProjectContentAsync' will log errors when it fails
-            return null;
+            // https://github.com/dotnet/roslyn/issues/78618: falling back to this until dotnet run-api is more widely available
+            _logger.LogInformation($"Failed to obtain virtual project for '{documentPath}' using dotnet run-api. Falling back to directly creating the virtual project.");
+            virtualProjectContent = VirtualProjectXmlProvider.MakeVirtualProjectContent_DirectFallback(documentPath);
+            diagnostics = [];
         }
 
         foreach (var diagnostic in diagnostics)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlProvider.cs
@@ -106,4 +106,106 @@ internal class VirtualProjectXmlProvider(DotnetCliHelper dotnetCliHelper, ILogge
         var isFileBasedProgram = root.GetLeadingTrivia().Any(SyntaxKind.IgnoredDirectiveTrivia) || root.ChildNodes().Any(node => node.IsKind(SyntaxKind.GlobalStatement));
         return isFileBasedProgram;
     }
+
+    #region Temporary copy of subset of dotnet run-api behavior for fallback: https://github.com/dotnet/roslyn/issues/78618
+    // See https://github.com/dotnet/sdk/blob/b5dbc69cc28676ac6ea615654c8016a11b75e747/src/Cli/Microsoft.DotNet.Cli.Utils/Sha256Hasher.cs#L10
+    private static class Sha256Hasher
+    {
+        public static string Hash(string text)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(text);
+            byte[] hash = SHA256.HashData(bytes);
+#if NET9_0_OR_GREATER
+            return Convert.ToHexStringLower(hash);
+#else
+            return Convert.ToHexString(hash).ToLowerInvariant();
+#endif
+        }
+
+        public static string HashWithNormalizedCasing(string text)
+        {
+            return Hash(text.ToUpperInvariant());
+        }
+    }
+
+    // See https://github.com/dotnet/sdk/blob/5a4292947487a9d34f4256c1d17fb3dc26859174/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs#L449
+    internal static string GetArtifactsPath(string entryPointFileFullPath)
+    {
+        // We want a location where permissions are expected to be restricted to the current user.
+        string directory = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Path.GetTempPath()
+            : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        // Include entry point file name so the directory name is not completely opaque.
+        string fileName = Path.GetFileNameWithoutExtension(entryPointFileFullPath);
+        string hash = Sha256Hasher.HashWithNormalizedCasing(entryPointFileFullPath);
+        string directoryName = $"{fileName}-{hash}";
+
+        return Path.Join(directory, "dotnet", "runfile", directoryName);
+    }
+    #endregion
+
+    // https://github.com/dotnet/roslyn/issues/78618: falling back to this until dotnet run-api is more widely available
+    internal static string MakeVirtualProjectContent_DirectFallback(string documentFilePath)
+    {
+        Contract.ThrowIfFalse(PathUtilities.IsAbsolute(documentFilePath));
+        var artifactsPath = GetArtifactsPath(documentFilePath);
+
+        var targetFramework = Environment.GetEnvironmentVariable("DOTNET_RUN_FILE_TFM") ?? "net10.0";
+
+        var virtualProjectXml = $"""
+            <Project>
+              <PropertyGroup>
+                <IncludeProjectNameInArtifactsPaths>false</IncludeProjectNameInArtifactsPaths>
+                <ArtifactsPath>{SecurityElement.Escape(artifactsPath)}</ArtifactsPath>
+              </PropertyGroup>
+              <!-- We need to explicitly import Sdk props/targets so we can override the targets below. -->
+              <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>{SecurityElement.Escape(targetFramework)}</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <PropertyGroup>
+                <EnableDefaultItems>false</EnableDefaultItems>
+              </PropertyGroup>
+              <PropertyGroup>
+                <LangVersion>preview</LangVersion>
+              </PropertyGroup>
+              <PropertyGroup>
+                <Features>$(Features);FileBasedProgram</Features>
+              </PropertyGroup>
+              <ItemGroup>
+                <Compile Include="{SecurityElement.Escape(documentFilePath)}" />
+              </ItemGroup>
+              <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+              <!--
+                Override targets which don't work with project files that are not present on disk.
+                See https://github.com/NuGet/Home/issues/14148.
+              -->
+              <Target Name="_FilterRestoreGraphProjectInputItems"
+                      DependsOnTargets="_LoadRestoreGraphEntryPoints"
+                      Returns="@(FilteredRestoreGraphProjectInputItems)">
+                <ItemGroup>
+                  <FilteredRestoreGraphProjectInputItems Include="@(RestoreGraphProjectInputItems)" />
+                </ItemGroup>
+              </Target>
+              <Target Name="_GetAllRestoreProjectPathItems"
+                      DependsOnTargets="_FilterRestoreGraphProjectInputItems"
+                      Returns="@(_RestoreProjectPathItems)">
+                <ItemGroup>
+                  <_RestoreProjectPathItems Include="@(FilteredRestoreGraphProjectInputItems)" />
+                </ItemGroup>
+              </Target>
+              <Target Name="_GenerateRestoreGraph"
+                      DependsOnTargets="_FilterRestoreGraphProjectInputItems;_GetAllRestoreProjectPathItems;_GenerateRestoreGraphProjectEntry;_GenerateProjectRestoreGraph"
+                      Returns="@(_RestoreGraphEntry)">
+                <!-- Output from dependency _GenerateRestoreGraphProjectEntry and _GenerateProjectRestoreGraph -->
+              </Target>
+            </Project>
+            """;
+
+        return virtualProjectXml;
+    }
 }


### PR DESCRIPTION
From discussion with @jasonmalinowski, we think we should keep in the "directly creating" virtual project behavior that we had prior to #78648, at minimum until we can be pretty sure .NET 10 users will have an SDK with run-api available.

Without this change, users running with .NET 10 preview 4 SDK will not get intellisense in VS Code. They would have to install a nightly .NET 10 or wait for preview 5 to come out.

I did manually verify that this change works when SDK is pinned to preview 4. The log message about taking the fallback path gets written out and so on.

Most of the change here is copy/pasted from deleted lines in the linked PR #78648.

FYI @dibarbet we probably want to make sure this is in the next prerelease that goes out. Apologies for the inconvenience.