### PR TITLE
Add a fallback path when launching the BuildHost

### DIFF
--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
@@ -186,10 +186,28 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
 
     internal static string GetNetCoreBuildHostPath()
     {
-        // The .NET Core build host is deployed as a content folder next to the application into the BuildHost-netcore path
-        var buildHostPath = Path.Combine(Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location)!, "BuildHost-netcore", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll");
-        AssertBuildHostExists(buildHostPath);
-        return buildHostPath;
+        // Possible BuildHost paths are relative to where the Workspaces.MSBuild assembly was loaded.
+        var msbuildWorkspaceDirectory = Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location)!;
+
+        // When Workspaces.MSBuild is deployed as part of an application the .NET Core build host is deployed as a content folder next to the application under the BuildHost-netcore path
+        var buildHostPath = Path.Combine(msbuildWorkspaceDirectory, "BuildHost-netcore", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll");
+        if (File.Exists(buildHostPath))
+        {
+            return buildHostPath;
+        }
+
+        // When Workspaces.MSBuild is loaded from the NuGet cache the .NET Core Build host is deployed under the contentFiles folder under the BuildHost-netcore path
+        // 
+        // Workspaces.MSBuild.dll Path - .nuget/packages/microsoft.codeanalysis.workspaces.msbuild/{version}/lib/{tfm}/Microsoft.CodeAnalysis.Workspaces.MSBuild.dll
+        // MSBuild.BuildHost.dll Path  - .nuget/packages/microsoft.codeanalysis.workspaces.msbuild/{version}/contentFiles/any/any/BuildHost-netcore/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll
+
+        var fallbackBuildHostPath = Path.GetFullPath(Path.Combine(msbuildWorkspaceDirectory, "..", "..", "contentFiles", "any", "any", "BuildHost-netcore", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll"));
+        if (File.Exists(fallbackBuildHostPath))
+        {
+            return fallbackBuildHostPath;
+        }
+
+        throw new Exception(string.Format(WorkspaceMSBuildResources.The_build_host_could_not_be_found_at_0, buildHostPath));
     }
 
     private ProcessStartInfo CreateDotNetFrameworkBuildHostStartInfo(string pipeName)
@@ -221,16 +239,28 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
 
     private static string GetDotNetFrameworkBuildHostPath()
     {
-        // The .NET Framework build host is deployed as a content folder next to the application into the BuildHost-net472 path
-        var netFrameworkBuildHost = Path.Combine(Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location)!, "BuildHost-net472", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe");
-        AssertBuildHostExists(netFrameworkBuildHost);
-        return netFrameworkBuildHost;
-    }
+        // Possible BuildHost paths are relative to where the Workspaces.MSBuild assembly was loaded.
+        var msbuildWorkspaceDirectory = Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location)!;
 
-    private static void AssertBuildHostExists(string buildHostPath)
-    {
-        if (!File.Exists(buildHostPath))
-            throw new Exception(string.Format(WorkspaceMSBuildResources.The_build_host_could_not_be_found_at_0, buildHostPath));
+        // When Workspaces.MSBuild is deployed as part of an application the .NET Framework build host is deployed as a content folder next to the application into the BuildHost-net472 path
+        var netFrameworkBuildHost = Path.Combine(msbuildWorkspaceDirectory, "BuildHost-net472", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe");
+        if (File.Exists(netFrameworkBuildHost))
+        {
+            return netFrameworkBuildHost;
+        }
+
+        // When Workspaces.MSBuild is loaded from the NuGet cache the .NET Core Build host is deployed under the contentFiles folder under the BuildHost-netcore path
+        // 
+        // Workspaces.MSBuild.dll Path - .nuget/packages/microsoft.codeanalysis.workspaces.msbuild/{version}/lib/{tfm}/Microsoft.CodeAnalysis.Workspaces.MSBuild.dll
+        // MSBuild.BuildHost.exe Path  - .nuget/packages/microsoft.codeanalysis.workspaces.msbuild/{version}/contentFiles/any/any/BuildHost-net472/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe
+
+        var fallbackBuildHostPath = Path.GetFullPath(Path.Combine(msbuildWorkspaceDirectory, "..", "..", "contentFiles", "any", "any", "BuildHost-net472", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe"));
+        if (File.Exists(fallbackBuildHostPath))
+        {
+            return fallbackBuildHostPath;
+        }
+
+        throw new Exception(string.Format(WorkspaceMSBuildResources.The_build_host_could_not_be_found_at_0, netFrameworkBuildHost));
     }
 
     private void AppendBuildHostCommandLineArgumentsConfigureProcess(ProcessStartInfo processStartInfo, string pipeName)


### PR DESCRIPTION
Resolves #78824