### PR TITLE
Fix locating startup objects

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
@@ -12,7 +12,7 @@ internal abstract class AbstractEntryPointFinderService : IEntryPointFinderServi
     protected abstract IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly);
 
     public IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly)
-        => symbol is not { ContainingAssembly: ISourceAssemblySymbol sourceAssembly }
-            ? []
-            : FindEntryPoints(sourceAssembly.Compilation, findFormsOnly);
+        => symbol is { ContainingCompilation: Compilation compilation }
+            ? FindEntryPoints(compilation, findFormsOnly)
+            : [];
 }


### PR DESCRIPTION
CPS passes us an INamespaceSymbol that is the global namespace symbol; it doesn't have a containing assembly. It does have a containing Compilation though, which is what we actually need.

This is a 17.14 backport of the specific fix from https://github.com/dotnet/roslyn/pull/78972 but removes the other cleanup and the introduction of a new API that won't ever be consumed in 17.14.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2506795
Fixes https://github.com/dotnet/roslyn/issues/78697