### PR TITLE
Allow Razor to configure source generator execution in tests

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/Testing/TestRoslynOptionsHelper.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Testing/TestRoslynOptionsHelper.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal static class TestRoslynOptionsHelper
+    {
+        public static void SetAutomaticSourceGeneratorExecution(Workspace workspace)
+        {
+            var globalOptions = workspace.CurrentSolution.Services.ExportProvider.GetService<IGlobalOptionService>();
+            globalOptions.SetGlobalOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Automatic);
+        }
+    }
+}


### PR DESCRIPTION
Until https://github.com/dotnet/razor/issues/11838 is in (which is being worked on: https://github.com/dotnet/roslyn/pull/77304) Razor can't run integration tests with cohosting on to identify regressions.

This PR, and https://github.com/dotnet/roslyn/pull/79048, and key to unblocking that.