### PR TITLE
Revert "Ensure the LSP server is loaded after a solution is closed"

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
@@ -110,16 +110,10 @@ internal abstract partial class AbstractInProcLanguageClient(
 
     public event AsyncEventHandler<EventArgs>? StartAsync;
 
-    public event AsyncEventHandler<EventArgs>? StopAsync;
-
     /// <summary>
-    /// Stops the server if it has been started.
+    /// Unused, implementing <see cref="ILanguageClient"/>
     /// </summary>
-    /// <remarks>
-    /// Per the documentation on <see cref="ILanguageClient.StopAsync"/>, the event is ignored if the server has not been started.
-    /// </remarks>
-    public Task StopServerAsync()
-        => StopAsync?.InvokeAsync(this, EventArgs.Empty) ?? Task.CompletedTask;
+    public event AsyncEventHandler<EventArgs>? StopAsync { add { } remove { } }
 
     public async Task<Connection?> ActivateAsync(CancellationToken cancellationToken)
     {

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
@@ -40,18 +40,8 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
     /// </summary>
     public void StartListening(Workspace workspace)
     {
-        _ = workspace.RegisterWorkspaceChangedHandler(Workspace_WorkspaceChanged);
-    }
-
-    private void Workspace_WorkspaceChanged(WorkspaceChangeEventArgs e)
-    {
-        if (e.Kind == WorkspaceChangeKind.SolutionAdded)
-        {
-            // Normally VS will load the language client when an editor window is created for one of our content types,
-            // but we want to load it as soon as a solution is loaded so workspace diagnostics work, and so 3rd parties
-            // like Razor can use dynamic registration.
-            Load();
-        }
+        // Trigger a fire and forget request to the VS LSP client to load our ILanguageClient.
+        Load();
     }
 
     public void StopListening(Workspace workspace)
@@ -66,14 +56,11 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
 
         async Task LoadAsync()
         {
+
             // Explicitly switch to the bg so that if this causes any expensive work (like mef loads) it 
             // doesn't block the UI thread. Note, we always yield because sometimes our caller starts
             // on the threadpool thread but is indirectly blocked on by the UI thread.
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-
-            // Sometimes the editor can be slow to stop the old server instance when the old solution is closed, so we force it here.
-            // This will no-op if the server hasn't been started yet.
-            await _languageClient.StopServerAsync().ConfigureAwait(false);
 
             await _languageClientBroker.Value.LoadAsync(new LanguageClientMetadata(
             [


### PR DESCRIPTION
Reverts dotnet/roslyn#79048. Appears to have introduced flaky RPS test failures.