### PR TITLE
Fix LSP references for using alias

### DIFF
--- a/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -253,7 +253,7 @@ internal sealed class FindUsagesLSPContext : FindUsagesContext
 
         // If we have no document span, our location may be in metadata or may be a namespace.
         var symbol = await SymbolFinder.FindSymbolAtPositionAsync(_document, _position, cancellationToken).ConfigureAwait(false);
-        if (symbol == null || symbol.Locations.IsEmpty || symbol.Kind == SymbolKind.Namespace)
+        if (symbol == null || symbol.Locations.IsEmpty || symbol.Kind is SymbolKind.Namespace or SymbolKind.Alias)
         {
             // Either:
             // (1) We couldn't find the location in metadata and it's not in any of our known documents.

--- a/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -253,12 +253,18 @@ internal sealed class FindUsagesLSPContext : FindUsagesContext
 
         // If we have no document span, our location may be in metadata or may be a namespace.
         var symbol = await SymbolFinder.FindSymbolAtPositionAsync(_document, _position, cancellationToken).ConfigureAwait(false);
-        if (symbol == null || symbol.Locations.IsEmpty || symbol.Kind is SymbolKind.Namespace or SymbolKind.Alias)
+        if (symbol == null || symbol.Locations.IsEmpty || symbol.Kind is SymbolKind.Namespace)
         {
             // Either:
             // (1) We couldn't find the location in metadata and it's not in any of our known documents.
             // (2) The symbol is a namespace (and therefore has no location).
             return null;
+        }
+
+        if (symbol is IAliasSymbol aliasSymbol)
+        {
+            // If the location symbol is an alias symbol, we need to get the target symbol to find the original location in metadata.
+            symbol = aliasSymbol.Target;
         }
 
         var options = _globalOptions.GetMetadataAsSourceOptions();

--- a/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
@@ -318,7 +318,10 @@ class C
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
 
         var results = await RunFindAllReferencesAsync(testLspServer, testLspServer.GetLocations("caret").First());
-        AssertLocationsEqual(testLspServer.GetLocations("reference"), results.Select(result => result.Location).WhereNotNull());
+        Assert.Equal(3, results.Length);
+        Assert.True(results[0].Location.DocumentUri.ToString().EndsWith("String.cs"));
+
+        AssertLocationsEqual(testLspServer.GetLocations("reference"), results.Skip(1).Select(r => r.Location));
     }
 
     private static LSP.ReferenceParams CreateReferenceParams(LSP.Location caret, IProgress<object> progress)


### PR DESCRIPTION
No bug link, just hit error here when I was investigating something else.  It was attempting to create a decompiled location for the definition because it had no `DocumentSpan`

```
2025-06-04 13:00:56.667 [info] [Error - 1:00:56 PM] [textDocument/references] [LSP] System.InvalidOperationException: Unexpected value 'MyType' of type 'Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.AliasSymbol'
   at Microsoft.CodeAnalysis.MetadataAsSource.MetadataAsSourceHelpers.GetTopLevelContainingNamedType(ISymbol symbol) in /_/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs:line 51
   at Microsoft.CodeAnalysis.MetadataAsSource.DecompilationMetadataAsSourceFileProvider.GetGeneratedFileAsync(MetadataAsSourceWorkspace metadataWorkspace, Workspace sourceWorkspace, Project sourceProject, ISymbol symbol, Boolean signaturesOnly, MetadataAsSourceOptions options, String tempPath, TelemetryMessage telemetryMessage, CancellationToken cancellationToken) in /_/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs:line 78
   at Microsoft.CodeAnalysis.MetadataAsSource.MetadataAsSourceFileService.GetGeneratedFileAsync(Workspace sourceWorkspace, Project sourceProject, ISymbol symbol, Boolean signaturesOnly, MetadataAsSourceOptions options, CancellationToken cancellationToken) in /_/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs:line 108
   at Microsoft.CodeAnalysis.LanguageServer.Handler.FindUsagesLSPContext.ComputeLocationAsync(Nullable`1 documentSpan, CancellationToken cancellationToken) in /_/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs:line 265
```