### PR TITLE
Fix ParseExecutableStatement method context

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -526,7 +526,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseExecutableStatementCore() As StatementSyntax
             Dim outerContext As New CompilationUnitContext(Me)
-            Dim fakeBegin = SyntaxFactory.SubStatement(Nothing, Nothing, InternalSyntaxFactory.MissingKeyword(SyntaxKind.SubKeyword),
+            Dim builder As New CoreInternalSyntax.SyntaxListBuilder(1)
+            builder.Add(InternalSyntaxFactory.Token(Nothing, SyntaxKind.AsyncKeyword, Nothing))
+            Dim fakeBegin = SyntaxFactory.SubStatement(Nothing, builder.ToList, InternalSyntaxFactory.MissingKeyword(SyntaxKind.SubKeyword),
                                                   InternalSyntaxFactory.MissingIdentifier(), Nothing, Nothing, Nothing, Nothing, Nothing)
             Dim methodContext = New MethodBlockContext(SyntaxKind.SubBlock, fakeBegin, outerContext)
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
@@ -1896,7 +1896,6 @@ End Module
         Assert.Equal(SyntaxKind.AwaitExpression, statement.ChildNodes.First.Kind)
     End Sub
 
-
     <Fact>
     Public Sub ParseOneLineStatement()
         Dim str = " Dim x = 3 "

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
@@ -1887,6 +1887,17 @@ End Module
     End Sub
 
     <Fact>
+    Public Sub ParseAwaitStatement()
+        Dim str = "Await Task.Delay(1000)"
+
+        Dim statement = SyntaxFactory.ParseExecutableStatement(str)
+        Assert.Equal(False, statement.ContainsDiagnostics)
+        Assert.Equal(SyntaxKind.ExpressionStatement, statement.Kind)
+        Assert.Equal(SyntaxKind.AwaitExpression, statement.ChildNodes.First.Kind)
+    End Sub
+
+
+    <Fact>
     Public Sub ParseOneLineStatement()
         Dim str = " Dim x = 3 "
 


### PR DESCRIPTION
Fixes #79226 

Basically added an `Async` syntax token to the modifiers fake parse context method.

Not sure if this is the best approach.