### PR TITLE
Use spans in low level lexer char array handling code

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2337,9 +2337,7 @@ top:
                 if (width < MaxCachedTokenSize)
                 {
                     return _cache.LookupTrivia(
-                        TextWindow.CharacterWindow,
-                        TextWindow.LexemeRelativeStart,
-                        width,
+                        TextWindow.CharacterWindow.AsSpan(TextWindow.LexemeRelativeStart, width),
                         hashCode,
                         CreateWhitespaceTrivia,
                         TextWindow);

--- a/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
@@ -182,19 +182,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         internal SyntaxTrivia LookupTrivia<TArg>(
-            char[] textBuffer,
-            int keyStart,
-            int keyLength,
+            ReadOnlySpan<char> textBuffer,
             int hashCode,
             Func<TArg, SyntaxTrivia> createTriviaFunction,
             TArg data)
         {
-            var value = TriviaMap.FindItem(textBuffer, keyStart, keyLength, hashCode);
+            var value = TriviaMap.FindItem(textBuffer, hashCode);
 
             if (value == null)
             {
                 value = createTriviaFunction(data);
-                TriviaMap.AddItem(textBuffer, keyStart, keyLength, hashCode, value);
+                TriviaMap.AddItem(textBuffer, hashCode, value);
             }
 
             return value;
@@ -222,14 +220,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 #endif
 
         internal SyntaxToken LookupToken<TArg>(
-            char[] textBuffer,
-            int keyStart,
-            int keyLength,
+            ReadOnlySpan<char> textBuffer,
             int hashCode,
             Func<TArg, SyntaxToken> createTokenFunction,
             TArg data)
         {
-            var value = TokenMap.FindItem(textBuffer, keyStart, keyLength, hashCode);
+            var value = TokenMap.FindItem(textBuffer, hashCode);
 
             if (value == null)
             {
@@ -237,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     Miss();
 #endif
                 value = createTokenFunction(data);
-                TokenMap.AddItem(textBuffer, keyStart, keyLength, hashCode, value);
+                TokenMap.AddItem(textBuffer, hashCode, value);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
+++ b/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
@@ -235,9 +235,7 @@ exitWhile:
             {
                 // this is a good token!
                 var token = _cache.LookupToken(
-                    TextWindow.CharacterWindow,
-                    TextWindow.LexemeRelativeStart,
-                    i - TextWindow.LexemeRelativeStart,
+                    TextWindow.CharacterWindow.AsSpan(TextWindow.LexemeRelativeStart, i - TextWindow.LexemeRelativeStart),
                     hashCode,
                     CreateQuickToken,
                     this);

--- a/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
@@ -416,7 +416,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public string Intern(char[] array, int start, int length)
         {
-            return _strings.Add(array, start, length);
+            return _strings.Add(array.AsSpan(start, length));
         }
 
         public string GetInternedText()

--- a/src/Compilers/Core/CodeAnalysisTest/StringTableTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/StringTableTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var s3 = st.Add(" ");
             Assert.Same(s2, s3);
 
-            var s4 = st.Add(new char[1] { ' ' }, 0, 1);
+            var s4 = st.Add([' ']);
             Assert.Same(s3, s4);
 
             var s5 = st.Add("ABC DEF", 3, 1);

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -363,17 +363,7 @@ namespace Roslyn.Utilities
         /// <param name="length">The number of characters, beginning with <paramref name="start"/> to hash</param>
         /// <returns>The FNV-1a hash code of the substring beginning at <paramref name="start"/> and ending after <paramref name="length"/> characters.</returns>
         internal static int GetFNVHashCode(char[] text, int start, int length)
-        {
-            int hashCode = Hash.FnvOffsetBias;
-            int end = start + length;
-
-            for (int i = start; i < end; i++)
-            {
-                hashCode = unchecked((hashCode ^ text[i]) * Hash.FnvPrime);
-            }
-
-            return hashCode;
-        }
+            => GetFNVHashCode(text.AsSpan(start, length));
 
         /// <summary>
         /// Compute the hashcode of a single character using the FNV-1a algorithm

--- a/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
@@ -111,10 +111,9 @@ namespace Roslyn.Utilities
 
         #endregion // Poolable
 
-        internal string Add(char[] chars, int start, int len)
+        internal string Add(ReadOnlySpan<char> chars)
         {
-            var span = chars.AsSpan(start, len);
-            var hashCode = Hash.GetFNVHashCode(chars, start, len);
+            var hashCode = Hash.GetFNVHashCode(chars);
 
             // capture array to avoid extra range checks
             var arr = _localTable;
@@ -125,13 +124,13 @@ namespace Roslyn.Utilities
             if (text != null && arr[idx].HashCode == hashCode)
             {
                 var result = arr[idx].Text;
-                if (StringTable.TextEquals(result, span))
+                if (TextEquals(result, chars))
                 {
                     return result;
                 }
             }
 
-            string? shared = FindSharedEntry(chars, start, len, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does element-wise assignment of a struct
@@ -143,7 +142,7 @@ namespace Roslyn.Utilities
                 return shared;
             }
 
-            return AddItem(chars, start, len, hashCode);
+            return AddItem(chars, hashCode);
         }
 
         internal string Add(string chars, int start, int len)
@@ -283,7 +282,7 @@ namespace Roslyn.Utilities
             return chars;
         }
 
-        private static string? FindSharedEntry(char[] chars, int start, int len, int hashCode)
+        private static string? FindSharedEntry(ReadOnlySpan<char> chars, int hashCode)
         {
             var arr = s_sharedTable;
             int idx = SharedIdxFromHash(hashCode);
@@ -298,7 +297,7 @@ namespace Roslyn.Utilities
 
                 if (e != null)
                 {
-                    if (hash == hashCode && TextEquals(e, chars.AsSpan(start, len)))
+                    if (hash == hashCode && TextEquals(e, chars))
                     {
                         break;
                     }
@@ -492,9 +491,9 @@ namespace Roslyn.Utilities
             return e;
         }
 
-        private string AddItem(char[] chars, int start, int len, int hashCode)
+        private string AddItem(ReadOnlySpan<char> chars, int hashCode)
         {
-            var text = new String(chars, start, len);
+            var text = chars.ToString();
             AddCore(text, hashCode);
             return text;
         }

--- a/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
@@ -105,7 +105,7 @@ namespace Roslyn.Utilities
 
         #endregion // Poolable
 
-        internal T? FindItem(char[] chars, int start, int len, int hashCode)
+        internal T? FindItem(ReadOnlySpan<char> chars, int hashCode)
         {
             // get direct element reference to avoid extra range checks
             ref var localSlot = ref _localTable[LocalIdxFromHash(hashCode)];
@@ -114,13 +114,13 @@ namespace Roslyn.Utilities
 
             if (text != null && localSlot.HashCode == hashCode)
             {
-                if (StringTable.TextEquals(text, chars.AsSpan(start, len)))
+                if (StringTable.TextEquals(text, chars))
                 {
                     return localSlot.Item;
                 }
             }
 
-            SharedEntryValue? e = FindSharedEntry(chars, start, len, hashCode);
+            SharedEntryValue? e = FindSharedEntry(chars, hashCode);
             if (e != null)
             {
                 localSlot.HashCode = hashCode;
@@ -135,7 +135,7 @@ namespace Roslyn.Utilities
             return null!;
         }
 
-        private SharedEntryValue? FindSharedEntry(char[] chars, int start, int len, int hashCode)
+        private SharedEntryValue? FindSharedEntry(ReadOnlySpan<char> chars, int hashCode)
         {
             var arr = _sharedTableInst;
             int idx = SharedIdxFromHash(hashCode);
@@ -151,7 +151,7 @@ namespace Roslyn.Utilities
 
                 if (e != null)
                 {
-                    if (hash == hashCode && StringTable.TextEquals(e.Text, chars.AsSpan(start, len)))
+                    if (hash == hashCode && StringTable.TextEquals(e.Text, chars))
                     {
                         break;
                     }
@@ -171,9 +171,9 @@ namespace Roslyn.Utilities
             return e;
         }
 
-        internal void AddItem(char[] chars, int start, int len, int hashCode, T item)
+        internal void AddItem(ReadOnlySpan<char> chars, int hashCode, T item)
         {
-            var text = _strings.Add(chars, start, len);
+            var text = _strings.Add(chars);
 
             // add to the shared table first (in case someone looks for same item)
             var e = new SharedEntryValue(text, item);

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -166,7 +166,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim quickToken = QuickScanToken(allowLeadingMultilineTrivia)
 
             If quickToken.Succeeded Then
-                Dim token = _quickTokenTable.FindItem(quickToken.Chars, quickToken.Start, quickToken.Length, quickToken.HashCode)
+                Dim token = _quickTokenTable.FindItem(quickToken.Chars.AsSpan(quickToken.Start, quickToken.Length), quickToken.HashCode)
                 If token IsNot Nothing Then
                     AdvanceChar(quickToken.Length)
                     If quickToken.TerminatorLength <> 0 Then
@@ -185,7 +185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             If quickToken.Succeeded Then
                 Debug.Assert(quickToken.Length = scannedToken.FullWidth)
 
-                _quickTokenTable.AddItem(quickToken.Chars, quickToken.Start, quickToken.Length, quickToken.HashCode, scannedToken)
+                _quickTokenTable.AddItem(quickToken.Chars.AsSpan(quickToken.Start, quickToken.Length), quickToken.HashCode, scannedToken)
             End If
 
             Return scannedToken
@@ -399,7 +399,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return _stringTable.Add(ch)
         End Function
         Friend Function Intern(arr As Char()) As String
-            Return _stringTable.Add(arr)
+            Return _stringTable.Add(arr.AsSpan())
         End Function
 #End Region
 

--- a/src/Compilers/VisualBasic/Test/Syntax/QuickTokenTableTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/QuickTokenTableTests.vb
@@ -89,8 +89,8 @@ Public Class QuickTokenTableTests
             Dim text = New String(qt.Chars, 0, qt.Length)
             Dim token = InternalSyntax.SyntaxFactory.Identifier(text)
 
-            Assert.Null(table.FindItem(qt.Chars, qt.Start, qt.Length, qt.HashCode))
-            table.AddItem(qt.Chars, qt.Start, qt.Length, qt.HashCode, DirectCast(token, InternalSyntax.SyntaxToken))
+            Assert.Null(table.FindItem(qt.Chars.AsSpan(qt.Start, qt.Length), qt.HashCode))
+            table.AddItem(qt.Chars.AsSpan(qt.Start, qt.Length), qt.HashCode, DirectCast(token, InternalSyntax.SyntaxToken))
             Return New Tuple(Of String, InternalSyntax.SyntaxToken)(text, token)
         End Using
     End Function
@@ -107,7 +107,7 @@ Public Class QuickTokenTableTests
             Dim qt = scanner.QuickScanToken(False)
             Assert.True(qt.Succeeded)
 
-            Dim tokFound = table.FindItem(qt.Chars, qt.Start, qt.Length, qt.HashCode)
+            Dim tokFound = table.FindItem(qt.Chars.AsSpan(qt.Start, qt.Length), qt.HashCode)
             Assert.Same(e.Item2, tokFound)
         End Using
     End Sub


### PR DESCRIPTION
Found while doing work in simplifying the lexer/sliding-text-window code.  As these are all about efficiently workign with contiguous segments of characters, this fell out as a nice simplification.

Note that a bunch of this code was already span-ified previously.  This just pushes that spanification higher to some internal component boundary points.  
