### PR TITLE
Reduce allocations in the ImageElementConverter and ImageIdConverter Read methods

### DIFF
--- a/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageElementConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageElementConverter.cs
@@ -9,6 +9,7 @@ using Roslyn.Core.Imaging;
 using Roslyn.Text.Adornments;
 
 namespace Roslyn.LanguageServer.Protocol;
+
 internal sealed class ImageElementConverter : JsonConverter<ImageElement>
 {
     public static readonly ImageElementConverter Instance = new();
@@ -20,6 +21,8 @@ internal sealed class ImageElementConverter : JsonConverter<ImageElement>
             ImageId? imageId = null;
             string? automationName = null;
 
+            Span<char> scratchChars = stackalloc char[64];
+
             while (reader.Read())
             {
                 if (reader.TokenType == JsonTokenType.EndObject)
@@ -30,7 +33,11 @@ internal sealed class ImageElementConverter : JsonConverter<ImageElement>
 
                 if (reader.TokenType == JsonTokenType.PropertyName)
                 {
-                    var propertyName = reader.GetString();
+                    var valueLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+
+                    var propertyNameLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
+                    var propertyName = propertyNameLength >= 0 ? scratchChars[..propertyNameLength] : reader.GetString().AsSpan();
+
                     reader.Read();
                     switch (propertyName)
                     {
@@ -41,7 +48,10 @@ internal sealed class ImageElementConverter : JsonConverter<ImageElement>
                             automationName = reader.GetString();
                             break;
                         case ObjectContentConverter.TypeProperty:
-                            if (reader.GetString() != nameof(ImageElement))
+                            var typePropertyLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
+                            var typeProperty = typePropertyLength >= 0 ? scratchChars[..typePropertyLength] : reader.GetString().AsSpan();
+
+                            if (!typeProperty.SequenceEqual(nameof(ImageElement)))
                                 throw new JsonException($"Expected {ObjectContentConverter.TypeProperty} property value {nameof(ImageElement)}");
                             break;
                         default:
@@ -60,7 +70,10 @@ internal sealed class ImageElementConverter : JsonConverter<ImageElement>
         writer.WriteStartObject();
         writer.WritePropertyName(nameof(ImageElement.ImageId));
         ImageIdConverter.Instance.Write(writer, value.ImageId, options);
-        writer.WriteString(nameof(ImageElement.AutomationName), value.AutomationName);
+
+        if (value.AutomationName != null)
+            writer.WriteString(nameof(ImageElement.AutomationName), value.AutomationName);
+
         writer.WriteString(ObjectContentConverter.TypeProperty, nameof(ImageElement));
         writer.WriteEndObject();
     }


### PR DESCRIPTION
Reduce allocations in the ImageElementConverter and ImageIdConverter Read methods

These methods show up in the typing scenario in the razor speedometer test as about 0.9% (63 MB) of allocations.

1) Changed ImageIdConverter to be more like ImageElementConverter and not create a JsonDocument object to query
2) Changed several Utf8JsonReader.GetString calls to instead use Utf8JsonReader.CopyString
3) Changed JsonElement.GetString and new Guid(...) to instead use Utf8JsonReader.GetGuid()

Note that if this PR is merged, I'll also try to make a change to vslanguageserverclient to also do the same as that code has the same issues and shows as about 0.4% more of allocations in this scenario.

Below is an image of the allocations under ImageElementConverter.Read from the razor speedometer test. As the only GetString call now is on something that is typically not sent across the wire, I expect all allocations to be removed under this codepath except for the highlighted line.

![image](https://github.com/user-attachments/assets/d1deea7e-ae85-4208-979c-440112d868ff)

