### PR TITLE
Expose a couple of MSBuildWorkspace methods as internal for prototyping purposes

### DIFF
--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
@@ -698,6 +698,38 @@ public sealed class MSBuildWorkspace : Workspace
 
         this.OnAnalyzerReferenceRemoved(projectId, analyzerReference);
     }
+    #endregion
+
+    #region temporarily exposed internal methods for prototyping purpose only
+    internal void OnDocumentRemovedInternal(DocumentId documentId)
+    {
+        this.OnDocumentRemoved(documentId);
+    }
+
+    internal void OnAdditionalDocumentRemovedInternal(DocumentId documentId)
+    {
+        this.OnAdditionalDocumentRemoved(documentId);
+    }
+
+    internal void OnAnalyzerConfigDocumentRemovedInternal(DocumentId documentId)
+    {
+        this.OnAnalyzerConfigDocumentRemoved(documentId);
+    }
+
+    internal void OnDocumentTextChangedInternal(DocumentId documentId, SourceText newText)
+    {
+        this.OnDocumentTextChanged(documentId, newText, PreservationMode.PreserveValue);
+    }
+
+    internal void OnAdditionalDocumentTextChangedInternal(DocumentId documentId, SourceText newText)
+    {
+        this.OnAdditionalDocumentTextChanged(documentId, newText, PreservationMode.PreserveValue);
+    }
+
+    internal void OnAnalyzerConfigDocumentTextChangedInternal(DocumentId documentId, SourceText newText)
+    {
+        this.OnAnalyzerConfigDocumentTextChanged(documentId, newText, PreservationMode.PreserveValue);
+    }
+    #endregion
 }
 
-#endregion

--- a/src/Workspaces/MSBuild/Core/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/MSBuild/Core/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -70,6 +70,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Workspaces.Test.Utilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" LoadsWithinVisualStudio="false" />
+    <InternalsVisibleTo Include="AITools.CodeAnalysis.MSBuild" Key="$(AIToolsKey)" />
   </ItemGroup>
   <!--
     Include certain project reference binaries into this package in lib/ regular library.


### PR DESCRIPTION
This is to support incremental update to MSBuildWorkspace from changes made in source files on disk. Intended as a temporary solution only for internal prototyping purpose, until we figure out a better way forward (e.g maybe refactor and reuse language server workspace?). An alternative and cleaner approach would be to unseal `MSBuildWorkspace` but since is public API so I opt for this instead.