### PR TITLE
Clear provider on disposal

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorDynamicFileInfoProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.Razor;
 [ExportMetadata("Extensions", new string[] { "cshtml", "razor", })]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed partial class RazorDynamicFileInfoProvider(Lazy<LanguageServerWorkspaceFactory> workspaceFactory, ILoggerFactory loggerFactory) : IDynamicFileInfoProvider, ILspService, IOnInitialized
+internal sealed partial class RazorDynamicFileInfoProvider(Lazy<LanguageServerWorkspaceFactory> workspaceFactory, ILoggerFactory loggerFactory) : IDynamicFileInfoProvider, ILspService, IOnInitialized, IDisposable
 {
     private RazorWorkspaceService? _razorWorkspaceService;
     private RazorLspDynamicFileInfoProvider? _dynamicFileInfoProvider;
@@ -79,5 +79,12 @@ internal sealed partial class RazorDynamicFileInfoProvider(Lazy<LanguageServerWo
         }
 
         await _dynamicFileInfoProvider.RemoveDynamicFileInfoAsync(workspaceFactory.Value.HostWorkspace, projectId, projectFilePath, filePath, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Dispose()
+    {
+        // Dispose is called when the LSP server is being shut down. Clear the dynamic file provider in case a workspace
+        // event is raised after, as the actual provider will try to make LSP requests.
+        _dynamicFileInfoProvider = null;
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2441953

Seeing the odd `ObjectDisposedException` when the Razor LSP dynamic file info provider tries to make an LSP request, presumably because a workspace event is happening while the LSP server is being shut down. No cabs to 100% confirm, but this change seems small and safe enough to me.