### PR TITLE
Re-enable IDE0051

### DIFF
--- a/src/Compilers/.editorconfig
+++ b/src/Compilers/.editorconfig
@@ -12,9 +12,6 @@ dotnet_diagnostic.RS0100.severity = none
 # RS0102: Braces must not have blank lines between them
 dotnet_diagnostic.RS0102.severity = none
 
-# IDE0051: Unused member
-dotnet_diagnostic.IDE0051.severity = none
-
 # IDE0170: Prefer extended property pattern
 dotnet_diagnostic.IDE0170.severity = suggestion
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6660,7 +6660,7 @@ class myClass
         }
 
         [ConditionalFact(typeof(WindowsOnly))]
-        private void SourceFileQuoting()
+        public void SourceFileQuoting()
         {
             string[] responseFile = new string[] {
                 @"d:\\""abc def""\baz.cs ab""c d""e.cs",
@@ -12060,7 +12060,6 @@ System.NotImplementedException: 28
 
             Assert.Equal(0, result.ExitCode);
         }
-#endif
 
         private static ImmutableArray<byte> CreateCSharpAnalyzerNetStandard13(string analyzerAssemblyName)
         {
@@ -12220,6 +12219,8 @@ public class TestAnalyzer : DiagnosticAnalyzer
 
             return analyzerImage;
         }
+
+#endif
 
         [WorkItem(406649, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=484417")]
         [ConditionalFact(typeof(WindowsDesktopOnly), typeof(IsEnglishLocal), Reason = "https://github.com/dotnet/roslyn/issues/30321")]

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/List/IEnumerable.Generic.Tests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/List/IEnumerable.Generic.Tests.cs
@@ -155,37 +155,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             RepeatTest((e, i, it) => testCode(e, i), iters);
         }
 
-        private void VerifyModifiedEnumerator(
-            IEnumerator<T> enumerator,
-            object expectedCurrent,
-            bool expectCurrentThrow,
-            bool atEnd)
-        {
-            if (expectCurrentThrow)
-            {
-                Assert.Throws<InvalidOperationException>(
-                    () => enumerator.Current);
-            }
-            else
-            {
-                object? current = enumerator.Current;
-                for (int i = 0; i < 3; i++)
-                {
-                    Assert.Equal(expectedCurrent, current);
-                    current = enumerator.Current;
-                }
-            }
-
-            Assert.Throws<InvalidOperationException>(
-                () => enumerator.MoveNext());
-
-            if (!!ResetImplemented)
-            {
-                Assert.Throws<InvalidOperationException>(
-                    () => enumerator.Reset());
-            }
-        }
-
         private void VerifyEnumerator(
             IEnumerator<T> enumerator,
             T[] expectedItems)

--- a/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
+++ b/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
@@ -38,11 +38,6 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
             FilePathToStreamMap.Add(Path.Combine(BuildPaths.WorkingDirectory, filePath), new TestableFile(content));
         }
 
-        private void AddReference(string filePath, byte[] imageBytes)
-        {
-            FilePathToStreamMap.Add(Path.Combine(BuildPaths.SdkDirectory!, filePath), new TestableFile(imageBytes));
-        }
-
         private void AddOutputFile(ref string? filePath)
         {
             if (filePath is object)

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -175,19 +175,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return $"'{prefix} ... {suffix}'";
         }
 
-        private static bool ShouldLogType(IOperation operation)
-        {
-            var operationKind = (int)operation.Kind;
-
-            // Expressions
-            if (operationKind >= 0x100 && operationKind < 0x400)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         protected void LogString(string str)
         {
             if (_pendingIndent)
@@ -407,11 +394,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             where T : IOperation
         {
             VisitArrayCommon(list, header, logElementCount, logNullForDefault, o => Visit(o));
-        }
-
-        private void VisitArray(ImmutableArray<ISymbol> list, string header, bool logElementCount, bool logNullForDefault = false)
-        {
-            VisitArrayCommon(list, header, logElementCount, logNullForDefault, VisitSymbolArrayElement);
         }
 
         private void VisitArray(ImmutableArray<string> list, string header, bool logElementCount, bool logNullForDefault = false)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -519,12 +519,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return _lazyNetModuleAttributesBag
         End Function
 
-        Private Function GetNetModuleAttributes() As ImmutableArray(Of VisualBasicAttributeData)
-            Dim attributesBag = Me.GetNetModuleAttributesBag()
-            Debug.Assert(attributesBag.IsSealed)
-            Return attributesBag.Attributes
-        End Function
-
         Friend Function GetNetModuleDecodedWellKnownAttributeData() As CommonAssemblyWellKnownAttributeData
             Dim attributesBag = Me.GetNetModuleAttributesBag()
             Debug.Assert(attributesBag.IsSealed)


### PR DESCRIPTION
This re-enables the unused member analyzer and removes all of the methods it flagged as unused.