### PR TITLE
Expose a couple of things to Razor

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/Constants.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Constants.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.LanguageServer;
-using Roslyn.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
 
 internal static class Constants
 {
     public const string RazorLanguageName = LanguageInfoProvider.RazorLanguageName;
+
+    public const string CompleteComplexEditCommand = CompletionResultFactory.CompleteComplexEditCommand;
 }

--- a/src/Tools/ExternalAccess/Razor/Features/RazorCSharpFormattingInteractionService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorCSharpFormattingInteractionService.cs
@@ -8,13 +8,13 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
@@ -23,6 +23,24 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     /// </summary>
     internal static class RazorCSharpFormattingInteractionService
     {
+        [Obsolete("This overload is for binary compat only. Use GetFormattingChangesAsync with all parameters instead.")]
+        public static Task<ImmutableArray<TextChange>> GetFormattingChangesAsync(
+            Document document,
+            char typedChar,
+            int position,
+            RazorIndentationOptions indentationOptions,
+            RazorAutoFormattingOptions autoFormattingOptions,
+            FormattingOptions.IndentStyle indentStyle,
+            CancellationToken cancellationToken)
+            => GetFormattingChangesAsync(
+                document,
+                typedChar,
+                position,
+                indentationOptions,
+                autoFormattingOptions,
+                indentStyle,
+                csharpSyntaxFormattingOptionsOverride: null,
+                cancellationToken);
 
         /// <summary>
         /// Returns the text changes necessary to format the document after the user enters a 
@@ -36,6 +54,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             RazorIndentationOptions indentationOptions,
             RazorAutoFormattingOptions autoFormattingOptions,
             FormattingOptions.IndentStyle indentStyle,
+            RazorCSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptionsOverride,
             CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(document.Project.Language is LanguageNames.CSharp);
@@ -44,10 +63,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
             if (!formattingService.ShouldFormatOnTypedCharacter(documentSyntax, typedChar, position, cancellationToken))
             {
-                return ImmutableArray<TextChange>.Empty;
+                return [];
             }
 
-            var formattingOptions = GetFormattingOptions(document.Project.Solution.Services, indentationOptions);
+            var formattingOptions = GetFormattingOptions(document.Project.Solution.Services, indentationOptions, csharpSyntaxFormattingOptionsOverride);
             var roslynIndentationOptions = new IndentationOptions(formattingOptions)
             {
                 AutoFormattingOptions = autoFormattingOptions.UnderlyingObject,
@@ -57,33 +76,63 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             return formattingService.GetFormattingChangesOnTypedCharacter(documentSyntax, position, roslynIndentationOptions, cancellationToken);
         }
 
+        [Obsolete("This overload is for binary compat only. Use GetFormattingChangesAsync with all parameters instead.")]
         public static IList<TextChange> GetFormattedTextChanges(
             HostWorkspaceServices services,
             SyntaxNode root,
             TextSpan span,
             RazorIndentationOptions indentationOptions,
             CancellationToken cancellationToken)
+            => GetFormattedTextChanges(
+                services,
+                root,
+                span,
+                indentationOptions,
+                csharpSyntaxFormattingOptionsOverride: null,
+                cancellationToken);
+
+        public static IList<TextChange> GetFormattedTextChanges(
+            HostWorkspaceServices services,
+            SyntaxNode root,
+            TextSpan span,
+            RazorIndentationOptions indentationOptions,
+            RazorCSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptionsOverride,
+            CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(root.Language is LanguageNames.CSharp);
-            return Formatter.GetFormattedTextChanges(root, span, services.SolutionServices, GetFormattingOptions(services.SolutionServices, indentationOptions), cancellationToken);
+            return Formatter.GetFormattedTextChanges(root, span, services.SolutionServices, GetFormattingOptions(services.SolutionServices, indentationOptions, csharpSyntaxFormattingOptionsOverride), cancellationToken);
         }
 
+        [Obsolete("This overload is for binary compat only. Use GetFormattingChangesAsync with all parameters instead.")]
         public static SyntaxNode Format(
             HostWorkspaceServices services,
             SyntaxNode root,
             RazorIndentationOptions indentationOptions,
             CancellationToken cancellationToken)
+            => Format(
+                services,
+                root,
+                indentationOptions,
+                csharpSyntaxFormattingOptionsOverride: null,
+                cancellationToken);
+
+        public static SyntaxNode Format(
+            HostWorkspaceServices services,
+            SyntaxNode root,
+            RazorIndentationOptions indentationOptions,
+            RazorCSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptionsOverride,
+            CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(root.Language is LanguageNames.CSharp);
-            return Formatter.Format(root, services.SolutionServices, GetFormattingOptions(services.SolutionServices, indentationOptions), cancellationToken: cancellationToken);
+            return Formatter.Format(root, services.SolutionServices, GetFormattingOptions(services.SolutionServices, indentationOptions, csharpSyntaxFormattingOptionsOverride), cancellationToken: cancellationToken);
         }
 
-        private static SyntaxFormattingOptions GetFormattingOptions(SolutionServices services, RazorIndentationOptions indentationOptions)
+        private static SyntaxFormattingOptions GetFormattingOptions(SolutionServices services, RazorIndentationOptions indentationOptions, RazorCSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptionsOverride)
         {
             var legacyOptionsService = services.GetService<ILegacyGlobalOptionsWorkspaceService>();
-            var formattingOptions = legacyOptionsService is null
-                ? new CSharpSyntaxFormattingOptions()
-                : legacyOptionsService.GetSyntaxFormattingOptions(services.GetLanguageServices(LanguageNames.CSharp));
+            var formattingOptions = csharpSyntaxFormattingOptionsOverride?.ToCSharpSyntaxFormattingOptions()
+                ?? legacyOptionsService?.GetSyntaxFormattingOptions(services.GetLanguageServices(LanguageNames.CSharp))
+                ?? new CSharpSyntaxFormattingOptions();
 
             return formattingOptions with
             {

--- a/src/Tools/ExternalAccess/Razor/Features/RazorCSharpFormattingInteractionService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorCSharpFormattingInteractionService.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             var legacyOptionsService = services.GetService<ILegacyGlobalOptionsWorkspaceService>();
             var formattingOptions = csharpSyntaxFormattingOptionsOverride?.ToCSharpSyntaxFormattingOptions()
                 ?? legacyOptionsService?.GetSyntaxFormattingOptions(services.GetLanguageServices(LanguageNames.CSharp))
-                ?? new CSharpSyntaxFormattingOptions();
+                ?? CSharpSyntaxFormattingOptions.Default;
 
             return formattingOptions with
             {

--- a/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
@@ -11,61 +11,42 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features
     /// <summary>
     /// Wrapper for CSharpSyntaxFormattingOptions for Razor external access.
     /// </summary>
-    internal sealed record class RazorCSharpSyntaxFormattingOptions
+    internal sealed record class RazorCSharpSyntaxFormattingOptions(
+        RazorSpacePlacement Spacing,
+        RazorBinaryOperatorSpacingOptions SpacingAroundBinaryOperator,
+        RazorNewLinePlacement NewLines,
+        RazorLabelPositionOptions LabelPositioning,
+        RazorIndentationPlacement Indentation,
+        bool WrappingKeepStatementsOnSingleLine,
+        bool WrappingPreserveSingleLine,
+        RazorNamespaceDeclarationPreference NamespaceDeclarations,
+        bool PreferTopLevelStatements,
+        int CollectionExpressionWrappingLength)
     {
-        public RazorSpacePlacement Spacing { get; init; }
-        public RazorBinaryOperatorSpacingOptions SpacingAroundBinaryOperator { get; init; }
-        public RazorNewLinePlacement NewLines { get; init; }
-        public RazorLabelPositionOptions LabelPositioning { get; init; }
-        public RazorIndentationPlacement Indentation { get; init; }
-        public bool WrappingKeepStatementsOnSingleLine { get; init; }
-        public bool WrappingPreserveSingleLine { get; init; }
-        public RazorNamespaceDeclarationPreference NamespaceDeclarations { get; init; }
-        public bool PreferTopLevelStatements { get; init; }
-        public int CollectionExpressionWrappingLength { get; init; }
+        public static readonly RazorCSharpSyntaxFormattingOptions Default = new();
 
-        public RazorCSharpSyntaxFormattingOptions(
-            RazorSpacePlacement spacing,
-            RazorBinaryOperatorSpacingOptions spacingAroundBinaryOperator,
-            RazorNewLinePlacement newLines,
-            RazorLabelPositionOptions labelPositioning,
-            RazorIndentationPlacement indentation,
-            bool wrappingKeepStatementsOnSingleLine,
-            bool wrappingPreserveSingleLine,
-            RazorNamespaceDeclarationPreference namespaceDeclarations,
-            bool preferTopLevelStatements,
-            int collectionExpressionWrappingLength)
+        private RazorCSharpSyntaxFormattingOptions()
+            : this(CSharpSyntaxFormattingOptions.Default)
         {
-            Spacing = spacing;
-            SpacingAroundBinaryOperator = spacingAroundBinaryOperator;
-            NewLines = newLines;
-            LabelPositioning = labelPositioning;
-            Indentation = indentation;
-            WrappingKeepStatementsOnSingleLine = wrappingKeepStatementsOnSingleLine;
-            WrappingPreserveSingleLine = wrappingPreserveSingleLine;
-            NamespaceDeclarations = namespaceDeclarations;
-            PreferTopLevelStatements = preferTopLevelStatements;
-            CollectionExpressionWrappingLength = collectionExpressionWrappingLength;
         }
 
-        public RazorCSharpSyntaxFormattingOptions()
+        public RazorCSharpSyntaxFormattingOptions(CSharpSyntaxFormattingOptions options)
+            : this(
+                (RazorSpacePlacement)options.Spacing,
+                (RazorBinaryOperatorSpacingOptions)options.SpacingAroundBinaryOperator,
+                (RazorNewLinePlacement)options.NewLines,
+                (RazorLabelPositionOptions)options.LabelPositioning,
+                (RazorIndentationPlacement)options.Indentation,
+                options.WrappingKeepStatementsOnSingleLine,
+                options.WrappingPreserveSingleLine,
+                (RazorNamespaceDeclarationPreference)options.NamespaceDeclarations.Value,
+                options.PreferTopLevelStatements.Value,
+                options.CollectionExpressionWrappingLength)
         {
-            var options = CSharpSyntaxFormattingOptions.Default;
-            Spacing = (RazorSpacePlacement)options.Spacing;
-            SpacingAroundBinaryOperator = (RazorBinaryOperatorSpacingOptions)options.SpacingAroundBinaryOperator;
-            NewLines = (RazorNewLinePlacement)options.NewLines;
-            LabelPositioning = (RazorLabelPositionOptions)options.LabelPositioning;
-            Indentation = (RazorIndentationPlacement)options.Indentation;
-            WrappingKeepStatementsOnSingleLine = options.WrappingKeepStatementsOnSingleLine;
-            WrappingPreserveSingleLine = options.WrappingPreserveSingleLine;
-            NamespaceDeclarations = (RazorNamespaceDeclarationPreference)options.NamespaceDeclarations.Value;
-            PreferTopLevelStatements = options.PreferTopLevelStatements.Value;
-            CollectionExpressionWrappingLength = options.CollectionExpressionWrappingLength;
         }
 
         public CSharpSyntaxFormattingOptions ToCSharpSyntaxFormattingOptions()
-        {
-            return new CSharpSyntaxFormattingOptions
+            => new()
             {
                 Spacing = (SpacePlacement)Spacing,
                 SpacingAroundBinaryOperator = (BinaryOperatorSpacingOptions)SpacingAroundBinaryOperator,
@@ -82,7 +63,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features
                     CSharpSyntaxFormattingOptions.Default.PreferTopLevelStatements.Notification),
                 CollectionExpressionWrappingLength = CollectionExpressionWrappingLength
             };
-        }
     }
 
     [Flags]

--- a/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
@@ -89,83 +89,80 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features
     public enum RazorSpacePlacement
     {
         None = 0,
-        IgnoreAroundVariableDeclaration = 1,
-        AfterMethodDeclarationName = 1 << 1,
-        BetweenEmptyMethodDeclarationParentheses = 1 << 2,
-        WithinMethodDeclarationParenthesis = 1 << 3,
-        AfterMethodCallName = 1 << 4,
-        BetweenEmptyMethodCallParentheses = 1 << 5,
-        WithinMethodCallParentheses = 1 << 6,
-        AfterControlFlowStatementKeyword = 1 << 7,
-        WithinExpressionParentheses = 1 << 8,
-        WithinCastParentheses = 1 << 9,
-        BeforeSemicolonsInForStatement = 1 << 10,
-        AfterSemicolonsInForStatement = 1 << 11,
-        WithinOtherParentheses = 1 << 12,
-        AfterCast = 1 << 13,
-        BeforeOpenSquareBracket = 1 << 14,
-        BetweenEmptySquareBrackets = 1 << 15,
-        WithinSquareBrackets = 1 << 16,
-        AfterColonInBaseTypeDeclaration = 1 << 17,
-        BeforeColonInBaseTypeDeclaration = 1 << 18,
-        AfterComma = 1 << 19,
-        BeforeComma = 1 << 20,
-        AfterDot = 1 << 21,
-        BeforeDot = 1 << 22,
-        All = (1 << 23) - 1
+        IgnoreAroundVariableDeclaration = SpacePlacement.IgnoreAroundVariableDeclaration,
+        AfterMethodDeclarationName = SpacePlacement.AfterMethodDeclarationName,
+        BetweenEmptyMethodDeclarationParentheses = SpacePlacement.BetweenEmptyMethodDeclarationParentheses,
+        WithinMethodDeclarationParenthesis = SpacePlacement.WithinMethodDeclarationParenthesis,
+        AfterMethodCallName = SpacePlacement.AfterMethodCallName,
+        BetweenEmptyMethodCallParentheses = SpacePlacement.BetweenEmptyMethodCallParentheses,
+        WithinMethodCallParentheses = SpacePlacement.WithinMethodCallParentheses,
+        AfterControlFlowStatementKeyword = SpacePlacement.AfterControlFlowStatementKeyword,
+        WithinExpressionParentheses = SpacePlacement.WithinExpressionParentheses,
+        WithinCastParentheses = SpacePlacement.WithinCastParentheses,
+        BeforeSemicolonsInForStatement = SpacePlacement.BeforeSemicolonsInForStatement,
+        AfterSemicolonsInForStatement = SpacePlacement.AfterSemicolonsInForStatement,
+        WithinOtherParentheses = SpacePlacement.WithinOtherParentheses,
+        AfterCast = SpacePlacement.AfterCast,
+        BeforeOpenSquareBracket = SpacePlacement.BeforeOpenSquareBracket,
+        BetweenEmptySquareBrackets = SpacePlacement.BetweenEmptySquareBrackets,
+        WithinSquareBrackets = SpacePlacement.WithinSquareBrackets,
+        AfterColonInBaseTypeDeclaration = SpacePlacement.AfterColonInBaseTypeDeclaration,
+        BeforeColonInBaseTypeDeclaration = SpacePlacement.BeforeColonInBaseTypeDeclaration,
+        AfterComma = SpacePlacement.AfterComma,
+        BeforeComma = SpacePlacement.BeforeComma,
+        AfterDot = SpacePlacement.AfterDot,
+        BeforeDot = SpacePlacement.BeforeDot,
     }
 
     [Flags]
     public enum RazorNewLinePlacement
     {
         None = 0,
-        BeforeMembersInObjectInitializers = 1,
-        BeforeMembersInAnonymousTypes = 1 << 1,
-        BeforeElse = 1 << 2,
-        BeforeCatch = 1 << 3,
-        BeforeFinally = 1 << 4,
-        BeforeOpenBraceInTypes = 1 << 5,
-        BeforeOpenBraceInAnonymousTypes = 1 << 6,
-        BeforeOpenBraceInObjectCollectionArrayInitializers = 1 << 7,
-        BeforeOpenBraceInProperties = 1 << 8,
-        BeforeOpenBraceInMethods = 1 << 9,
-        BeforeOpenBraceInAccessors = 1 << 10,
-        BeforeOpenBraceInAnonymousMethods = 1 << 11,
-        BeforeOpenBraceInLambdaExpressionBody = 1 << 12,
-        BeforeOpenBraceInControlBlocks = 1 << 13,
-        BetweenQueryExpressionClauses = 1 << 14,
-        All = (1 << 15) - 1
+        BeforeMembersInObjectInitializers = NewLinePlacement.BeforeMembersInObjectInitializers,
+        BeforeMembersInAnonymousTypes = NewLinePlacement.BeforeMembersInAnonymousTypes,
+        BeforeElse = NewLinePlacement.BeforeElse,
+        BeforeCatch = NewLinePlacement.BeforeCatch,
+        BeforeFinally = NewLinePlacement.BeforeFinally,
+        BeforeOpenBraceInTypes = NewLinePlacement.BeforeOpenBraceInTypes,
+        BeforeOpenBraceInAnonymousTypes = NewLinePlacement.BeforeOpenBraceInAnonymousTypes,
+        BeforeOpenBraceInObjectCollectionArrayInitializers = NewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers,
+        BeforeOpenBraceInProperties = NewLinePlacement.BeforeOpenBraceInProperties,
+        BeforeOpenBraceInMethods = NewLinePlacement.BeforeOpenBraceInMethods,
+        BeforeOpenBraceInAccessors = NewLinePlacement.BeforeOpenBraceInAccessors,
+        BeforeOpenBraceInAnonymousMethods = NewLinePlacement.BeforeOpenBraceInAnonymousMethods,
+        BeforeOpenBraceInLambdaExpressionBody = NewLinePlacement.BeforeOpenBraceInLambdaExpressionBody,
+        BeforeOpenBraceInControlBlocks = NewLinePlacement.BeforeOpenBraceInControlBlocks,
+        BetweenQueryExpressionClauses = NewLinePlacement.BetweenQueryExpressionClauses,
     }
 
     [Flags]
     public enum RazorIndentationPlacement
     {
         None = 0,
-        Braces = 1,
-        BlockContents = 1 << 1,
-        SwitchCaseContents = 1 << 2,
-        SwitchCaseContentsWhenBlock = 1 << 3,
-        SwitchSection = 1 << 4,
-        All = (1 << 5) - 1
+        Braces = IndentationPlacement.Braces,
+        BlockContents = IndentationPlacement.BlockContents,
+        SwitchCaseContents = IndentationPlacement.SwitchCaseContents,
+        SwitchCaseContentsWhenBlock = IndentationPlacement.SwitchCaseContentsWhenBlock,
+        SwitchSection = IndentationPlacement.SwitchSection,
     }
 
     public enum RazorBinaryOperatorSpacingOptions
     {
-        Single = 0,
-        Ignore = 1,
-        Remove = 2,
+        Single = BinaryOperatorSpacingOptions.Single,
+        Ignore = BinaryOperatorSpacingOptions.Ignore,
+        Remove = BinaryOperatorSpacingOptions.Remove,
     }
 
     public enum RazorLabelPositionOptions
     {
-        LeftMost = 0,
-        OneLess = 1,
-        NoIndent = 2,
+        LeftMost = LabelPositionOptions.LeftMost,
+        OneLess = LabelPositionOptions.OneLess,
+        NoIndent = LabelPositionOptions.NoIndent,
     }
 
     public enum RazorNamespaceDeclarationPreference
     {
-        BlockScoped = 0,
-        FileScoped = 1,
+        BlockScoped = NamespaceDeclarationPreference.BlockScoped,
+        FileScoped = NamespaceDeclarationPreference.FileScoped,
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features
+{
+    /// <summary>
+    /// Wrapper for CSharpSyntaxFormattingOptions for Razor external access.
+    /// </summary>
+    internal sealed record class RazorCSharpSyntaxFormattingOptions
+    {
+        public RazorSpacePlacement Spacing { get; init; }
+        public RazorBinaryOperatorSpacingOptions SpacingAroundBinaryOperator { get; init; }
+        public RazorNewLinePlacement NewLines { get; init; }
+        public RazorLabelPositionOptions LabelPositioning { get; init; }
+        public RazorIndentationPlacement Indentation { get; init; }
+        public bool WrappingKeepStatementsOnSingleLine { get; init; }
+        public bool WrappingPreserveSingleLine { get; init; }
+        public RazorNamespaceDeclarationPreference NamespaceDeclarations { get; init; }
+        public bool PreferTopLevelStatements { get; init; }
+        public int CollectionExpressionWrappingLength { get; init; }
+
+        public RazorCSharpSyntaxFormattingOptions(
+            RazorSpacePlacement spacing,
+            RazorBinaryOperatorSpacingOptions spacingAroundBinaryOperator,
+            RazorNewLinePlacement newLines,
+            RazorLabelPositionOptions labelPositioning,
+            RazorIndentationPlacement indentation,
+            bool wrappingKeepStatementsOnSingleLine,
+            bool wrappingPreserveSingleLine,
+            RazorNamespaceDeclarationPreference namespaceDeclarations,
+            bool preferTopLevelStatements,
+            int collectionExpressionWrappingLength)
+        {
+            Spacing = spacing;
+            SpacingAroundBinaryOperator = spacingAroundBinaryOperator;
+            NewLines = newLines;
+            LabelPositioning = labelPositioning;
+            Indentation = indentation;
+            WrappingKeepStatementsOnSingleLine = wrappingKeepStatementsOnSingleLine;
+            WrappingPreserveSingleLine = wrappingPreserveSingleLine;
+            NamespaceDeclarations = namespaceDeclarations;
+            PreferTopLevelStatements = preferTopLevelStatements;
+            CollectionExpressionWrappingLength = collectionExpressionWrappingLength;
+        }
+
+        public RazorCSharpSyntaxFormattingOptions()
+        {
+            var options = CSharpSyntaxFormattingOptions.Default;
+            Spacing = (RazorSpacePlacement)options.Spacing;
+            SpacingAroundBinaryOperator = (RazorBinaryOperatorSpacingOptions)options.SpacingAroundBinaryOperator;
+            NewLines = (RazorNewLinePlacement)options.NewLines;
+            LabelPositioning = (RazorLabelPositionOptions)options.LabelPositioning;
+            Indentation = (RazorIndentationPlacement)options.Indentation;
+            WrappingKeepStatementsOnSingleLine = options.WrappingKeepStatementsOnSingleLine;
+            WrappingPreserveSingleLine = options.WrappingPreserveSingleLine;
+            NamespaceDeclarations = (RazorNamespaceDeclarationPreference)options.NamespaceDeclarations.Value;
+            PreferTopLevelStatements = options.PreferTopLevelStatements.Value;
+            CollectionExpressionWrappingLength = options.CollectionExpressionWrappingLength;
+        }
+
+        public CSharpSyntaxFormattingOptions ToCSharpSyntaxFormattingOptions()
+        {
+            return new CSharpSyntaxFormattingOptions
+            {
+                Spacing = (SpacePlacement)Spacing,
+                SpacingAroundBinaryOperator = (BinaryOperatorSpacingOptions)SpacingAroundBinaryOperator,
+                NewLines = (NewLinePlacement)NewLines,
+                LabelPositioning = (LabelPositionOptions)LabelPositioning,
+                Indentation = (IndentationPlacement)Indentation,
+                WrappingKeepStatementsOnSingleLine = WrappingKeepStatementsOnSingleLine,
+                WrappingPreserveSingleLine = WrappingPreserveSingleLine,
+                NamespaceDeclarations = new CodeStyleOption2<NamespaceDeclarationPreference>(
+                    (NamespaceDeclarationPreference)NamespaceDeclarations,
+                    CSharpSyntaxFormattingOptions.Default.NamespaceDeclarations.Notification),
+                PreferTopLevelStatements = new CodeStyleOption2<bool>(
+                    PreferTopLevelStatements,
+                    CSharpSyntaxFormattingOptions.Default.PreferTopLevelStatements.Notification),
+                CollectionExpressionWrappingLength = CollectionExpressionWrappingLength
+            };
+        }
+    }
+
+    [Flags]
+    public enum RazorSpacePlacement
+    {
+        None = 0,
+        IgnoreAroundVariableDeclaration = 1,
+        AfterMethodDeclarationName = 1 << 1,
+        BetweenEmptyMethodDeclarationParentheses = 1 << 2,
+        WithinMethodDeclarationParenthesis = 1 << 3,
+        AfterMethodCallName = 1 << 4,
+        BetweenEmptyMethodCallParentheses = 1 << 5,
+        WithinMethodCallParentheses = 1 << 6,
+        AfterControlFlowStatementKeyword = 1 << 7,
+        WithinExpressionParentheses = 1 << 8,
+        WithinCastParentheses = 1 << 9,
+        BeforeSemicolonsInForStatement = 1 << 10,
+        AfterSemicolonsInForStatement = 1 << 11,
+        WithinOtherParentheses = 1 << 12,
+        AfterCast = 1 << 13,
+        BeforeOpenSquareBracket = 1 << 14,
+        BetweenEmptySquareBrackets = 1 << 15,
+        WithinSquareBrackets = 1 << 16,
+        AfterColonInBaseTypeDeclaration = 1 << 17,
+        BeforeColonInBaseTypeDeclaration = 1 << 18,
+        AfterComma = 1 << 19,
+        BeforeComma = 1 << 20,
+        AfterDot = 1 << 21,
+        BeforeDot = 1 << 22,
+        All = (1 << 23) - 1
+    }
+
+    [Flags]
+    public enum RazorNewLinePlacement
+    {
+        None = 0,
+        BeforeMembersInObjectInitializers = 1,
+        BeforeMembersInAnonymousTypes = 1 << 1,
+        BeforeElse = 1 << 2,
+        BeforeCatch = 1 << 3,
+        BeforeFinally = 1 << 4,
+        BeforeOpenBraceInTypes = 1 << 5,
+        BeforeOpenBraceInAnonymousTypes = 1 << 6,
+        BeforeOpenBraceInObjectCollectionArrayInitializers = 1 << 7,
+        BeforeOpenBraceInProperties = 1 << 8,
+        BeforeOpenBraceInMethods = 1 << 9,
+        BeforeOpenBraceInAccessors = 1 << 10,
+        BeforeOpenBraceInAnonymousMethods = 1 << 11,
+        BeforeOpenBraceInLambdaExpressionBody = 1 << 12,
+        BeforeOpenBraceInControlBlocks = 1 << 13,
+        BetweenQueryExpressionClauses = 1 << 14,
+        All = (1 << 15) - 1
+    }
+
+    [Flags]
+    public enum RazorIndentationPlacement
+    {
+        None = 0,
+        Braces = 1,
+        BlockContents = 1 << 1,
+        SwitchCaseContents = 1 << 2,
+        SwitchCaseContentsWhenBlock = 1 << 3,
+        SwitchSection = 1 << 4,
+        All = (1 << 5) - 1
+    }
+
+    public enum RazorBinaryOperatorSpacingOptions
+    {
+        Single = 0,
+        Ignore = 1,
+        Remove = 2,
+    }
+
+    public enum RazorLabelPositionOptions
+    {
+        LeftMost = 0,
+        OneLess = 1,
+        NoIndent = 2,
+    }
+
+    public enum RazorNamespaceDeclarationPreference
+    {
+        BlockScoped = 0,
+        FileScoped = 1,
+    }
+}


### PR DESCRIPTION
Allow Razor to not have to copy the complex edit command name, and override formatting settings (in tests for now, but possibly more later)

Razor side: https://github.com/dotnet/razor/pull/11949