### PR TITLE
Add parsing of StateMachine GeneratedNames to StackFrameParser

### DIFF
--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
@@ -420,7 +420,6 @@ public sealed partial class StackFrameParserTests
     [InlineData(@"at M.1c()")] // Invalid start character for identifier
     [InlineData(@"at 1M.C()")]
     [InlineData(@"at M.C(string& s)")] // "string&" represents a reference (ref, out) and is not supported yet
-    [InlineData(@"at StreamJsonRpc.JsonRpc.<InvokeCoreAsync>d__139`1.MoveNext()")] // Generated/Inline methods are not supported yet
     [InlineData(@"at M(")] // Missing closing paren
     [InlineData(@"at M)")] // MIssing open paren
     [InlineData(@"at M.M[T>(T t)")] // Mismatched generic opening/close
@@ -519,4 +518,18 @@ public sealed partial class StackFrameParserTests
                 line: CreateToken(StackFrameKind.NumberToken, "16", leadingTrivia: [CreateTrivia(StackFrameKind.LineTrivia, $"{line} ")]),
                 inTrivia: CreateTrivia(StackFrameKind.InTrivia, $" {@in} "))
                 );
+
+    [Fact]
+    public void TestStateMachineMethod()
+        => Verify("Test.<MyAsyncMethod>d__610.MoveNext()",
+            methodDeclaration: MethodDeclaration(
+                QualifiedName(
+                    Identifier("Test"),
+                    StateMachineMethod(
+                        GeneratedName("MyAsyncMethod", endWithDollar: false),
+                        suffix: "610",
+                        stateMachineMethod: "MoveNext")
+                    ),
+                argumentList: EmptyParams)
+            );
 }

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
@@ -217,4 +217,11 @@ internal static class StackFrameSyntaxFactory
             IdentifierToken(identifier),
             PipeToken,
             CreateToken(StackFrameKind.GeneratedNameSuffixToken, suffix));
+
+    public static StackFrameStateMachineMethodNameNode StateMachineMethod(StackFrameGeneratedMethodNameNode encapsulatingMethod, string suffix, string stateMachineMethod)
+        => new(
+            encapsulatingMethod,
+            CreateToken(StackFrameKind.GeneratedNameSeparatorToken, "d__" + suffix),
+            DotToken,
+            IdentifierToken(stateMachineMethod));
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/IStackFrameNodeVisitor.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/IStackFrameNodeVisitor.cs
@@ -20,4 +20,5 @@ internal interface IStackFrameNodeVisitor
     void Visit(StackFrameGeneratedMethodNameNode stackFrameGeneratedNameNode);
     void Visit(StackFrameLocalMethodNameNode stackFrameLocalMethodNameNode);
     void Visit(StackFrameConstructorNode constructorNode);
+    void Visit(StackFrameStateMachineMethodNameNode stackFrameStateMachineMethodNameNode);
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameKind.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameKind.cs
@@ -16,6 +16,7 @@ internal enum StackFrameKind
     GenericTypeIdentifier,
     GeneratedIdentifier,
     LocalMethodIdentifier,
+    StateMachineMethodIdentifier,
     TypeArgument,
     TypeIdentifier,
     Parameter,

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -325,9 +325,10 @@ internal struct StackFrameLexer
 
     /// <summary>
     /// Scans a form similar to g__, where g is a GeneratedNameKind (a single character)
-    /// and identifier is valid identifier characters as with <see cref="TryScanIdentifier()"/>
+    /// and identifier is valid identifier characters as with <see cref="TryScanIdentifier()"/>.
+    /// If <see cref="scanNumericsAfter"/> is true, it will also scan for a numeric suffix after "__"
     /// </summary>
-    public Result<StackFrameToken> TryScanRequiredGeneratedNameSeparator()
+    public Result<StackFrameToken> TryScanRequiredGeneratedNameSeparator(bool scanNumericsAfter = false)
     {
         var start = Position;
         if (IsAsciiAlphaCharacter(CurrentChar))
@@ -346,6 +347,14 @@ internal struct StackFrameLexer
         else
         {
             return Result<StackFrameToken>.Abort;
+        }
+
+        if (scanNumericsAfter)
+        {
+            while (IsNumber(CurrentChar))
+            {
+                Position++;
+            }
         }
 
         return CreateToken(StackFrameKind.GeneratedNameSeparatorToken, GetSubSequenceToCurrentPos(start));

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameNodeDefinitions.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameNodeDefinitions.cs
@@ -205,16 +205,17 @@ internal abstract class StackFrameGeneratedNameNode : StackFrameSimpleNameNode
 }
 
 /// <summary>
-/// Generated methods follow the pattern Namespace.ClassName.&gt;MethodName$&lt;(), where 
-/// the "$" is optional.
+/// Generated methods follow the pattern Namespace.ClassName.&gt;MethodName$&lt;Suffix(), where 
+/// the "$" and "Suffix" are optional.
 /// </summary>
 internal sealed class StackFrameGeneratedMethodNameNode : StackFrameGeneratedNameNode
 {
     public readonly StackFrameToken LessThanToken;
     public readonly StackFrameToken GreaterThanToken;
     public readonly StackFrameToken? DollarToken;
+    public readonly StackFrameToken? Suffix;
 
-    internal override int ChildCount => 4;
+    internal override int ChildCount => 5;
 
     public StackFrameGeneratedMethodNameNode(StackFrameToken lessThanToken, StackFrameToken identifier, StackFrameToken greaterThanToken, StackFrameToken? dollarToken)
         : base(identifier, StackFrameKind.GeneratedIdentifier)
@@ -238,6 +239,7 @@ internal sealed class StackFrameGeneratedMethodNameNode : StackFrameGeneratedNam
             1 => Identifier,
             2 => GreaterThanToken,
             3 => DollarToken.HasValue ? DollarToken.Value : null,
+            4 => Suffix.HasValue ? Suffix.Value : null,
             _ => throw new InvalidOperationException()
         };
 }
@@ -292,6 +294,44 @@ internal sealed class StackFrameLocalMethodNameNode : StackFrameGeneratedNameNod
         2 => Identifier,
         3 => PipeToken,
         4 => Suffix,
+        _ => throw new InvalidOperationException()
+    };
+}
+
+internal sealed class StackFrameStateMachineMethodNameNode : StackFrameGeneratedNameNode
+{
+    internal readonly StackFrameGeneratedMethodNameNode EncapsulatingMethod;
+    internal readonly StackFrameToken GeneratedNameSeparator;
+    internal readonly StackFrameToken DotToken;
+
+    internal override int ChildCount => 4;
+
+    public StackFrameStateMachineMethodNameNode(
+        StackFrameGeneratedMethodNameNode encapsulatngMethod,
+        StackFrameToken generatedNameSeparator,
+        StackFrameToken dotToken,
+        StackFrameToken stateMachineIdentifier)
+        : base(stateMachineIdentifier, StackFrameKind.StateMachineMethodIdentifier)
+    {
+        Debug.Assert(generatedNameSeparator.Kind == StackFrameKind.GeneratedNameSeparatorToken);
+        Debug.Assert(dotToken.Kind == StackFrameKind.DotToken);
+        Debug.Assert(stateMachineIdentifier.Kind == StackFrameKind.IdentifierToken);
+
+        EncapsulatingMethod = encapsulatngMethod;
+        GeneratedNameSeparator = generatedNameSeparator;
+        DotToken = dotToken;
+    }
+
+    public override void Accept(IStackFrameNodeVisitor visitor)
+        => visitor.Visit(this);
+
+    internal override StackFrameNodeOrToken ChildAt(int index)
+    => index switch
+    {
+        0 => EncapsulatingMethod,
+        1 => GeneratedNameSeparator,
+        2 => DotToken,
+        3 => Identifier,
         _ => throw new InvalidOperationException()
     };
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameParser.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameParser.cs
@@ -248,6 +248,14 @@ internal struct StackFrameParser
     ///                                 ^----^--------------- "Local" is the name of the local function
     ///                                      ^---^----------- "|0_0" is suffix information such as slot 
     ///                                           ^--------^- "(String s)" identifiers the method paramters
+    ///     3. StateMachineMethodName
+    ///             Program.$lt;Main$gt;d__6.MoveNext()
+    ///                     ^---------------------------- Beginning of generated name
+    ///                         ^---^-------------------- Encapsulating method name
+    ///                                 ^---------------- "d__6" identifies this as a state machine method
+    ///                                      ^-------^--- "MoveNext" is the name of the method in the state machine
+    ///                     
+    ///                     
     /// </code>
     /// </summary>
     private Result<StackFrameGeneratedNameNode> TryScanGeneratedName()
@@ -284,39 +292,70 @@ internal struct StackFrameParser
 
         // Check for generated name kinds we can handle
         // See https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs 
-        if (currentChar == 'g')
+        switch (currentChar)
         {
-            // Local function
-            var encapsulatingMethod = new StackFrameGeneratedMethodNameNode(lessThanToken, identifier.Value, greaterThanToken, dollarToken: null);
-            var (success, generatedNameSeparator) = _lexer.TryScanRequiredGeneratedNameSeparator();
-            if (!success)
-            {
-                return Result<StackFrameGeneratedNameNode>.Abort;
-            }
+            case 'g': // Local function
+                return TryParseLocalMethodName(lessThanToken, identifier.Value, greaterThanToken);
 
-            var generatedIdentifier = _lexer.TryScanIdentifier();
-            if (!generatedIdentifier.HasValue)
-            {
-                return Result<StackFrameGeneratedNameNode>.Abort;
-            }
+            case 'd': // State Machine (such as async methods)
+                return TryParseStateMachineMethodName(lessThanToken, identifier.Value, greaterThanToken);
 
-            if (!_lexer.ScanCurrentCharAsTokenIfMatch(StackFrameKind.PipeToken, out var suffixSeparator))
-            {
+            default:
                 return Result<StackFrameGeneratedNameNode>.Abort;
-            }
-
-            (success, var suffix) = _lexer.TryScanRequiredGeneratedNameSuffix();
-            if (!success)
-            {
-                return Result<StackFrameGeneratedNameNode>.Abort;
-            }
-
-            return new StackFrameLocalMethodNameNode(encapsulatingMethod, generatedNameSeparator, generatedIdentifier.Value, suffixSeparator, suffix);
         }
-        else
+    }
+
+    private Result<StackFrameGeneratedNameNode> TryParseStateMachineMethodName(StackFrameToken lessThanToken, StackFrameToken identifier, StackFrameToken greaterThanToken)
+    {
+        var encapsulatingMethod = new StackFrameGeneratedMethodNameNode(lessThanToken, identifier, greaterThanToken, dollarToken: null);
+        var (success, generatedNameSeparator) = _lexer.TryScanRequiredGeneratedNameSeparator(scanNumericsAfter: true);
+        if (!success)
         {
             return Result<StackFrameGeneratedNameNode>.Abort;
         }
+
+        if (!_lexer.ScanCurrentCharAsTokenIfMatch(StackFrameKind.DotToken, out var dotToken))
+        {
+            return Result<StackFrameGeneratedNameNode>.Abort;
+        }
+
+        var generatedIdentifier = _lexer.TryScanIdentifier();
+        if (!generatedIdentifier.HasValue)
+        {
+            return Result<StackFrameGeneratedNameNode>.Abort;
+        }
+
+        return new StackFrameStateMachineMethodNameNode(encapsulatingMethod, generatedNameSeparator, dotToken, generatedIdentifier.Value);
+    }
+
+    private Result<StackFrameGeneratedNameNode> TryParseLocalMethodName(StackFrameToken lessThanToken, StackFrameToken identifier, StackFrameToken greaterThanToken)
+    {
+
+        var encapsulatingMethod = new StackFrameGeneratedMethodNameNode(lessThanToken, identifier, greaterThanToken, dollarToken: null);
+        var (success, generatedNameSeparator) = _lexer.TryScanRequiredGeneratedNameSeparator();
+        if (!success)
+        {
+            return Result<StackFrameGeneratedNameNode>.Abort;
+        }
+
+        var generatedIdentifier = _lexer.TryScanIdentifier();
+        if (!generatedIdentifier.HasValue)
+        {
+            return Result<StackFrameGeneratedNameNode>.Abort;
+        }
+
+        if (!_lexer.ScanCurrentCharAsTokenIfMatch(StackFrameKind.PipeToken, out var suffixSeparator))
+        {
+            return Result<StackFrameGeneratedNameNode>.Abort;
+        }
+
+        (success, var suffix) = _lexer.TryScanRequiredGeneratedNameSuffix();
+        if (!success)
+        {
+            return Result<StackFrameGeneratedNameNode>.Abort;
+        }
+
+        return new StackFrameLocalMethodNameNode(encapsulatingMethod, generatedNameSeparator, generatedIdentifier.Value, suffixSeparator, suffix);
     }
 
     /// <summary>


### PR DESCRIPTION
Needed to resolve https://github.com/dotnet/roslyn/issues/60079

Very similar to local functions but includes a call to the state machine methods. 

Unsure if there will be more things necessary for navigation to work correctly. As of writing I can't test the VSIX locally due to some references not being available in GA of VS

Other things to think about: what does an async v2 stack look like? I assume it won't have generated members at all so should _just work_
