### PR TITLE
Revert "Make the new Workspace.Register*Handler methods public"

### DIFF
--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -71,3 +71,10 @@ M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(CSystem.
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(CancellationToken); Use overload that takes progress
 M:Microsoft.CodeAnalysis.DesktopStrongNameProvider.#ctor(System.Collections.Immutable.ImmutableArray{System.String}); Use overload that takes in temp directory
 M:System.Diagnostics.Tracing.EventSource.WriteEvent(System.Int32,System.Object[]); Use WriteEventCore instead
+E:Microsoft.CodeAnalysis.Workspace.WorkspaceChanged; Use RegisterWorkspaceChangedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.WorkspaceFailed; Use RegisterWorkspaceFailedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.DocumentOpened; Use RegisterDocumentOpenedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.TextDocumentOpened; Use RegisterTextDocumentOpenedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.DocumentClosed; Use RegisterDocumentClosedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.TextDocumentClosed; Use RegisterTextDocumentClosedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.DocumentActiveContextChanged; Use RegisterDocumentActiveContextChangedHandler instead

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/BannedSymbols.txt
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/BannedSymbols.txt
@@ -71,3 +71,10 @@ M:Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputeOperationsAsync(System.Th
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(CSystem.Threading.CancellationToken); Use overload that takes progress
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(CancellationToken); Use overload that takes progress
 M:System.Diagnostics.Tracing.EventSource.WriteEvent(System.Int32,System.Object[]); Use WriteEventCore instead
+E:Microsoft.CodeAnalysis.Workspace.WorkspaceChanged; Use RegisterWorkspaceChangedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.WorkspaceFailed; Use RegisterWorkspaceFailedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.DocumentOpened; Use RegisterDocumentOpenedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.TextDocumentOpened; Use RegisterTextDocumentOpenedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.DocumentClosed; Use RegisterDocumentClosedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.TextDocumentClosed; Use RegisterTextDocumentClosedHandler instead
+E:Microsoft.CodeAnalysis.Workspace.DocumentActiveContextChanged; Use RegisterDocumentActiveContextChangedHandler instead

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 *REMOVED*abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithModifiers(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithModifiers(Microsoft.CodeAnalysis.SyntaxNode declaration, Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> Microsoft.CodeAnalysis.SyntaxNode
+
 Microsoft.CodeAnalysis.Editing.OperatorKind.AdditionAssignment = 27 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.BitwiseAndAssignment = 33 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.BitwiseOrAssignment = 34 -> Microsoft.CodeAnalysis.Editing.OperatorKind
@@ -11,27 +12,3 @@ Microsoft.CodeAnalysis.Editing.OperatorKind.MultiplicationAssignment = 29 -> Mic
 Microsoft.CodeAnalysis.Editing.OperatorKind.RightShiftAssignment = 36 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.SubtractionAssignment = 28 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.OperatorKind.UnsignedRightShiftAssignment = 37 -> Microsoft.CodeAnalysis.Editing.OperatorKind
-Microsoft.CodeAnalysis.Workspace.RegisterDocumentActiveContextChangedHandler(System.Action<Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.Workspace.RegisterDocumentClosedHandler(System.Action<Microsoft.CodeAnalysis.DocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.Workspace.RegisterDocumentOpenedHandler(System.Action<Microsoft.CodeAnalysis.DocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.Workspace.RegisterTextDocumentClosedHandler(System.Action<Microsoft.CodeAnalysis.TextDocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.Workspace.RegisterTextDocumentOpenedHandler(System.Action<Microsoft.CodeAnalysis.TextDocumentEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.Workspace.RegisterWorkspaceChangedHandler(System.Action<Microsoft.CodeAnalysis.WorkspaceChangeEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.Workspace.RegisterWorkspaceChangedImmediateHandler(System.Action<Microsoft.CodeAnalysis.WorkspaceChangeEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.Workspace.RegisterWorkspaceFailedHandler(System.Action<Microsoft.CodeAnalysis.WorkspaceDiagnosticEventArgs> handler, Microsoft.CodeAnalysis.WorkspaceEventOptions? options = null) -> Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.WorkspaceEventOptions
-Microsoft.CodeAnalysis.WorkspaceEventOptions.Deconstruct(out bool RequiresMainThread) -> void
-Microsoft.CodeAnalysis.WorkspaceEventOptions.Equals(Microsoft.CodeAnalysis.WorkspaceEventOptions other) -> bool
-Microsoft.CodeAnalysis.WorkspaceEventOptions.RequiresMainThread.get -> bool
-Microsoft.CodeAnalysis.WorkspaceEventOptions.RequiresMainThread.set -> void
-Microsoft.CodeAnalysis.WorkspaceEventOptions.WorkspaceEventOptions() -> void
-Microsoft.CodeAnalysis.WorkspaceEventOptions.WorkspaceEventOptions(bool RequiresMainThread) -> void
-Microsoft.CodeAnalysis.WorkspaceEventRegistration
-Microsoft.CodeAnalysis.WorkspaceEventRegistration.Dispose() -> void
-override Microsoft.CodeAnalysis.WorkspaceEventOptions.Equals(object obj) -> bool
-override Microsoft.CodeAnalysis.WorkspaceEventOptions.GetHashCode() -> int
-override Microsoft.CodeAnalysis.WorkspaceEventOptions.ToString() -> string
-static Microsoft.CodeAnalysis.WorkspaceEventOptions.operator !=(Microsoft.CodeAnalysis.WorkspaceEventOptions left, Microsoft.CodeAnalysis.WorkspaceEventOptions right) -> bool
-static Microsoft.CodeAnalysis.WorkspaceEventOptions.operator ==(Microsoft.CodeAnalysis.WorkspaceEventOptions left, Microsoft.CodeAnalysis.WorkspaceEventOptions right) -> bool
-static readonly Microsoft.CodeAnalysis.WorkspaceEventOptions.DefaultOptions -> Microsoft.CodeAnalysis.WorkspaceEventOptions
-static readonly Microsoft.CodeAnalysis.WorkspaceEventOptions.RequiresMainThreadOptions -> Microsoft.CodeAnalysis.WorkspaceEventOptions

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceEventOptions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceEventOptions.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CodeAnalysis;
 
-public record struct WorkspaceEventOptions(bool RequiresMainThread)
+internal record struct WorkspaceEventOptions(bool RequiresMainThread)
 {
     public static readonly WorkspaceEventOptions DefaultOptions = new(RequiresMainThread: false);
     public static readonly WorkspaceEventOptions RequiresMainThreadOptions = new(RequiresMainThread: true);

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceEventRegistration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceEventRegistration.cs
@@ -14,18 +14,11 @@ namespace Microsoft.CodeAnalysis;
 /// </summary>
 /// <remarks>This class is used to manage the lifecycle of an event handler associated with a workspace event. 
 /// When the instance is disposed, the event handler is automatically unregistered from the event map.</remarks>
-public sealed class WorkspaceEventRegistration : IDisposable
+internal sealed class WorkspaceEventRegistration(WorkspaceEventMap eventMap, WorkspaceEventType eventType, WorkspaceEventHandlerAndOptions handlerAndOptions) : IDisposable
 {
-    private readonly WorkspaceEventType _eventType;
-    private readonly WorkspaceEventHandlerAndOptions _handlerAndOptions;
-    private WorkspaceEventMap? _eventMap;
-
-    internal WorkspaceEventRegistration(WorkspaceEventMap eventMap, WorkspaceEventType eventType, WorkspaceEventHandlerAndOptions handlerAndOptions)
-    {
-        _eventType = eventType;
-        _handlerAndOptions = handlerAndOptions;
-        _eventMap = eventMap;
-    }
+    private readonly WorkspaceEventType _eventType = eventType;
+    private readonly WorkspaceEventHandlerAndOptions _handlerAndOptions = handlerAndOptions;
+    private WorkspaceEventMap? _eventMap = eventMap;
 
     public void Dispose()
     {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -33,7 +33,7 @@ public abstract partial class Workspace
     /// <summary>
     /// Registers a handler that is fired whenever the current solution is changed.
     /// </summary>
-    public WorkspaceEventRegistration RegisterWorkspaceChangedHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterWorkspaceChangedHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.WorkspaceChange, handler, options);
 
     /// <summary>
@@ -42,45 +42,45 @@ public abstract partial class Workspace
     /// regardless of the preferences indicated by the passed in options. This thread my vary depending
     /// on the workspace.
     /// </summary>
-    public WorkspaceEventRegistration RegisterWorkspaceChangedImmediateHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterWorkspaceChangedImmediateHandler(Action<WorkspaceChangeEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.WorkspaceChangedImmediate, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired whenever the workspace or part of its solution model
     /// fails to access a file or other external resource.
     /// </summary>
-    public WorkspaceEventRegistration RegisterWorkspaceFailedHandler(Action<WorkspaceDiagnosticEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterWorkspaceFailedHandler(Action<WorkspaceDiagnosticEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.WorkspaceFailed, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when a <see cref="Document"/> is opened in the editor.
     /// </summary>
-    public WorkspaceEventRegistration RegisterDocumentOpenedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterDocumentOpenedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.DocumentOpened, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when a <see cref="Document"/> is closed in the editor.
     /// </summary>
-    public WorkspaceEventRegistration RegisterDocumentClosedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterDocumentClosedHandler(Action<DocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.DocumentClosed, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when any <see cref="TextDocument"/> is opened in the editor.
     /// </summary>
-    public WorkspaceEventRegistration RegisterTextDocumentOpenedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterTextDocumentOpenedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.TextDocumentOpened, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when any <see cref="TextDocument"/> is closed in the editor.
     /// </summary>
-    public WorkspaceEventRegistration RegisterTextDocumentClosedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterTextDocumentClosedHandler(Action<TextDocumentEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.TextDocumentClosed, handler, options);
 
     /// <summary>
     /// Registers a handler that is fired when the active context document associated with a buffer 
     /// changes.
     /// </summary>
-    public WorkspaceEventRegistration RegisterDocumentActiveContextChangedHandler(Action<DocumentActiveContextChangedEventArgs> handler, WorkspaceEventOptions? options = null)
+    internal WorkspaceEventRegistration RegisterDocumentActiveContextChangedHandler(Action<DocumentActiveContextChangedEventArgs> handler, WorkspaceEventOptions? options = null)
         => RegisterHandler(WorkspaceEventType.DocumentActiveContextChanged, handler, options);
 
     private WorkspaceEventRegistration RegisterHandler<TEventArgs>(WorkspaceEventType eventType, Action<TEventArgs> handler, WorkspaceEventOptions? options = null)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_EventsLegacy.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_EventsLegacy.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 namespace Microsoft.CodeAnalysis;
 
@@ -20,8 +19,6 @@ public abstract partial class Workspace
     /// <summary>
     /// An event raised whenever the current solution is changed.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete($"Use {nameof(RegisterWorkspaceChangedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<WorkspaceChangeEventArgs> WorkspaceChanged
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.WorkspaceChange);
@@ -32,8 +29,6 @@ public abstract partial class Workspace
     /// An event raised whenever the workspace or part of its solution model
     /// fails to access a file or other external resource.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete($"Use {nameof(RegisterWorkspaceFailedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<WorkspaceDiagnosticEventArgs> WorkspaceFailed
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.WorkspaceFailed);
@@ -43,8 +38,6 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when a <see cref="Document"/> is opened in the editor.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete($"Use {nameof(RegisterDocumentOpenedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<DocumentEventArgs> DocumentOpened
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.DocumentOpened);
@@ -54,8 +47,6 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when any <see cref="TextDocument"/> is opened in the editor.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete($"Use {nameof(RegisterTextDocumentOpenedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<TextDocumentEventArgs> TextDocumentOpened
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.TextDocumentOpened);
@@ -65,8 +56,6 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when a <see cref="Document"/> is closed in the editor.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete($"Use {nameof(RegisterDocumentClosedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<DocumentEventArgs> DocumentClosed
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.DocumentClosed);
@@ -76,8 +65,6 @@ public abstract partial class Workspace
     /// <summary>
     /// An event that is fired when any <see cref="TextDocument"/> is closed in the editor.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete($"Use {nameof(RegisterTextDocumentClosedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<TextDocumentEventArgs> TextDocumentClosed
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.TextDocumentClosed);
@@ -88,8 +75,6 @@ public abstract partial class Workspace
     /// An event that is fired when the active context document associated with a buffer 
     /// changes.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete($"Use {nameof(RegisterDocumentActiveContextChangedHandler)} instead, which by default will no longer run on the UI thread.", error: false)]
     public event EventHandler<DocumentActiveContextChangedEventArgs> DocumentActiveContextChanged
     {
         add => AddLegacyEventHandler(value, WorkspaceEventType.DocumentActiveContextChanged);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/SemanticModelReuse/SemanticModelWorkspaceServiceFactory.SemanticModelWorkspaceService.cs
@@ -62,10 +62,11 @@ internal sealed partial class SemanticModelReuseWorkspaceServiceFactory : IWorks
         {
             _workspace = workspace;
 
-#if ROSLYN_4_12_OR_LOWER
-            _workspace.WorkspaceChanged += (sender, e) =>
-#else
+#pragma warning disable RS0030 // Do not use banned APIs
+#if WORKSPACE
             _workspace.RegisterWorkspaceChangedHandler((e) =>
+#else
+            _workspace.WorkspaceChanged += (sender, e) =>
 #endif
             {
                 // if our map points at documents not in the current solution, then we want to clear things out.
@@ -84,11 +85,12 @@ internal sealed partial class SemanticModelReuseWorkspaceServiceFactory : IWorks
                     }
                 }
             }
-#if ROSLYN_4_12_OR_LOWER
-            ;
-#else
+#if WORKSPACE
             );
+#else
+            ;
 #endif
+#pragma warning restore RS0030 // Do not use banned APIs
         }
 
         public async ValueTask<SemanticModel> ReuseExistingSpeculativeModelAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)


### PR DESCRIPTION
Reverts dotnet/roslyn#79238

Seeing regressions in https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/649076. Queueing the revert in case this is the best short term solution.

```log
D:\dbs\el\ddvsm\src\CodeSense\Framework\Roslyn\Roslyn\Editor\CodeElementTagger.cs(77,17): error CS0618: 'Workspace.DocumentActiveContextChanged' is obsolete: 'Use RegisterDocumentActiveContextChangedHandler instead, which by default will no longer run on the UI thread.'
D:\dbs\el\ddvsm\src\CodeSense\Framework\Roslyn\Roslyn\Editor\CodeElementTagger.cs(85,17): error CS0618: 'Workspace.DocumentActiveContextChanged' is obsolete: 'Use RegisterDocumentActiveContextChangedHandler instead, which by default will no longer run on the UI thread.'
```

@jasonmalinowski if it is practical, could you try pushing a commit to resolve the errors to the above linked VS insertion. Otherwise let's figure out a way to unblock here.