### PR TITLE
WIP: candidate fix for 78640

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -739,4 +739,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
     }
+
+    internal partial class BoundMethodDefIndex
+    {
+        private partial void Validate()
+        {
+            Debug.Assert(Method.IsDefinition);
+        }
+    }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -739,7 +739,7 @@
   
   <!-- Represents the raw metadata RowId value for a method definition.
        Used by dynamic instrumentation to index into tables or arrays of per-method information. -->
-  <Node Name="BoundMethodDefIndex" Base="BoundExpression">
+  <Node Name="BoundMethodDefIndex" Base="BoundExpression" HasValidate="true">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Method" Type="MethodSymbol"/>

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -2284,7 +2284,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Method = method;
+            Validate();
         }
+
+        [Conditional("DEBUG")]
+        private partial void Validate();
 
         public BoundMethodDefIndex(SyntaxNode syntax, MethodSymbol method, TypeSymbol type)
             : base(BoundKind.MethodDefIndex, syntax, type)

--- a/src/Compilers/CSharp/Portable/Lowering/BoundTreeToDifferentEnclosingContextRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/BoundTreeToDifferentEnclosingContextRewriter.cs
@@ -188,6 +188,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ;
         }
 
+        public override BoundNode? VisitMethodDefIndex(BoundMethodDefIndex node)
+        {
+            // Cannot replace a MethodDefIndex's Method/Type with a substituted symbol.
+            return node;
+        }
+
         [return: NotNullIfNotNull(nameof(method))]
         public override MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
         {


### PR DESCRIPTION
Closes #78640

It looks like certain forms of rewriting break the invariants of `BoundMethodDefIndex`. Looking for a minimal repro now.