### PR TITLE
Refactor binary operator binding in preparation for future work.

### DIFF
--- a/src/Compilers/CSharp/Test/Emit3/Symbols/UserDefinedCompoundAssignmentOperatorsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Symbols/UserDefinedCompoundAssignmentOperatorsTests.cs
@@ -20232,5 +20232,81 @@ class Program
             var comp = CreateCompilation([source, CompilerFeatureRequiredAttribute], options: TestOptions.DebugExe);
             var verifier = CompileAndVerify(comp, expectedOutput: "+=3+=55nullnull").VerifyDiagnostics();
         }
+
+        [Fact]
+        public void CompoundAssignment_01610_Consumption_RightIsImplicitObjectCreation()
+        {
+            var source = @"
+struct S1
+{
+    public void operator +=(S1 y) {}
+}
+
+struct S2
+{
+    public static S2 operator +(S2 x, S2 y) => x;
+}
+
+class Program
+{
+    static void Main()
+    {
+        var s1 = new S1();
+        s1 += new();
+
+        var s2 = new S2();
+        s2 += new();
+    } 
+}
+";
+
+            var comp = CreateCompilation([source, CompilerFeatureRequiredAttribute]);
+            comp.VerifyDiagnostics(
+                // (17,9): error CS8310: Operator '+=' cannot be applied to operand 'new()'
+                //         s1 += new();
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefaultOrNew, "s1 += new()").WithArguments("+=", "new()").WithLocation(17, 9),
+                // (20,9): error CS8310: Operator '+=' cannot be applied to operand 'new()'
+                //         s2 += new();
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefaultOrNew, "s2 += new()").WithArguments("+=", "new()").WithLocation(20, 9)
+                );
+        }
+
+        [Fact]
+        public void CompoundAssignment_01620_Consumption_RightIsDefault()
+        {
+            var source = @"
+struct S1
+{
+    public void operator +=(S1 y) {}
+}
+
+struct S2
+{
+    public static S2 operator +(S2 x, S2 y) => x;
+}
+
+class Program
+{
+    static void Main()
+    {
+        var s1 = new S1();
+        s1 += default;
+
+        var s2 = new S2();
+        s2 += default;
+    } 
+}
+";
+
+            var comp = CreateCompilation([source, CompilerFeatureRequiredAttribute]);
+            comp.VerifyDiagnostics(
+                // (17,9): error CS8310: Operator '+=' cannot be applied to operand 'default'
+                //         s1 += default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefaultOrNew, "s1 += default").WithArguments("+=", "default").WithLocation(17, 9),
+                // (20,9): error CS8310: Operator '+=' cannot be applied to operand 'default'
+                //         s2 += default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefaultOrNew, "s2 += default").WithArguments("+=", "default").WithLocation(20, 9)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -7383,7 +7383,8 @@ public class RubyTime
                 else
                 {
                     var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-                    overloadResolution.BinaryOperatorOverloadResolution_NoEasyOut(kind, isChecked, left, right, result, ref discardedUseSiteInfo);
+                    OverloadResolution.GetStaticUserDefinedBinaryOperatorMethodNames(kind, isChecked, out string name1, out string name2Opt);
+                    overloadResolution.BinaryOperatorOverloadResolution_NoEasyOut(kind, isChecked, name1, name2Opt, left, right, result, ref discardedUseSiteInfo);
                 }
                 var signature = result.Best.Signature.Kind;
                 result.Free();


### PR DESCRIPTION
In the process a small bug was fixed. Binding of instance compound assignment operators was made consistent with binding against static binary operators with respect to `implicit object creation` and `default` operands.