### PR TITLE
Revert "Move methods back to a place where TypeScript can reference them

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;

--- a/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
@@ -1031,99 +1031,6 @@ namespace Microsoft.CodeAnalysis
             set.Free();
             return true;
         }
-
-        #region Binary Compat
-
-        // These helpers should be in System.Linq namespace below.  However, they are currently
-        // used by partners with IVT access to Roslyn, so they have to stay here for now.
-
-        /// <summary>
-        /// Specialization of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/> for <see cref="ImmutableArray{T}"/>.
-        /// </summary>
-        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second)
-            => first.AddRange(second);
-
-        /// <summary>
-        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
-        /// </summary>
-        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third)
-        {
-            var builder = new T[first.Length + second.Length + third.Length];
-
-            var index = 0;
-            first.CopyTo(builder, index);
-            index += first.Length;
-            second.CopyTo(builder, index);
-            index += second.Length;
-            third.CopyTo(builder, index);
-
-            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
-        }
-
-        /// <summary>
-        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
-        /// </summary>
-        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth)
-        {
-            var builder = new T[first.Length + second.Length + third.Length + fourth.Length];
-
-            var index = 0;
-            first.CopyTo(builder, index);
-            index += first.Length;
-            second.CopyTo(builder, index);
-            index += second.Length;
-            third.CopyTo(builder, index);
-            index += third.Length;
-            fourth.CopyTo(builder, index);
-
-            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
-        }
-
-        /// <summary>
-        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
-        /// </summary>
-        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth, ImmutableArray<T> fifth)
-        {
-            var builder = new T[first.Length + second.Length + third.Length + fourth.Length + fifth.Length];
-
-            var index = 0;
-            first.CopyTo(builder, index);
-            index += first.Length;
-            second.CopyTo(builder, index);
-            index += second.Length;
-            third.CopyTo(builder, index);
-            index += third.Length;
-            fourth.CopyTo(builder, index);
-            index += fourth.Length;
-            fifth.CopyTo(builder, index);
-
-            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
-        }
-
-        /// <summary>
-        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
-        /// </summary>
-        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth, ImmutableArray<T> fifth, ImmutableArray<T> sixth)
-        {
-            var builder = new T[first.Length + second.Length + third.Length + fourth.Length + fifth.Length + sixth.Length];
-
-            var index = 0;
-            first.CopyTo(builder, index);
-            index += first.Length;
-            second.CopyTo(builder, index);
-            index += second.Length;
-            third.CopyTo(builder, index);
-            index += third.Length;
-            fourth.CopyTo(builder, index);
-            index += fourth.Length;
-            fifth.CopyTo(builder, index);
-            index += fifth.Length;
-            sixth.CopyTo(builder, index);
-
-            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
-        }
-
-        #endregion
     }
 }
 
@@ -1263,10 +1170,150 @@ namespace System.Linq
         }
 
         /// <summary>
+        /// Specialization of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/> for <see cref="ImmutableArray{T}"/>.
+        /// </summary>
+        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second)
+            => first.AddRange(second);
+
+        /// <summary>
         /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
         /// </summary>
         public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, T second)
             => first.Add(second);
+
+        /// <summary>
+        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
+        /// </summary>
+        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third)
+        {
+            var builder = new T[first.Length + second.Length + third.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
+        }
+
+        /// <summary>
+        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
+        /// </summary>
+        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth)
+        {
+            var builder = new T[first.Length + second.Length + third.Length + fourth.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fourth)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
+        }
+
+        /// <summary>
+        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
+        /// </summary>
+        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth, ImmutableArray<T> fifth)
+        {
+            var builder = new T[first.Length + second.Length + third.Length + fourth.Length + fifth.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fourth)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fifth)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
+        }
+
+        /// <summary>
+        /// Variant of <see cref="System.Linq.Enumerable.Concat{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
+        /// </summary>
+        public static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth, ImmutableArray<T> fifth, ImmutableArray<T> sixth)
+        {
+            var builder = new T[first.Length + second.Length + third.Length + fourth.Length + fifth.Length + sixth.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fourth)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fifth)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in sixth)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
+        }
 
         /// <summary>
         /// Returns an array of distinct elements, preserving the order in the original array.


### PR DESCRIPTION
This reverts commit 8790094293e09ce9033d4e291771b9a203272cfe.

Validation passed:
- https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12065967&view=results