### PR TITLE
Completion for `#:project` paths

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/DirectiveCompletionProviderUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/DirectiveCompletionProviderUtilities.cs
@@ -2,14 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 
 internal static class DirectiveCompletionProviderUtilities
 {
-    internal static bool TryGetStringLiteralToken(SyntaxTree tree, int position, SyntaxKind directiveKind, out SyntaxToken stringLiteral, CancellationToken cancellationToken)
+    internal static bool TryGetStringLiteralToken(SyntaxTree tree, int position, SyntaxKind directiveKind, [NotNullWhen(true)] out string? literalValue, out TextSpan textSpan, CancellationToken cancellationToken)
     {
         if (tree.IsEntirelyWithinStringLiteral(position, cancellationToken))
         {
@@ -21,12 +23,14 @@ internal static class DirectiveCompletionProviderUtilities
 
             if (token.Kind() == SyntaxKind.StringLiteralToken && token.Parent!.Kind() == directiveKind)
             {
-                stringLiteral = token;
+                literalValue = token.ToString();
+                textSpan = token.Span;
                 return true;
             }
         }
 
-        stringLiteral = default;
+        literalValue = null;
+        textSpan = default;
         return false;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/LoadDirectiveCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/LoadDirectiveCompletionProvider.cs
@@ -4,11 +4,13 @@
 
 using System;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.Completion.CompletionProviders.Snippets;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 
@@ -25,6 +27,6 @@ internal sealed class LoadDirectiveCompletionProvider : AbstractLoadDirectiveCom
 
     protected override string DirectiveName => "load";
 
-    protected override bool TryGetStringLiteralToken(SyntaxTree tree, int position, out SyntaxToken stringLiteral, CancellationToken cancellationToken)
-        => DirectiveCompletionProviderUtilities.TryGetStringLiteralToken(tree, position, SyntaxKind.LoadDirectiveTrivia, out stringLiteral, cancellationToken);
+    protected override bool TryGetCompletionPrefix(SyntaxTree tree, int position, [NotNullWhen(true)] out string? literalValue, out TextSpan textSpan, CancellationToken cancellationToken)
+        => DirectiveCompletionProviderUtilities.TryGetStringLiteralToken(tree, position, SyntaxKind.LoadDirectiveTrivia, out literalValue, out textSpan, cancellationToken);
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/ProjectDirectiveCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/ProjectDirectiveCompletionProvider.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+
+[ExportCompletionProvider(nameof(ProjectDirectiveCompletionProvider), LanguageNames.CSharp)]
+[Shared]
+internal sealed class ProjectDirectiveCompletionProvider : AbstractDirectivePathCompletionProvider
+{
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public ProjectDirectiveCompletionProvider()
+    {
+    }
+
+    private static ImmutableArray<char> GetCommitCharacters()
+    {
+        using var builder = TemporaryArray<char>.Empty;
+        builder.Add('"');
+        if (PathUtilities.IsUnixLikePlatform)
+        {
+            builder.Add('/');
+        }
+        else
+        {
+            builder.Add('/');
+            builder.Add('\\');
+        }
+
+        return builder.ToImmutableAndClear();
+    }
+
+    private static readonly CompletionItemRules s_rules = CompletionItemRules.Create(
+         filterCharacterRules: [],
+         commitCharacterRules: [CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, GetCommitCharacters())],
+         enterKeyRule: EnterKeyRule.Never,
+         selectionBehavior: CompletionItemSelectionBehavior.HardSelection);
+
+    protected override bool RequireQuotes => false;
+    protected override string DirectiveName => ":project";
+
+    protected override bool TryGetCompletionPrefix(SyntaxTree tree, int position, [NotNullWhen(true)] out string? literalValue, out TextSpan textSpan, CancellationToken cancellationToken)
+    {
+        if (tree.IsEntirelyWithinStringLiteral(position, cancellationToken))
+        {
+            var token = tree.GetRoot(cancellationToken).FindToken(position, findInsideTrivia: true);
+            if (token.Kind() is SyntaxKind.EndOfDirectiveToken or SyntaxKind.EndOfFileToken)
+            {
+                token = token.GetPreviousToken(includeSkipped: true, includeDirectives: true);
+            }
+
+            const string tokenValuePrefix = "project ";
+            if (token.Kind() == SyntaxKind.StringLiteralToken
+                && token.Parent!.Kind() == SyntaxKind.IgnoredDirectiveTrivia
+                && token.ToString() is var wholeValue
+                && wholeValue.StartsWith(tokenValuePrefix)
+                && token.SpanStart + tokenValuePrefix.Length <= position)
+            {
+                literalValue = wholeValue.Substring(startIndex: tokenValuePrefix.Length);
+                textSpan = TextSpan.FromBounds(token.SpanStart + tokenValuePrefix.Length, token.Span.End);
+                return true;
+            }
+        }
+
+        literalValue = null;
+        textSpan = default;
+        return false;
+    }
+
+    protected override async Task ProvideCompletionsAsync(CompletionContext context, string pathThroughLastSlash)
+    {
+        var helper = GetFileSystemCompletionHelper(context.Document, Glyph.CSharpFile, extensions: [".csproj", ".vbproj"], s_rules);
+        context.AddItems(await helper.GetItemsAsync(pathThroughLastSlash, context.CancellationToken).ConfigureAwait(false));
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/ReferenceDirectiveCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/Scripting/ReferenceDirectiveCompletionProvider.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 
@@ -24,6 +26,6 @@ internal sealed class ReferenceDirectiveCompletionProvider : AbstractReferenceDi
 
     protected override string DirectiveName => "r";
 
-    protected override bool TryGetStringLiteralToken(SyntaxTree tree, int position, out SyntaxToken stringLiteral, CancellationToken cancellationToken)
-        => DirectiveCompletionProviderUtilities.TryGetStringLiteralToken(tree, position, SyntaxKind.ReferenceDirectiveTrivia, out stringLiteral, cancellationToken);
+    protected override bool TryGetCompletionPrefix(SyntaxTree tree, int position, [NotNullWhen(true)] out string? literalValue, out TextSpan textSpan, CancellationToken cancellationToken)
+        => DirectiveCompletionProviderUtilities.TryGetStringLiteralToken(tree, position, SyntaxKind.ReferenceDirectiveTrivia, out literalValue, out textSpan, cancellationToken);
 }


### PR DESCRIPTION
Adjusts the scripting file path completion providers to work with `#:project`.

There is no issue tracking this. We could open one if that is helpful. I felt this was part of the fit and finish that we want for this experience, and knew how to do it, so just went ahead and did it.

Remaining issues:
- It feels like a new completion list should appear when a `/` or `\` character is typed, so that you are guided through referencing a project in a nested folder. I'm not sure how to do that yet. Hitting ctrl+space works at least.
