### PR TITLE
Make synthesized primary constructor baking field return the original parameter as an associated symbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -77,12 +77,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract TypeWithAnnotations GetFieldType(ConsList<FieldSymbol> fieldsBeingBound);
 
         /// <summary>
+        /// <list type="bullet">
+        /// <item>
         /// If this field serves as a backing variable for an automatically generated
-        /// property or a field-like event, returns that 
-        /// property/event. Otherwise returns null.
+        /// property or a field-like event, returns that property/event
+        /// </item>
+        /// <item>
+        /// If this field serves as a backing variable for a captured primary constructor parameter,
+        /// returns that primary constructor parameter
+        /// </item>
+        /// </list>
+        /// Otherwise returns <see langword="null"/>
+        /// </summary>
+        /// <remarks>
         /// Note, the set of possible associated symbols might be expanded in the future to 
         /// reflect changes in the languages.
-        /// </summary>
+        /// </remarks>
         public abstract Symbol AssociatedSymbol { get; }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructorParameterBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructorParameterBackingFieldSymbol.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             => OneOrMany<SyntaxList<AttributeListSyntax>>.Empty;
 
         public override Symbol? AssociatedSymbol
-            => null;
+            => ParameterSymbol;
 
         public override ImmutableArray<Location> Locations
             => ParameterSymbol.Locations;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -506,7 +506,13 @@ namespace Microsoft.CodeAnalysis.Emit
             var associated = GetAssociatedSymbol(symbol);
             if (associated is not null)
             {
-                return associated;
+                // Baking fields of captured primary constructor parameters
+                // point back to the original parameters as associated symbols,
+                // but are not considered to be contained in their respective parameters
+                if (associated is not IParameterSymbolInternal)
+                {
+                    return associated;
+                }
             }
 
             symbol = symbol.ContainingSymbol;

--- a/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
@@ -17,12 +17,22 @@ namespace Microsoft.CodeAnalysis
     public interface IFieldSymbol : ISymbol
     {
         /// <summary>
+        /// <list type="bullet">
+        /// <item>
         /// If this field serves as a backing variable for an automatically generated
-        /// property or a field-like event, returns that 
-        /// property/event. Otherwise returns null.
+        /// property or a field-like event, returns that property/event
+        /// </item>
+        /// <item>
+        /// If this field serves as a backing variable for a captured primary constructor parameter,
+        /// returns that primary constructor parameter
+        /// </item>
+        /// </list>
+        /// Otherwise returns <see langword="null"/>
+        /// </summary>
+        /// <remarks>
         /// Note, the set of possible associated symbols might be expanded in the future to 
         /// reflect changes in the languages.
-        /// </summary>
+        /// </remarks>
         ISymbol? AssociatedSymbol { get; }
 
         /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
@@ -504,7 +504,7 @@ internal static partial class SyntaxGeneratorExtensions
 
             return containingType.GetMembers()
                 .OfType<IFieldSymbol>()
-                .Where(field => !field.IsStatic)
+                .Where(field => !field.IsStatic && field.AssociatedSymbol is not IParameterSymbol)
                 .Select(field => field.AssociatedSymbol ?? field)
                 .Except(parameterToExistingFieldMap?.Values ?? [])
                 .Any();


### PR DESCRIPTION
Closes: https://github.com/dotnet/roslyn/issues/70208