### PR TITLE
Revert "Avoid acquiring the workspace lock on the UI thread if unneeded (#79025)"

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -369,15 +369,9 @@ internal partial class VisualStudioWorkspaceImpl
                             // and if it was actually open, we'll schedule an update asynchronously.
                             if (TryOpeningDocumentsForFilePathCore(w, newFileName, textBuffer, hierarchy: null))
                             {
-                                // We've opened the document, but unless we have more than one project with this document, there's no reason to actually
-                                // go to the UI thread to fix up the context -- the one we arbitrarily picked in TryOpeningDocumentsForFilePathCore
-                                // is the right one, because there is only one.
-                                if (w.CurrentSolution.GetDocumentIdsWithFilePath(newFileName).Length >= 2)
-                                {
-                                    // Update the context on the UI thread as necessary.
-                                    var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(UpdateContextAfterOpenAsync));
-                                    UpdateContextAfterOpenAsync(newFileName).CompletesAsyncOperation(token);
-                                }
+                                // The files are now tied to the buffer, but let's schedule work to correctly update the context.
+                                var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(CheckForAddedFileBeingOpenMaybeAsync));
+                                UpdateContextAfterOpenAsync(newFileName).CompletesAsyncOperation(token);
                             }
                         }
                     }


### PR DESCRIPTION
This reverts commit f479243b5639e0d052f8dff9babc449abe23da6b, reversing changes made to 438638eb1200d89f4f8e927648833a9d3dbeaddb.

The original PR broke lightbulbs.