### PR TITLE
Support using a simple overload resolution for finding Await helpers from the BCL

### DIFF
--- a/docs/compilers/CSharp/Runtime Async Design.md
+++ b/docs/compilers/CSharp/Runtime Async Design.md
@@ -135,9 +135,11 @@ For any `await expr` with where `expr` has type `E`, the compiler will attempt t
       2. There is an identity or implicit reference conversion from `E` to the type of `P`.
    4. Otherwise, if `Mi` has a generic arity of 1 with type param `Tm`, all of the following must be true, or `Mi` is removed:
       1. The return type is `Tm`
-      2. There is an identity or implicit reference conversion from `E`'s unsubstituted definition to `P`
-      3. `E`'s type argument, `Te`, is valid to substitute for `Tm`
-6. If only one `Mi` remains, that method is used for the following rewrites. Otherwise, we instead move to [await any other type].
+      2. The generic parameter of `E` is `Te`
+      3. `Ti` satisfies any constraints on `Tm`
+      4. `Mie` is `Mi` with `Te` substituted for `Tm`, and `Pe` is the resulting parameter of `Mie`
+      5. There is an identity or implicit reference conversion from `E` to the type of `Pe`
+5. If only one `Mi` remains, that method is used for the following rewrites. Otherwise, we instead move to [await any other type].
 
 We'll generally rewrite `await expr` into `System.Runtime.CompilerServices.AsyncHelpers.Await(expr)`. A number of different example scenarios for this are covered below. The
 main interesting deviations are when `struct` rvalues need to be hoisted across an `await`, and exception handling rewriting.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -570,10 +570,6 @@ namespace System
                     || special == SpecialMember.System_ReadOnlySpan_T__ctor_Reference
                     || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter
                     || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter
-                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
-                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
-                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
-                    || special == SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
                     )
                 {
                     Assert.Null(symbol); // Not available

--- a/src/Compilers/Core/Portable/SpecialMember.cs
+++ b/src/Compilers/Core/Portable/SpecialMember.cs
@@ -194,10 +194,6 @@ namespace Microsoft.CodeAnalysis
 
         System_Type__GetTypeFromHandle,
 
-        System_Runtime_CompilerServices_AsyncHelpers__AwaitTask,
-        System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T,
-        System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask,
-        System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T,
         System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter,
         System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter,
 

--- a/src/Compilers/Core/Portable/SpecialMembers.cs
+++ b/src/Compilers/Core/Portable/SpecialMembers.cs
@@ -1314,42 +1314,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Type, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_RuntimeTypeHandle,
 
-                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_Task,
-
-                // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
-                1,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return Type
-                    (byte)SignatureTypeCode.GenericTypeInstance, (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_Task_T,
-                    1,
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
-
-                // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_ValueTask,
-
-                // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
-                1,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return Type
-                    (byte)SignatureTypeCode.GenericTypeInstance, (byte)SignatureTypeCode.TypeHandle, (byte)InternalSpecialType.System_Threading_Tasks_ValueTask_T,
-                    1,
-                    (byte)SignatureTypeCode.GenericMethodParameter, 0,
-
                 // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)InternalSpecialType.System_Runtime_CompilerServices_AsyncHelpers,                                     // DeclaringTypeId
@@ -1526,10 +1490,6 @@ namespace Microsoft.CodeAnalysis
                 "Empty",                                    // System_Array__Empty
                 "SetValue",                                 // System_Array__SetValue
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
-                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitTask
-                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T
-                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask
-                "Await",                                    // System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T
                 "AwaitAwaiter",                             // System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter
                 "UnsafeAwaitAwaiter",                       // System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter
             };

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -499,11 +499,7 @@ End Namespace
                    special = SpecialMember.System_Runtime_CompilerServices_InlineArrayAttribute__ctor OrElse
                    special = SpecialMember.System_ReadOnlySpan_T__ctor_Reference OrElse
                    special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitAwaiter_TAwaiter OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTask OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitTaskT_T OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTask OrElse
-                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__AwaitValueTaskT_T Then
+                   special = SpecialMember.System_Runtime_CompilerServices_AsyncHelpers__UnsafeAwaitAwaiter_TAwaiter Then
                     Assert.Null(symbol) ' Not available
                 Else
                     Assert.NotNull(symbol)


### PR DESCRIPTION
This PR removes special knowledge of what `Await` helpers correspond to what types, and instead implements a very simple form of overload resolution. We immediately bail on any conflict or error and fall back to attempting to use `AwaitAwaiter` or `UnsafeAwaitAwaiter` when such scenarios are detected. I've also updated the rules to better reflect what is actually implementable.