### PR TITLE
Switch behavior of "Go to definition" and "Go to implementation" for partial members

### DIFF
--- a/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
@@ -217,7 +217,9 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/900438")>
+        <WpfFact>
+        <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/900438")>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
         Public Async Function TestCSharpGotoDefinitionPartialMethod() As Task
             Dim workspace =
 <Workspace>
@@ -225,7 +227,7 @@ class Program
         <Document>
             partial class Test
             {
-                partial void M();
+                partial void [|M|]();
             }
         </Document>
         <Document>
@@ -237,7 +239,7 @@ class Program
                     t.M$$();
                 }
 
-                partial void [|M|]()
+                partial void M()
                 {
                     throw new NotImplementedException();
                 }
@@ -249,7 +251,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
         Public Async Function TestCSharpGotoDefinitionExtendedPartialMethod() As Task
             Dim workspace =
 <Workspace>
@@ -257,7 +259,7 @@ class Program
         <Document>
             partial class Test
             {
-                public partial void M();
+                public partial void [|M|]();
             }
         </Document>
         <Document>
@@ -269,7 +271,7 @@ class Program
                     t.M$$();
                 }
 
-                public partial void [|M|]()
+                public partial void M()
                 {
                     throw new NotImplementedException();
                 }
@@ -281,7 +283,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
         Public Async Function TestCSharpGotoDefinitionPartialProperty() As Task
             Dim workspace =
 <Workspace>
@@ -289,7 +291,7 @@ class Program
         <Document>
             partial class Test
             {
-                public partial int Prop { get; set; }
+                public partial int [|Prop|] { get; set; }
             }
         </Document>
         <Document>
@@ -301,7 +303,7 @@ class Program
                     int i = t.Prop$$;
                 }
 
-                public partial void [|Prop|]
+                public partial void Prop
                 {
                     get => throw new NotImplementedException();
                     set => throw new NotImplementedException();
@@ -314,7 +316,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
         Public Async Function TestCSharpGotoDefinitionPartialEvent() As Task
             Dim workspace =
 <Workspace>
@@ -322,7 +324,7 @@ class Program
         <Document>
             partial class Test
             {
-                public partial event System.Action E;
+                public partial event System.Action [|E|];
             }
         </Document>
         <Document>
@@ -334,7 +336,7 @@ class Program
                     int i = t.E$$;
                 }
 
-                public partial event System.Action [|E|]
+                public partial event System.Action E
                 {
                     add { }
                     remove { }
@@ -347,7 +349,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
         Public Async Function TestCSharpGotoDefinitionPartialConstructor() As Task
             Dim workspace =
 <Workspace>
@@ -355,7 +357,7 @@ class Program
         <Document>
             partial class Test
             {
-                public partial Test();
+                public partial [|Test|]();
             }
         </Document>
         <Document>
@@ -366,7 +368,7 @@ class Program
                     var t = new Te$$st();
                 }
 
-                public partial [|Test|]()
+                public partial Test()
                 {
                 }
             }

--- a/src/EditorFeatures/Test2/GoToDefinition/VisualBasicGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/VisualBasicGoToDefinitionTests.vb
@@ -216,7 +216,7 @@ End Class
     <Project Language="Visual Basic" CommonReferences="true">
         <Document>
             Partial Class Customer
-                Private Sub [|OnNameChanged|]()
+                Private Sub OnNameChanged()
 
                 End Sub
             End Class
@@ -227,7 +227,7 @@ End Class
                     Dim x As New Customer()
                     x.OnNameChanged$$()
                 End Sub
-                Partial Private Sub OnNameChanged()
+                Partial Private Sub [|OnNameChanged|]()
 
                 End Sub
             End Class

--- a/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
+++ b/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
@@ -999,5 +999,170 @@ class D : C
 
             Await TestAsync(workspace, host)
         End Function
+
+        <Theory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
+        Public Async Function TestPartialMethod(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            partial class Test
+            {
+                partial void M();
+            }
+        </Document>
+        <Document>
+            partial class Test
+            {
+                void Goo()
+                {
+                    var t = new Test();
+                    t.M$$();
+                }
+
+                partial void [|M|]()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
+
+        <Theory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
+        Public Async Function TestExtendedPartialMethod(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            partial class Test
+            {
+                public partial void M();
+            }
+        </Document>
+        <Document>
+            partial class Test
+            {
+                void Goo()
+                {
+                    var t = new Test();
+                    t.M$$();
+                }
+
+                public partial void [|M|]()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
+
+        <Theory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
+        Public Async Function TestPartialProperty(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            partial class Test
+            {
+                public partial int Prop { get; set; }
+            }
+        </Document>
+        <Document>
+            partial class Test
+            {
+                void Goo()
+                {
+                    var t = new Test();
+                    int i = t.Prop$$;
+                }
+
+                public partial void [|Prop|]
+                {
+                    get => throw new NotImplementedException();
+                    set => throw new NotImplementedException();
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
+
+        <Theory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
+        Public Async Function TestPartialEvent(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            partial class Test
+            {
+                public partial event System.Action E;
+            }
+        </Document>
+        <Document>
+            partial class Test
+            {
+                void Goo()
+                {
+                    var t = new Test();
+                    int i = t.E$$;
+                }
+
+                public partial event System.Action [|E|]
+                {
+                    add { }
+                    remove { }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
+
+        <Theory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/77916")>
+        Public Async Function TestPartialConstructor(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
+        <Document>
+            partial class Test
+            {
+                public partial Test();
+            }
+        </Document>
+        <Document>
+            partial class Test
+            {
+                void Goo()
+                {
+                    var t = new Te$$st();
+                }
+
+                public partial [|Test|]()
+                {
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService_FindImplementations.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService_FindImplementations.cs
@@ -206,7 +206,16 @@ internal abstract partial class AbstractFindUsagesService
         }
         else
         {
-            return [];
+            // If a symbol is partial definition, return its implementation part
+            var implementationPart = symbol switch
+            {
+                IMethodSymbol method => method.PartialImplementationPart,
+                IPropertySymbol property => property.PartialImplementationPart,
+                IEventSymbol ev => ev.PartialImplementationPart,
+                _ => symbol,
+            };
+
+            return implementationPart is null ? [] : [implementationPart];
         }
     }
 }

--- a/src/Features/Core/Portable/GoToDefinition/GoToDefinitionFeatureHelpers.cs
+++ b/src/Features/Core/Portable/GoToDefinition/GoToDefinitionFeatureHelpers.cs
@@ -46,18 +46,7 @@ internal static class GoToDefinitionFeatureHelpers
         var definition = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
 
-        symbol = definition ?? symbol;
-
-        // If symbol has a partial implementation part, prefer to go to it, since that is where the body is.
-        symbol = symbol switch
-        {
-            IMethodSymbol method => method.PartialImplementationPart,
-            IPropertySymbol property => property.PartialImplementationPart,
-            IEventSymbol ev => ev.PartialImplementationPart,
-            _ => symbol,
-        } ?? symbol;
-
-        return symbol;
+        return definition ?? symbol;
     }
 
     public static async Task<ImmutableArray<DefinitionItem>> GetDefinitionsAsync(


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/77916