### PR TITLE
Demonstration of problem with doc comments

### DIFF
--- a/src/RoslynAnalyzers/Tools/Metrics.Legacy/Foo.cs
+++ b/src/RoslynAnalyzers/Tools/Metrics.Legacy/Foo.cs
@@ -12,6 +12,8 @@ namespace Microsoft.CodeAnalysis
 {
     /// <summary>
     /// <see cref="global::System.ObsoleteAttribute"/>
+    /// <see cref="System.ObsoleteAttribute"/>
+    /// <see cref="ObsoleteAttribute"/>
     /// </summary>
     [System.Obsolete]
     internal class Foo

--- a/src/RoslynAnalyzers/Tools/Metrics.Legacy/Foo.cs
+++ b/src/RoslynAnalyzers/Tools/Metrics.Legacy/Foo.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// <see cref="global::System.ObsoleteAttribute"/>
+    /// </summary>
+    [System.Obsolete]
+    internal class Foo
+    {
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fddcd1a8-ffda-4bfa-aeef-7ebc74228964)

```
Ambiguous reference in cref attribute: 'global::System.ObsoleteAttribute'. Assuming 'ObsoleteAttribute', but could have also matched other overloads including 'ObsoleteAttribute'.
Ambiguous reference in cref attribute: 'ObsoleteAttribute'. Assuming 'ObsoleteAttribute', but could have also matched other overloads including 'ObsoleteAttribute'.
Ambiguous reference in cref attribute: 'System.ObsoleteAttribute'. Assuming 'ObsoleteAttribute', but could have also matched other overloads including 'ObsoleteAttribute'.
```