### PR TITLE
Allow the LSP workspace configuration handler to get the open solution from the project system.

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -52,6 +52,11 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         _projectFileExtensionRegistry = new ProjectFileExtensionRegistry(workspace.CurrentSolution.Services, new DiagnosticReporter(workspace));
     }
 
+    /// <summary>
+    /// Gets the path to the last opened solution file, or null if no solution is loaded.
+    /// </summary>
+    public string? SolutionPath => ProjectFactory.SolutionPath;
+
     public async Task OpenSolutionAsync(string solutionFilePath)
     {
         _logger.LogInformation(string.Format(LanguageServerResources.Loading_0, solutionFilePath));

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/DebugConfiguration/WorkspaceDebugConfigurationHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/DebugConfiguration/WorkspaceDebugConfigurationHandler.cs
@@ -4,6 +4,7 @@
 
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Utilities;
 
@@ -16,12 +17,14 @@ internal sealed class WorkspaceDebugConfigurationHandler : ILspServiceRequestHan
     private const string MethodName = "workspace/debugConfiguration";
 
     private readonly ProjectTargetFrameworkManager _targetFrameworkManager;
+    private readonly LanguageServerProjectSystem _projectSystem;
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public WorkspaceDebugConfigurationHandler(ProjectTargetFrameworkManager targetFrameworkManager)
+    public WorkspaceDebugConfigurationHandler(ProjectTargetFrameworkManager targetFrameworkManager, LanguageServerProjectSystem projectSystem)
     {
         _targetFrameworkManager = targetFrameworkManager;
+        _projectSystem = projectSystem;
     }
 
     public bool MutatesSolutionState => false;
@@ -48,7 +51,7 @@ internal sealed class WorkspaceDebugConfigurationHandler : ILspServiceRequestHan
     {
         var isExe = project.CompilationOptions?.OutputKind is OutputKind.ConsoleApplication or OutputKind.WindowsApplication;
         var targetsDotnetCore = _targetFrameworkManager.IsDotnetCoreProject(project.Id);
-        return new ProjectDebugConfiguration(project.FilePath!, project.OutputFilePath!, GetProjectName(project), targetsDotnetCore, isExe, project.Solution.FilePath);
+        return new ProjectDebugConfiguration(project.FilePath!, project.OutputFilePath!, GetProjectName(project), targetsDotnetCore, isExe, _projectSystem.SolutionPath);
     }
 
     private static string GetProjectName(Project project)


### PR DESCRIPTION
Because the C# extension allows the user to open a solution file then another and because we have not implemented unload solution, the solution attributes never change and the project debug configuration always reports the first solution opened. This manifests itself when the user generates build assets for their workspace. The generated tasks.json will have build tasks for the first opened solution.

Resolves https://github.com/dotnet/vscode-csharp/issues/8377