### PR TITLE
Avoid acquiring the workspace lock on the UI thread if unneeded

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -369,9 +369,15 @@ internal partial class VisualStudioWorkspaceImpl
                             // and if it was actually open, we'll schedule an update asynchronously.
                             if (TryOpeningDocumentsForFilePathCore(w, newFileName, textBuffer, hierarchy: null))
                             {
-                                // The files are now tied to the buffer, but let's schedule work to correctly update the context.
-                                var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(CheckForAddedFileBeingOpenMaybeAsync));
-                                UpdateContextAfterOpenAsync(newFileName).CompletesAsyncOperation(token);
+                                // We've opened the document, but unless we have more than one project with this document, there's no reason to actually
+                                // go to the UI thread to fix up the context -- the one we arbitrarily picked in TryOpeningDocumentsForFilePathCore
+                                // is the right one, because there is only one.
+                                if (w.CurrentSolution.GetDocumentIdsWithFilePath(newFileName).Length >= 2)
+                                {
+                                    // Update the context on the UI thread as necessary.
+                                    var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(UpdateContextAfterOpenAsync));
+                                    UpdateContextAfterOpenAsync(newFileName).CompletesAsyncOperation(token);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
If the project system tells us about a file that's open and we are told about it on a background thread, we connect the file to the workspace on that background thread but then schedule work to the UI thread to ensure we correctly connect it to the right context (linked files, shared projects, multitargeting, etc.) That code on the UI thread then acquires the workspace lock, and we're seeing cases in the wild where that lock acquisition is taking longer than we'd like. Although there are deeper fixes we can do there, there's one trivial fix we can make: don't schedule the work to the UI thread unless the file is in at least two projects. Otherwise, we don't actually need to figure out the context in the first place and it's just wasting time.

An entirely unscientific analysis of a handful of traces from users hitting this, there weren't any cases where the file was actually in more than one project, so this should have a nice improvement overall.

Closes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2471561