### PR TITLE
Take reachability into account when rewriting `await`s in `finally` blocks

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -455,6 +455,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     deconstructStep,
                     awaitInfo,
                     body,
+                    AsyncTryFinallyEndReachable.Unknown,
                     this.BreakLabel,
                     this.ContinueLabel,
                     hasErrors);
@@ -596,6 +597,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 deconstructStep,
                 awaitInfo,
                 body,
+                AsyncTryFinallyEndReachable.Unknown,
                 this.BreakLabel,
                 this.ContinueLabel,
                 hasErrors);

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // In the future it might be better to have a separate shared type that we add the info to, and have the callers create the appropriate bound nodes from it
             if (isUsingDeclaration)
             {
-                return new BoundUsingLocalDeclarations(syntax, patternDisposeInfo, awaitOpt, declarationsOpt, hasErrors);
+                return new BoundUsingLocalDeclarations(syntax, patternDisposeInfo, awaitOpt, AsyncTryFinallyEndReachable.Unknown, declarationsOpt, hasErrors);
             }
             else
             {
@@ -178,6 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     boundBody,
                     awaitOpt,
                     patternDisposeInfo,
+                    AsyncTryFinallyEndReachable.Unknown,
                     hasErrors);
             }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/AsyncTryFinallyEndReachable.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/AsyncTryFinallyEndReachable.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+/// <summary>
+/// Tracks the reachability of the end of a bound node that either already is a try/finally, or has the potential to become one during lowering.
+/// Only nodes that can have an await in the finally block are tracked with this enum, for use in <see cref="AsyncExceptionHandlerRewriter.VisitTryStatement(BoundTryStatement)"/>.
+/// Try/finally nodes that are synthesized by the compiler during lowering and do not have an await in the finally block can use <see cref="AsyncTryFinallyEndReachable.Ignored"/>.
+/// </summary>
+internal enum AsyncTryFinallyEndReachable
+{
+    /// <summary>
+    /// The reachability of the end of the node has not been determined yet.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The end of the node is reachable.
+    /// </summary>
+    Reachable,
+
+    /// <summary>
+    /// The end of the node is unreachable.
+    /// </summary>
+    Unreachable,
+
+    /// <summary>
+    /// The reachability of the end of the node is intentionally not set. This should never be encountered in a try/finally that has an await in the finally block.
+    /// </summary>
+    Ignored
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -40,6 +40,7 @@
   <ValueType Name="CollectionExpressionTypeKind"/>
   <ValueType Name="AccessorKind" />
   <ValueType Name="SafeContext" />
+  <ValueType Name="AsyncTryFinallyEndReachable"/>
 
   <AbstractNode Name="BoundInitializer" Base="BoundNode"/>
 
@@ -1119,6 +1120,7 @@
   <Node Name="BoundUsingLocalDeclarations" Base="BoundMultipleLocalDeclarationsBase">
     <Field Name="PatternDisposeInfoOpt" Type="MethodArgumentInfo?"/>
     <Field Name="AwaitOpt" Type="BoundAwaitableInfo?"/>
+    <Field Name="EndIsReachable" Type="AsyncTryFinallyEndReachable" />
   </Node>
 
   <!-- 
@@ -1280,6 +1282,7 @@
     <Field Name="DeconstructionOpt" Type="BoundForEachDeconstructStep?"/>
     <Field Name="AwaitOpt" Type="BoundAwaitableInfo?"/>
     <Field Name="Body" Type="BoundStatement"/>
+    <Field Name="EndIsReachable" Type="AsyncTryFinallyEndReachable" />
   </Node>
 
   <!-- All the information need to apply a deconstruction at each iteration of a foreach loop involving a deconstruction-declaration. -->
@@ -1296,6 +1299,7 @@
     <Field Name="Body" Type="BoundStatement"/>
     <Field Name="AwaitOpt" Type="BoundAwaitableInfo?"/>
     <Field Name="PatternDisposeInfoOpt" Type="MethodArgumentInfo?"/>
+    <Field Name="EndIsReachable" Type="AsyncTryFinallyEndReachable" />
   </Node>
 
   <Node Name="BoundFixedStatement" Base="BoundStatement">
@@ -1309,7 +1313,7 @@
     <Field Name="Body" Type="BoundStatement"/>
   </Node>
 
-  <Node Name="BoundTryStatement" Base="BoundStatement">
+  <Node Name="BoundTryStatement" Base="BoundStatement" HasValidate="true">
     <Field Name="TryBlock" Type="BoundBlock"/>
     <Field Name="CatchBlocks" Type="ImmutableArray&lt;BoundCatchBlock&gt;"/>
     <Field Name="FinallyBlockOpt" Type="BoundBlock?"/>
@@ -1349,6 +1353,8 @@
     -->
     
     <Field Name="PreferFaultHandler" Type="bool"/>
+
+    <Field Name="EndIsReachable" Type="AsyncTryFinallyEndReachable" />
   </Node>
 
   <Node Name="BoundCatchBlock" Base="BoundNode">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTryStatement.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTryStatement.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+internal partial class BoundTryStatement : BoundStatement
+{
+    private partial void Validate()
+    {
+#if DEBUG
+        if (EndIsReachable == AsyncTryFinallyEndReachable.Ignored && FinallyBlockOpt != null)
+        {
+            Debug.Assert(!AsyncExceptionHandlerRewriter.AwaitsInFinally(this),
+                "There are awaits in this finally block, reachability cannot be ignored! Ensure that valid reachability " +
+                "is set for this try statement, and ensure that we have async tests for the case where the end of the " +
+                "try is not reachable and the construct is in a Task<T> or ValueTask<T>-returning method, and runtime " +
+                "async is enabled for the test case to ensure that we not branching to invalid locations.");
+        }
+#endif
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -613,8 +613,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundTryStatement
     {
-        public BoundTryStatement(SyntaxNode syntax, BoundBlock tryBlock, ImmutableArray<BoundCatchBlock> catchBlocks, BoundBlock? finallyBlockOpt, LabelSymbol? finallyLabelOpt = null)
-            : this(syntax, tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, preferFaultHandler: false, hasErrors: false)
+        public BoundTryStatement(SyntaxNode syntax, BoundBlock tryBlock, ImmutableArray<BoundCatchBlock> catchBlocks, BoundBlock? finallyBlockOpt, AsyncTryFinallyEndReachable endIsReachable, LabelSymbol? finallyLabelOpt = null)
+            : this(syntax, tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, preferFaultHandler: false, endIsReachable: endIsReachable, hasErrors: false)
         {
         }
     }

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1676,7 +1676,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             EnsureOnlyEvalStack();
 
-            return node.Update(tryBlock, catchBlocks, finallyBlock, finallyLabelOpt: node.FinallyLabelOpt, node.PreferFaultHandler);
+            return node.Update(tryBlock, catchBlocks, finallyBlock, finallyLabelOpt: node.FinallyLabelOpt, node.PreferFaultHandler, node.EndIsReachable);
         }
 
         public override BoundNode VisitCatchBlock(BoundCatchBlock node)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
@@ -567,14 +567,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                         new BoundTryStatement(
                             syntax,
                             block,
-                            ImmutableArray<BoundCatchBlock>.Empty,
-                            new BoundBlock(
+                            catchBlocks: ImmutableArray<BoundCatchBlock>.Empty,
+                            finallyBlockOpt: new BoundBlock(
                                 syntax,
                                 ImmutableArray<LocalSymbol>.Empty,
                                 ImmutableArray.Create<BoundStatement>(
                                     baseFinalizeCall)
                             )
-                            { WasCompilerGenerated = true }
+                            { WasCompilerGenerated = true },
+                            AsyncTryFinallyEndReachable.Ignored
                         )
                         { WasCompilerGenerated = true }));
             }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3457,7 +3457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundUsingLocalDeclarations : BoundMultipleLocalDeclarationsBase
     {
-        public BoundUsingLocalDeclarations(SyntaxNode syntax, MethodArgumentInfo? patternDisposeInfoOpt, BoundAwaitableInfo? awaitOpt, ImmutableArray<BoundLocalDeclaration> localDeclarations, bool hasErrors = false)
+        public BoundUsingLocalDeclarations(SyntaxNode syntax, MethodArgumentInfo? patternDisposeInfoOpt, BoundAwaitableInfo? awaitOpt, AsyncTryFinallyEndReachable endIsReachable, ImmutableArray<BoundLocalDeclaration> localDeclarations, bool hasErrors = false)
             : base(BoundKind.UsingLocalDeclarations, syntax, localDeclarations, hasErrors || awaitOpt.HasErrors() || localDeclarations.HasErrors())
         {
 
@@ -3465,19 +3465,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.PatternDisposeInfoOpt = patternDisposeInfoOpt;
             this.AwaitOpt = awaitOpt;
+            this.EndIsReachable = endIsReachable;
         }
 
         public MethodArgumentInfo? PatternDisposeInfoOpt { get; }
         public BoundAwaitableInfo? AwaitOpt { get; }
+        public AsyncTryFinallyEndReachable EndIsReachable { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitUsingLocalDeclarations(this);
 
-        public BoundUsingLocalDeclarations Update(MethodArgumentInfo? patternDisposeInfoOpt, BoundAwaitableInfo? awaitOpt, ImmutableArray<BoundLocalDeclaration> localDeclarations)
+        public BoundUsingLocalDeclarations Update(MethodArgumentInfo? patternDisposeInfoOpt, BoundAwaitableInfo? awaitOpt, AsyncTryFinallyEndReachable endIsReachable, ImmutableArray<BoundLocalDeclaration> localDeclarations)
         {
-            if (patternDisposeInfoOpt != this.PatternDisposeInfoOpt || awaitOpt != this.AwaitOpt || localDeclarations != this.LocalDeclarations)
+            if (patternDisposeInfoOpt != this.PatternDisposeInfoOpt || awaitOpt != this.AwaitOpt || endIsReachable != this.EndIsReachable || localDeclarations != this.LocalDeclarations)
             {
-                var result = new BoundUsingLocalDeclarations(this.Syntax, patternDisposeInfoOpt, awaitOpt, localDeclarations, this.HasErrors);
+                var result = new BoundUsingLocalDeclarations(this.Syntax, patternDisposeInfoOpt, awaitOpt, endIsReachable, localDeclarations, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -4017,7 +4019,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundForEachStatement : BoundLoopStatement
     {
-        public BoundForEachStatement(SyntaxNode syntax, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors = false)
+        public BoundForEachStatement(SyntaxNode syntax, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, AsyncTryFinallyEndReachable endIsReachable, LabelSymbol breakLabel, LabelSymbol continueLabel, bool hasErrors = false)
             : base(BoundKind.ForEachStatement, syntax, breakLabel, continueLabel, hasErrors || elementPlaceholder.HasErrors() || elementConversion.HasErrors() || iterationVariableType.HasErrors() || iterationErrorExpressionOpt.HasErrors() || expression.HasErrors() || deconstructionOpt.HasErrors() || awaitOpt.HasErrors() || body.HasErrors())
         {
 
@@ -4038,6 +4040,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.DeconstructionOpt = deconstructionOpt;
             this.AwaitOpt = awaitOpt;
             this.Body = body;
+            this.EndIsReachable = endIsReachable;
         }
 
         public ForEachEnumeratorInfo? EnumeratorInfoOpt { get; }
@@ -4050,15 +4053,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundForEachDeconstructStep? DeconstructionOpt { get; }
         public BoundAwaitableInfo? AwaitOpt { get; }
         public BoundStatement Body { get; }
+        public AsyncTryFinallyEndReachable EndIsReachable { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitForEachStatement(this);
 
-        public BoundForEachStatement Update(ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, LabelSymbol breakLabel, LabelSymbol continueLabel)
+        public BoundForEachStatement Update(ForEachEnumeratorInfo? enumeratorInfoOpt, BoundValuePlaceholder? elementPlaceholder, BoundExpression? elementConversion, BoundTypeExpression iterationVariableType, ImmutableArray<LocalSymbol> iterationVariables, BoundExpression? iterationErrorExpressionOpt, BoundExpression expression, BoundForEachDeconstructStep? deconstructionOpt, BoundAwaitableInfo? awaitOpt, BoundStatement body, AsyncTryFinallyEndReachable endIsReachable, LabelSymbol breakLabel, LabelSymbol continueLabel)
         {
-            if (enumeratorInfoOpt != this.EnumeratorInfoOpt || elementPlaceholder != this.ElementPlaceholder || elementConversion != this.ElementConversion || iterationVariableType != this.IterationVariableType || iterationVariables != this.IterationVariables || iterationErrorExpressionOpt != this.IterationErrorExpressionOpt || expression != this.Expression || deconstructionOpt != this.DeconstructionOpt || awaitOpt != this.AwaitOpt || body != this.Body || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(continueLabel, this.ContinueLabel))
+            if (enumeratorInfoOpt != this.EnumeratorInfoOpt || elementPlaceholder != this.ElementPlaceholder || elementConversion != this.ElementConversion || iterationVariableType != this.IterationVariableType || iterationVariables != this.IterationVariables || iterationErrorExpressionOpt != this.IterationErrorExpressionOpt || expression != this.Expression || deconstructionOpt != this.DeconstructionOpt || awaitOpt != this.AwaitOpt || body != this.Body || endIsReachable != this.EndIsReachable || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(breakLabel, this.BreakLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(continueLabel, this.ContinueLabel))
             {
-                var result = new BoundForEachStatement(this.Syntax, enumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, breakLabel, continueLabel, this.HasErrors);
+                var result = new BoundForEachStatement(this.Syntax, enumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, endIsReachable, breakLabel, continueLabel, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -4099,7 +4103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundUsingStatement : BoundStatement
     {
-        public BoundUsingStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations? declarationsOpt, BoundExpression? expressionOpt, BoundStatement body, BoundAwaitableInfo? awaitOpt, MethodArgumentInfo? patternDisposeInfoOpt, bool hasErrors = false)
+        public BoundUsingStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations? declarationsOpt, BoundExpression? expressionOpt, BoundStatement body, BoundAwaitableInfo? awaitOpt, MethodArgumentInfo? patternDisposeInfoOpt, AsyncTryFinallyEndReachable endIsReachable, bool hasErrors = false)
             : base(BoundKind.UsingStatement, syntax, hasErrors || declarationsOpt.HasErrors() || expressionOpt.HasErrors() || body.HasErrors() || awaitOpt.HasErrors())
         {
 
@@ -4112,6 +4116,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Body = body;
             this.AwaitOpt = awaitOpt;
             this.PatternDisposeInfoOpt = patternDisposeInfoOpt;
+            this.EndIsReachable = endIsReachable;
         }
 
         public ImmutableArray<LocalSymbol> Locals { get; }
@@ -4120,15 +4125,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundStatement Body { get; }
         public BoundAwaitableInfo? AwaitOpt { get; }
         public MethodArgumentInfo? PatternDisposeInfoOpt { get; }
+        public AsyncTryFinallyEndReachable EndIsReachable { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitUsingStatement(this);
 
-        public BoundUsingStatement Update(ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations? declarationsOpt, BoundExpression? expressionOpt, BoundStatement body, BoundAwaitableInfo? awaitOpt, MethodArgumentInfo? patternDisposeInfoOpt)
+        public BoundUsingStatement Update(ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations? declarationsOpt, BoundExpression? expressionOpt, BoundStatement body, BoundAwaitableInfo? awaitOpt, MethodArgumentInfo? patternDisposeInfoOpt, AsyncTryFinallyEndReachable endIsReachable)
         {
-            if (locals != this.Locals || declarationsOpt != this.DeclarationsOpt || expressionOpt != this.ExpressionOpt || body != this.Body || awaitOpt != this.AwaitOpt || patternDisposeInfoOpt != this.PatternDisposeInfoOpt)
+            if (locals != this.Locals || declarationsOpt != this.DeclarationsOpt || expressionOpt != this.ExpressionOpt || body != this.Body || awaitOpt != this.AwaitOpt || patternDisposeInfoOpt != this.PatternDisposeInfoOpt || endIsReachable != this.EndIsReachable)
             {
-                var result = new BoundUsingStatement(this.Syntax, locals, declarationsOpt, expressionOpt, body, awaitOpt, patternDisposeInfoOpt, this.HasErrors);
+                var result = new BoundUsingStatement(this.Syntax, locals, declarationsOpt, expressionOpt, body, awaitOpt, patternDisposeInfoOpt, endIsReachable, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -4203,7 +4209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundTryStatement : BoundStatement
     {
-        public BoundTryStatement(SyntaxNode syntax, BoundBlock tryBlock, ImmutableArray<BoundCatchBlock> catchBlocks, BoundBlock? finallyBlockOpt, LabelSymbol? finallyLabelOpt, bool preferFaultHandler, bool hasErrors = false)
+        public BoundTryStatement(SyntaxNode syntax, BoundBlock tryBlock, ImmutableArray<BoundCatchBlock> catchBlocks, BoundBlock? finallyBlockOpt, LabelSymbol? finallyLabelOpt, bool preferFaultHandler, AsyncTryFinallyEndReachable endIsReachable, bool hasErrors = false)
             : base(BoundKind.TryStatement, syntax, hasErrors || tryBlock.HasErrors() || catchBlocks.HasErrors() || finallyBlockOpt.HasErrors())
         {
 
@@ -4215,22 +4221,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.FinallyBlockOpt = finallyBlockOpt;
             this.FinallyLabelOpt = finallyLabelOpt;
             this.PreferFaultHandler = preferFaultHandler;
+            this.EndIsReachable = endIsReachable;
+            Validate();
         }
+
+        [Conditional("DEBUG")]
+        private partial void Validate();
 
         public BoundBlock TryBlock { get; }
         public ImmutableArray<BoundCatchBlock> CatchBlocks { get; }
         public BoundBlock? FinallyBlockOpt { get; }
         public LabelSymbol? FinallyLabelOpt { get; }
         public bool PreferFaultHandler { get; }
+        public AsyncTryFinallyEndReachable EndIsReachable { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitTryStatement(this);
 
-        public BoundTryStatement Update(BoundBlock tryBlock, ImmutableArray<BoundCatchBlock> catchBlocks, BoundBlock? finallyBlockOpt, LabelSymbol? finallyLabelOpt, bool preferFaultHandler)
+        public BoundTryStatement Update(BoundBlock tryBlock, ImmutableArray<BoundCatchBlock> catchBlocks, BoundBlock? finallyBlockOpt, LabelSymbol? finallyLabelOpt, bool preferFaultHandler, AsyncTryFinallyEndReachable endIsReachable)
         {
-            if (tryBlock != this.TryBlock || catchBlocks != this.CatchBlocks || finallyBlockOpt != this.FinallyBlockOpt || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(finallyLabelOpt, this.FinallyLabelOpt) || preferFaultHandler != this.PreferFaultHandler)
+            if (tryBlock != this.TryBlock || catchBlocks != this.CatchBlocks || finallyBlockOpt != this.FinallyBlockOpt || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(finallyLabelOpt, this.FinallyLabelOpt) || preferFaultHandler != this.PreferFaultHandler || endIsReachable != this.EndIsReachable)
             {
-                var result = new BoundTryStatement(this.Syntax, tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, preferFaultHandler, this.HasErrors);
+                var result = new BoundTryStatement(this.Syntax, tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, preferFaultHandler, endIsReachable, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -11377,7 +11389,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
             ImmutableArray<BoundLocalDeclaration> localDeclarations = this.VisitList(node.LocalDeclarations);
-            return node.Update(node.PatternDisposeInfoOpt, awaitOpt, localDeclarations);
+            return node.Update(node.PatternDisposeInfoOpt, awaitOpt, node.EndIsReachable, localDeclarations);
         }
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
@@ -11485,7 +11497,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundForEachDeconstructStep? deconstructionOpt = (BoundForEachDeconstructStep?)this.Visit(node.DeconstructionOpt);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.EnumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, breakLabel, continueLabel);
+            return node.Update(node.EnumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, node.EndIsReachable, breakLabel, continueLabel);
         }
         public override BoundNode? VisitForEachDeconstructStep(BoundForEachDeconstructStep node)
         {
@@ -11500,7 +11512,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? expressionOpt = (BoundExpression?)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
-            return node.Update(locals, declarationsOpt, expressionOpt, body, awaitOpt, node.PatternDisposeInfoOpt);
+            return node.Update(locals, declarationsOpt, expressionOpt, body, awaitOpt, node.PatternDisposeInfoOpt, node.EndIsReachable);
         }
         public override BoundNode? VisitFixedStatement(BoundFixedStatement node)
         {
@@ -11521,7 +11533,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundBlock tryBlock = (BoundBlock)this.Visit(node.TryBlock);
             ImmutableArray<BoundCatchBlock> catchBlocks = this.VisitList(node.CatchBlocks);
             BoundBlock? finallyBlockOpt = (BoundBlock?)this.Visit(node.FinallyBlockOpt);
-            return node.Update(tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, node.PreferFaultHandler);
+            return node.Update(tryBlock, catchBlocks, finallyBlockOpt, finallyLabelOpt, node.PreferFaultHandler, node.EndIsReachable);
         }
         public override BoundNode? VisitCatchBlock(BoundCatchBlock node)
         {
@@ -13604,7 +13616,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundForEachDeconstructStep? deconstructionOpt = (BoundForEachDeconstructStep?)this.Visit(node.DeconstructionOpt);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.EnumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, node.BreakLabel, node.ContinueLabel);
+            return node.Update(node.EnumeratorInfoOpt, elementPlaceholder, elementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, awaitOpt, body, node.EndIsReachable, node.BreakLabel, node.ContinueLabel);
         }
 
         public override BoundNode? VisitUsingStatement(BoundUsingStatement node)
@@ -13614,7 +13626,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? expressionOpt = (BoundExpression?)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
             BoundAwaitableInfo? awaitOpt = (BoundAwaitableInfo?)this.Visit(node.AwaitOpt);
-            return node.Update(locals, declarationsOpt, expressionOpt, body, awaitOpt, node.PatternDisposeInfoOpt);
+            return node.Update(locals, declarationsOpt, expressionOpt, body, awaitOpt, node.PatternDisposeInfoOpt, node.EndIsReachable);
         }
 
         public override BoundNode? VisitFixedStatement(BoundFixedStatement node)
@@ -15915,6 +15927,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             new TreeDumperNode("patternDisposeInfoOpt", node.PatternDisposeInfoOpt, null),
             new TreeDumperNode("awaitOpt", null, new TreeDumperNode[] { Visit(node.AwaitOpt, null) }),
+            new TreeDumperNode("endIsReachable", node.EndIsReachable, null),
             new TreeDumperNode("localDeclarations", null, from x in node.LocalDeclarations select Visit(x, null)),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
@@ -16047,6 +16060,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("deconstructionOpt", null, new TreeDumperNode[] { Visit(node.DeconstructionOpt, null) }),
             new TreeDumperNode("awaitOpt", null, new TreeDumperNode[] { Visit(node.AwaitOpt, null) }),
             new TreeDumperNode("body", null, new TreeDumperNode[] { Visit(node.Body, null) }),
+            new TreeDumperNode("endIsReachable", node.EndIsReachable, null),
             new TreeDumperNode("breakLabel", node.BreakLabel, null),
             new TreeDumperNode("continueLabel", node.ContinueLabel, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
@@ -16067,6 +16081,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("body", null, new TreeDumperNode[] { Visit(node.Body, null) }),
             new TreeDumperNode("awaitOpt", null, new TreeDumperNode[] { Visit(node.AwaitOpt, null) }),
             new TreeDumperNode("patternDisposeInfoOpt", node.PatternDisposeInfoOpt, null),
+            new TreeDumperNode("endIsReachable", node.EndIsReachable, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
@@ -16092,6 +16107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("finallyBlockOpt", null, new TreeDumperNode[] { Visit(node.FinallyBlockOpt, null) }),
             new TreeDumperNode("finallyLabelOpt", node.FinallyLabelOpt, null),
             new TreeDumperNode("preferFaultHandler", node.PreferFaultHandler, null),
+            new TreeDumperNode("endIsReachable", node.EndIsReachable, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundStatement UnpendException(LocalSymbol pendingExceptionLocal)
         {
             // create a temp. 
-            // pendingExceptionLocal will certainly be captured, no need to access it over and over.
+            // pendingExceptionLocal will certainly be captured to the async state machine, no need to access it over and over.
             LocalSymbol obj = _F.SynthesizedLocal(_F.SpecialType(SpecialType.System_Object));
             var objInit = _F.Assignment(_F.Local(obj), _F.Local(pendingExceptionLocal));
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 node = node.Update(
                     tryBlock: F.Block(node.TryBlock, F.Label(finallyEntry)),
-                    node.CatchBlocks, node.FinallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler);
+                    node.CatchBlocks, node.FinallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler, node.EndIsReachable);
             }
             else if (node.FinallyLabelOpt is object)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         protected virtual BoundStatement GenerateTopLevelTry(BoundBlock tryBlock, ImmutableArray<BoundCatchBlock> catchBlocks)
-            => F.Try(tryBlock, catchBlocks);
+            => F.Try(tryBlock, catchBlocks, AsyncTryFinallyEndReachable.Ignored);
 
         protected virtual BoundStatement GenerateSetResultCall()
         {

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // }
 
                 var faultBlock = F.Block(F.ExpressionStatement(F.Call(F.This(), disposeMethod)));
-                newBody = F.Fault((BoundBlock)newBody, faultBlock);
+                newBody = F.Fault((BoundBlock)newBody, faultBlock, endIsReachable: AsyncTryFinallyEndReachable.Ignored);
             }
 
             newBody = F.Instrument(F.SequencePoint(body.Syntax, HandleReturn(newBody)), instrumentation);
@@ -285,6 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 body = F.Try(
                     tryBlock,
                     ImmutableArray<BoundCatchBlock>.Empty,
+                    AsyncTryFinallyEndReachable.Ignored,
                     F.Block(F.ExpressionStatement(F.Call(F.This(), frame.handler))));
             }
 
@@ -379,7 +380,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     VisitList(node.CatchBlocks),
                                     (BoundBlock)Visit(node.FinallyBlockOpt),
                                     node.FinallyLabelOpt,
-                                    node.PreferFaultHandler);
+                                    node.PreferFaultHandler,
+                                    node.EndIsReachable);
 
                 _tryNestingLevel--;
                 return result;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -1410,7 +1410,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     awaitableInfo: null,
                     breakLabel,
                     continueLabel,
-                    rewrittenBody);
+                    rewrittenBody,
+                    endIsReachable: AsyncTryFinallyEndReachable.Reachable);
             }
 
             RemovePlaceholderReplacement(expressionPlaceholder);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -65,7 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         _factory.Syntax,
                         _factory.Block(statementBuilder.ToImmutableAndFree()),
                         ImmutableArray<BoundCatchBlock>.Empty,
-                        _factory.Block(cleanup)));
+                        _factory.Block(cleanup),
+                        endIsReachable: AsyncTryFinallyEndReachable.Ignored));
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -129,7 +129,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node.AwaitOpt,
                 node.BreakLabel,
                 node.ContinueLabel,
-                rewrittenBody);
+                rewrittenBody,
+                node.EndIsReachable);
         }
 
         private BoundStatement RewriteForEachEnumerator(
@@ -143,7 +144,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundAwaitableInfo? awaitableInfo,
             LabelSymbol breakLabel,
             LabelSymbol continueLabel,
-            BoundStatement rewrittenBody)
+            BoundStatement rewrittenBody,
+            AsyncTryFinallyEndReachable endIsReachable)
         {
             var forEachSyntax = (CSharpSyntaxNode)node.Syntax;
             bool isAsync = awaitableInfo != null;
@@ -258,7 +260,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     forEachSyntax,
                     tryBlock: new BoundBlock(forEachSyntax, locals: ImmutableArray<LocalSymbol>.Empty, statements: ImmutableArray.Create(whileLoop)),
                     catchBlocks: ImmutableArray<BoundCatchBlock>.Empty,
-                    finallyBlockOpt: disposalFinallyBlock);
+                    finallyBlockOpt: disposalFinallyBlock,
+                    endIsReachable);
 
                 // E e = ((C)(x)).GetEnumerator();
                 // try {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
@@ -73,7 +73,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     boundTemp,
                     awaitKeywordOpt: default,
                     awaitOpt: null,
-                    patternDisposeInfo: MethodArgumentInfo.CreateParameterlessMethod(lockTypeInfo.ScopeDisposeMethod));
+                    patternDisposeInfo: MethodArgumentInfo.CreateParameterlessMethod(lockTypeInfo.ScopeDisposeMethod),
+                    AsyncTryFinallyEndReachable.Ignored);
 
                 return new BoundBlock(
                     lockSyntax,
@@ -177,8 +178,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 enterCall,
                                 rewrittenBody)),
                             ImmutableArray<BoundCatchBlock>.Empty,
-                            BoundBlock.SynthesizedNoLocals(lockSyntax,
-                                exitCall))));
+                            finallyBlockOpt: BoundBlock.SynthesizedNoLocals(lockSyntax,
+                                exitCall),
+                            AsyncTryFinallyEndReachable.Ignored)));
             }
             else
             {
@@ -226,7 +228,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             lockSyntax,
                             BoundBlock.SynthesizedNoLocals(lockSyntax, rewrittenBody),
                             ImmutableArray<BoundCatchBlock>.Empty,
-                            BoundBlock.SynthesizedNoLocals(lockSyntax, exitCall))));
+                            finallyBlockOpt: BoundBlock.SynthesizedNoLocals(lockSyntax, exitCall),
+                            AsyncTryFinallyEndReachable.Ignored)));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
@@ -34,9 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 finallyBlockOpt = null;
             }
 
-            return (catchBlocks.IsDefaultOrEmpty && finallyBlockOpt == null)
-                ? (BoundNode)tryBlock
-                : (BoundNode)node.Update(tryBlock, catchBlocks, finallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler);
+            return catchBlocks.IsDefaultOrEmpty && finallyBlockOpt == null
+                ? tryBlock
+                : node.Update(tryBlock, catchBlocks, finallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler, node.EndIsReachable);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -913,7 +913,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ),
                 F.HiddenSequencePoint());
 
-            BoundStatement result = node.Update(tryBlock, catchBlocks, finallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler);
+            BoundStatement result = node.Update(tryBlock, catchBlocks, finallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler, node.EndIsReachable);
 
             if ((object)dispatchLabel != null)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (instrumentation.Epilogue != null)
             {
-                statements.Add(Try(Block(statement), ImmutableArray<BoundCatchBlock>.Empty, Block(instrumentation.Epilogue)));
+                statements.Add(Try(Block(statement), ImmutableArray<BoundCatchBlock>.Empty, AsyncTryFinallyEndReachable.Ignored, Block(instrumentation.Epilogue)));
             }
             else
             {
@@ -1593,10 +1593,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal BoundStatement Try(
             BoundBlock tryBlock,
             ImmutableArray<BoundCatchBlock> catchBlocks,
+            AsyncTryFinallyEndReachable endIsReachable,
             BoundBlock? finallyBlock = null,
             LabelSymbol? finallyLabel = null)
         {
-            return new BoundTryStatement(Syntax, tryBlock, catchBlocks, finallyBlock, finallyLabel) { WasCompilerGenerated = true };
+            return new BoundTryStatement(Syntax, tryBlock, catchBlocks, finallyBlock, endIsReachable, finallyLabel) { WasCompilerGenerated = true };
         }
 
         internal ImmutableArray<BoundCatchBlock> CatchBlocks(
@@ -1620,9 +1621,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundCatchBlock(Syntax, ImmutableArray<LocalSymbol>.Empty, source, source.Type, exceptionFilterPrologueOpt: null, exceptionFilterOpt: null, body: block, isSynthesizedAsyncCatchAll: false);
         }
 
-        internal BoundTryStatement Fault(BoundBlock tryBlock, BoundBlock faultBlock)
+        internal BoundTryStatement Fault(BoundBlock tryBlock, BoundBlock faultBlock, AsyncTryFinallyEndReachable endIsReachable)
         {
-            return new BoundTryStatement(Syntax, tryBlock, ImmutableArray<BoundCatchBlock>.Empty, faultBlock, finallyLabelOpt: null, preferFaultHandler: true);
+            return new BoundTryStatement(Syntax, tryBlock, ImmutableArray<BoundCatchBlock>.Empty, faultBlock, finallyLabelOpt: null, preferFaultHandler: true, endIsReachable);
         }
 
         internal BoundExpression NullOrDefault(TypeSymbol typeSymbol)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -841,7 +841,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
 ");
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
+        [Fact]
         public void AsyncInFinally002()
         {
             var source = @"
@@ -893,12 +893,13 @@ class Test
         }
     }
 }";
-            var expected = @"FOne or more errors occurred.
-";
+            var expected = ExecutionConditionUtil.IsWindowsDesktop
+                ? "FOne or more errors occurred."
+                : "FOne or more errors occurred. (hello)";
             CompileAndVerify(source, expectedOutput: expected);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         public void AsyncInFinally003()
         {
             var source = @"
@@ -954,7 +955,9 @@ class Test
                 }, module.GetFieldNames("Test.<G>d__1"));
             });
 
-            v.VerifyPdb("Test.G", @"
+            if (ExecutionConditionUtil.IsDesktop)
+            {
+                v.VerifyPdb("Test.G", @"
 <symbols>
   <files>
     <file id=""1"" name="""" language=""C#"" />
@@ -982,10 +985,11 @@ class Test
   </methods>
 </symbols>
 ");
+            }
 
             v.VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"{
-  // Code size      461 (0x1cd)
+  // Code size      444 (0x1bc)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -993,8 +997,7 @@ class Test
                 Test.<G>d__1 V_3,
                 object V_4,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
-                System.Exception V_6,
-                int V_7)
+                System.Exception V_6)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Test.<G>d__1.<>1__state""
   IL_0006:  stloc.0
@@ -1049,7 +1052,7 @@ class Test
       IL_0066:  ldloca.s   V_3
       IL_0068:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
       IL_006d:  nop
-      IL_006e:  leave      IL_01cc
+      IL_006e:  leave      IL_01bb
      >IL_0073:  ldarg.0
       IL_0074:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
       IL_0079:  stloc.2
@@ -1114,7 +1117,7 @@ class Test
     IL_0108:  ldloca.s   V_3
     IL_010a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
     IL_010f:  nop
-    IL_0110:  leave      IL_01cc
+    IL_0110:  leave      IL_01bb
    >IL_0115:  ldarg.0
     IL_0116:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
     IL_011b:  stloc.s    V_5
@@ -1156,42 +1159,34 @@ class Test
     IL_017b:  nop
     IL_017c:  ldarg.0
     IL_017d:  ldfld      ""int Test.<G>d__1.<>s__3""
-    IL_0182:  stloc.s    V_7
-    IL_0184:  ldloc.s    V_7
-    IL_0186:  ldc.i4.1
-    IL_0187:  beq.s      IL_018b
-    IL_0189:  br.s       IL_0194
-    IL_018b:  ldarg.0
-    IL_018c:  ldfld      ""int Test.<G>d__1.<>s__4""
-    IL_0191:  stloc.1
-    IL_0192:  leave.s    IL_01b7
-    IL_0194:  ldarg.0
-    IL_0195:  ldnull
-    IL_0196:  stfld      ""object Test.<G>d__1.<>s__2""
-    IL_019b:  leave.s    IL_01b7
+    IL_0182:  pop
+    IL_0183:  ldarg.0
+    IL_0184:  ldfld      ""int Test.<G>d__1.<>s__4""
+    IL_0189:  stloc.1
+    IL_018a:  leave.s    IL_01a6
   }
   catch System.Exception
   {
-   ~IL_019d:  stloc.s    V_6
-    IL_019f:  ldarg.0
-    IL_01a0:  ldc.i4.s   -2
-    IL_01a2:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_01a7:  ldarg.0
-    IL_01a8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_01ad:  ldloc.s    V_6
-    IL_01af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_01b4:  nop
-    IL_01b5:  leave.s    IL_01cc
+   ~IL_018c:  stloc.s    V_6
+    IL_018e:  ldarg.0
+    IL_018f:  ldc.i4.s   -2
+    IL_0191:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_0196:  ldarg.0
+    IL_0197:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_019c:  ldloc.s    V_6
+    IL_019e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_01a3:  nop
+    IL_01a4:  leave.s    IL_01bb
   }
- -IL_01b7:  ldarg.0
-  IL_01b8:  ldc.i4.s   -2
-  IL_01ba:  stfld      ""int Test.<G>d__1.<>1__state""
- ~IL_01bf:  ldarg.0
-  IL_01c0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-  IL_01c5:  ldloc.1
-  IL_01c6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_01cb:  nop
-  IL_01cc:  ret
+ -IL_01a6:  ldarg.0
+  IL_01a7:  ldc.i4.s   -2
+  IL_01a9:  stfld      ""int Test.<G>d__1.<>1__state""
+ ~IL_01ae:  ldarg.0
+  IL_01af:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+  IL_01b4:  ldloc.1
+  IL_01b5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_01ba:  nop
+  IL_01bb:  ret
 }", sequencePoints: "Test+<G>d__1.MoveNext");
         }
 
@@ -1241,6 +1236,211 @@ class Test
 2
 ";
             CompileAndVerify(source, expectedOutput: expected);
+        }
+
+        [Fact]
+        public void AsyncInFinally005()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+class Test
+{
+    static async Task<int> F()
+    {
+        return 2;
+    }
+
+    static async Task<int> G()
+    {
+        int x = 0;
+        try
+        {
+            x = await F();
+            throw new Exception(x.ToString());
+        }
+        finally
+        {
+            x += await F();
+        }
+    }
+
+    public static void Main()
+    {
+        Task<int> t2 = G();
+        try
+        {
+            t2.Wait(1000 * 60);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+        }
+    }
+}";
+            var expected = "One or more errors occurred. (2)";
+            var verifier = CompileAndVerify(source, expectedOutput: expected);
+            verifier.VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
+                {
+                  // Code size      346 (0x15a)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                int V_1,
+                                int V_2,
+                                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                                object V_4,
+                                System.Exception V_5)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldfld      "int Test.<G>d__1.<>1__state"
+                  IL_0006:  stloc.0
+                  .try
+                  {
+                    IL_0007:  ldloc.0
+                    IL_0008:  brfalse.s  IL_0026
+                    IL_000a:  ldloc.0
+                    IL_000b:  ldc.i4.1
+                    IL_000c:  beq        IL_00e9
+                    IL_0011:  ldarg.0
+                    IL_0012:  ldc.i4.0
+                    IL_0013:  stfld      "int Test.<G>d__1.<x>5__2"
+                    IL_0018:  ldarg.0
+                    IL_0019:  ldnull
+                    IL_001a:  stfld      "object Test.<G>d__1.<>7__wrap2"
+                    IL_001f:  ldarg.0
+                    IL_0020:  ldc.i4.0
+                    IL_0021:  stfld      "int Test.<G>d__1.<>7__wrap3"
+                    IL_0026:  nop
+                    .try
+                    {
+                      IL_0027:  ldloc.0
+                      IL_0028:  brfalse.s  IL_0061
+                      IL_002a:  call       "System.Threading.Tasks.Task<int> Test.F()"
+                      IL_002f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()"
+                      IL_0034:  stloc.3
+                      IL_0035:  ldloca.s   V_3
+                      IL_0037:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get"
+                      IL_003c:  brtrue.s   IL_007d
+                      IL_003e:  ldarg.0
+                      IL_003f:  ldc.i4.0
+                      IL_0040:  dup
+                      IL_0041:  stloc.0
+                      IL_0042:  stfld      "int Test.<G>d__1.<>1__state"
+                      IL_0047:  ldarg.0
+                      IL_0048:  ldloc.3
+                      IL_0049:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1"
+                      IL_004e:  ldarg.0
+                      IL_004f:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder"
+                      IL_0054:  ldloca.s   V_3
+                      IL_0056:  ldarg.0
+                      IL_0057:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)"
+                      IL_005c:  leave      IL_0159
+                      IL_0061:  ldarg.0
+                      IL_0062:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1"
+                      IL_0067:  stloc.3
+                      IL_0068:  ldarg.0
+                      IL_0069:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1"
+                      IL_006e:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<int>"
+                      IL_0074:  ldarg.0
+                      IL_0075:  ldc.i4.m1
+                      IL_0076:  dup
+                      IL_0077:  stloc.0
+                      IL_0078:  stfld      "int Test.<G>d__1.<>1__state"
+                      IL_007d:  ldloca.s   V_3
+                      IL_007f:  call       "int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()"
+                      IL_0084:  stloc.2
+                      IL_0085:  ldarg.0
+                      IL_0086:  ldloc.2
+                      IL_0087:  stfld      "int Test.<G>d__1.<x>5__2"
+                      IL_008c:  ldarg.0
+                      IL_008d:  ldflda     "int Test.<G>d__1.<x>5__2"
+                      IL_0092:  call       "string int.ToString()"
+                      IL_0097:  newobj     "System.Exception..ctor(string)"
+                      IL_009c:  throw
+                    }
+                    catch object
+                    {
+                      IL_009d:  stloc.s    V_4
+                      IL_009f:  ldarg.0
+                      IL_00a0:  ldloc.s    V_4
+                      IL_00a2:  stfld      "object Test.<G>d__1.<>7__wrap2"
+                      IL_00a7:  leave.s    IL_00a9
+                    }
+                    IL_00a9:  ldarg.0
+                    IL_00aa:  ldarg.0
+                    IL_00ab:  ldfld      "int Test.<G>d__1.<x>5__2"
+                    IL_00b0:  stfld      "int Test.<G>d__1.<>7__wrap4"
+                    IL_00b5:  call       "System.Threading.Tasks.Task<int> Test.F()"
+                    IL_00ba:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()"
+                    IL_00bf:  stloc.3
+                    IL_00c0:  ldloca.s   V_3
+                    IL_00c2:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get"
+                    IL_00c7:  brtrue.s   IL_0105
+                    IL_00c9:  ldarg.0
+                    IL_00ca:  ldc.i4.1
+                    IL_00cb:  dup
+                    IL_00cc:  stloc.0
+                    IL_00cd:  stfld      "int Test.<G>d__1.<>1__state"
+                    IL_00d2:  ldarg.0
+                    IL_00d3:  ldloc.3
+                    IL_00d4:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1"
+                    IL_00d9:  ldarg.0
+                    IL_00da:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder"
+                    IL_00df:  ldloca.s   V_3
+                    IL_00e1:  ldarg.0
+                    IL_00e2:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)"
+                    IL_00e7:  leave.s    IL_0159
+                    IL_00e9:  ldarg.0
+                    IL_00ea:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1"
+                    IL_00ef:  stloc.3
+                    IL_00f0:  ldarg.0
+                    IL_00f1:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1"
+                    IL_00f6:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<int>"
+                    IL_00fc:  ldarg.0
+                    IL_00fd:  ldc.i4.m1
+                    IL_00fe:  dup
+                    IL_00ff:  stloc.0
+                    IL_0100:  stfld      "int Test.<G>d__1.<>1__state"
+                    IL_0105:  ldloca.s   V_3
+                    IL_0107:  call       "int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()"
+                    IL_010c:  stloc.2
+                    IL_010d:  ldarg.0
+                    IL_010e:  ldarg.0
+                    IL_010f:  ldfld      "int Test.<G>d__1.<>7__wrap4"
+                    IL_0114:  ldloc.2
+                    IL_0115:  add
+                    IL_0116:  stfld      "int Test.<G>d__1.<x>5__2"
+                    IL_011b:  ldarg.0
+                    IL_011c:  ldfld      "object Test.<G>d__1.<>7__wrap2"
+                    IL_0121:  stloc.s    V_4
+                    IL_0123:  ldloc.s    V_4
+                    IL_0125:  brfalse.s  IL_013e
+                    IL_0127:  ldloc.s    V_4
+                    IL_0129:  isinst     "System.Exception"
+                    IL_012e:  dup
+                    IL_012f:  brtrue.s   IL_0134
+                    IL_0131:  ldloc.s    V_4
+                    IL_0133:  throw
+                    IL_0134:  call       "System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)"
+                    IL_0139:  callvirt   "void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()"
+                    IL_013e:  ldnull
+                    IL_013f:  throw
+                  }
+                  catch System.Exception
+                  {
+                    IL_0140:  stloc.s    V_5
+                    IL_0142:  ldarg.0
+                    IL_0143:  ldc.i4.s   -2
+                    IL_0145:  stfld      "int Test.<G>d__1.<>1__state"
+                    IL_014a:  ldarg.0
+                    IL_014b:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder"
+                    IL_0150:  ldloc.s    V_5
+                    IL_0152:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)"
+                    IL_0157:  leave.s    IL_0159
+                  }
+                  IL_0159:  ret
+                }
+                """);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -260,7 +260,7 @@ class C
             });
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         public void SynthesizedVariables1()
         {
             var source =
@@ -334,7 +334,9 @@ class C
                 }, module.GetFieldNames("C.<M>d__3"));
             });
 
-            vd.VerifyPdb("C.M", @"
+            if (ExecutionConditionUtil.IsWindows)
+            {
+                vd.VerifyPdb("C.M", @"
 <symbols>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""disposable"">
@@ -374,6 +376,7 @@ class C
   </methods>
 </symbols>
 ", options: PdbValidationOptions.ExcludeDocuments);
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
@@ -1567,7 +1567,7 @@ class Program
             var verifier = CompileAndVerify(comp, expectedOutput: "");
             verifier.VerifyIL("Program.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
 @"{
-  // Code size      426 (0x1aa)
+  // Code size      406 (0x196)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
@@ -1583,7 +1583,7 @@ class Program
     IL_0008:  brfalse.s  IL_001f
     IL_000a:  ldloc.0
     IL_000b:  ldc.i4.1
-    IL_000c:  beq        IL_0125
+    IL_000c:  beq        IL_0111
     IL_0011:  ldarg.0
     IL_0012:  ldnull
     IL_0013:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
@@ -1640,7 +1640,7 @@ class Program
         IL_0071:  ldloca.s   V_2
         IL_0073:  ldarg.0
         IL_0074:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Program.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Program.<Main>d__0)""
-        IL_0079:  leave      IL_01a9
+        IL_0079:  leave      IL_0195
         IL_007e:  ldarg.0
         IL_007f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
         IL_0084:  stloc.2
@@ -1667,114 +1667,104 @@ class Program
         IL_00b5:  throw
         IL_00b6:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
         IL_00bb:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-        IL_00c0:  ldarg.0
-        IL_00c1:  ldfld      ""int Program.<Main>d__0.<>7__wrap4""
-        IL_00c6:  stloc.3
-        IL_00c7:  ldloc.3
-        IL_00c8:  ldc.i4.1
-        IL_00c9:  bne.un.s   IL_00cd
-        IL_00cb:  leave.s    IL_00db
-        IL_00cd:  ldarg.0
-        IL_00ce:  ldnull
-        IL_00cf:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
-        IL_00d4:  leave.s    IL_00d9
+        IL_00c0:  leave.s    IL_00c7
       }
       catch object
       {
-        IL_00d6:  pop
-        IL_00d7:  leave.s    IL_00d9
+        IL_00c2:  pop
+        IL_00c3:  leave.s    IL_00c5
       }
-      IL_00d9:  leave.s    IL_00ee
-      IL_00db:  ldarg.0
-      IL_00dc:  ldc.i4.1
-      IL_00dd:  stfld      ""int Program.<Main>d__0.<>7__wrap2""
-      IL_00e2:  leave.s    IL_00ee
+      IL_00c5:  leave.s    IL_00da
+      IL_00c7:  ldarg.0
+      IL_00c8:  ldc.i4.1
+      IL_00c9:  stfld      ""int Program.<Main>d__0.<>7__wrap2""
+      IL_00ce:  leave.s    IL_00da
     }
     catch object
     {
-      IL_00e4:  stloc.1
-      IL_00e5:  ldarg.0
-      IL_00e6:  ldloc.1
-      IL_00e7:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
-      IL_00ec:  leave.s    IL_00ee
+      IL_00d0:  stloc.1
+      IL_00d1:  ldarg.0
+      IL_00d2:  ldloc.1
+      IL_00d3:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
+      IL_00d8:  leave.s    IL_00da
     }
-    IL_00ee:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get""
-    IL_00f3:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_00f8:  stloc.2
-    IL_00f9:  ldloca.s   V_2
-    IL_00fb:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_0100:  brtrue.s   IL_0141
-    IL_0102:  ldarg.0
-    IL_0103:  ldc.i4.1
-    IL_0104:  dup
-    IL_0105:  stloc.0
-    IL_0106:  stfld      ""int Program.<Main>d__0.<>1__state""
-    IL_010b:  ldarg.0
-    IL_010c:  ldloc.2
-    IL_010d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
-    IL_0112:  ldarg.0
-    IL_0113:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
-    IL_0118:  ldloca.s   V_2
-    IL_011a:  ldarg.0
-    IL_011b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Program.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Program.<Main>d__0)""
-    IL_0120:  leave      IL_01a9
-    IL_0125:  ldarg.0
-    IL_0126:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
-    IL_012b:  stloc.2
-    IL_012c:  ldarg.0
-    IL_012d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
-    IL_0132:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0138:  ldarg.0
-    IL_0139:  ldc.i4.m1
-    IL_013a:  dup
-    IL_013b:  stloc.0
-    IL_013c:  stfld      ""int Program.<Main>d__0.<>1__state""
-    IL_0141:  ldloca.s   V_2
-    IL_0143:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_0148:  ldarg.0
-    IL_0149:  ldfld      ""object Program.<Main>d__0.<>7__wrap1""
-    IL_014e:  stloc.1
-    IL_014f:  ldloc.1
-    IL_0150:  brfalse.s  IL_0167
-    IL_0152:  ldloc.1
-    IL_0153:  isinst     ""System.Exception""
-    IL_0158:  dup
-    IL_0159:  brtrue.s   IL_015d
-    IL_015b:  ldloc.1
-    IL_015c:  throw
-    IL_015d:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_0162:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_0167:  ldarg.0
-    IL_0168:  ldfld      ""int Program.<Main>d__0.<>7__wrap2""
-    IL_016d:  stloc.3
-    IL_016e:  ldloc.3
-    IL_016f:  ldc.i4.1
-    IL_0170:  bne.un.s   IL_0174
-    IL_0172:  leave.s    IL_0196
-    IL_0174:  ldarg.0
-    IL_0175:  ldnull
-    IL_0176:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
-    IL_017b:  leave.s    IL_0196
+    IL_00da:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get""
+    IL_00df:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_00e4:  stloc.2
+    IL_00e5:  ldloca.s   V_2
+    IL_00e7:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_00ec:  brtrue.s   IL_012d
+    IL_00ee:  ldarg.0
+    IL_00ef:  ldc.i4.1
+    IL_00f0:  dup
+    IL_00f1:  stloc.0
+    IL_00f2:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_00f7:  ldarg.0
+    IL_00f8:  ldloc.2
+    IL_00f9:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+    IL_00fe:  ldarg.0
+    IL_00ff:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+    IL_0104:  ldloca.s   V_2
+    IL_0106:  ldarg.0
+    IL_0107:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Program.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Program.<Main>d__0)""
+    IL_010c:  leave      IL_0195
+    IL_0111:  ldarg.0
+    IL_0112:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+    IL_0117:  stloc.2
+    IL_0118:  ldarg.0
+    IL_0119:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+    IL_011e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0124:  ldarg.0
+    IL_0125:  ldc.i4.m1
+    IL_0126:  dup
+    IL_0127:  stloc.0
+    IL_0128:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_012d:  ldloca.s   V_2
+    IL_012f:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_0134:  ldarg.0
+    IL_0135:  ldfld      ""object Program.<Main>d__0.<>7__wrap1""
+    IL_013a:  stloc.1
+    IL_013b:  ldloc.1
+    IL_013c:  brfalse.s  IL_0153
+    IL_013e:  ldloc.1
+    IL_013f:  isinst     ""System.Exception""
+    IL_0144:  dup
+    IL_0145:  brtrue.s   IL_0149
+    IL_0147:  ldloc.1
+    IL_0148:  throw
+    IL_0149:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_014e:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_0153:  ldarg.0
+    IL_0154:  ldfld      ""int Program.<Main>d__0.<>7__wrap2""
+    IL_0159:  stloc.3
+    IL_015a:  ldloc.3
+    IL_015b:  ldc.i4.1
+    IL_015c:  bne.un.s   IL_0160
+    IL_015e:  leave.s    IL_0182
+    IL_0160:  ldarg.0
+    IL_0161:  ldnull
+    IL_0162:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
+    IL_0167:  leave.s    IL_0182
   }
   catch System.Exception
   {
-    IL_017d:  stloc.s    V_4
-    IL_017f:  ldarg.0
-    IL_0180:  ldc.i4.s   -2
-    IL_0182:  stfld      ""int Program.<Main>d__0.<>1__state""
-    IL_0187:  ldarg.0
-    IL_0188:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
-    IL_018d:  ldloc.s    V_4
-    IL_018f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0194:  leave.s    IL_01a9
+    IL_0169:  stloc.s    V_4
+    IL_016b:  ldarg.0
+    IL_016c:  ldc.i4.s   -2
+    IL_016e:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_0173:  ldarg.0
+    IL_0174:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+    IL_0179:  ldloc.s    V_4
+    IL_017b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0180:  leave.s    IL_0195
   }
-  IL_0196:  ldarg.0
-  IL_0197:  ldc.i4.s   -2
-  IL_0199:  stfld      ""int Program.<Main>d__0.<>1__state""
-  IL_019e:  ldarg.0
-  IL_019f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
-  IL_01a4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_01a9:  ret
+  IL_0182:  ldarg.0
+  IL_0183:  ldc.i4.s   -2
+  IL_0185:  stfld      ""int Program.<Main>d__0.<>1__state""
+  IL_018a:  ldarg.0
+  IL_018b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+  IL_0190:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0195:  ret
 }");
         }
 
@@ -1809,7 +1799,7 @@ class Program
             var verifier = CompileAndVerify(comp, expectedOutput: "");
             verifier.VerifyIL("Program.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
 @"{
-  // Code size      320 (0x140)
+  // Code size      306 (0x132)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
@@ -1826,7 +1816,7 @@ class Program
     IL_000a:  ldarg.0
     IL_000b:  ldc.i4.0
     IL_000c:  stfld      ""int Program.<Main>d__0.<i>5__2""
-    IL_0011:  br         IL_0105
+    IL_0011:  br         IL_00f7
     IL_0016:  ldarg.0
     IL_0017:  newobj     ""System.IO.MemoryStream..ctor()""
     IL_001c:  stfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
@@ -1876,7 +1866,7 @@ class Program
       IL_0071:  ldloca.s   V_2
       IL_0073:  ldarg.0
       IL_0074:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Program.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Program.<Main>d__0)""
-      IL_0079:  leave      IL_013f
+      IL_0079:  leave      IL_0131
       IL_007e:  ldarg.0
       IL_007f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
       IL_0084:  stloc.2
@@ -1909,61 +1899,56 @@ class Program
       IL_00c7:  ldloc.3
       IL_00c8:  ldc.i4.1
       IL_00c9:  bne.un.s   IL_00cd
-      IL_00cb:  leave.s    IL_00f5
-      IL_00cd:  ldarg.0
-      IL_00ce:  ldnull
-      IL_00cf:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
-      IL_00d4:  leave.s    IL_00ee
+      IL_00cb:  leave.s    IL_00e7
+      IL_00cd:  ldnull
+      IL_00ce:  throw
     }
     finally
     {
-      IL_00d6:  ldloc.0
-      IL_00d7:  ldc.i4.0
-      IL_00d8:  bge.s      IL_00ed
-      IL_00da:  ldarg.0
-      IL_00db:  ldfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
-      IL_00e0:  brfalse.s  IL_00ed
-      IL_00e2:  ldarg.0
-      IL_00e3:  ldfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
-      IL_00e8:  callvirt   ""void System.IDisposable.Dispose()""
-      IL_00ed:  endfinally
+      IL_00cf:  ldloc.0
+      IL_00d0:  ldc.i4.0
+      IL_00d1:  bge.s      IL_00e6
+      IL_00d3:  ldarg.0
+      IL_00d4:  ldfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
+      IL_00d9:  brfalse.s  IL_00e6
+      IL_00db:  ldarg.0
+      IL_00dc:  ldfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
+      IL_00e1:  callvirt   ""void System.IDisposable.Dispose()""
+      IL_00e6:  endfinally
     }
+    IL_00e7:  ldarg.0
+    IL_00e8:  ldfld      ""int Program.<Main>d__0.<i>5__2""
+    IL_00ed:  stloc.3
     IL_00ee:  ldarg.0
-    IL_00ef:  ldnull
-    IL_00f0:  stfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
-    IL_00f5:  ldarg.0
-    IL_00f6:  ldfld      ""int Program.<Main>d__0.<i>5__2""
-    IL_00fb:  stloc.3
-    IL_00fc:  ldarg.0
-    IL_00fd:  ldloc.3
-    IL_00fe:  ldc.i4.1
-    IL_00ff:  add
-    IL_0100:  stfld      ""int Program.<Main>d__0.<i>5__2""
-    IL_0105:  ldarg.0
-    IL_0106:  ldfld      ""int Program.<Main>d__0.<i>5__2""
-    IL_010b:  ldc.i4.5
-    IL_010c:  blt        IL_0016
-    IL_0111:  leave.s    IL_012c
+    IL_00ef:  ldloc.3
+    IL_00f0:  ldc.i4.1
+    IL_00f1:  add
+    IL_00f2:  stfld      ""int Program.<Main>d__0.<i>5__2""
+    IL_00f7:  ldarg.0
+    IL_00f8:  ldfld      ""int Program.<Main>d__0.<i>5__2""
+    IL_00fd:  ldc.i4.5
+    IL_00fe:  blt        IL_0016
+    IL_0103:  leave.s    IL_011e
   }
   catch System.Exception
   {
-    IL_0113:  stloc.s    V_4
-    IL_0115:  ldarg.0
-    IL_0116:  ldc.i4.s   -2
-    IL_0118:  stfld      ""int Program.<Main>d__0.<>1__state""
-    IL_011d:  ldarg.0
-    IL_011e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
-    IL_0123:  ldloc.s    V_4
-    IL_0125:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_012a:  leave.s    IL_013f
+    IL_0105:  stloc.s    V_4
+    IL_0107:  ldarg.0
+    IL_0108:  ldc.i4.s   -2
+    IL_010a:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_010f:  ldarg.0
+    IL_0110:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+    IL_0115:  ldloc.s    V_4
+    IL_0117:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_011c:  leave.s    IL_0131
   }
-  IL_012c:  ldarg.0
-  IL_012d:  ldc.i4.s   -2
-  IL_012f:  stfld      ""int Program.<Main>d__0.<>1__state""
-  IL_0134:  ldarg.0
-  IL_0135:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
-  IL_013a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_013f:  ret
+  IL_011e:  ldarg.0
+  IL_011f:  ldc.i4.s   -2
+  IL_0121:  stfld      ""int Program.<Main>d__0.<>1__state""
+  IL_0126:  ldarg.0
+  IL_0127:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+  IL_012c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0131:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -2417,7 +2417,7 @@ class Driver
             CompileAndVerify(source, expected);
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [Fact]
         public void SpillArglist()
         {
             var source = @"
@@ -2474,12 +2474,12 @@ class Driver
         Console.WriteLine(Result);
     }
 }";
-            var expected = @"
+            var expected = ExecutionConditionUtil.IsDesktop ? @"
 1
 2
 0
-";
-            CompileAndVerify(source, expectedOutput: expected);
+" : null;
+            CompileAndVerify(source, targetFramework: TargetFramework.NetFramework, expectedOutput: expected, verify: Verification.FailsILVerify);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -3300,7 +3300,7 @@ public class C
                 expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3) Dispose(4)");
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         public void TestWithPattern_WithUnsealed_WithIAsyncDisposable()
         {
             string source = @"
@@ -5066,7 +5066,7 @@ class C
             Assert.True(internalInfo.NeedsDisposal);
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         public void TestWithInterfaceImplementingPattern()
         {
             string source = @"
@@ -5289,7 +5289,7 @@ class C
 }", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         public void TestWithInterfaceImplementingPattern_ChildImplementsDisposeAsync()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -1121,15 +1121,14 @@ class C : System.IAsyncDisposable
             var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      306 (0x132)
+  // Code size      282 (0x11a)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
                 System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
                 System.Threading.Tasks.ValueTask V_3,
                 C.<Main>d__0 V_4,
-                System.Exception V_5,
-                int V_6)
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1198,7 +1197,7 @@ class C : System.IAsyncDisposable
     IL_008c:  ldloca.s   V_4
     IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
     IL_0093:  nop
-    IL_0094:  leave      IL_0131
+    IL_0094:  leave      IL_0119
     IL_0099:  ldarg.0
     IL_009a:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
     IL_009f:  stloc.2
@@ -1231,41 +1230,30 @@ class C : System.IAsyncDisposable
     IL_00e1:  nop
     IL_00e2:  ldarg.0
     IL_00e3:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_00e8:  stloc.s    V_6
-    IL_00ea:  ldloc.s    V_6
-    IL_00ec:  ldc.i4.1
-    IL_00ed:  beq.s      IL_00f1
-    IL_00ef:  br.s       IL_00f3
-    IL_00f1:  leave.s    IL_011d
-    IL_00f3:  ldarg.0
-    IL_00f4:  ldnull
-    IL_00f5:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_00fa:  ldarg.0
-    IL_00fb:  ldnull
-    IL_00fc:  stfld      ""C C.<Main>d__0.<>s__1""
-    IL_0101:  leave.s    IL_011d
+    IL_00e8:  pop
+    IL_00e9:  leave.s    IL_0105
   }
   catch System.Exception
   {
-    IL_0103:  stloc.s    V_5
-    IL_0105:  ldarg.0
-    IL_0106:  ldc.i4.s   -2
-    IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_010d:  ldarg.0
-    IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0113:  ldloc.s    V_5
-    IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_011a:  nop
-    IL_011b:  leave.s    IL_0131
+    IL_00eb:  stloc.s    V_5
+    IL_00ed:  ldarg.0
+    IL_00ee:  ldc.i4.s   -2
+    IL_00f0:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00f5:  ldarg.0
+    IL_00f6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00fb:  ldloc.s    V_5
+    IL_00fd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0102:  nop
+    IL_0103:  leave.s    IL_0119
   }
-  IL_011d:  ldarg.0
-  IL_011e:  ldc.i4.s   -2
-  IL_0120:  stfld      ""int C.<Main>d__0.<>1__state""
-  IL_0125:  ldarg.0
-  IL_0126:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_012b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0130:  nop
-  IL_0131:  ret
+  IL_0105:  ldarg.0
+  IL_0106:  ldc.i4.s   -2
+  IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_010d:  ldarg.0
+  IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_0113:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0118:  nop
+  IL_0119:  ret
 }");
         }
 
@@ -1295,15 +1283,14 @@ class C : System.IAsyncDisposable
             var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      306 (0x132)
+  // Code size      282 (0x11a)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
                 System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
                 System.Threading.Tasks.ValueTask V_3,
                 C.<Main>d__0 V_4,
-                System.Exception V_5,
-                int V_6)
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1372,7 +1359,7 @@ class C : System.IAsyncDisposable
     IL_008c:  ldloca.s   V_4
     IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
     IL_0093:  nop
-    IL_0094:  leave      IL_0131
+    IL_0094:  leave      IL_0119
     IL_0099:  ldarg.0
     IL_009a:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
     IL_009f:  stloc.2
@@ -1405,41 +1392,30 @@ class C : System.IAsyncDisposable
     IL_00e1:  nop
     IL_00e2:  ldarg.0
     IL_00e3:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_00e8:  stloc.s    V_6
-    IL_00ea:  ldloc.s    V_6
-    IL_00ec:  ldc.i4.1
-    IL_00ed:  beq.s      IL_00f1
-    IL_00ef:  br.s       IL_00f3
-    IL_00f1:  leave.s    IL_011d
-    IL_00f3:  ldarg.0
-    IL_00f4:  ldnull
-    IL_00f5:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_00fa:  ldarg.0
-    IL_00fb:  ldnull
-    IL_00fc:  stfld      ""C C.<Main>d__0.<>s__1""
-    IL_0101:  leave.s    IL_011d
+    IL_00e8:  pop
+    IL_00e9:  leave.s    IL_0105
   }
   catch System.Exception
   {
-    IL_0103:  stloc.s    V_5
-    IL_0105:  ldarg.0
-    IL_0106:  ldc.i4.s   -2
-    IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_010d:  ldarg.0
-    IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0113:  ldloc.s    V_5
-    IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_011a:  nop
-    IL_011b:  leave.s    IL_0131
+    IL_00eb:  stloc.s    V_5
+    IL_00ed:  ldarg.0
+    IL_00ee:  ldc.i4.s   -2
+    IL_00f0:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00f5:  ldarg.0
+    IL_00f6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00fb:  ldloc.s    V_5
+    IL_00fd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0102:  nop
+    IL_0103:  leave.s    IL_0119
   }
-  IL_011d:  ldarg.0
-  IL_011e:  ldc.i4.s   -2
-  IL_0120:  stfld      ""int C.<Main>d__0.<>1__state""
-  IL_0125:  ldarg.0
-  IL_0126:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_012b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0130:  nop
-  IL_0131:  ret
+  IL_0105:  ldarg.0
+  IL_0106:  ldc.i4.s   -2
+  IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_010d:  ldarg.0
+  IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_0113:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0118:  nop
+  IL_0119:  ret
 }
 ");
         }
@@ -1470,15 +1446,14 @@ class C
             var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      306 (0x132)
+  // Code size      282 (0x11a)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
                 System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
                 System.Threading.Tasks.ValueTask V_3,
                 C.<Main>d__0 V_4,
-                System.Exception V_5,
-                int V_6)
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1547,7 +1522,7 @@ class C
     IL_008c:  ldloca.s   V_4
     IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
     IL_0093:  nop
-    IL_0094:  leave      IL_0131
+    IL_0094:  leave      IL_0119
     IL_0099:  ldarg.0
     IL_009a:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
     IL_009f:  stloc.2
@@ -1580,41 +1555,30 @@ class C
     IL_00e1:  nop
     IL_00e2:  ldarg.0
     IL_00e3:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_00e8:  stloc.s    V_6
-    IL_00ea:  ldloc.s    V_6
-    IL_00ec:  ldc.i4.1
-    IL_00ed:  beq.s      IL_00f1
-    IL_00ef:  br.s       IL_00f3
-    IL_00f1:  leave.s    IL_011d
-    IL_00f3:  ldarg.0
-    IL_00f4:  ldnull
-    IL_00f5:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_00fa:  ldarg.0
-    IL_00fb:  ldnull
-    IL_00fc:  stfld      ""C C.<Main>d__0.<>s__1""
-    IL_0101:  leave.s    IL_011d
+    IL_00e8:  pop
+    IL_00e9:  leave.s    IL_0105
   }
   catch System.Exception
   {
-    IL_0103:  stloc.s    V_5
-    IL_0105:  ldarg.0
-    IL_0106:  ldc.i4.s   -2
-    IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_010d:  ldarg.0
-    IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0113:  ldloc.s    V_5
-    IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_011a:  nop
-    IL_011b:  leave.s    IL_0131
+    IL_00eb:  stloc.s    V_5
+    IL_00ed:  ldarg.0
+    IL_00ee:  ldc.i4.s   -2
+    IL_00f0:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00f5:  ldarg.0
+    IL_00f6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00fb:  ldloc.s    V_5
+    IL_00fd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0102:  nop
+    IL_0103:  leave.s    IL_0119
   }
-  IL_011d:  ldarg.0
-  IL_011e:  ldc.i4.s   -2
-  IL_0120:  stfld      ""int C.<Main>d__0.<>1__state""
-  IL_0125:  ldarg.0
-  IL_0126:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_012b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0130:  nop
-  IL_0131:  ret
+  IL_0105:  ldarg.0
+  IL_0106:  ldc.i4.s   -2
+  IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_010d:  ldarg.0
+  IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_0113:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0118:  nop
+  IL_0119:  ret
 }
 ");
         }
@@ -1715,15 +1679,14 @@ struct S : System.IAsyncDisposable
             var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
             verifier.VerifyIL("S.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      298 (0x12a)
+  // Code size      281 (0x119)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
                 System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
                 System.Threading.Tasks.ValueTask V_3,
                 S.<Main>d__0 V_4,
-                System.Exception V_5,
-                int V_6)
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int S.<Main>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1790,7 +1753,7 @@ struct S : System.IAsyncDisposable
     IL_008b:  ldloca.s   V_4
     IL_008d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, S.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref S.<Main>d__0)""
     IL_0092:  nop
-    IL_0093:  leave      IL_0129
+    IL_0093:  leave      IL_0118
     IL_0098:  ldarg.0
     IL_0099:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
     IL_009e:  stloc.2
@@ -1823,38 +1786,30 @@ struct S : System.IAsyncDisposable
     IL_00e0:  nop
     IL_00e1:  ldarg.0
     IL_00e2:  ldfld      ""int S.<Main>d__0.<>s__3""
-    IL_00e7:  stloc.s    V_6
-    IL_00e9:  ldloc.s    V_6
-    IL_00eb:  ldc.i4.1
-    IL_00ec:  beq.s      IL_00f0
-    IL_00ee:  br.s       IL_00f2
-    IL_00f0:  leave.s    IL_0115
-    IL_00f2:  ldarg.0
-    IL_00f3:  ldnull
-    IL_00f4:  stfld      ""object S.<Main>d__0.<>s__2""
-    IL_00f9:  leave.s    IL_0115
+    IL_00e7:  pop
+    IL_00e8:  leave.s    IL_0104
   }
   catch System.Exception
   {
-    IL_00fb:  stloc.s    V_5
-    IL_00fd:  ldarg.0
-    IL_00fe:  ldc.i4.s   -2
-    IL_0100:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_0105:  ldarg.0
-    IL_0106:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-    IL_010b:  ldloc.s    V_5
-    IL_010d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0112:  nop
-    IL_0113:  leave.s    IL_0129
+    IL_00ea:  stloc.s    V_5
+    IL_00ec:  ldarg.0
+    IL_00ed:  ldc.i4.s   -2
+    IL_00ef:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_00f4:  ldarg.0
+    IL_00f5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+    IL_00fa:  ldloc.s    V_5
+    IL_00fc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0101:  nop
+    IL_0102:  leave.s    IL_0118
   }
-  IL_0115:  ldarg.0
-  IL_0116:  ldc.i4.s   -2
-  IL_0118:  stfld      ""int S.<Main>d__0.<>1__state""
-  IL_011d:  ldarg.0
-  IL_011e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-  IL_0123:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0128:  nop
-  IL_0129:  ret
+  IL_0104:  ldarg.0
+  IL_0105:  ldc.i4.s   -2
+  IL_0107:  stfld      ""int S.<Main>d__0.<>1__state""
+  IL_010c:  ldarg.0
+  IL_010d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+  IL_0112:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0117:  nop
+  IL_0118:  ret
 }");
         }
 
@@ -1884,15 +1839,14 @@ struct S : System.IAsyncDisposable
             var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
             verifier.VerifyIL("S.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      292 (0x124)
+  // Code size      275 (0x113)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
                 System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
                 System.Threading.Tasks.ValueTask V_3,
                 S.<Main>d__0 V_4,
-                System.Exception V_5,
-                int V_6)
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int S.<Main>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1958,7 +1912,7 @@ struct S : System.IAsyncDisposable
     IL_0085:  ldloca.s   V_4
     IL_0087:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, S.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref S.<Main>d__0)""
     IL_008c:  nop
-    IL_008d:  leave      IL_0123
+    IL_008d:  leave      IL_0112
     IL_0092:  ldarg.0
     IL_0093:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
     IL_0098:  stloc.2
@@ -1991,38 +1945,30 @@ struct S : System.IAsyncDisposable
     IL_00da:  nop
     IL_00db:  ldarg.0
     IL_00dc:  ldfld      ""int S.<Main>d__0.<>s__3""
-    IL_00e1:  stloc.s    V_6
-    IL_00e3:  ldloc.s    V_6
-    IL_00e5:  ldc.i4.1
-    IL_00e6:  beq.s      IL_00ea
-    IL_00e8:  br.s       IL_00ec
-    IL_00ea:  leave.s    IL_010f
-    IL_00ec:  ldarg.0
-    IL_00ed:  ldnull
-    IL_00ee:  stfld      ""object S.<Main>d__0.<>s__2""
-    IL_00f3:  leave.s    IL_010f
+    IL_00e1:  pop
+    IL_00e2:  leave.s    IL_00fe
   }
   catch System.Exception
   {
-    IL_00f5:  stloc.s    V_5
-    IL_00f7:  ldarg.0
-    IL_00f8:  ldc.i4.s   -2
-    IL_00fa:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_00ff:  ldarg.0
-    IL_0100:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-    IL_0105:  ldloc.s    V_5
-    IL_0107:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_010c:  nop
-    IL_010d:  leave.s    IL_0123
+    IL_00e4:  stloc.s    V_5
+    IL_00e6:  ldarg.0
+    IL_00e7:  ldc.i4.s   -2
+    IL_00e9:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_00ee:  ldarg.0
+    IL_00ef:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+    IL_00f4:  ldloc.s    V_5
+    IL_00f6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00fb:  nop
+    IL_00fc:  leave.s    IL_0112
   }
-  IL_010f:  ldarg.0
-  IL_0110:  ldc.i4.s   -2
-  IL_0112:  stfld      ""int S.<Main>d__0.<>1__state""
-  IL_0117:  ldarg.0
-  IL_0118:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-  IL_011d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0122:  nop
-  IL_0123:  ret
+  IL_00fe:  ldarg.0
+  IL_00ff:  ldc.i4.s   -2
+  IL_0101:  stfld      ""int S.<Main>d__0.<>1__state""
+  IL_0106:  ldarg.0
+  IL_0107:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+  IL_010c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0111:  nop
+  IL_0112:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -2670,7 +2670,7 @@ public class C
                 Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "var x = new C()").WithArguments("C").WithLocation(6, 22));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
         public void TestPatternBasedDisposal_InstanceMethod_UsingDeclaration()
         {


### PR DESCRIPTION
Our current approach to rewriting `await` expressions in `finally` blocks is technically unsound: the rewrite can result in a new exit block from the original method being created. As a simple example, here is an original method, and what it gets rewritten to by `AsyncExceptionHandlerRewriter` (slightly simplified):

```cs
static async Task G()
{
    int x = 0;

    try
    {
        x = await F();
    }
    finally
    {
        x += await F();
    }
}
```

```cs
async Task<int> M()
{
    int x = 0;
    object ex = null;
    int retTaken = 0;
    int retTemp = 0;
    try
    {
        x = await F();
        goto @finally;
    }
    catch (object o)
    {
        ex = o;
        goto @finally;
    }

@finally:
    x += await F();
    if (ex != null)
    {
        if (ex is Exception e) ExceptionDispatchInfo.Capture(e).Throw();
        throw ex;
    }

    switch(retTaken)
    {
        case 2:
            return retTemp;
        default:
            break; // This is the problem
    }
}
```

While we can statically walk the method and prove via flow analysis that the `default` case of the switch isn't reachable, the generalized version of this problem is the halting problem. To date, this has never been a problem because the code that the async rewriter rewrites is then wrapped rewritten again into the async state machine, and the missing return becomes completely unobservable. However, for runtime async, we're going to be emitting this general structure, essentially unchanged: that `break;`, then, becomes a branch to an invalid IL location and the method ends without a `ret`. To solve this, we need to take reachability analysis into consideration when rewriting `try/finally`s. If the end of the `finally` is reachable, meaning the method continues beyond the end of the `try/finally`, then the `break;` is necessary, as that's the path by which the rest of the method will be reached. However, in the case where the end of the `try/finally` is not reachable, we need to unconditionally return, rather than letting it fall through. The other case would be if there was no returns, just unconditional throws in the body of the method. In this case, we want to insert a `throw null;` to the end of the switch to ensure that the exit remains covered. The problematic code above becomes this instead:

```cs
async Task<int> M()
{
    int x = 0;
    object ex = null;
    int retTaken = 0;
    int retTemp = 0;
    try
    {
        x = await F();
        goto @finally;
    }
    catch (object o)
    {
        ex = o;
        goto @finally;
    }

@finally:
    x += await F();
    if (ex != null)
    {
        if (ex is Exception e) ExceptionDispatchInfo.Capture(e).Throw();
        throw ex;
    }

    return retTemp;
}
```

Commit-by-commit review recommended here. Commit 1 unskips a bunch of tests that don't need to be skipped on non-windows; commit 2 is the real change, and commit 3 is a related comment clarification.