### PR TITLE
Simplify initialization of OpenFileTracker

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -15,13 +14,11 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
-using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -35,7 +32,9 @@ internal partial class VisualStudioWorkspaceImpl
     {
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly ProjectSystemProjectFactory _projectSystemProjectFactory;
-        private readonly IEditorOptionsFactoryService _editorOptionsFactoryService;
+
+        // This is lazily initialized to avoid loading editor components when they're not needed until we actually open a file.
+        private readonly Lazy<IEditorOptionsFactoryService> _editorOptionsFactoryService;
         private readonly IAsynchronousOperationListener _asynchronousOperationListener;
         private readonly OpenTextBufferProvider _openTextBufferProvider;
 
@@ -60,14 +59,18 @@ internal partial class VisualStudioWorkspaceImpl
         /// </remarks>
         private bool _suggestedActionSourceProviderEnabled;
 
-        private OpenFileTracker(VisualStudioWorkspaceImpl workspace, ProjectSystemProjectFactory projectSystemProjectFactory, IComponentModel componentModel)
+        public OpenFileTracker(
+            VisualStudioWorkspaceImpl workspace,
+            ProjectSystemProjectFactory projectSystemProjectFactory,
+            Lazy<IEditorOptionsFactoryService> editorOptionsFactoryService,
+            IAsynchronousOperationListener workspaceOperationListener,
+            OpenTextBufferProvider openTextBufferProvider)
         {
-            workspace._threadingContext.ThrowIfNotOnUIThread();
             _workspace = workspace;
             _projectSystemProjectFactory = projectSystemProjectFactory;
-            _editorOptionsFactoryService = componentModel.GetService<IEditorOptionsFactoryService>();
-            _asynchronousOperationListener = componentModel.GetService<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.Workspace);
-            _openTextBufferProvider = componentModel.GetService<OpenTextBufferProvider>();
+            _editorOptionsFactoryService = editorOptionsFactoryService;
+            _asynchronousOperationListener = workspaceOperationListener;
+            _openTextBufferProvider = openTextBufferProvider;
             _openTextBufferProvider.AddListener(this);
         }
 
@@ -86,14 +89,6 @@ internal partial class VisualStudioWorkspaceImpl
         {
             TryClosingDocumentsForMoniker(oldMoniker);
             TryOpeningDocumentsForMonikerAndSetContextOnUIThread(newMoniker, buffer, hierarchy: _openTextBufferProvider.GetDocumentHierarchy(newMoniker));
-        }
-
-        public static async Task<OpenFileTracker> CreateAsync(VisualStudioWorkspaceImpl workspace, ProjectSystemProjectFactory projectSystemProjectFactory, IAsyncServiceProvider asyncServiceProvider)
-        {
-            var componentModel = (IComponentModel?)await asyncServiceProvider.GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(true);
-            Assumes.Present(componentModel);
-
-            return new OpenFileTracker(workspace, projectSystemProjectFactory, componentModel);
         }
 
         private void TryOpeningDocumentsForMonikerAndSetContextOnUIThread(string moniker, ITextBuffer textBuffer, IVsHierarchy? hierarchy)
@@ -120,7 +115,7 @@ internal partial class VisualStudioWorkspaceImpl
                 // First document opened in the workspace.
                 // We enable quick actions from SuggestedActionsSourceProvider via an editor option.
                 // NOTE: We need to be on the UI thread to enable the editor option.
-                SuggestedActionsSourceProvider.Enable(_editorOptionsFactoryService);
+                SuggestedActionsSourceProvider.Enable(_editorOptionsFactoryService.Value);
             }
         }
 
@@ -405,18 +400,6 @@ internal partial class VisualStudioWorkspaceImpl
             }
 
             EnsureSuggestedActionsSourceProviderEnabled();
-        }
-
-        internal void CheckForOpenFilesThatWeMissed()
-        {
-            // It's possible that Roslyn is loading asynchronously after documents were already opened by the user; this is a one-time check for
-            // any of those -- after this point, we are subscribed to events so we'll know of anything else.
-            _workspace._threadingContext.ThrowIfNotOnUIThread();
-
-            foreach (var (filePath, textBuffer, hierarchy) in _openTextBufferProvider.EnumerateDocumentSet())
-            {
-                TryOpeningDocumentsForMonikerAndSetContextOnUIThread(filePath, textBuffer, hierarchy);
-            }
         }
 
         private sealed class HierarchyEventSink : IVsHierarchyEvents, IDisposable

--- a/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
+++ b/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
@@ -55,6 +55,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
                 Case GetType(SVsFileChangeEx)
                     Return _fileChangeEx
 
+                Case GetType(SVsRunningDocumentTable)
+                    Dim mock = New Mock(Of IVsRunningDocumentTable)
+                    mock.As(Of IVsRunningDocumentTable4)()
+
+                    mock.Setup(Function(m) m.AdviseRunningDocTableEvents(It.IsAny(Of IVsRunningDocTableEvents), It.IsAny(Of UInteger))).Returns(VSConstants.S_OK)
+                    Return mock.Object
+
                 Case Else
                     Throw New Exception($"{NameOf(MockServiceProvider)} does not implement {serviceType.FullName}.")
             End Select

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -67,7 +67,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                 GetType(MockWorkspaceEventListenerProvider),
                 GetType(HierarchyItemToProjectIdMap),
                 GetType(DiagnosticAnalyzerService),
-                GetType(VisualStudioWorkspaceTelemetryService))
+                GetType(VisualStudioWorkspaceTelemetryService),
+                GetType(OpenTextBufferProvider),
+                GetType(StubVsEditorAdaptersFactoryService))
 
         Private ReadOnly _workspace As VisualStudioWorkspaceImpl
         Private ReadOnly _projectFilePaths As New List(Of String)


### PR DESCRIPTION
There's only two things here that could potentially need the UI thread:

1. The Running Document Table subscription, but OpenTextBufferProvider already abstracted that away.
2. The IEditorOptionsFactoryService usage, which being a MEF component shouldn't care, but even then we don't need it right away.

It's easy to clean all this up, so just do so.