### PR TITLE
Don't load the razor redirector unless it could actually be a razor assembly

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/RazorAnalyzerAssemblyRedirector.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorAnalyzerAssemblyRedirector.cs
@@ -12,9 +12,17 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
 [Export(typeof(IAnalyzerAssemblyRedirector)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class RazorAnalyzerAssemblyRedirector([Import(AllowDefault = true)] RazorAnalyzerAssemblyRedirector.IRazorAnalyzerAssemblyRedirector? razorRedirector = null) : IAnalyzerAssemblyRedirector
+internal sealed class RazorAnalyzerAssemblyRedirector([Import(AllowDefault = true)] Lazy<RazorAnalyzerAssemblyRedirector.IRazorAnalyzerAssemblyRedirector>? razorRedirector) : IAnalyzerAssemblyRedirector
 {
-    public string? RedirectPath(string fullPath) => razorRedirector?.RedirectPath(fullPath);
+    public string? RedirectPath(string fullPath)
+    {
+        // Simple heuristic so we don't load razor unnecessarily.
+        if (fullPath.Contains("razor", StringComparison.OrdinalIgnoreCase))
+        {
+            return razorRedirector?.Value.RedirectPath(fullPath);
+        }
+        return null;
+    }
 
     internal interface IRazorAnalyzerAssemblyRedirector
     {

--- a/src/Tools/ExternalAccess/Razor/Features/RazorAnalyzerAssemblyRedirector.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorAnalyzerAssemblyRedirector.cs
@@ -17,7 +17,7 @@ internal sealed class RazorAnalyzerAssemblyRedirector([Import(AllowDefault = tru
     public string? RedirectPath(string fullPath)
     {
         // Simple heuristic so we don't load razor unnecessarily.
-        if (fullPath.Contains("razor", StringComparison.OrdinalIgnoreCase))
+        if (fullPath.IndexOf("razor", StringComparison.OrdinalIgnoreCase) >= 0)
         {
             return razorRedirector?.Value.RedirectPath(fullPath);
         }


### PR DESCRIPTION
Adds a simple heuristic so we don't load the razor redirector unless it could plausibly be a razor assembly. 

This will give false positives, but that's fine. The actual razor redirector knows the specific assemblies to redirect.

All the razor assemblies have 'razor' in their name and live in a directory with 'razor' in their name, so we should never have false negatives from this. 