### PR TITLE
Add more ETW events to trace assembly loading

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -87,8 +87,8 @@ namespace Microsoft.CodeAnalysis
             {
                 if (!_loadContextByDirectory.TryGetValue(fullDirectoryPath, out loadContext))
                 {
-                    CodeAnalysisEventSource.Log.CreateAssemblyLoadContext(fullDirectoryPath);
                     loadContext = new DirectoryLoadContext(fullDirectoryPath, this);
+                    CodeAnalysisEventSource.Log.CreateAssemblyLoadContext(fullDirectoryPath, loadContext.ToString());
                     _loadContextByDirectory[fullDirectoryPath] = loadContext;
                 }
             }
@@ -179,11 +179,11 @@ namespace Microsoft.CodeAnalysis
                 try
                 {
                     context.Unload();
-                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContext(context.Directory);
+                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContext(context.Directory, ToString());
                 }
                 catch (Exception ex) when (FatalError.ReportAndCatch(ex, ErrorSeverity.Critical))
                 {
-                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContextException(context.Directory, ex.ToString());
+                    CodeAnalysisEventSource.Log.DisposeAssemblyLoadContextException(context.Directory, ex.ToString(), ToString());
                 }
             }
 
@@ -209,10 +209,12 @@ namespace Microsoft.CodeAnalysis
                     var assembly = resolver.Resolve(_loader, assemblyName, this, Directory);
                     if (assembly is not null)
                     {
+                        CodeAnalysisEventSource.Log.ResolvedAssembly(Directory, assemblyName.ToString(), resolver.GetType().Name, assembly.Location, GetLoadContext(assembly)!.ToString());
                         return assembly;
                     }
                 }
 
+                CodeAnalysisEventSource.Log.ResolveAssemblyFailed(Directory, assemblyName.ToString());
                 return null;
             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerPathResolver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerPathResolver.cs
@@ -16,7 +16,7 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
-    /// This interface gives the host the ability to control the actaul path used to load an analyzer into the 
+    /// This interface gives the host the ability to control the actual path used to load an analyzer into the 
     /// compiler.
     ///
     /// Instances of these types are considered in the order they are added to the <see cref="AnalyzerAssemblyLoader"/>.

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1054,6 +1054,7 @@ internal sealed partial class ProjectSystemProject
     public void AddAnalyzerReference(string fullPath)
     {
         CompilerPathUtilities.RequireAbsolutePath(fullPath, nameof(fullPath));
+        CodeAnalysisEventSource.Log.AnalyzerReferenceRequestAddToProject(fullPath, DisplayName);
 
         var mappedPaths = GetMappedAnalyzerPaths(fullPath);
 
@@ -1084,6 +1085,7 @@ internal sealed partial class ProjectSystemProject
                 // Are we adding one we just recently removed? If so, we can just keep using that one, and avoid
                 // removing it once we apply the batch
                 _projectAnalyzerPaths.Add(mappedFullPath);
+                CodeAnalysisEventSource.Log.AnalyzerReferenceAddedToProject(mappedFullPath, DisplayName);
 
                 if (!_analyzersRemovedInBatch.Remove(mappedFullPath))
                     _analyzersAddedInBatch.Add(mappedFullPath);
@@ -1097,6 +1099,8 @@ internal sealed partial class ProjectSystemProject
     {
         if (string.IsNullOrEmpty(fullPath))
             throw new ArgumentException("message", nameof(fullPath));
+
+        CodeAnalysisEventSource.Log.AnalyzerReferenceRequestRemoveFromProject(fullPath, DisplayName);
 
         var mappedPaths = GetMappedAnalyzerPaths(fullPath);
 
@@ -1125,6 +1129,7 @@ internal sealed partial class ProjectSystemProject
             foreach (var mappedFullPath in mappedPaths)
             {
                 _projectAnalyzerPaths.Remove(mappedFullPath);
+                CodeAnalysisEventSource.Log.AnalyzerReferenceRemovedFromProject(fullPath, DisplayName);
 
                 // This analyzer may be one we've just added in the same batch; in that case, just don't add it in
                 // the first place.
@@ -1175,6 +1180,7 @@ internal sealed partial class ProjectSystemProject
                     if (redirectedPath == null)
                     {
                         redirectedPath = currentlyRedirectedPath;
+                        CodeAnalysisEventSource.Log.AnanlyzerReferenceRedirected(redirector.GetType().Name, fullPath, redirectedPath, DisplayName);
                     }
                     else if (redirectedPath != currentlyRedirectedPath)
                     {


### PR DESCRIPTION
While working on https://github.com/dotnet/roslyn/issues/76868 I wanted to increase the available amount of information we have for loading assemblies, as it can be pretty opaque why any given assembly ends up where it was.

This adds enough tracking to let us see:

1. Which analyzer reference is requested to be added
2. If that reference was redirected to a different path[s]
3. What references were actually added
4. When resolving the assembly, which actual assembly was used, which resolver provided it and which alc it actually exists in.

That allows to trace for any given assembly where it came from, where it was loaded, and why. 