### PR TITLE
Convert to regular constructor for partial types

### DIFF
--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -2969,8 +2969,8 @@ public sealed class ConvertPrimaryToRegularConstructorTests
 
                         public C(int i)
                         {
-                            I2 = i + 2;
                             I1 = i + 1;
+                            I2 = i + 2;
                         }
                     }
                     """, """


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/79077

Also tweaked ordering of assignments in generated regular constructor to be more expected in partial types scenarios