### PR TITLE
Fix "Use auto property" refactoring for System.Guid in net48

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ITypeSymbolExtensions.cs
@@ -679,6 +679,14 @@ internal static partial class ITypeSymbolExtensions
                 return false;
 
             default:
+                if (type is INamedTypeSymbol namedType && 
+                    namedType.SpecialType == SpecialType.None && // Not a special type
+                    namedType.TypeKind == TypeKind.Struct &&
+                    namedType.ContainingNamespace?.Name == "System" &&
+                    namedType.Name == "Guid")
+                {
+                    return false;
+                }
                 break;
         }
 


### PR DESCRIPTION
The issue: https://github.com/dotnet/roslyn/issues/76815 occurred because the analyzer treated System.Guid as potentially mutable in .NET Framework 4.8, preventing the auto-property refactoring. This change ensures consistent behavior across all .NET versions by explicitly marking System.Guid as immutable.
