### PR TITLE
Updates to unblock dartlab pipeline

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -440,7 +440,7 @@ function TestUsingRunTests() {
     }
 
   } elseif ($testVsi) {
-    $args += " --timeout 110"
+    $args += " --timeout 220"
     $args += " --runtime both"
     $args += " --sequential"
     $args += " --include '\.IntegrationTests'"

--- a/src/VisualStudio/Core/Def/ProjectSystem/OpenTextBufferProvider.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/OpenTextBufferProvider.cs
@@ -340,7 +340,7 @@ internal sealed class OpenTextBufferProvider : IVsRunningDocTableEvents3, IDispo
             return;
         }
 
-        var runningDocumentTableForEvents = (IVsRunningDocumentTable)_runningDocumentTable;
+        var runningDocumentTableForEvents = (IVsRunningDocumentTable)_runningDocumentTable.Value;
         runningDocumentTableForEvents.UnadviseRunningDocTableEvents(_runningDocumentTableEventsCookie);
         _runningDocumentTableEventsCookie = 0;
 


### PR DESCRIPTION
Some fixes to unblock the dartlab pipeline. Still not entirely fixed, need to workout why CSharpImmediate.DumpLocalVariableValue and BasicImmediate.DumpLocalVariableValue are continuing to fail.