### PR TITLE
Don't output empty blank lines for ValueTypes in bound nodes

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -254,25 +254,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         WithExpression,
     }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     internal abstract partial class BoundInitializer : BoundNode
     {
         protected BoundInitializer(BoundKind kind, SyntaxNode syntax, bool hasErrors)

--- a/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
@@ -194,22 +194,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Interpolation
     End Enum
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     Partial Friend MustInherit Class BoundExpression
         Inherits BoundNode
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -275,7 +275,7 @@ namespace BoundTreeGenerator
 
         private void WriteTypes()
         {
-            foreach (var node in _tree.Types.Where(n => n is not PredefinedNode))
+            foreach (var node in _tree.Types.OfType<AbstractNode>())
             {
                 Blank();
                 WriteType(node);
@@ -901,10 +901,8 @@ namespace BoundTreeGenerator
             }
         }
 
-        private void WriteType(TreeType node)
+        private void WriteType(AbstractNode node)
         {
-            if (node is not AbstractNode)
-                return;
             WriteClassHeader(node);
 
             bool unsealed = !CanBeSealed(node);


### PR DESCRIPTION
Just a small cleanup I noticed that we were adding blank lines to our generated BoundNodes files for every single ValueType entry.