### PR TITLE
Remove semantic snippets feature flag

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -10793,7 +10793,7 @@ class MyClass
 }
                               </Document>)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, True)
+                state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp, True)
                 state.SendTypeChars("if")
                 Await state.AssertSelectedCompletionItem(displayText:="if", inlineDescription:=Nothing, isHardSelected:=True)
                 state.SendDownKey()
@@ -10867,7 +10867,7 @@ class MyClass
 }
                               </Document>)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, False)
+                state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp, False)
                 state.SendInvokeCompletionList()
                 ' We should still work normally w/o pythia recommender
                 Await state.AssertCompletionItemsContainAll("argumentException", "exception")
@@ -10890,7 +10890,7 @@ class MyClass
                               </Document>,
                               extraExportedTypes:={GetType(TestPythiaDeclarationNameRecommenderImplmentation)}.ToList())
 
-                state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, False)
+                state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp, False)
 
                 state.SendInvokeCompletionList()
                 Dim computedItems = (Await state.GetCompletionSession()).GetComputedItems(CancellationToken.None)

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -78,7 +78,7 @@ public abstract class AbstractCompletionProviderTests<TWorkspaceFixture> : TestB
             options = options with { ShowNameSuggestions = ShowNameSuggestions.Value };
 
         if (ShowNewSnippetExperience.HasValue)
-            options = options with { ShowNewSnippetExperienceUserOption = ShowNewSnippetExperience.Value };
+            options = options with { ShowNewSnippetExperience = ShowNewSnippetExperience.Value };
 
         if (TriggerOnDeletion.HasValue)
             options = options with { TriggerOnDeletion = TriggerOnDeletion.Value };

--- a/src/EditorFeatures/TestUtilities/Options/OptionSerializerTests.cs
+++ b/src/EditorFeatures/TestUtilities/Options/OptionSerializerTests.cs
@@ -28,7 +28,7 @@ public sealed class OptionSerializerTests
             FeatureOnOffOptions.OfferRemoveUnusedReferences,
             InheritanceMarginOptionsStorage.ShowInheritanceMargin,
             CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces,
-            CompletionOptionsStorage.ShowNewSnippetExperienceUserOption,
+            CompletionOptionsStorage.ShowNewSnippetExperience,
             CompletionOptionsStorage.TriggerOnDeletion,
         };
 

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -47,7 +47,7 @@ internal sealed record class CompletionOptions
 
     public bool FilterOutOfScopeLocals { get; init; } = true;
     public bool ShowXmlDocCommentCompletion { get; init; } = true;
-    public bool ShowNewSnippetExperienceUserOption { get; init; } = false;
+    public bool ShowNewSnippetExperience { get; init; } = false;
     public ExpandedCompletionMode ExpandedCompletionBehavior { get; init; } = ExpandedCompletionMode.AllItems;
 
     public static readonly CompletionOptions Default = new();
@@ -83,6 +83,6 @@ internal sealed record class CompletionOptions
             return false;
         }
 
-        return ShowNewSnippetExperienceUserOption;
+        return ShowNewSnippetExperience;
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -47,8 +47,7 @@ internal sealed record class CompletionOptions
 
     public bool FilterOutOfScopeLocals { get; init; } = true;
     public bool ShowXmlDocCommentCompletion { get; init; } = true;
-    public bool? ShowNewSnippetExperienceUserOption { get; init; } = null;
-    public bool ShowNewSnippetExperienceFeatureFlag { get; init; } = true;
+    public bool ShowNewSnippetExperienceUserOption { get; init; } = false;
     public ExpandedCompletionMode ExpandedCompletionBehavior { get; init; } = ExpandedCompletionMode.AllItems;
 
     public static readonly CompletionOptions Default = new();
@@ -68,8 +67,6 @@ internal sealed record class CompletionOptions
 
     /// <summary>
     /// Whether items from new snippet experience should be included in the completion list.
-    /// This takes into consideration the experiment we are running in addition to the value
-    /// from user facing options.
     /// </summary>
     public bool ShouldShowNewSnippetExperience(Document document)
     {
@@ -86,7 +83,6 @@ internal sealed record class CompletionOptions
             return false;
         }
 
-        // Don't trigger snippet completion if the option value is "default" and the experiment is disabled for the user. 
-        return ShowNewSnippetExperienceUserOption ?? ShowNewSnippetExperienceFeatureFlag;
+        return ShowNewSnippetExperienceUserOption;
     }
 }

--- a/src/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
@@ -32,7 +32,7 @@ internal static class CompletionOptionsStorage
             ProvideDateAndTimeCompletions = options.GetOption(ProvideDateAndTimeCompletions, language),
             ProvideRegexCompletions = options.GetOption(ProvideRegexCompletions, language),
             ForceExpandedCompletionIndexCreation = options.GetOption(ForceExpandedCompletionIndexCreation),
-            ShowNewSnippetExperienceUserOption = options.GetOption(ShowNewSnippetExperienceUserOption, language)
+            ShowNewSnippetExperience = options.GetOption(ShowNewSnippetExperience, language)
         };
 
     private static readonly OptionGroup s_completionOptionGroup = new(name: "completion", description: "");
@@ -61,5 +61,5 @@ internal static class CompletionOptionsStorage
 
     public static PerLanguageOption2<bool> ProvideRegexCompletions = new("dotnet_provide_regex_completions", CompletionOptions.Default.ProvideRegexCompletions, group: s_completionOptionGroup);
     public static readonly PerLanguageOption2<bool> ProvideDateAndTimeCompletions = new("dotnet_provide_date_and_time_completions", CompletionOptions.Default.ProvideDateAndTimeCompletions, group: s_completionOptionGroup);
-    public static readonly PerLanguageOption2<bool> ShowNewSnippetExperienceUserOption = new("dotnet_show_new_snippet_experience", CompletionOptions.Default.ShowNewSnippetExperienceUserOption, group: s_completionOptionGroup);
+    public static readonly PerLanguageOption2<bool> ShowNewSnippetExperience = new("dotnet_show_new_snippet_experience", CompletionOptions.Default.ShowNewSnippetExperience, group: s_completionOptionGroup);
 }

--- a/src/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
@@ -32,8 +32,7 @@ internal static class CompletionOptionsStorage
             ProvideDateAndTimeCompletions = options.GetOption(ProvideDateAndTimeCompletions, language),
             ProvideRegexCompletions = options.GetOption(ProvideRegexCompletions, language),
             ForceExpandedCompletionIndexCreation = options.GetOption(ForceExpandedCompletionIndexCreation),
-            ShowNewSnippetExperienceUserOption = options.GetOption(ShowNewSnippetExperienceUserOption, language),
-            ShowNewSnippetExperienceFeatureFlag = options.GetOption(ShowNewSnippetExperienceFeatureFlag)
+            ShowNewSnippetExperienceUserOption = options.GetOption(ShowNewSnippetExperienceUserOption, language)
         };
 
     private static readonly OptionGroup s_completionOptionGroup = new(name: "completion", description: "");
@@ -41,7 +40,6 @@ internal static class CompletionOptionsStorage
     // feature flags
 
     public static readonly Option2<bool> UnnamedSymbolCompletionDisabledFeatureFlag = new("dotnet_disable_unnamed_symbol_completion", CompletionOptions.Default.UnnamedSymbolCompletionDisabled, group: s_completionOptionGroup);
-    public static readonly Option2<bool> ShowNewSnippetExperienceFeatureFlag = new("dotnet_show_new_snippet_experience_feature_flag", CompletionOptions.Default.ShowNewSnippetExperienceFeatureFlag, group: s_completionOptionGroup);
     public static readonly PerLanguageOption2<bool> TriggerOnTyping = new("dotnet_trigger_completion_on_typing", CompletionOptions.Default.TriggerOnTyping, group: s_completionOptionGroup);
     public static readonly PerLanguageOption2<bool> TriggerOnTypingLetters = new("dotnet_trigger_completion_on_typing_letters", CompletionOptions.Default.TriggerOnTypingLetters, group: s_completionOptionGroup);
     public static readonly PerLanguageOption2<bool?> TriggerOnDeletion = new("dotnet_trigger_completion_on_deletion", CompletionOptions.Default.TriggerOnDeletion, group: s_completionOptionGroup);
@@ -63,5 +61,5 @@ internal static class CompletionOptionsStorage
 
     public static PerLanguageOption2<bool> ProvideRegexCompletions = new("dotnet_provide_regex_completions", CompletionOptions.Default.ProvideRegexCompletions, group: s_completionOptionGroup);
     public static readonly PerLanguageOption2<bool> ProvideDateAndTimeCompletions = new("dotnet_provide_date_and_time_completions", CompletionOptions.Default.ProvideDateAndTimeCompletions, group: s_completionOptionGroup);
-    public static readonly PerLanguageOption2<bool?> ShowNewSnippetExperienceUserOption = new("dotnet_show_new_snippet_experience", CompletionOptions.Default.ShowNewSnippetExperienceUserOption, group: s_completionOptionGroup);
+    public static readonly PerLanguageOption2<bool> ShowNewSnippetExperienceUserOption = new("dotnet_show_new_snippet_experience", CompletionOptions.Default.ShowNewSnippetExperienceUserOption, group: s_completionOptionGroup);
 }

--- a/src/LanguageServer/Protocol/Handler/Completion/Extensions.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/Extensions.cs
@@ -37,7 +37,7 @@ internal static class Extensions
             var updateImportCompletionCacheInBackground = options.ShowItemsFromUnimportedNamespaces is true;
             options = options with
             {
-                ShowNewSnippetExperienceUserOption = false,
+                ShowNewSnippetExperience = false,
                 UpdateImportCompletionCacheInBackground = updateImportCompletionCacheInBackground
             };
         }

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -357,7 +357,7 @@ link text";
             """;
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new LSP.VSInternalClientCapabilities { SupportsVisualStudioExtensions = true });
         testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.CSharp, SnippetsRule.AlwaysInclude);
-        testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, true);
+        testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp, true);
 
         var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.VSInternalCompletionItem>(testLspServer, label: "svm").ConfigureAwait(false);
 

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -533,9 +533,6 @@
   <data name="Collapse_usings_on_file_open" xml:space="preserve">
     <value>Collapse usings on file open</value>
   </data>
-  <data name="Show_new_snippet_experience_experimental" xml:space="preserve">
-    <value>Show new snippet experience (experimental)</value>
-  </data>
   <data name="Show_new_snippet_experience" xml:space="preserve">
     <value>Show new snippet experience</value>
   </data>

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -80,7 +80,7 @@
 
                     <CheckBox x:Uid="Show_new_snippet_experience"
                                   x:Name="Show_new_snippet_experience"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_new_snippet_experience_experimental}" />
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_new_snippet_experience}" />
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -42,8 +42,7 @@ internal sealed partial class IntelliSenseOptionPageControl : AbstractOptionPage
         BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, onNullValue: static () => true);
 
         BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp, onNullValue: static () => false);
-        BindToOption(Show_new_snippet_experience, CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp,
-            onNullValue: () => this.OptionStore.GetOption(CompletionOptionsStorage.ShowNewSnippetExperienceFeatureFlag));
+        BindToOption(Show_new_snippet_experience, CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp);
     }
 
     private void SetSnippetsDefaultBehavior()

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -42,7 +42,7 @@ internal sealed partial class IntelliSenseOptionPageControl : AbstractOptionPage
         BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, onNullValue: static () => true);
 
         BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp, onNullValue: static () => false);
-        BindToOption(Show_new_snippet_experience, CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp);
+        BindToOption(Show_new_snippet_experience, CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp);
     }
 
     private void SetSnippetsDefaultBehavior()

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
@@ -78,6 +78,6 @@ internal static class IntelliSenseOptionPageStrings
     public static string Automatically_show_completion_list_in_argument_lists
         => CSharpVSResources.Automatically_show_completion_list_in_argument_lists;
 
-    public static string Option_Show_new_snippet_experience_experimental
-        => CSharpVSResources.Show_new_snippet_experience_experimental;
+    public static string Option_Show_new_snippet_experience
+        => CSharpVSResources.Show_new_snippet_experience;
 }

--- a/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
@@ -198,4 +198,4 @@
 [$RootKey$\SettingsManifests\{13c3bbb4-f18f-4111-9f54-a0fb010d9194}]
 @="Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\csharpSettings.registration.json"
-"CacheTag"=qword:18C11F0A543B8AD0
+"CacheTag"=qword:D802A79004FEEDEF

--- a/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
+++ b/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
@@ -228,16 +228,6 @@
       "title": "@Show_new_snippet_experience;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
       "type": "boolean",
       "default": false,
-      "messages": [
-        {
-          "text": "@Experimental_feature;..\\Microsoft.VisualStudio.LanguageServices.dll"
-        }
-      ],
-      "alternateDefault": {
-        // CompletionOptionsStorage.ShowNewSnippetExperienceFeatureFlag
-        "flagName": "Roslyn.SnippetCompletion",
-        "default": true
-      },
       "order": 100,
       "migration": {
         "pass": {

--- a/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
+++ b/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
@@ -223,7 +223,7 @@
         }
       }
     },
-    // CompletionOptionsStorage.ShowNewSnippetExperienceUserOption
+    // CompletionOptionsStorage.ShowNewSnippetExperience
     "textEditor.csharp.intellisense.showNewSnippetExperience": {
       "title": "@Show_new_snippet_experience;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
       "type": "boolean",

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Zobrazit nové prostředí fragmentů kódu</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Zobrazit nové prostředí fragmentů kódu (experimentální)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Navrhnout použití typů v sestaveních .NET Framework</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Neue Codeausschnittoberfläche anzeigen</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Neue Ausschnittsoberfläche anzeigen (experimentell)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Using-Anweisungen für Typen in .NET Framework-Assemblys vorschlagen</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Mostrar nueva experiencia de fragmento de código</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Mostrar nueva experiencia de fragmento de código (experimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Sugerir usos para tipos en ensamblados .NET Framework</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Afficher une nouvelle expérience d’extrait de code</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Afficher une nouvelle expérience d’extrait de code (expérimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Suggérer des using pour les types dans les assemblys .NET Framework</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Mostra nuova esperienza frammento</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Mostra nuova esperienza del frammento (sperimentale)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Suggerisci le direttive using per i tipi in assembly .NET Framework</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -192,11 +192,6 @@
         <target state="translated">新しいスニペット エクスペリエンスを表示する</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">新しいスニペット エクスペリエンスの表示 (試験段階)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">.NET Framework アセンブリの型に using を提案する</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -192,11 +192,6 @@
         <target state="translated">새 코드 조각 환경 표시</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">새 코드 조각 환경 표시(실험적)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">.NET Framework 어셈블리의 형식에 using 제안</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Pokaż nowe środowisko fragmentu kodu</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Pokaż nowe środowisko fragmentu kodu (eksperymentalne)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Sugeruj dyrektywy using dla typów w zestawach platformy .NET Framework</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Mostrar a nova experiência de trecho</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Mostrar nova experiência de snippet de código (experimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Sugerir usings para tipos nos assemblies do .NET Framework</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Показывать новый интерфейс фрагмента кода</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Показывать новый интерфейс фрагмента кода (экспериментальная функция)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">Предлагать using для типов в сборках .NET Framework</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -192,11 +192,6 @@
         <target state="translated">Yeni kod parçacığı deneyimini göster</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Yeni kod parçacığı deneyimini göster (deneysel)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">.NET Framework bütünleştirilmiş kodlarında türler için using öner</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -192,11 +192,6 @@
         <target state="translated">显示新的代码片段体验</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">显示新的代码片段体验(试验)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">建议对 .NET Framework 程序集中的类型使用 using</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -192,11 +192,6 @@
         <target state="translated">顯示新的程式碼片段體驗</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">顯示新的程式碼片段體驗 (實驗性)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggest_usings_for_types_in_dotnet_framework_assemblies">
         <source>Suggest usings for types in .NET Framework assemblies</source>
         <target state="translated">為 .NET Framework 組件中的類型建議 using</target>

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -132,7 +132,6 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_show_completion_item_filters", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ShowCompletionItemFilters")},
         {"dotnet_show_completion_items_from_unimported_namespaces", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ShowItemsFromUnimportedNamespaces")},
         {"dotnet_show_name_completion_suggestions", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ShowNameSuggestions")},
-        {"dotnet_show_new_snippet_experience_feature_flag", new FeatureFlagStorage(@"Roslyn.SnippetCompletion")},
         {"dotnet_show_new_snippet_experience", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ShowNewSnippetExperience")},
         {"dotnet_snippets_behavior", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.SnippetsBehavior")},
         {"dotnet_trigger_completion_in_argument_lists", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.TriggerInArgumentLists")},

--- a/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
@@ -120,8 +120,7 @@ public sealed class UnifiedSettingsTests
             title: "Show new snippet experience",
             customDefaultValue: false,
             order: 100,
-            languageName: LanguageNames.CSharp,
-            featureFlagAndExperimentValue: (CompletionOptionsStorage.ShowNewSnippetExperienceFeatureFlag, true))),
+            languageName: LanguageNames.CSharp)),
     ];
 
     [Fact]

--- a/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
@@ -42,7 +42,7 @@ public sealed class UnifiedSettingsTests
         Add(CompletionOptionsStorage.ShowNameSuggestions, "textEditor.csharp.intellisense.showNameCompletionSuggestions").
         Add(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, "textEditor.csharp.intellisense.showCompletionItemsFromUnimportedNamespaces").
         Add(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, "textEditor.csharp.intellisense.enableArgumentCompletionSnippets").
-        Add(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, "textEditor.csharp.intellisense.showNewSnippetExperience");
+        Add(CompletionOptionsStorage.ShowNewSnippetExperience, "textEditor.csharp.intellisense.showNewSnippetExperience");
 
     /// <summary>
     /// Array containing the option to expected unified settings for C# intellisense page.
@@ -115,8 +115,8 @@ public sealed class UnifiedSettingsTests
             customDefaultValue: false,
             order: 90,
             languageName: LanguageNames.CSharp)),
-        (CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, CreateBooleanOption(
-            CompletionOptionsStorage.ShowNewSnippetExperienceUserOption,
+        (CompletionOptionsStorage.ShowNewSnippetExperience, CreateBooleanOption(
+            CompletionOptionsStorage.ShowNewSnippetExperience,
             title: "Show new snippet experience",
             customDefaultValue: false,
             order: 100,

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -136,7 +136,7 @@ class C
 
             Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService(Of ISnippetInfoService)(), TestCSharpSnippetInfoService)
             testSnippetInfoService.SetSnippetShortcuts(snippetShortcuts)
-            state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, False)
+            state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp, False)
             Return state
         End Function
     End Class


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/pull/71583
Closes https://github.com/dotnet/roslyn/pull/72254

This is basically a redo of https://github.com/dotnet/roslyn/pull/71583 with resolved merge conflicts, removing of feature flag from unified settings, renaming the option (removing `UserOption` suffix as it is no longer needed) and removed mention of "experimental" feature