### PR TITLE
Track changed text instead of clearing immediate window.

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpImmediate.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpImmediate.cs
@@ -47,12 +47,13 @@ class Program
         await TestServices.Debugger.SetBreakpointAsync(ProjectName, "Program.cs", "}", HangMitigatingCancellationToken);
         await TestServices.Debugger.GoAsync(waitForBreakMode: true, HangMitigatingCancellationToken);
         await TestServices.ImmediateWindow.ShowAsync(HangMitigatingCancellationToken);
-        await TestServices.ImmediateWindow.ClearAllAsync(HangMitigatingCancellationToken);
-        await TestServices.Input.SendWithoutActivateAsync("?n", HangMitigatingCancellationToken);
+        var existingText = await TestServices.ImmediateWindow.GetTextAsync(HangMitigatingCancellationToken);
         await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.CompletionSet, HangMitigatingCancellationToken);
-        await TestServices.Input.SendWithoutActivateAsync(["1", VirtualKeyCode.TAB, VirtualKeyCode.RETURN], HangMitigatingCancellationToken);
+        await TestServices.Input.SendWithoutActivateAsync("?", HangMitigatingCancellationToken);
+        await TestServices.Input.SendWithoutActivateAsync(["n1", VirtualKeyCode.TAB, VirtualKeyCode.RETURN], HangMitigatingCancellationToken);
+        var immediateText = await TestServices.ImmediateWindow.GetTextAsync(HangMitigatingCancellationToken);
         // Skip checking the EE result "42" (see https://github.com/dotnet/roslyn/issues/75456), without
         // skipping the test completely (see https://github.com/dotnet/roslyn/issues/75478).
-        Assert.Contains("?n1Var\r\n", await TestServices.ImmediateWindow.GetTextAsync(HangMitigatingCancellationToken));
+        Assert.Contains("?n1Var\r\n", immediateText.Substring(existingText.Length));
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicImmediate.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicImmediate.cs
@@ -45,12 +45,13 @@ End Module
         await TestServices.Debugger.SetBreakpointAsync(ProjectName, "Module1.vb", "End Sub", HangMitigatingCancellationToken);
         await TestServices.Debugger.GoAsync(waitForBreakMode: true, HangMitigatingCancellationToken);
         await TestServices.ImmediateWindow.ShowAsync(HangMitigatingCancellationToken);
-        await TestServices.ImmediateWindow.ClearAllAsync(HangMitigatingCancellationToken);
-        await TestServices.Input.SendWithoutActivateAsync("?", HangMitigatingCancellationToken);
+        var existingText = await TestServices.ImmediateWindow.GetTextAsync(HangMitigatingCancellationToken);
         await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.CompletionSet, HangMitigatingCancellationToken);
+        await TestServices.Input.SendWithoutActivateAsync("?", HangMitigatingCancellationToken);
         await TestServices.Input.SendWithoutActivateAsync(["n1", VirtualKeyCode.TAB, VirtualKeyCode.RETURN], HangMitigatingCancellationToken);
+        var immediateText = await TestServices.ImmediateWindow.GetTextAsync(HangMitigatingCancellationToken);
         // Skip checking the EE result "42" (see https://github.com/dotnet/roslyn/issues/75456), without
         // skipping the test completely (see https://github.com/dotnet/roslyn/issues/75478).
-        Assert.Contains("?n1Var\r\n", await TestServices.ImmediateWindow.GetTextAsync(HangMitigatingCancellationToken));
+        Assert.Contains("?n1Var\r\n", immediateText.Substring(existingText.Length));
     }
 }


### PR DESCRIPTION
Instead of clearing the immediate window in our tests, we will capture the text before and after our activity and verify the new text is what we expect.

Test [DartLab run](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11709419&view=results)