### PR TITLE
call TryGetValue to get dictionary entry

### DIFF
--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemSourceProvider.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemSourceProvider.cs
@@ -116,7 +116,10 @@ internal sealed partial class RootSymbolTreeItemSourceProvider : AttachedCollect
         lock (_filePathToCollectionSources)
         {
             foreach (var filePath in updatedFilePaths)
-                sources.AddRange(_filePathToCollectionSources[filePath]);
+            {
+                if (_filePathToCollectionSources.TryGetValue(filePath, out var pathSources))
+                    sources.AddRange(pathSources);
+            }
         }
 
         // Update all the affected documents in parallel.


### PR DESCRIPTION
Fix exceptions in https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/641956

```
06/08/2025 10:55:35 Coordinated Universal Time: Error : 1 :[devenv:3884] Unexpected exception: System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.ThrowHelper.ThrowKeyNotFoundException()
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer.RootSymbolTreeItemSourceProvider.<UpdateCollectionSourcesAsync>d__12.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Threading.AsyncBatchingWorkQueue`1.<>c__DisplayClass2_0.<<Convert>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Threading.AsyncBatchingWorkQueue`2.<ProcessNextBatchAsync>d__18.MoveNext()
```