### PR TITLE
[REDO] Ensure the LSP server is loaded after a solution is closed

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
@@ -110,10 +110,16 @@ internal abstract partial class AbstractInProcLanguageClient(
 
     public event AsyncEventHandler<EventArgs>? StartAsync;
 
+    public event AsyncEventHandler<EventArgs>? StopAsync;
+
     /// <summary>
-    /// Unused, implementing <see cref="ILanguageClient"/>
+    /// Stops the server if it has been started.
     /// </summary>
-    public event AsyncEventHandler<EventArgs>? StopAsync { add { } remove { } }
+    /// <remarks>
+    /// Per the documentation on <see cref="ILanguageClient.StopAsync"/>, the event is ignored if the server has not been started.
+    /// </remarks>
+    public Task StopServerAsync()
+        => StopAsync?.InvokeAsync(this, EventArgs.Empty) ?? Task.CompletedTask;
 
     public async Task<Connection?> ActivateAsync(CancellationToken cancellationToken)
     {

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
@@ -50,14 +50,14 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
             // Normally VS will load the language client when an editor window is created for one of our content types,
             // but we want to load it as soon as a solution is loaded so workspace diagnostics work, and so 3rd parties
             // like Razor can use dynamic registration.
-            Load();
+            LoadLanguageClient();
         }
         else if (e.Kind is WorkspaceChangeKind.SolutionRemoved)
         {
             // VS will unload the language client when the solution is closed, but sometimes its a little slow to do so,
             // and we can end up trying to load it, above, before it has been asked to unload. We wait for the previous
             // instance to shutdown when we load, but we have to ensure that it at least gets signaled to do so first.
-            Unload();
+            UnloadLanguageClient();
         }
     }
 
@@ -66,9 +66,9 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
         // Nothing to do here.  There's no concept of unloading an ILanguageClient.
     }
 
-    private void Load()
+    private void LoadLanguageClient()
     {
-        using var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(Load));
+        using var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(LoadLanguageClient));
         LoadAsync().ReportNonFatalErrorAsync().CompletesAsyncOperation(token);
 
         async Task LoadAsync()
@@ -87,7 +87,7 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
         }
     }
 
-    private void Unload()
+    private void UnloadLanguageClient()
     {
         // We just want to signal that an unload should happen, in case the above call to Load comes in quick.
         // We don't want to wait for it to complete, not do we care about errors that may occur during the unload.

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
@@ -40,8 +40,25 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
     /// </summary>
     public void StartListening(Workspace workspace)
     {
-        // Trigger a fire and forget request to the VS LSP client to load our ILanguageClient.
-        Load();
+        _ = workspace.RegisterWorkspaceChangedHandler(Workspace_WorkspaceChanged);
+    }
+
+    private void Workspace_WorkspaceChanged(WorkspaceChangeEventArgs e)
+    {
+        if (e.Kind == WorkspaceChangeKind.SolutionAdded)
+        {
+            // Normally VS will load the language client when an editor window is created for one of our content types,
+            // but we want to load it as soon as a solution is loaded so workspace diagnostics work, and so 3rd parties
+            // like Razor can use dynamic registration.
+            Load();
+        }
+        else if (e.Kind is WorkspaceChangeKind.SolutionRemoved)
+        {
+            // VS will unload the language client when the solution is closed, but sometimes its a little slow to do so,
+            // and we can end up trying to load it, above, before it has been asked to unload. We wait for the previous
+            // instance to shutdown when we load, but we have to ensure that it at least gets signaled to do so first.
+            Unload();
+        }
     }
 
     public void StopListening(Workspace workspace)
@@ -56,7 +73,6 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
 
         async Task LoadAsync()
         {
-
             // Explicitly switch to the bg so that if this causes any expensive work (like mef loads) it 
             // doesn't block the UI thread. Note, we always yield because sometimes our caller starts
             // on the threadpool thread but is indirectly blocked on by the UI thread.
@@ -69,6 +85,14 @@ internal sealed class AlwaysActiveLanguageClientEventListener(
                 ContentTypeNames.FSharpContentType
             ]), _languageClient).ConfigureAwait(false);
         }
+    }
+
+    private void Unload()
+    {
+        // We just want to signal that an unload should happen, in case the above call to Load comes in quick.
+        // We don't want to wait for it to complete, not do we care about errors that may occur during the unload.
+        // The language client/server does its own error reporting as necessary.
+        _languageClient.StopServerAsync().Forget();
     }
 
     /// <summary>


### PR DESCRIPTION
Redo of https://github.com/dotnet/roslyn/pull/79048 with a minor tweak to try to prevent the completion test flakiness that caused the revert in https://github.com/dotnet/roslyn/pull/79125