### PR TITLE
Backport quick info crash when hovering over PP directives

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -5544,6 +5544,32 @@ MainDescription($"({FeaturesResources.parameter}) params int[] xs"));
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78171")]
+    public async Task TestPreprocessingSymbol()
+    {
+        var markup = """
+
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            class Program
+            {
+                async Task Process(CancellationToken cancellationToken = default)
+                {
+            #if N$$ET
+                    // .NET requires 100ms delay in this fictional example
+                    await Task.Delay(100, cancellationToken);
+            #else
+                    // .NET Framework requires 200ms delay in this fictional example, and we can't pass a CT on it
+                    await Task.Delay(200);
+            #endif
+                }
+            }
+            """;
+
+        await TestAsync(markup, MainDescription("NET"));
+    }
+
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546849")]
     public async Task TestIndexedProperty()
     {

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -5548,7 +5548,6 @@ MainDescription($"({FeaturesResources.parameter}) params int[] xs"));
     public async Task TestPreprocessingSymbol()
     {
         var markup = """
-
             using System.Threading;
             using System.Threading.Tasks;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions_Accessibility.cs
@@ -133,6 +133,7 @@ internal static partial class ISymbolExtensions
             case SymbolKind.Assembly:
             case SymbolKind.NetModule:
             case SymbolKind.RangeVariable:
+            case SymbolKind.Preprocessing:
                 // These types of symbols are always accessible (if visible).
                 return true;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/78569
Backports https://github.com/dotnet/roslyn/pull/78173 to 17.14.