### PR TITLE
Fix issue with not resetting valueLength

### DIFF
--- a/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageElementConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageElementConverter.cs
@@ -33,10 +33,7 @@ internal sealed class ImageElementConverter : JsonConverter<ImageElement>
 
                 if (reader.TokenType == JsonTokenType.PropertyName)
                 {
-                    var valueLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
-
-                    var propertyNameLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
-                    var propertyName = propertyNameLength >= 0 ? scratchChars[..propertyNameLength] : reader.GetString().AsSpan();
+                    var propertyName = reader.GetStringSpan(scratchChars);
 
                     reader.Read();
                     switch (propertyName)
@@ -48,12 +45,9 @@ internal sealed class ImageElementConverter : JsonConverter<ImageElement>
                             automationName = reader.GetString();
                             break;
                         case ObjectContentConverter.TypeProperty:
-                            valueLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+                            var typePropertyValue = reader.GetStringSpan(scratchChars);
 
-                            var typePropertyLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
-                            var typeProperty = typePropertyLength >= 0 ? scratchChars[..typePropertyLength] : reader.GetString().AsSpan();
-
-                            if (!typeProperty.SequenceEqual(nameof(ImageElement).AsSpan()))
+                            if (!typePropertyValue.SequenceEqual(nameof(ImageElement).AsSpan()))
                                 throw new JsonException($"Expected {ObjectContentConverter.TypeProperty} property value {nameof(ImageElement)}");
                             break;
                         default:

--- a/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageElementConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageElementConverter.cs
@@ -48,6 +48,8 @@ internal sealed class ImageElementConverter : JsonConverter<ImageElement>
                             automationName = reader.GetString();
                             break;
                         case ObjectContentConverter.TypeProperty:
+                            valueLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+
                             var typePropertyLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
                             var typeProperty = typePropertyLength >= 0 ? scratchChars[..typePropertyLength] : reader.GetString().AsSpan();
 

--- a/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageIdConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageIdConverter.cs
@@ -34,10 +34,7 @@ internal sealed class ImageIdConverter : JsonConverter<ImageId>
 
                 if (reader.TokenType == JsonTokenType.PropertyName)
                 {
-                    var valueLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
-
-                    var propertyNameLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
-                    var propertyName = propertyNameLength >= 0 ? scratchChars[..propertyNameLength] : reader.GetString().AsSpan();
+                    var propertyName = reader.GetStringSpan(scratchChars);
 
                     reader.Read();
                     switch (propertyName)
@@ -49,12 +46,9 @@ internal sealed class ImageIdConverter : JsonConverter<ImageId>
                             id = reader.GetInt32();
                             break;
                         case ObjectContentConverter.TypeProperty:
-                            valueLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+                            var typePropertyValue = reader.GetStringSpan(scratchChars);
 
-                            var typePropertyLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
-                            var typeProperty = typePropertyLength >= 0 ? scratchChars[..typePropertyLength] : reader.GetString().AsSpan();
-
-                            if (!typeProperty.SequenceEqual(nameof(ImageId).AsSpan()))
+                            if (!typePropertyValue.SequenceEqual(nameof(ImageId).AsSpan()))
                                 throw new JsonException($"Expected {ObjectContentConverter.TypeProperty} property value {nameof(ImageId)}");
                             break;
                         default:

--- a/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageIdConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Converters/ImageIdConverter.cs
@@ -49,6 +49,8 @@ internal sealed class ImageIdConverter : JsonConverter<ImageId>
                             id = reader.GetInt32();
                             break;
                         case ObjectContentConverter.TypeProperty:
+                            valueLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+
                             var typePropertyLength = valueLength <= scratchChars.Length ? reader.CopyString(scratchChars) : -1;
                             var typeProperty = typePropertyLength >= 0 ? scratchChars[..typePropertyLength] : reader.GetString().AsSpan();
 


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/78881 was just merged with a small bug, in that valueLength wasn't reset before it was used a second time. 

If the typeName is > 64 chars (which it should never be), then this would have thrown a different exception than it should have down a couple lines.

Also, found a way to move the logic to a shared method, which is quite a bit nicer.