### PR TITLE
Obsolete api

### DIFF
--- a/src/VisualStudio/Core/Def/Progression/GraphNodeCreation.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphNodeCreation.cs
@@ -2,20 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.GraphModel;
 
-#pragma warning disable IDE0060 // Remove unused parameter
-
 namespace Microsoft.VisualStudio.LanguageServices.Progression;
 
+[Obsolete("This class is not implemented and should not be used.", error: true)]
 public static class GraphNodeCreation
 {
+    [Obsolete("This method is not implemented and always returns an empty GraphNodeId.", error: true)]
     public static Task<GraphNodeId> CreateNodeIdAsync(ISymbol symbol, Solution solution, CancellationToken cancellationToken)
         => Task.FromResult(GraphNodeId.Empty);
 
+    [Obsolete("This method is not implemented and always returns an empty GraphNode.", error: true)]
     public static Task<GraphNode> CreateNodeAsync(this Graph graph, ISymbol symbol, Solution solution, CancellationToken cancellationToken)
        => Task.FromResult(graph.Nodes.GetOrCreate(GraphNodeId.Empty));
 }


### PR DESCRIPTION
This API was lifted and shifted entirely to the ManagedProvider package in azdo.

Obsoleting this fully to ensure that nothing ever uses it.  Will also take through API review to eventually make the change to remove this entirely.