### PR TITLE
Fix document diagnostics document open check

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractDocumentPullDiagnosticHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractDocumentPullDiagnosticHandler.cs
@@ -34,16 +34,16 @@ internal abstract class AbstractDocumentPullDiagnosticHandler<TDiagnosticsParams
         //
         // Only consider open documents here (and only closed ones in the WorkspacePullDiagnosticHandler).  Each
         // handler treats those as separate worlds that they are responsible for.
-        var textDocument = context.TextDocument;
-        if (textDocument is null)
+        var identifier = GetTextDocumentIdentifier(diagnosticsParams);
+        if (identifier is null || context.Document is null)
         {
             context.TraceDebug("Ignoring diagnostics request because no text document was provided");
             return new([]);
         }
 
-        if (!context.IsTracking(textDocument.GetURI()))
+        if (!context.IsTracking(identifier.DocumentUri))
         {
-            context.TraceWarning($"Ignoring diagnostics request for untracked document: {textDocument.GetURI()}");
+            context.TraceWarning($"Ignoring diagnostics request for untracked document: {identifier.DocumentUri}");
             return new([]);
         }
 

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSourceProviders/DocumentSyntaxAndSemanticDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSourceProviders/DocumentSyntaxAndSemanticDiagnosticSourceProvider.cs
@@ -24,12 +24,7 @@ internal abstract class AbstractDocumentSyntaxAndSemanticDiagnosticSourceProvide
 
     public ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
-        if (context.GetTrackedDocument<TextDocument>() is { } document)
-        {
-            return new([new DocumentDiagnosticSource(kind, document)]);
-        }
-
-        return new([]);
+        return new([new DocumentDiagnosticSource(kind, context.GetRequiredDocument())]);
     }
 
     [Export(typeof(IDiagnosticSourceProvider)), Shared]

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicDocumentNonLocalDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicDocumentNonLocalDiagnosticSourceProvider.cs
@@ -31,11 +31,10 @@ internal sealed class PublicDocumentNonLocalDiagnosticSourceProvider(
     public ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
         // Non-local document diagnostics are reported only when full solution analysis is enabled for analyzer execution.
-        if (context.GetTrackedDocument<TextDocument>() is { } textDocument &&
-            globalOptions.GetBackgroundAnalysisScope(textDocument.Project.Language) == BackgroundAnalysisScope.FullSolution)
+        if (globalOptions.GetBackgroundAnalysisScope(context.GetRequiredDocument().Project.Language) == BackgroundAnalysisScope.FullSolution)
         {
             // NOTE: Compiler does not report any non-local diagnostics, so we bail out for compiler analyzer.
-            return new([new NonLocalDocumentDiagnosticSource(textDocument, a => !a.IsCompilerAnalyzer())]);
+            return new([new NonLocalDocumentDiagnosticSource(context.GetRequiredDocument(), a => !a.IsCompilerAnalyzer())]);
         }
 
         return new([]);

--- a/src/LanguageServer/Protocol/Handler/EditAndContinue/DocumentEditAndContinueDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/EditAndContinue/DocumentEditAndContinueDiagnosticSourceProvider.cs
@@ -25,11 +25,6 @@ internal sealed class DocumentEditAndContinueDiagnosticSourceProvider() : IDiagn
 
     public ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
-        if (context.GetTrackedDocument<Document>() is { } document)
-        {
-            return new([EditAndContinueDiagnosticSource.CreateOpenDocumentSource(document)]);
-        }
-
-        return new([]);
+        return new([EditAndContinueDiagnosticSource.CreateOpenDocumentSource(context.GetRequiredDocument())]);
     }
 }

--- a/src/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -320,29 +320,6 @@ internal readonly struct RequestContext
         return _trackedDocuments[documentUri].Text;
     }
 
-    public TDocument? GetTrackedDocument<TDocument>() where TDocument : TextDocument
-    {
-        // Note: context.Document may be null in the case where the client is asking about a document that we have
-        // since removed from the workspace.  In this case, we don't really have anything to process.
-        // GetPreviousResults will be used to properly realize this and notify the client that the doc is gone.
-        //
-        // Only consider open documents here (and only closed ones in the WorkspacePullDiagnosticHandler).  Each
-        // handler treats those as separate worlds that they are responsible for.
-        if (TextDocument is not TDocument document)
-        {
-            TraceDebug($"Ignoring diagnostics request because no {typeof(TDocument).Name} was provided");
-            return null;
-        }
-
-        if (!IsTracking(document.GetURI()))
-        {
-            TraceDebug($"Ignoring diagnostics request for untracked document: {document.GetURI()}");
-            return null;
-        }
-
-        return document;
-    }
-
     /// <summary>
     /// Allows a mutating request to close a document and stop it being tracked.
     /// Mutating requests are serialized by the execution queue in order to prevent concurrent access.

--- a/src/LanguageServer/Protocol/Handler/Tasks/DocumentTaskDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/Tasks/DocumentTaskDiagnosticSourceProvider.cs
@@ -25,12 +25,7 @@ internal sealed class DocumentTaskDiagnosticSourceProvider([Import] IGlobalOptio
 
     public ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
-        if (context.GetTrackedDocument<Document>() is { } document)
-        {
-            return new([new TaskListDiagnosticSource(document, globalOptions)]);
-        }
-
-        return new([]);
+        return new([new TaskListDiagnosticSource(context.GetRequiredDocument(), globalOptions)]);
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/8400

VSCode normalizes URIs and always uses the URI based on when the file was first opened (even if it is renamed to change casing).  See https://github.com/microsoft/vscode-languageserver-node/issues/1186.  So VSCode sends the server a URI that may not match the casing of file on disk. 

 While we already ignore casing when looking up file paths in the workspace (and therefore find the correct document in the workspace for requests), we had an issue with diagnostics when checking if the file was open.  We were comparing a URI created from the file with the URI VSCode sends us.  With UNC URIs (windows file paths), case sensitivity is ignored when comparing paths, and so it doesn't matter.  However with unix file paths, case sensitivity is not ignored and so the file path URI and VSCode open URI did not match.

The fix here is to instead use the request URI we were given to check if the document is open, instead of attempting to derive it from the file path.


