### PR TITLE
Change StringTextWriter to use a PooledStringBuilder

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException"><paramref name="checksumAlgorithm"/> is not supported.</exception>
         public SourceText GetText(Encoding? encoding = null, SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
         {
-            var writer = SourceTextWriter.Create(encoding, checksumAlgorithm, this.Green.FullWidth);
+            using var writer = SourceTextWriter.Create(encoding, checksumAlgorithm, this.Green.FullWidth);
             this.WriteTo(writer);
             return writer.ToSourceText();
         }

--- a/src/Compilers/Core/Portable/Text/CompositeText.cs
+++ b/src/Compilers/Core/Portable/Text/CompositeText.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.Text
                         var encoding = segments[i].Encoding;
                         var algorithm = segments[i].ChecksumAlgorithm;
 
-                        var writer = SourceTextWriter.Create(encoding, algorithm, combinedLength);
+                        using var writer = SourceTextWriter.Create(encoding, algorithm, combinedLength);
 
                         for (int j = i; j < i + count; j++)
                             segments[j].Write(writer);
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.Text
                 var encoding = segments[0].Encoding;
                 var algorithm = segments[0].ChecksumAlgorithm;
 
-                var writer = SourceTextWriter.Create(encoding, algorithm, length);
+                using var writer = SourceTextWriter.Create(encoding, algorithm, length);
                 foreach (var segment in segments)
                 {
                     segment.Write(writer);


### PR DESCRIPTION
The char[] allocation in the StringBuilder.ctor shows up as 0.8% (55 MB) of allocations during the typing scenario in the razor speedometer test.

This PR changes StringTextWriter to use a PooledStringBuilder to generally avoid those allocations, and adds the IDisposable implementation to release the builder back to the pool.

![image](https://github.com/user-attachments/assets/e27e0aac-426a-4fc5-8a84-d17f0d6d0584)