### PR TITLE
Allow VS extensions to participate in Roslyn OOP MEF:

### DIFF
--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.cs
@@ -23,7 +23,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider
 {
     private const string AnalyzerContentTypeName = "Microsoft.VisualStudio.Analyzer";
 
-    internal const string RazorContentTypeName = "Microsoft.VisualStudio.RazorAssembly";
+    internal const string RoslynOopMefContentName = "Microsoft.VisualStudio.RoslynOopMefComponent";
 
     /// <summary>
     /// Loader for VSIX-based analyzers.
@@ -35,6 +35,8 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider
 
     private readonly Lazy<ImmutableArray<(AnalyzerFileReference reference, string extensionId)>> _lazyAnalyzerReferences;
 
+    private readonly Lazy<ImmutableArray<(string path, string extensionId)>> _lazyOopMefComponents;
+
     // internal for testing
     internal VisualStudioDiagnosticAnalyzerProvider(object extensionManager, Type typeIExtensionContent)
     {
@@ -44,10 +46,14 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerProvider
         _extensionManager = extensionManager;
         _typeIExtensionContent = typeIExtensionContent;
         _lazyAnalyzerReferences = new Lazy<ImmutableArray<(AnalyzerFileReference, string)>>(() => GetExtensionContent(AnalyzerContentTypeName).SelectAsArray(c => (new AnalyzerFileReference(c.path, AnalyzerAssemblyLoader), c.extensionId)));
+        _lazyOopMefComponents = new Lazy<ImmutableArray<(string path, string extensionId)>>(() => GetExtensionContent(RoslynOopMefContentName));
     }
 
     public ImmutableArray<(AnalyzerFileReference reference, string extensionId)> GetAnalyzerReferencesInExtensions()
         => _lazyAnalyzerReferences.Value;
+
+    public ImmutableArray<(string path, string extensionId)> GetOopMefComponentsInExtensions()
+        => _lazyOopMefComponents.Value;
 
     private ImmutableArray<(string path, string extensionId)> GetExtensionContent(string contentTypeName)
     {

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -742,7 +742,7 @@ public sealed partial class ServiceHubServicesTests
         var workspaceConfigurationService = workspace.Services.GetRequiredService<IWorkspaceConfigurationService>();
 
         _ = await client.TryInvokeAsync<IRemoteInitializationService, (int, string)>(
-            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, TempRoot.Root, cancellationToken),
+            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, TempRoot.Root, [], cancellationToken),
             CancellationToken.None).ConfigureAwait(false);
 
         var solution = workspace.CurrentSolution;
@@ -826,7 +826,7 @@ public sealed partial class ServiceHubServicesTests
         var workspaceConfigurationService = workspace.Services.GetRequiredService<IWorkspaceConfigurationService>();
 
         _ = await client.TryInvokeAsync<IRemoteInitializationService, (int, string)>(
-            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, TempRoot.Root, cancellationToken),
+            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, TempRoot.Root, [], cancellationToken),
             CancellationToken.None).ConfigureAwait(false);
 
         var solution = workspace.CurrentSolution;
@@ -881,7 +881,7 @@ public sealed partial class ServiceHubServicesTests
         var workspaceConfigurationService = workspace.Services.GetRequiredService<IWorkspaceConfigurationService>();
 
         _ = await client.TryInvokeAsync<IRemoteInitializationService, (int, string)>(
-            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, TempRoot.Root, cancellationToken),
+            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, TempRoot.Root, [], cancellationToken),
             CancellationToken.None).ConfigureAwait(false);
 
         var solution = workspace.CurrentSolution;

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -99,32 +99,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         End Function
 
         <WpfFact>
-        Public Async Function RazorSourceGenerator_FromSdk() As Task
-            Using environment = New TestEnvironment()
-                Dim providerFactory = DirectCast(environment.ExportProvider.GetExportedValue(Of IVisualStudioDiagnosticAnalyzerProviderFactory), MockVisualStudioDiagnosticAnalyzerProviderFactory)
-                providerFactory.ContentTypeName = VisualStudioDiagnosticAnalyzerProvider.RazorContentTypeName
-                providerFactory.Extensions =
-                {
-                    ({
-                        Path.Combine(TempRoot.Root, "File.dll")
-                     },
-                     "AnotherExtension")
-                }
-
-                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
-                    "Project", LanguageNames.CSharp, CancellationToken.None)
-
-                ' add Razor source generator and a couple more other analyzer files:
-                Dim path1 = Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.NET.Sdk.Razor.SourceGenerators.dll")
-                Dim path2 = Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "SdkDependency1.dll")
-                project.AddAnalyzerReference(path1)
-                project.AddAnalyzerReference(path2)
-
-                AssertEx.Equal({path1, path2}, environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Select(Function(r) r.FullPath))
-            End Using
-        End Function
-
-        <WpfFact>
         Public Async Function CodeStyleAnalyzers_CSharp_FromSdk_AreIgnored() As Task
             Using environment = New TestEnvironment()
                 Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -1430,7 +1430,7 @@ public sealed class SolutionWithSourceGeneratorTests : TestBase
         var workspaceConfigurationService = workspace.Services.GetRequiredService<IWorkspaceConfigurationService>();
 
         _ = await client.TryInvokeAsync<IRemoteInitializationService, (int, string?)>(
-            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options with { SourceGeneratorExecution = executionPreference }, TempRoot.Root, cancellationToken),
+            (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options with { SourceGeneratorExecution = executionPreference }, TempRoot.Root, [], cancellationToken),
             CancellationToken.None).ConfigureAwait(false);
 
         var solution = workspace.CurrentSolution;

--- a/src/Workspaces/Remote/Core/IRemoteInitializationService.cs
+++ b/src/Workspaces/Remote/Core/IRemoteInitializationService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -15,5 +16,5 @@ internal interface IRemoteInitializationService
     /// Called as soon as the remote process is created.
     /// </summary>
     /// <returns>Process ID of the remote process and an error message if the server encountered initialization issues.</returns>
-    ValueTask<(int processId, string? errorMessage)> InitializeAsync(WorkspaceConfigurationOptions options, string localSettingsDirectory, CancellationToken cancellationToken);
+    ValueTask<(int processId, string? errorMessage)> InitializeAsync(WorkspaceConfigurationOptions options, string localSettingsDirectory, ImmutableArray<string> oopMefComponentPaths, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -58,6 +59,7 @@ internal sealed partial class ServiceHubRemoteHostClient : RemoteHostClient
         AsynchronousOperationListenerProvider listenerProvider,
         IServiceBroker serviceBroker,
         RemoteServiceCallbackDispatcherRegistry callbackDispatchers,
+        ImmutableArray<string> oopMefComponentPaths,
         CancellationToken cancellationToken)
     {
         using (Logger.LogBlock(FunctionId.ServiceHubRemoteHostClient_CreateAsync, KeyValueLogMessage.NoProperty, cancellationToken))
@@ -74,7 +76,7 @@ internal sealed partial class ServiceHubRemoteHostClient : RemoteHostClient
             var workspaceConfigurationService = services.GetRequiredService<IWorkspaceConfigurationService>();
 
             var remoteProcessIdAndErrorMessage = await client.TryInvokeAsync<IRemoteInitializationService, (int processId, string? errorMessage)>(
-                (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, localSettingsDirectory, cancellationToken),
+                (service, cancellationToken) => service.InitializeAsync(workspaceConfigurationService.Options, localSettingsDirectory, oopMefComponentPaths, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
 
             if (remoteProcessIdAndErrorMessage.HasValue)

--- a/src/Workspaces/Remote/ServiceHub/Services/Initialization/RemoteInitializationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Initialization/RemoteInitializationService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,11 +21,11 @@ internal sealed class RemoteInitializationService(
             => new RemoteInitializationService(arguments);
     }
 
-    public async ValueTask<(int processId, string? errorMessage)> InitializeAsync(WorkspaceConfigurationOptions options, string localSettingsDirectory, CancellationToken cancellationToken)
+    public async ValueTask<(int processId, string? errorMessage)> InitializeAsync(WorkspaceConfigurationOptions options, string localSettingsDirectory, ImmutableArray<string> oopMefComponentPaths, CancellationToken cancellationToken)
     {
         // Performed before RunServiceAsync to ensure that the export provider is initialized before the RemoteWorkspaceManager is created
         // as part of the RunServiceAsync call.
-        var errorMessage = await RemoteExportProviderBuilder.InitializeAsync(localSettingsDirectory, cancellationToken).ConfigureAwait(false);
+        var errorMessage = await RemoteExportProviderBuilder.InitializeAsync(localSettingsDirectory, oopMefComponentPaths, cancellationToken).ConfigureAwait(false);
 
         var processId = await RunServiceAsync(cancellationToken =>
         {


### PR DESCRIPTION
- Allow extensions to supply a set of RoslynOopMefComponent
- Load those from extensions and pass them over to the OOP process at init
- Add the passed assembly paths into the OOP MEF catalog construction