### PR TITLE
Allow the Razor extension to report telemetry (and initialize)

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorInitializer.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/RazorInitializer.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Contracts.Telemetry;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.Razor;
+
+[Shared]
+[ExportRazorStatelessLspService(typeof(RazorInitializer))]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class RazorInitializer(Lazy<LanguageServerWorkspaceFactory> workspaceFactory, [Import(AllowDefault = true)] ITelemetryReporter? telemetryReporter) : ILspService, IOnInitialized
+{
+    public Task OnInitializedAsync(ClientCapabilities clientCapabilities, RequestContext context, CancellationToken cancellationToken)
+    {
+        var razorInitializerService = context.GetService<AbstractRazorInitializer>();
+        if (razorInitializerService is null)
+        {
+            // No initializer service registered, nothing to do.
+            return Task.CompletedTask;
+        }
+
+        razorInitializerService.Initialize(workspaceFactory.Value.HostWorkspace);
+
+        var razorTelemetryReporter = context.GetService<RazorTelemetryReporter>();
+        if (telemetryReporter is not null && razorTelemetryReporter is not null)
+        {
+            razorTelemetryReporter.Initialize(new TelemetryReporterWrapper(telemetryReporter));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/TelemetryReporterWrapper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/Razor/TelemetryReporterWrapper.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Contracts.Telemetry;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.Razor;
+
+internal class TelemetryReporterWrapper(ITelemetryReporter telemetryReporter) : ILanguageServerTelemetryReporterWrapper
+{
+    public void ReportEvent(string name, List<KeyValuePair<string, object?>> properties)
+    {
+        telemetryReporter.Log(name, properties);
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/Features/AbstractRazorInitializer.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/AbstractRazorInitializer.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+
+internal abstract class AbstractRazorInitializer : AbstractRazorLspService
+{
+    internal abstract void Initialize(Workspace workspace);
+}

--- a/src/Tools/ExternalAccess/Razor/Features/ILanguageServerTelemetryReporterWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/ILanguageServerTelemetryReporterWrapper.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+
+internal interface ILanguageServerTelemetryReporterWrapper
+{
+    void ReportEvent(string name, List<KeyValuePair<string, object?>> properties);
+}

--- a/src/Tools/ExternalAccess/Razor/Features/RazorTelemetryReporter.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorTelemetryReporter.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+
+internal abstract class RazorTelemetryReporter : AbstractRazorLspService
+{
+    private ILanguageServerTelemetryReporterWrapper? _wrapper;
+
+    internal void Initialize(ILanguageServerTelemetryReporterWrapper wrapper)
+    {
+        _wrapper = wrapper;
+    }
+
+    public void ReportEvent(string name, List<KeyValuePair<string, object?>> properties)
+    {
+        _wrapper?.ReportEvent(name, properties);
+    }
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/12009

Razor currently has a DevKit DLL to support telemetry in `rzls.exe`, but for the assembly that runs in the language server as an extension, we had nothing. This allows us to report through the Roslyn reporter, which does the same DevKit stuff.

Also creates a new initializer service we can provide, because previously we were abusing the dynamic file info system to get the workspace, and one day (with a bit of luck) that whole system will go away, so it's nice to remove a lynchpin.