### PR TITLE
Fix SubText ctor parameter verification.

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -59,6 +59,28 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void TestSubTextSubTextStart()
+        {
+            var text = SourceText.From("Hello World");
+            var subText = text.GetSubText(new TextSpan(0, 5));
+            var subSubText = subText.GetSubText(new TextSpan(0, 0));
+
+            Assert.Equal("Hello", subText.ToString());
+            Assert.Equal(0, subSubText.Length);
+        }
+
+        [Fact]
+        public void TestSubTextSubTextEnd()
+        {
+            var text = SourceText.From("Hello World");
+            var subText = text.GetSubText(6);
+            var subSubText = subText.GetSubText(subText.Length);
+
+            Assert.Equal("World", subText.ToString());
+            Assert.Equal(0, subSubText.Length);
+        }
+
+        [Fact]
         public void TestChangedText()
         {
             var text = SourceText.From("Hello World");

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        [WorkItem(78989, "https://github.com/dotnet/roslyn/pull/78989")]
         public void TestSubTextSubTextEnd()
         {
             var text = SourceText.From("Hello World");

--- a/src/Compilers/Core/Portable/Text/SubText.cs
+++ b/src/Compilers/Core/Portable/Text/SubText.cs
@@ -22,9 +22,9 @@ namespace Microsoft.CodeAnalysis.Text
                 throw new ArgumentNullException(nameof(text));
             }
 
+            // span.Start and span.End are valid wrt eachother by nature of being passed in as a TextSpan,
+            // so there is no need to verify span.Start against text.Length or span.End against zero.
             if (span.Start < 0
-                || span.Start >= text.Length
-                || span.End < 0
                 || span.End > text.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(span));


### PR DESCRIPTION
This ctor currently throws given a zero length span at the end (and only the end) of the subtext. This evidently became far more prevalent with this (fairly) recent change to optimize newline information in our sourcetext classes. (https://github.com/dotnet/roslyn/pull/74728)

It seens odd to allow zero length spans at all locations but at the end of the subtext, so the fix is to allow construction in that case too.

Big props to Manish Vasani for providing a very actionable repro for this.

Fixes https://github.com/dotnet/roslyn/issues/78985

Note there is a potentially related issue outlined in https://github.com/dotnet/roslyn/issues/76225 that looks attributable to the PR above too. It is possible that this addresses that issue too, but I'm not completely convinced.