### PR TITLE
Fix roslyn test modifiers in semantic tokens

### DIFF
--- a/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -127,12 +127,35 @@ internal static class SemanticTokensHelpers
         var spans = await ClassifierHelper.GetClassifiedSpansAsync(
             document, textSpans, options, includeAdditiveSpans: true, cancellationToken).ConfigureAwait(false);
 
-        // The spans returned to us may include some empty spans, which we don't care about. We also don't care
-        // about the 'text' classification.  It's added for everything between real classifications (including
+        // Some classified spans may not be relevant and should be filtered out before we convert to tokens.
+        var filteredSpans = spans.Where(s => !ShouldFilterClassification(s));
+
+        classifiedSpans.AddRange(filteredSpans);
+    }
+
+    private static bool ShouldFilterClassification(ClassifiedSpan s)
+    {
+        // The spans returned to us may include some empty spans, which we don't care about.
+        if (s.TextSpan.IsEmpty)
+        {
+            return true;
+        }
+
+        // We also don't care about the 'text' classification.  It's added for everything between real classifications (including
         // whitespace), and just means 'don't classify this'.  No need for us to actually include that in
         // semantic tokens as it just wastes space in the result.
-        var nonEmptySpans = spans.Where(s => !s.TextSpan.IsEmpty && s.ClassificationType != ClassificationTypeNames.Text);
-        classifiedSpans.AddRange(nonEmptySpans);
+        if (s.ClassificationType == ClassificationTypeNames.Text)
+        {
+            return true;
+        }
+
+        // Additive classification types that are mapped to TokenModifiers.None are not rendered by the client and do not need to be included.
+        if (SemanticTokensSchema.AdditiveClassificationTypeToTokenModifier.TryGetValue(s.ClassificationType, out var modifier) && modifier == TokenModifiers.None)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static void ConvertMultiLineToSingleLineSpans(SourceText text, SegmentedList<ClassifiedSpan> classifiedSpans, SegmentedList<ClassifiedSpan> updatedClassifiedSpans)
@@ -288,8 +311,6 @@ internal static class SemanticTokensHelpers
         var tokenLength = originalTextSpan.Length;
         Contract.ThrowIfFalse(tokenLength > 0);
 
-        // We currently only have one modifier (static). The logic below will need to change in the future if other
-        // modifiers are added in the future.
         var modifierBits = TokenModifiers.None;
         var tokenTypeIndex = 0;
 
@@ -297,28 +318,14 @@ internal static class SemanticTokensHelpers
         while (classifiedSpans[currentClassifiedSpanIndex].TextSpan == originalTextSpan)
         {
             var classificationType = classifiedSpans[currentClassifiedSpanIndex].ClassificationType;
-            if (classificationType == ClassificationTypeNames.StaticSymbol)
+
+            if (SemanticTokensSchema.AdditiveClassificationTypeToTokenModifier.TryGetValue(classificationType, out var modifier))
             {
-                // 4. Token modifiers - each set bit will be looked up in SemanticTokensLegend.tokenModifiers
-                modifierBits |= TokenModifiers.Static;
-            }
-            else if (classificationType == ClassificationTypeNames.ReassignedVariable)
-            {
-                // 5. Token modifiers - each set bit will be looked up in SemanticTokensLegend.tokenModifiers
-                modifierBits |= TokenModifiers.ReassignedVariable;
-            }
-            else if (classificationType == ClassificationTypeNames.ObsoleteSymbol)
-            {
-                // 6. Token modifiers - each set bit will be looked up in SemanticTokensLegend.tokenModifiers
-                modifierBits |= TokenModifiers.Deprecated;
-            }
-            else if (classificationType == ClassificationTypeNames.TestCode)
-            {
-                // Skip additive types that are not being converted to token modifiers.
+                modifierBits |= modifier;
             }
             else
             {
-                // 7. Token type - looked up in SemanticTokensLegend.tokenTypes (language server defined mapping
+                // 5. Token type - looked up in SemanticTokensLegend.tokenTypes (language server defined mapping
                 // from integer to LSP token types).
                 tokenTypeIndex = GetTokenTypeIndex(classificationType);
             }

--- a/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensSchema.cs
+++ b/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensSchema.cs
@@ -76,6 +76,17 @@ internal readonly struct SemanticTokensSchema
             classificationTypeName => IDictionaryExtensions.GetValueOrDefault(s_pureLspDirectTypeMap, classificationTypeName) ?? CustomLspSemanticTokenNames.ClassificationTypeNameToCustomTokenName[classificationTypeName]));
 
     /// <summary>
+    /// Mapping from additive classification type names to LSP token modifiers.
+    /// </summary>
+    public static ImmutableDictionary<string, TokenModifiers> AdditiveClassificationTypeToTokenModifier => new Dictionary<string, TokenModifiers>()
+    {
+        [ClassificationTypeNames.StaticSymbol] = SemanticTokens.TokenModifiers.Static,
+        [ClassificationTypeNames.ReassignedVariable] = SemanticTokens.TokenModifiers.ReassignedVariable,
+        [ClassificationTypeNames.ObsoleteSymbol] = SemanticTokens.TokenModifiers.Deprecated,
+        [ClassificationTypeNames.TestCode] = SemanticTokens.TokenModifiers.None,
+    }.ToImmutableDictionary();
+
+    /// <summary>
     /// Mapping from roslyn <see cref="ClassificationTypeNames"/> to the LSP token name.  This is either a standard
     /// <see cref="SemanticTokenTypes"/> or a custom token name.
     /// </summary>

--- a/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -635,54 +635,222 @@ public sealed class SemanticTokensRangeTests(ITestOutputHelper testOutputHelper)
         {
             expectedResults.Data =
             [
-                // Line | Char | Len | Token type                        | Modifier
-                4,     8,    15,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
-                1,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
-                0,     6,     6,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
-                0,     7,     4,   tokenTypeToIndex[ClassificationTypeNames.ConstantName],      1,
-                0,     5,     1,   tokenTypeToIndex[SemanticTokenTypes.Operator],               0,
-                0,     2,     2,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
-                1,     0,    17,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
-                0,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
-                0,     5,     1,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
-                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.ClassName],                  0,
-                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
-                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
-                1,     0,    12,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
-                0,     0,    14,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
-                0,    12,     2,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
-                1,     0,     8,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
-                0,     0,     9,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
-                0,     8,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
-                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],0,
-                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+                // Line | Char | Len | Token type                                                       | Modifier
+                   4,     8,     15,   tokenTypeToIndex[SemanticTokenTypes.Comment],                      0,
+                   1,     8,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     7,     4,    tokenTypeToIndex[ClassificationTypeNames.ConstantName],            1,
+                   0,     5,     1,    tokenTypeToIndex[SemanticTokenTypes.Operator],                     0,
+                   0,     2,     2,    tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],   0,
+                   1,     8,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     5,     1,    tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],   0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.ClassName],               0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],   0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     12,   tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],   0,
+                   0,     12,    2,    tokenTypeToIndex[SemanticTokenTypes.Comment],                      0,
+                   1,     0,     8,    tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],   0,
+                   0,     8,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral],   0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
             ];
         }
         else
         {
             expectedResults.Data =
             [
-                // Line | Char | Len | Token type                        | Modifier
-                4,     8,    15,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
-                1,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
-                0,     6,     6,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
-                0,     7,     4,   tokenTypeToIndex[CustomLspSemanticTokenNames.ConstantName],      1,
-                0,     5,     1,   tokenTypeToIndex[SemanticTokenTypes.Operator],               0,
-                0,     2,     2,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
-                1,     0,    17,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
-                0,     8,     5,   tokenTypeToIndex[SemanticTokenTypes.Keyword],                0,
-                0,     5,     1,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
-                0,     1,     1,   tokenTypeToIndex[SemanticTokenTypes.Class],                  0,
-                0,     1,     1,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
-                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
-                1,     0,    12,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
-                0,     0,    14,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
-                0,    12,     2,   tokenTypeToIndex[SemanticTokenTypes.Comment],                0,
-                1,     0,     8,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
-                0,     0,     9,   tokenTypeToIndex[SemanticTokenTypes.Namespace],              0,
-                0,     8,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
-                0,     1,     1,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],0,
-                0,     1,     1,   tokenTypeToIndex[ClassificationTypeNames.Punctuation],       0,
+                // Line | Char | Len | Token type                                                       | Modifier
+                   4,     8,     15,   tokenTypeToIndex[SemanticTokenTypes.Comment],                      0,
+                   1,     8,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     7,     4,    tokenTypeToIndex[CustomLspSemanticTokenNames.ConstantName],        1,
+                   0,     5,     1,    tokenTypeToIndex[SemanticTokenTypes.Operator],                     0,
+                   0,     2,     2,    tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],      0,
+                   1,     8,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     5,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],      0,
+                   0,     1,     1,    tokenTypeToIndex[SemanticTokenTypes.Class],                        0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],      0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     12,   tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],      0,
+                   0,     12,    2,    tokenTypeToIndex[SemanticTokenTypes.Comment],                      0,
+                   1,     0,     8,    tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],      0,
+                   0,     8,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.StringVerbatim],      0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+            ];
+        }
+
+        await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results.Data).ConfigureAwait(false);
+        AssertEx.Equal(ConvertToReadableFormat(testLspServer.ClientCapabilities, expectedResults.Data), ConvertToReadableFormat(testLspServer.ClientCapabilities, results.Data));
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/74435")]
+    public async Task TestGetSemanticTokensRange_AdditiveTestCodeClassification(bool mutatingLspWorkspace, bool isVS)
+    {
+        var markup =
+            """"
+            // lang=c#-test
+            var code2 = {|range:"""
+                using System;
+                namespace Test;
+                public class Program
+                {
+                    public static void Main(string[] args)
+                    {
+                        return;
+                    }
+                }
+                public struct Person {}
+                public interface ICan {}
+                """;|}
+            """";
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup, mutatingLspWorkspace, GetCapabilities(isVS));
+
+        var location = testLspServer.GetLocations("range").Single();
+        var results = await RunGetSemanticTokensRangeAsync(testLspServer, location);
+
+        var expectedResults = new LSP.SemanticTokens();
+        var tokenTypeToIndex = GetTokenTypeToIndex(testLspServer);
+        if (isVS)
+        {
+            expectedResults.Data =
+            [
+                // Line | Char | Len | Token type                                                       | Modifier
+                   1,     12,    3,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     5,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[ClassificationTypeNames.NamespaceName],           0,
+                   0,     6,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     9,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     9,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[ClassificationTypeNames.NamespaceName],           0,
+                   0,     4,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     5,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     7,    tokenTypeToIndex[ClassificationTypeNames.ClassName],               0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     8,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     4,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[ClassificationTypeNames.MethodName],              1,
+                   0,     4,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   0,     1,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[ClassificationTypeNames.ParameterName],           0,
+                   0,     4,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     8,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     12,    6,    tokenTypeToIndex[ClassificationTypeNames.ControlKeyword],          0,
+                   0,     6,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     8,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[ClassificationTypeNames.StructName],              0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     9,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     9,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[ClassificationTypeNames.InterfaceName],           0,
+                   0,     4,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   0,     1,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+                   1,     0,     7,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     7,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation],             0,
+            ];
+        }
+        else
+        {
+            expectedResults.Data =
+            [
+                // Line | Char | Len | Token type                                                       | Modifier
+                   1,     12,    3,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     5,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Namespace],                    0,
+                   0,     6,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     9,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     9,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[SemanticTokenTypes.Namespace],                    0,
+                   0,     4,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     5,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     5,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     7,    tokenTypeToIndex[SemanticTokenTypes.Class],                        0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     8,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     4,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[SemanticTokenTypes.Method],                       1,
+                   0,     4,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   0,     1,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[SemanticTokenTypes.Parameter],                    0,
+                   0,     4,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     8,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     12,    6,    tokenTypeToIndex[CustomLspSemanticTokenNames.KeywordControl],      0,
+                   0,     6,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     8,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     6,    tokenTypeToIndex[SemanticTokenTypes.Struct],                       0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     4,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     4,     6,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     6,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     9,    tokenTypeToIndex[SemanticTokenTypes.Keyword],                      0,
+                   0,     9,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     4,    tokenTypeToIndex[SemanticTokenTypes.Interface],                    0,
+                   0,     4,     1,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   0,     1,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
+                   1,     0,     7,    tokenTypeToIndex[SemanticTokenTypes.String],                       0,
+                   0,     7,     1,    tokenTypeToIndex[CustomLspSemanticTokenNames.Punctuation],         0,
             ];
         }
 

--- a/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensSchemaTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensSchemaTests.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SemanticTokens;
+
+public class SemanticTokensSchemaTests
+{
+    [Fact]
+    public void TestAllAdditiveClassificationsMappedToTokenModifiers()
+    {
+        foreach (var additiveClassification in ClassificationTypeNames.AdditiveTypeNames)
+        {
+            Assert.True(SemanticTokensSchema.AdditiveClassificationTypeToTokenModifier.ContainsKey(additiveClassification), $"Modifier '{additiveClassification}' is not mapped to a {nameof(TokenModifiers)}");
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/74435

Previously we were reporting roslyn-test classification spans overlapping others because we didn't properly filter them out.