### PR TITLE
Small but trivial allocation improvement in FileWatchedReferenceFactory.StopWatchingReference

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -142,7 +142,6 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     {
         lock (_gate)
         {
-            var disposalLocation = callerFilePath + ", line " + callerLineNumber;
             if (!_referenceFileWatchingTokens.TryGetValue(fullFilePath, out var watchedFileReference))
             {
                 if (referenceToTrack != null)
@@ -167,6 +166,8 @@ internal sealed class FileWatchedReferenceFactory<TReference>
 
                 if (referenceToTrack != null)
                 {
+                    var disposalLocation = callerFilePath + ", line " + callerLineNumber;
+
                     _previousDisposalLocations.Remove(referenceToTrack);
                     _previousDisposalLocations.Add(referenceToTrack, disposalLocation);
                 }


### PR DESCRIPTION
String.Concat shows up as 0.3% of allocations in cohost scrolling razor speedometer test. Just moved the concatenation closer to where it's used, as I see it not used over 95% of the time this method is called.

![image](https://github.com/user-attachments/assets/32b1fe5a-ffbe-49c5-ad84-123b97310675)