### PR TITLE
Inline Hints - do not allow double click for collection expression type hint

### DIFF
--- a/src/EditorFeatures/Test2/InlineHints/CSharpInlineTypeHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/CSharpInlineTypeHintsTests.vb
@@ -936,7 +936,7 @@ class C
         End Function
 
         <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/48941")>
-        Public Async Function TestNoDoubeClickWithCollectionExpression() As Task
+        Public Async Function TestNoDoubleClickWithCollectionExpression() As Task
             Dim input =
             <Workspace>
                 <Project Language="C#" CommonReferences="true">

--- a/src/EditorFeatures/Test2/InlineHints/CSharpInlineTypeHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/CSharpInlineTypeHintsTests.vb
@@ -934,5 +934,34 @@ class C
 
             Await VerifyTypeHints(input, output)
         End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/48941")>
+        Public Async Function TestNoDoubeClickWithCollectionExpression() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class A
+{
+    private static readonly ImmutableHashSet&lt;string?&gt; Hashes = {| ImmutableHashSet&lt;string?&gt;:|}[];
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class A
+{
+    private static readonly ImmutableHashSet&lt;string?&gt; Hashes = [];
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyTypeHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineTypeHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineTypeHintsService.cs
@@ -105,7 +105,7 @@ internal sealed class CSharpInlineTypeHintsService() : AbstractInlineTypeHintsSe
                 if (IsValidType(type))
                 {
                     var span = new TextSpan(collectionExpression.OpenBracketToken.SpanStart, 0);
-                    return new(type, span, new TextChange(span, GetTypeDisplayString(type)), leadingSpace: true);
+                    return new(type, span, textChange: null, leadingSpace: true);
                 }
             }
         }

--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineTypeHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineTypeHintsService.cs
@@ -105,6 +105,9 @@ internal sealed class CSharpInlineTypeHintsService() : AbstractInlineTypeHintsSe
                 if (IsValidType(type))
                 {
                     var span = new TextSpan(collectionExpression.OpenBracketToken.SpanStart, 0);
+
+                    // We pass null for the TextChange in collection expressions because
+                    // inserting with the type is incorrect and will make the code uncompilable.
                     return new(type, span, textChange: null, leadingSpace: true);
                 }
             }


### PR DESCRIPTION
Fixes: #78818 