### PR TITLE
Preserve trailing directives when converting a Program.Main program to top level statements.

### DIFF
--- a/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_TopLevelStatements.cs
+++ b/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_TopLevelStatements.cs
@@ -145,7 +145,7 @@ internal static partial class ConvertProgramTransform
             // type wasn't in a namespace.  just remove the type and replace it with the new global statements.
             editor.ReplaceNode(typeDeclaration, (_, _) => globalStatements);
 
-            // We're removing the namespace itself.  So we want to plae the trailing directive on the element that follows that.
+            // We're removing the namespace itself.  So we want to place the trailing directive on the element that follows that.
             AddDirectivesToNextMemberOrEndOfFile(root.Members.IndexOf(typeDeclaration) + 1);
         }
 

--- a/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_TopLevelStatements.cs
+++ b/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_TopLevelStatements.cs
@@ -137,7 +137,7 @@ internal static partial class ConvertProgramTransform
 
             editor.ReplaceNode(namespaceDeclaration, (_, _) => globalStatements);
 
-            // We're removing the namespace itself.  So we want to plae the trailing directive on the element that follows that.
+            // We're removing the namespace itself.  So we want to place the trailing directive on the element that follows that.
             AddDirectivesToNextMemberOrEndOfFile(root.Members.IndexOf(namespaceDeclaration) + 1);
         }
         else

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
@@ -252,10 +252,11 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
     public async Task TestPreserveStatementDirectives1()
     {
-        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
         await new VerifyCS.Test
         {
             TestCode = """
+                using System;
+
                 class Program
                 {
                     static void $$Main(string[] args)
@@ -269,12 +270,14 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
                 }
                 """,
             FixedCode = """
+                using System;
+
                 #if true
                         Console.WriteLine("true");
                 #else
                         Console.WriteLine("false");
                 #endif
-            """,
+                """,
             LanguageVersion = LanguageVersion.CSharp10,
             TestState = { OutputKind = OutputKind.ConsoleApplication },
             Options =
@@ -287,10 +290,11 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
     public async Task TestPreserveStatementDirectives2()
     {
-        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
         await new VerifyCS.Test
         {
             TestCode = """
+                using System;
+
                 class Program
                 {
                     static void $$Main(string[] args)
@@ -308,6 +312,8 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
                 }
                 """,
             FixedCode = """
+                using System;
+
                 #if true
                         Console.WriteLine("true");
                 #else
@@ -330,10 +336,11 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
     public async Task TestPreserveStatementDirectives3()
     {
-        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
         await new VerifyCS.Test
         {
             TestCode = """
+                using System;
+
                 namespace N
                 {
                     class Program
@@ -350,11 +357,14 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
                 }
                 """,
             FixedCode = """
+                using System;
+
                 #if true
-                        Console.WriteLine("true");
+                Console.WriteLine("true");
                 #else
-                        Console.WriteLine("false");
+                            Console.WriteLine("false");
                 #endif
+
                 """,
             LanguageVersion = LanguageVersion.CSharp10,
             TestState = { OutputKind = OutputKind.ConsoleApplication },
@@ -368,10 +378,11 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
     public async Task TestPreserveStatementDirectives4()
     {
-        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
         await new VerifyCS.Test
         {
             TestCode = """
+                using System;
+
                 namespace N
                 {
                     class Program
@@ -392,14 +403,19 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
                 }
                 """,
             FixedCode = """
-                #if true
-                        Console.WriteLine("true");
-                #else
-                        Console.WriteLine("false");
-                #endif
+                using System;
 
-                class Next
+                #if true
+                Console.WriteLine("true");
+                #else
+                            Console.WriteLine("false");
+                #endif
+                
+                namespace N
                 {
+                    class Next
+                    {
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp10,

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
@@ -22,9 +22,9 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
     [Fact]
     public async Task TestNotOnEmptyFile()
     {
-        var code = @"
-$$
-";
+        var code = """
+            $$
+            """;
 
         // default preference is to prefer top level namespaces.  As such, we should not have the refactoring here
         // since the analyzer will take over.
@@ -44,14 +44,15 @@ $$
     [Fact]
     public async Task TestConvertToTopLevelStatementsWithDefaultTopLevelStatementPreference()
     {
-        var code = @"
-class Program
-{
-    static void $$Main(string[] args)
-    {
-        System.Console.WriteLine(args[0]);
-    }
-}";
+        var code = """
+            class Program
+            {
+                static void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(args[0]);
+                }
+            }
+            """;
 
         // default preference is to prefer top level namespaces.  As such, we should not have the refactoring here
         // since the analyzer will take over.
@@ -69,18 +70,18 @@ class Program
         // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
         await new VerifyCS.Test
         {
-            TestCode = @"
-class Program
-{
-    static void $$Main(string[] args)
-    {
-        System.Console.WriteLine(args[0]);
-    }
-}
-",
-            FixedCode = @"
-System.Console.WriteLine(args[0]);
-",
+            TestCode = """
+            class Program
+            {
+                static void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(args[0]);
+                }
+            }
+            """,
+            FixedCode = """
+            System.Console.WriteLine(args[0]);
+            """,
             LanguageVersion = LanguageVersion.CSharp10,
             TestState = { OutputKind = OutputKind.ConsoleApplication },
             Options =
@@ -93,15 +94,15 @@ System.Console.WriteLine(args[0]);
     [Fact]
     public async Task TestNotOfferedInLibrary()
     {
-        var code = @"
-class Program
-{
-    static void $$Main(string[] args)
-    {
-        System.Console.WriteLine(args[0]);
-    }
-}
-";
+        var code = """
+            class Program
+            {
+                static void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(args[0]);
+                }
+            }
+            """;
 
         await new VerifyCS.Test
         {
@@ -117,15 +118,15 @@ class Program
     [Fact]
     public async Task TestNotWithNonViableType()
     {
-        var code = @"
-class Program
-{
-    void $$Main(string[] args)
-    {
-        System.Console.WriteLine(args[0]);
-    }
-}
-";
+        var code = """
+            class Program
+            {
+                void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(args[0]);
+                }
+            }
+            """;
 
         await new VerifyCS.Test
         {
@@ -147,15 +148,15 @@ class Program
     [Fact]
     public async Task TestNoConvertToTopLevelStatementsWithProgramMainPreferenceSuggestionBeforeCSharp9()
     {
-        var code = @"
-class Program
-{
-    static void $$Main(string[] args)
-    {
-        System.Console.WriteLine(args[0]);
-    }
-}
-";
+        var code = """
+            class Program
+            {
+                static void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(args[0]);
+                }
+            }
+            """;
 
         // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
         await new VerifyCS.Test
@@ -173,15 +174,15 @@ class Program
     [Fact]
     public async Task TestNoConvertToTopLevelStatementsWithTopLevelStatementsPreferenceSuggestion()
     {
-        var code = @"
-class Program
-{
-    static void $$Main(string[] args)
-    {
-        System.Console.WriteLine(args[0]);
-    }
-}
-";
+        var code = """
+            class Program
+            {
+                static void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(args[0]);
+                }
+            }
+            """;
         await new VerifyCS.Test
         {
             TestCode = code,
@@ -197,15 +198,15 @@ class Program
     [Fact]
     public async Task TestNoConvertToTopLevelStatementsWithTopLevelStatementsPreferenceSilent()
     {
-        var code = @"
-class Program
-{
-    static void $$Main(string[] args)
-    {
-        System.Console.WriteLine(args[0]);
-    }
-}
-";
+        var code = """
+            class Program
+            {
+                static void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(args[0]);
+                }
+            }
+            """;
         await new VerifyCS.Test
         {
             TestCode = code,
@@ -224,18 +225,18 @@ class Program
         // if the user has the analyzer suppressed, then we want to supply teh refactoring.
         await new VerifyCS.Test
         {
-            TestCode = @"
-internal class Program
-{
-    private static void $$Main(string[] args)
-    {
-        System.Console.WriteLine(0);
-    }
-}
-",
-            FixedCode = @"
-System.Console.WriteLine(0);
-",
+            TestCode = """
+            internal class Program
+            {
+                private static void $$Main(string[] args)
+                {
+                    System.Console.WriteLine(0);
+                }
+            }
+            """,
+            FixedCode = """
+            System.Console.WriteLine(0);
+            """,
             LanguageVersion = LanguageVersion.CSharp10,
             TestState = { OutputKind = OutputKind.ConsoleApplication },
             Options =

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
@@ -273,10 +273,11 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
                 using System;
 
                 #if true
-                        Console.WriteLine("true");
+                Console.WriteLine("true");
                 #else
                         Console.WriteLine("false");
                 #endif
+
                 """,
             LanguageVersion = LanguageVersion.CSharp10,
             TestState = { OutputKind = OutputKind.ConsoleApplication },
@@ -315,7 +316,7 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
                 using System;
 
                 #if true
-                        Console.WriteLine("true");
+                Console.WriteLine("true");
                 #else
                         Console.WriteLine("false");
                 #endif

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsRefactoringTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.ConvertProgram;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertProgram;
@@ -81,6 +82,7 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
             """,
             FixedCode = """
             System.Console.WriteLine(args[0]);
+
             """,
             LanguageVersion = LanguageVersion.CSharp10,
             TestState = { OutputKind = OutputKind.ConsoleApplication },
@@ -236,12 +238,175 @@ public sealed class ConvertToTopLevelStatementsRefactoringTests
             """,
             FixedCode = """
             System.Console.WriteLine(0);
+
             """,
             LanguageVersion = LanguageVersion.CSharp10,
             TestState = { OutputKind = OutputKind.ConsoleApplication },
             Options =
             {
                 { CSharpCodeStyleOptions.PreferTopLevelStatements, true, NotificationOption2.None },
+            }
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
+    public async Task TestPreserveStatementDirectives1()
+    {
+        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class Program
+                {
+                    static void $$Main(string[] args)
+                    {
+                #if true
+                        Console.WriteLine("true");
+                #else
+                        Console.WriteLine("false");
+                #endif
+                    }
+                }
+                """,
+            FixedCode = """
+                #if true
+                        Console.WriteLine("true");
+                #else
+                        Console.WriteLine("false");
+                #endif
+            """,
+            LanguageVersion = LanguageVersion.CSharp10,
+            TestState = { OutputKind = OutputKind.ConsoleApplication },
+            Options =
+            {
+                { CSharpCodeStyleOptions.PreferTopLevelStatements, false, NotificationOption2.Suggestion },
+            }
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
+    public async Task TestPreserveStatementDirectives2()
+    {
+        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class Program
+                {
+                    static void $$Main(string[] args)
+                    {
+                #if true
+                        Console.WriteLine("true");
+                #else
+                        Console.WriteLine("false");
+                #endif
+                    }
+                }
+
+                class Next
+                {
+                }
+                """,
+            FixedCode = """
+                #if true
+                        Console.WriteLine("true");
+                #else
+                        Console.WriteLine("false");
+                #endif
+            
+                class Next
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp10,
+            TestState = { OutputKind = OutputKind.ConsoleApplication },
+            Options =
+            {
+                { CSharpCodeStyleOptions.PreferTopLevelStatements, false, NotificationOption2.Suggestion },
+            }
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
+    public async Task TestPreserveStatementDirectives3()
+    {
+        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class Program
+                    {
+                        static void $$Main(string[] args)
+                        {
+                    #if true
+                            Console.WriteLine("true");
+                    #else
+                            Console.WriteLine("false");
+                    #endif
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                #if true
+                        Console.WriteLine("true");
+                #else
+                        Console.WriteLine("false");
+                #endif
+                """,
+            LanguageVersion = LanguageVersion.CSharp10,
+            TestState = { OutputKind = OutputKind.ConsoleApplication },
+            Options =
+            {
+                { CSharpCodeStyleOptions.PreferTopLevelStatements, false, NotificationOption2.Suggestion },
+            }
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78002")]
+    public async Task TestPreserveStatementDirectives4()
+    {
+        // user actually prefers Program.Main.  As such, we only offer to convert to the alternative as a refactoring.
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class Program
+                    {
+                        static void $$Main(string[] args)
+                        {
+                    #if true
+                            Console.WriteLine("true");
+                    #else
+                            Console.WriteLine("false");
+                    #endif
+                        }
+                    }
+
+                    class Next
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                #if true
+                        Console.WriteLine("true");
+                #else
+                        Console.WriteLine("false");
+                #endif
+
+                class Next
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp10,
+            TestState = { OutputKind = OutputKind.ConsoleApplication },
+            Options =
+            {
+                { CSharpCodeStyleOptions.PreferTopLevelStatements, false, NotificationOption2.Suggestion },
             }
         }.RunAsync();
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/78002