### PR TITLE
Fix locating startup objects

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpEntryPointFinder.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpEntryPointFinder.cs
@@ -18,8 +18,7 @@ internal sealed class CSharpEntryPointFinder(Compilation compilation)
     {
         // This differs from the VB implementation
         // (Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.EntryPointFinder) because we don't
-        // ever consider forms entry points. Technically, this is wrong but it just doesn't matter since the ref
-        // assemblies are unlikely to have a random Main() method that matches
+        // ever consider forms entry points.
         var visitor = new CSharpEntryPointFinder(compilation);
         visitor.Visit(compilation.SourceModule.GlobalNamespace);
         return visitor.EntryPoints;

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpEntryPointFinderService.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpEntryPointFinderService.cs
@@ -16,6 +16,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class CSharpEntryPointFinderService() : AbstractEntryPointFinderService
 {
-    protected override IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly)
+    public override IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly)
         => CSharpEntryPointFinder.FindEntryPoints(compilation);
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 
 internal abstract class AbstractEntryPointFinderService : IEntryPointFinderService
 {
-    protected abstract IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly);
+    public abstract IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly);
 
     public IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly)
         => symbol is { ContainingCompilation: Compilation compilation }

--- a/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
@@ -12,7 +12,7 @@ internal abstract class AbstractEntryPointFinderService : IEntryPointFinderServi
     protected abstract IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly);
 
     public IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly)
-        => symbol is not { ContainingAssembly: ISourceAssemblySymbol sourceAssembly }
-            ? []
-            : FindEntryPoints(sourceAssembly.Compilation, findFormsOnly);
+        => symbol is { ContainingCompilation: Compilation compilation }
+            ? FindEntryPoints(compilation, findFormsOnly)
+            : [];
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/IEntryPointFinderService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/IEntryPointFinderService.cs
@@ -19,4 +19,11 @@ internal interface IEntryPointFinderService : ILanguageService
     /// <param name="symbol">The namespace to search.</param>
     /// <param name="findFormsOnly">Restrict the search to only Windows Forms classes. Note that this is only implemented for VisualBasic</param>
     IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly);
+
+    /// <summary>
+    /// Finds the types that contain entry points like the Main method in a given compilation.
+    /// </summary>
+    /// <param name="compilation">The compilation to search.</param>
+    /// <param name="findFormsOnly">Restrict the search to only Windows Forms classes. Note that this is only implemented for VisualBasic</param>
+    IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly);
 }

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinder.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinder.vb
@@ -28,12 +28,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
             Dim visitor = New VisualBasicEntryPointFinder(compilation, findFormsOnly)
             Dim symbol = compilation.SourceModule.GlobalNamespace
 
-            ' Attempt to only search source symbols
-            ' Some callers will give a symbol that is not part of a compilation
-            If symbol.ContainingCompilation IsNot Nothing Then
-                symbol = symbol.ContainingCompilation.SourceModule.GlobalNamespace
-            End If
-
             visitor.Visit(symbol)
             Return visitor.EntryPoints
         End Function

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinderService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinderService.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         Public Sub New()
         End Sub
 
-        Protected Overrides Function FindEntryPoints(compilation As Compilation, findFormsOnly As Boolean) As IEnumerable(Of INamedTypeSymbol)
+        Public Overrides Function FindEntryPoints(compilation As Compilation, findFormsOnly As Boolean) As IEnumerable(Of INamedTypeSymbol)
             Return VisualBasicEntryPointFinder.FindEntryPoints(compilation, findFormsOnly)
         End Function
     End Class


### PR DESCRIPTION
CPS passes us an INamespaceSymbol that is the global namespace symbol; it doesn't have a containing assembly. It does have a containing Compilation though, which is what we actually need.

While I'm here, let's expose a better API for this to avoid this silly dance in the first place.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2506795
Fixes https://github.com/dotnet/roslyn/issues/78697