### PR TITLE
Make the new Workspace.Register*Handler methods public

### DIFF
--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -71,10 +71,3 @@ M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(CSystem.
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(CancellationToken); Use overload that takes progress
 M:Microsoft.CodeAnalysis.DesktopStrongNameProvider.#ctor(System.Collections.Immutable.ImmutableArray{System.String}); Use overload that takes in temp directory
 M:System.Diagnostics.Tracing.EventSource.WriteEvent(System.Int32,System.Object[]); Use WriteEventCore instead
-E:Microsoft.CodeAnalysis.Workspace.WorkspaceChanged; Use RegisterWorkspaceChangedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.WorkspaceFailed; Use RegisterWorkspaceFailedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.DocumentOpened; Use RegisterDocumentOpenedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.TextDocumentOpened; Use RegisterTextDocumentOpenedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.DocumentClosed; Use RegisterDocumentClosedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.TextDocumentClosed; Use RegisterTextDocumentClosedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.DocumentActiveContextChanged; Use RegisterDocumentActiveContextChangedHandler instead

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/BannedSymbols.txt
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/BannedSymbols.txt
@@ -71,10 +71,3 @@ M:Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputeOperationsAsync(System.Th
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(CSystem.Threading.CancellationToken); Use overload that takes progress
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(CancellationToken); Use overload that takes progress
 M:System.Diagnostics.Tracing.EventSource.WriteEvent(System.Int32,System.Object[]); Use WriteEventCore instead
-E:Microsoft.CodeAnalysis.Workspace.WorkspaceChanged; Use RegisterWorkspaceChangedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.WorkspaceFailed; Use RegisterWorkspaceFailedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.DocumentOpened; Use RegisterDocumentOpenedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.TextDocumentOpened; Use RegisterTextDocumentOpenedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.DocumentClosed; Use RegisterDocumentClosedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.TextDocumentClosed; Use RegisterTextDocumentClosedHandler instead
-E:Microsoft.CodeAnalysis.Workspace.DocumentActiveContextChanged; Use RegisterDocumentActiveContextChangedHandler instead

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 *REMOVED*abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithModifiers(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithModifiers(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> Microsoft.CodeAnalysis.SyntaxNode
-
 Microsoft.CodeAnalysis.Editing.OperatorKind.AdditionAssignment = 27 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.BitwiseAndAssignment = 33 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.BitwiseOrAssignment = 34 -> Microsoft.CodeAnalysis.Editing.OperatorKind
@@ -12,3 +11,27 @@ Microsoft.CodeAnalysis.Editing.OperatorKind.MultiplicationAssignment = 29 -> Mic
 Microsoft.CodeAnalysis.Editing.OperatorKind.RightShiftAssignment = 36 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.SubtractionAssignment = 28 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.UnsignedRightShiftAssignment = 37 -> Microsoft.CodeAnalysis.Editing.OperatorKind
+Microsoft.CodeAnalysis.Workspace.RegisterDocumentActiveContextChangedHandler(System.Action<Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.Workspace.RegisterDocumentClosedHandler(System.Action<Microsoft.CodeAnalysis.DocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.Workspace.RegisterDocumentOpenedHandler(System.Action<Microsoft.CodeAnalysis.DocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.Workspace.RegisterTextDocumentClosedHandler(System.Action<Microsoft.CodeAnalysis.TextDocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.Workspace.RegisterTextDocumentOpenedHandler(System.Action<Microsoft.CodeAnalysis.TextDocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.Workspace.RegisterWorkspaceChangedHandler(System.Action<Microsoft.CodeAnalysis.WorkspaceChangeEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.Workspace.RegisterWorkspaceChangedImmediateHandler(System.Action<Microsoft.CodeAnalysis.WorkspaceChangeEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.Workspace.RegisterWorkspaceFailedHandler(System.Action<Microsoft.CodeAnalysis.WorkspaceDiagnosticEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.WorkspaceEventOptions
+Microsoft.CodeAnalysis.WorkspaceEventOptions.Deconstruct(out bool RequiresMainThread) -> void
+Microsoft.CodeAnalysis.WorkspaceEventOptions.Equals(Microsoft.CodeAnalysis.WorkspaceEventOptions other) -> bool
+Microsoft.CodeAnalysis.WorkspaceEventOptions.RequiresMainThread.get -> bool
+Microsoft.CodeAnalysis.WorkspaceEventOptions.RequiresMainThread.set -> void
+Microsoft.CodeAnalysis.WorkspaceEventOptions.WorkspaceEventOptions() -> void
+Microsoft.CodeAnalysis.WorkspaceEventOptions.WorkspaceEventOptions(bool RequiresMainThread) -> void
+Microsoft.CodeAnalysis.WorkspaceEventRegistration
+Microsoft.CodeAnalysis.WorkspaceEventRegistration.Dispose() -> void
+override Microsoft.CodeAnalysis.WorkspaceEventOptions.Equals(object obj) -> bool
+override Microsoft.CodeAnalysis.WorkspaceEventOptions.GetHashCode() -> int
+override Microsoft.CodeAnalysis.WorkspaceEventOptions.ToString() -> string
+static Microsoft.CodeAnalysis.WorkspaceEventOptions.operator !=(Microsoft.CodeAnalysis.WorkspaceEventOptions left, Microsoft.CodeAnalysis.WorkspaceEventOptions right) -> bool
+static Microsoft.CodeAnalysis.WorkspaceEventOptions.operator ==(Microsoft.CodeAnalysis.WorkspaceEventOptions left, Microsoft.CodeAnalysis.WorkspaceEventOptions right) -> bool
+static readonly Microsoft.CodeAnalysis.WorkspaceEventOptions.DefaultOptions -> Microsoft.CodeAnalysis.WorkspaceEventOptions
+static readonly Microsoft.CodeAnalysis.WorkspaceEventOptions.RequiresMainThreadOptions -> Microsoft.CodeAnalysis.WorkspaceEventOptions

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceEventOptions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceEventOptions.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CodeAnalysis;
 
-internal record struct WorkspaceEventOptions(bool RequiresMainThread)
+public record struct WorkspaceEventOptions(bool RequiresMainThread)
 {
     public static readonly WorkspaceEventOptions DefaultOptions = new(RequiresMainThread: false);
     public static readonly WorkspaceEventOptions RequiresMainThreadOptions = new(RequiresMainThread: true);

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceEventRegistration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceEventRegistration.cs
@@ -14,11 +14,18 @@ namespace Microsoft.CodeAnalysis;
 /// </summary>
 /// <remarks>This class is used to manage the lifecycle of an event handler associated with a workspace event. 
 /// When the instance is disposed, the event handler is automatically unregistered from the event map.</remarks>
-internal sealed class WorkspaceEventRegistration(WorkspaceEventMap eventMap, WorkspaceEventType eventType, WorkspaceEventHandlerAndOptions handlerAndOptions) : IDisposable
+public sealed class WorkspaceEventRegistration : IDisposable
 {
-    private readonly WorkspaceEventType _eventType = eventType;
-    private readonly WorkspaceEventHandlerAndOptions _handlerAndOptions = handlerAndOptions;
-    private WorkspaceEventMap? _eventMap = eventMap;
+    private readonly WorkspaceEventType _eventType;
+    private readonly WorkspaceEventHandlerAndOptions _handlerAndOptions;
+    private WorkspaceEventMap? _eventMap;
+
+    internal WorkspaceEventRegistration(WorkspaceEventMap eventMap, WorkspaceEventType eventType, WorkspaceEventHandlerAndOptions handlerAndOptions)
+    {
+        _eventType = eventType;
+        _handlerAndOptions = handlerAndOptions;
+        _eventMap = eventMap;
+    }
 
     public void Dispose()
     {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -33,7 +33,7 @@ public abstract partial class Workspace
     /// <summary>
     /// Registers a handler that is fired whenever the current solution is changed.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterWorkspaceChangedHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterWorkspaceChangedHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.WorkspaceChange, handler, options);
 
     /// <summary>
@@ -42,45 +42,45 @@ public abstract partial class Workspace
     /// regardless of the preferences indicated by the passed in options. This thread my vary depending
     /// on the workspace.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterWorkspaceChangedImmediateHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterWorkspaceChangedImmediateHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.WorkspaceChangedImmediate, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired whenever the workspace or part of its solution model
     /// fails to access a file or other external resource.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterWorkspaceFailedHandler(Action<WorkspaceDiagnosticEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterWorkspaceFailedHandler(Action<WorkspaceDiagnosticEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.WorkspaceFailed, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when a <see cref="Document"/> is opened in the editor.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterDocumentOpenedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterDocumentOpenedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.DocumentOpened, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when a <see cref="Document"/> is closed in the editor.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterDocumentClosedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterDocumentClosedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.DocumentClosed, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when any <see cref="TextDocument"/> is opened in the editor.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterTextDocumentOpenedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterTextDocumentOpenedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.TextDocumentOpened, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when any <see cref="TextDocument"/> is closed in the editor.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterTextDocumentClosedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterTextDocumentClosedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.TextDocumentClosed, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when the active context document associated with a buffer 
     /// changes.
     /// </summary>
-    internal WorkspaceEventRegistration RegisterDocumentActiveContextChangedHandler(Action<DocumentActiveContextChangedEventArgs> handler, WorkspaceEventOptions? options = null)
+    public WorkspaceEventRegistration RegisterDocumentActiveContextChangedHandler(Action<DocumentActiveContextChangedEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.DocumentActiveContextChanged, handler, options);
 
     private WorkspaceEventRegistration RegisterHandler<TEventArgs>(WorkspaceEventType eventType, Action<TEventArgs> handler, WorkspaceEventOptions? options = null)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_EventsLegacy.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_EventsLegacy.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Microsoft.CodeAnalysis;
 
@@ -19,6 +20,8 @@ public abstract partial class Workspace
     /// <summary>
     /// An event raised whenever the current solution is changed.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete($"Use {nameof(RegisterWorkspaceChangedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<WorkspaceChangeEventArgs> WorkspaceChanged
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.WorkspaceChange);
@@ -29,6 +32,8 @@ public abstract partial class Workspace
     /// An event raised whenever the workspace or part of its solution model
     /// fails to access a file or other external resource.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete($"Use {nameof(RegisterWorkspaceFailedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<WorkspaceDiagnosticEventArgs> WorkspaceFailed
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.WorkspaceFailed);
@@ -38,6 +43,8 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when a <see cref="Document"/> is opened in the editor.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete($"Use {nameof(RegisterDocumentOpenedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<DocumentEventArgs> DocumentOpened
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.DocumentOpened);
@@ -47,6 +54,8 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when any <see cref="TextDocument"/> is opened in the editor.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete($"Use {nameof(RegisterTextDocumentOpenedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<TextDocumentEventArgs> TextDocumentOpened
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.TextDocumentOpened);
@@ -56,6 +65,8 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when a <see cref="Document"/> is closed in the editor.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete($"Use {nameof(RegisterDocumentClosedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<DocumentEventArgs> DocumentClosed
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.DocumentClosed);
@@ -65,6 +76,8 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when any <see cref="TextDocument"/> is closed in the editor.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete($"Use {nameof(RegisterTextDocumentClosedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<TextDocumentEventArgs> TextDocumentClosed
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.TextDocumentClosed);
@@ -75,6 +88,8 @@ public abstract partial class Workspace
     /// An event that is fired when the active context document associated with a buffer 
     /// changes.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete($"Use {nameof(RegisterDocumentActiveContextChangedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<DocumentActiveContextChangedEventArgs> DocumentActiveContextChanged
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.DocumentActiveContextChanged);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -62,11 +62,10 @@ internal sealed partial class SemanticModelReuseWorkspaceServiceFactory : IWorks
         {
             _workspace = workspace;
 
-#pragma warning disable RS0030 // Do not use banned APIs
-#if WORKSPACE
-            _workspace.RegisterWorkspaceChangedHandler((e) =>
-#else
+#if ROSLYN_4_12_OR_LOWER
             _workspace.WorkspaceChanged += (sender, e) =>
+#else
+            _workspace.RegisterWorkspaceChangedHandler((e) =>
 #endif
             {
                 // if our map points at documents not in the current solution, then we want to clear things out.
@@ -85,12 +84,11 @@ internal sealed partial class SemanticModelReuseWorkspaceServiceFactory : IWorks
                     }
                 }
             }
-#if WORKSPACE
-            );
-#else
+#if ROSLYN_4_12_OR_LOWER
             ;
+#else
+            );
 #endif
-#pragma warning restore RS0030 // Do not use banned APIs
         }
 
         public async ValueTask<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)


### PR DESCRIPTION
We're obsoleting the old ones since the expectation going forward is most users can use the new ones only.

Closes https://github.com/dotnet/roslyn/issues/79007 which was approved by the API review.