### PR TITLE
Fix nullable analysis involving extensions and collection expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -123,9 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return null;
                 }
 
-                // See NullableWalker.VisitCollectionExpression.getCollectionDetails() which
-                // does not have an element type for the ImplementsIEnumerable case.
-                bool hasElementType = node.CollectionTypeKind is not (CollectionExpressionTypeKind.None or CollectionExpressionTypeKind.ImplementsIEnumerable);
+                bool hasElementType = node.CollectionTypeKind is not CollectionExpressionTypeKind.None;
                 foreach (var element in node.Elements)
                 {
                     if (element is BoundCollectionExpressionSpreadElement spread)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3870,6 +3870,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         SetUnknownResultNullability(node.Placeholder);
 
                         var argIndex = initializer.AddMethod.IsExtensionMethod ? 1 : 0;
+                        Debug.Assert(initializer.ArgsToParamsOpt.IsDefault);
                         var addArgument = initializer.Arguments[argIndex];
                         VisitRvalue(addArgument);
                         var addArgumentResult = _visitResult;
@@ -3878,14 +3879,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // Reinfer the addMethod signature and convert the argument to parameter type
                             var addMethod = initializer.AddMethod;
-                            MethodSymbol reinferredAddMethod = addMethod;
+                            MethodSymbol reinferredAddMethod;
                             if (!addMethod.IsExtensionMethod)
                             {
                                 reinferredAddMethod = (MethodSymbol)AsMemberOfType(targetCollectionType, addMethod);
                             }
-                            // TODO: test extension method scenario
+                            else
+                            {
+                                // https://github.com/dotnet/roslyn/issues/68786: reinfer type arguments of a generic extension Add method
+                                reinferredAddMethod = addMethod;
+                            }
 
-                            Debug.Assert(initializer.ArgsToParamsOpt.IsDefault);
                             var reinferredParameter = reinferredAddMethod.Parameters[argIndex];
                             var resultType = VisitConversion(
                                 conversionOpt: null,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3866,7 +3866,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // We do not analyze the full call or all the arguments.
                         // We only analyze the single argument that represents the collection-expression element.
                         SetUnknownResultNullability(initializer);
-                        Debug.Assert(node.Placeholder is not null);
+                        Debug.Assert(node.Placeholder is { });
                         SetUnknownResultNullability(node.Placeholder);
 
                         var argIndex = initializer.AddMethod.IsExtensionMethod ? 1 : 0;
@@ -3939,11 +3939,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else
                         {
-                            var completion1 = VisitOptionalImplicitConversion(elementExpr, targetElementType,
+                            var completion = VisitOptionalImplicitConversion(elementExpr, targetElementType,
                                 useLegacyWarnings: false, trackMembers: false, AssignmentKind.Assignment, delayCompletionForTargetType: true).completion;
 
-                            Debug.Assert(completion1 is not null);
-                            elementConversionCompletions.Add((elementType, _) => completion1(elementType));
+                            Debug.Assert(completion is not null);
+                            elementConversionCompletions.Add((elementType, _) => completion(elementType));
                         }
                         break;
                 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -14077,9 +14077,9 @@ namespace System
                     {
                         S<object?> x = [1];
                         x[0].ToString(); // 1
-                        S<object> y = [null];
+                        S<object> y = [null]; // 2
                         y[0].ToString();
-                        y = [2, null];
+                        y = [2, null]; // 3
                         y[1].ToString();
                     }
                 }
@@ -14088,7 +14088,13 @@ namespace System
             comp.VerifyEmitDiagnostics(
                 // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         x[0].ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x[0]").WithLocation(14, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x[0]").WithLocation(14, 9),
+                // (15,24): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         S<object> y = [null]; // 2
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(15, 24),
+                // (17,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         y = [2, null]; // 3
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(17, 17));
         }
 
         [Fact]
@@ -31966,8 +31972,10 @@ partial class Program
                 }
                 """;
 
-            // We don't analyze the Add methods
-            CreateCompilation(src).VerifyEmitDiagnostics();
+            CreateCompilation(src).VerifyEmitDiagnostics(
+                // (5,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                // CNotNull x1 = [null];
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(5, 16));
         }
 
         [Fact]
@@ -31990,7 +31998,7 @@ partial class Program
                 M(CreateUnannotated(maybeNull), [maybeNull]);
                 M(CreateUnannotated(maybeNull), [notNull]);
 
-                M(CreateUnannotated(notNull), [maybeNull]);
+                M(CreateUnannotated(notNull), [maybeNull]); // 1
                 M(CreateUnannotated(notNull), [notNull]);
 
                 void M<T>(T t1, T t2) { }
@@ -32011,8 +32019,10 @@ partial class Program
                 }
                 """;
 
-            // We don't analyze the Add methods
-            CreateCompilation(source).VerifyEmitDiagnostics();
+            CreateCompilation(source).VerifyEmitDiagnostics(
+                // (17,32): warning CS8604: Possible null reference argument for parameter 't' in 'void CUnannotated<object>.Add(object t)'.
+                // M(CreateUnannotated(notNull), [maybeNull]);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "maybeNull").WithArguments("t", "void CUnannotated<object>.Add(object t)").WithLocation(17, 32));
         }
 
         [Fact]
@@ -32041,8 +32051,10 @@ partial class Program
                 }
                 """;
 
-            // We don't analyze the Add methods
-            CreateCompilation(source).VerifyEmitDiagnostics();
+            CreateCompilation(source).VerifyEmitDiagnostics(
+                // (8,13): warning CS8604: Possible null reference argument for parameter 't' in 'void C.Add<object>(object t)'.
+                // M(new C(), [maybeNull]);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "maybeNull").WithArguments("t", "void C.Add<object>(object t)").WithLocation(8, 13));
         }
 
         [Fact]
@@ -32088,15 +32100,10 @@ partial class Program
                 }
                 """;
 
-            // note that the nullability of the Add parameter doesn't matter at all for collection expr analysis.
-            // We simply infer an element type and then convert the elements to it.
             CreateCompilation(source).VerifyEmitDiagnostics(
-                // (11,30): warning CS8601: Possible null reference assignment.
-                // M(CreateAnnotated(notNull), [maybeNull]);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "maybeNull").WithLocation(11, 30),
-                // (17,32): warning CS8601: Possible null reference assignment.
-                // M(CreateUnannotated(notNull), [maybeNull]);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "maybeNull").WithLocation(17, 32));
+                // (17,32): warning CS8604: Possible null reference argument for parameter 't' in 'void CUnannotated<object>.Add(object t)'.
+                // M(CreateUnannotated(notNull), [maybeNull]); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "maybeNull").WithArguments("t", "void CUnannotated<object>.Add(object t)").WithLocation(17, 32));
         }
 
         [Fact]
@@ -32110,7 +32117,7 @@ partial class Program
                 object? maybeNull = null;
                 object? notNull = new object();
 
-                M(new C(), [maybeNull]);
+                M(new C(), [maybeNull]); // 1
                 C c1 = [maybeNull];
 
                 M(new C(), [notNull]);
@@ -32126,8 +32133,10 @@ partial class Program
                 }
                 """;
 
-            // We don't analyze the Add methods
-            CreateCompilation(source).VerifyEmitDiagnostics();
+            CreateCompilation(source).VerifyEmitDiagnostics(
+                // (8,13): warning CS8604: Possible null reference argument for parameter 't' in 'void C.Add<object>(object t)'.
+                // M(new C(), [maybeNull]); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "maybeNull").WithArguments("t", "void C.Add<object>(object t)").WithLocation(8, 13));
         }
 
         [Fact]
@@ -32141,13 +32150,13 @@ partial class Program
                 object? maybeNull = null;
                 object notNull = new object();
 
-                CAnnotated<object> c1 = [maybeNull]; // 1
+                CAnnotated<object> c1 = [maybeNull];
                 CAnnotated<object?> c2 = [maybeNull];
 
                 CAnnotated<object> c3 = [notNull];
                 CAnnotated<object?> c4 = [notNull];
 
-                CUnannotated<object> c5 = [maybeNull]; // 2
+                CUnannotated<object> c5 = [maybeNull]; // 1
                 CUnannotated<object?> c6 = [maybeNull];
 
                 CUnannotated<object> c7 = [notNull];
@@ -32169,12 +32178,9 @@ partial class Program
                 """;
 
             CreateCompilation(source).VerifyEmitDiagnostics(
-                // (8,26): warning CS8601: Possible null reference assignment.
-                // CAnnotated<object> c1 = [maybeNull]; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "maybeNull").WithLocation(8, 26),
-                // (14,28): warning CS8601: Possible null reference assignment.
-                // CUnannotated<object> c5 = [maybeNull]; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "maybeNull").WithLocation(14, 28));
+                // (14,28): warning CS8604: Possible null reference argument for parameter 't' in 'void CUnannotated<object>.Add(object t)'.
+                // CUnannotated<object> c5 = [maybeNull]; // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "maybeNull").WithArguments("t", "void CUnannotated<object>.Add(object t)").WithLocation(14, 28));
         }
 
         [Fact]
@@ -32191,13 +32197,13 @@ partial class Program
                 M(CreateAnnotated(maybeNull), [maybeNull]);
                 M(CreateAnnotated(maybeNull), [notNull]);
 
-                M(CreateAnnotated(notNull), [maybeNull]); // 1
+                M(CreateAnnotated(notNull), [maybeNull]);
                 M(CreateAnnotated(notNull), [notNull]);
 
-                M(CreateUnannotated(maybeNull), [maybeNull]);
+                M(CreateUnannotated(maybeNull), [maybeNull]); // 1
                 M(CreateUnannotated(maybeNull), [notNull]);
 
-                M(CreateUnannotated(notNull), [maybeNull]); // 2
+                M(CreateUnannotated(notNull), [maybeNull]); // 1
                 M(CreateUnannotated(notNull), [notNull]);
 
                 void M<T>(T t1, T t2) { }
@@ -32221,12 +32227,9 @@ partial class Program
                 """;
 
             CreateCompilation(source).VerifyEmitDiagnostics(
-                // (11,30): warning CS8601: Possible null reference assignment.
-                // M(CreateAnnotated(notNull), [maybeNull]); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "maybeNull").WithLocation(11, 30),
-                // (17,32): warning CS8601: Possible null reference assignment.
-                // M(CreateUnannotated(notNull), [maybeNull]); // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "maybeNull").WithLocation(17, 32));
+                // (14,34): warning CS8604: Possible null reference argument for parameter 'u' in 'void CUnannotated<object?>.Add<object>(object u)'.
+                // M(CreateUnannotated(maybeNull), [maybeNull]);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "maybeNull").WithArguments("u", "void CUnannotated<object?>.Add<object>(object u)").WithLocation(14, 34));
         }
 
         [Fact]
@@ -32490,9 +32493,9 @@ partial class Program
                 """;
 
             var comp = CreateCompilation(src).VerifyEmitDiagnostics(
-                // (6,26): warning CS8619: Nullability of reference types in value of type 'Container<string?>' doesn't match target type 'Container<string>'.
+                // (6,26): warning CS8620: Argument of type 'Container<string?>' cannot be used for parameter 'item' of type 'Container<string>' in 'void List<Container<string>>.Add(Container<string> item)' due to differences in the nullability of reference types.
                 // var collection = IdList([element1, element2]); // 1
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "element1").WithArguments("Container<string?>", "Container<string>").WithLocation(6, 26));
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "element1").WithArguments("Container<string?>", "Container<string>", "item", "void List<Container<string>>.Add(Container<string> item)").WithLocation(6, 26));
 
             var tree = comp.SyntaxTrees.First();
             var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "IdList([element1, element2])");

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -40061,9 +40061,16 @@ public class MyCollection : IEnumerable<object>
 """;
         // Tracked by https://github.com/dotnet/roslyn/issues/78828 : missing nullability diagnostic
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
+        comp.VerifyEmitDiagnostics(
+            // (7,19): warning CS8601: Possible null reference assignment.
+            // MyCollection c = [oNull, oNotNull];
+            Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "oNull").WithLocation(7, 19));
+    }
 
-        src = """
+    [Fact]
+    public void Nullability_CollectionExpression_Add_01_Classic()
+    {
+        var src = """
 #nullable enable
 using System.Collections;
 using System.Collections.Generic;
@@ -40083,15 +40090,11 @@ public class MyCollection : IEnumerable<object>
     IEnumerator IEnumerable.GetEnumerator() => throw null!;
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/78452 : assertion hit during nullability analysis
-        try
-        {
-            comp = CreateCompilation(src);
-            comp.VerifyEmitDiagnostics();
-        }
-        catch (InvalidOperationException)
-        {
-        }
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (7,19): warning CS8601: Possible null reference assignment.
+            // MyCollection c = [oNull, oNotNull];
+            Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "oNull").WithLocation(7, 19));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -40059,12 +40059,11 @@ public class MyCollection : IEnumerable<object>
     IEnumerator IEnumerable.GetEnumerator() => throw null!;
 }
 """;
-        // Tracked by https://github.com/dotnet/roslyn/issues/78828 : missing nullability diagnostic
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
-            // (7,19): warning CS8601: Possible null reference assignment.
+            // (7,19): warning CS8604: Possible null reference argument for parameter 'o' in 'void extension(MyCollection).Add(object o)'.
             // MyCollection c = [oNull, oNotNull];
-            Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "oNull").WithLocation(7, 19));
+            Diagnostic(ErrorCode.WRN_NullReferenceArgument, "oNull").WithArguments("o", "void extension(MyCollection).Add(object o)").WithLocation(7, 19));
     }
 
     [Fact]
@@ -40092,9 +40091,9 @@ public class MyCollection : IEnumerable<object>
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics(
-            // (7,19): warning CS8601: Possible null reference assignment.
+            // (7,19): warning CS8604: Possible null reference argument for parameter 'o' in 'void E.Add(MyCollection c, object o)'.
             // MyCollection c = [oNull, oNotNull];
-            Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "oNull").WithLocation(7, 19));
+            Diagnostic(ErrorCode.WRN_NullReferenceArgument, "oNull").WithArguments("o", "void E.Add(MyCollection c, object o)").WithLocation(7, 19));
     }
 
     [Fact]


### PR DESCRIPTION
Related to #78828 (fixes an assertion failure for a collection-expression involving extension Add)
Related to #68786.

I decided to go ahead and implement analysis of the mainline case of `List<string> list = [null];` for example as there have been multiple bug reports about the diagnostic being missing. Analysis of extension Add methods is punted as it seems much less common.