### PR TITLE
Fix Rename adornment positioning after scrolling

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -152,7 +152,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             MaxWidth = _textView.ViewportRight;
             MinWidth = Math.Min(DefaultMinWidth, _textView.ViewportWidth);
 
-            Canvas.SetTop(this, Math.Max(0, top));
+            // Top can be negative if the viewport is scrolled up, but not left
+            Canvas.SetTop(this, top);
             Canvas.SetLeft(this, Math.Max(0, left));
         }
 


### PR DESCRIPTION
When Rename is invoked after scrolling up, the adornment is occasionally displayed misplaced out of viewport. See https://developercommunity.visualstudio.com/t/Rename-dialog-opens-up-outside-of-editor/10919621.


This is a regression from #77466, which was a fix for horizontal clipping but also changed vertical positioning to never be negative. Unfortunately, when scrolling up, text view's viewport top and bottom can be negative.
The fix is to remove unnecessary Math.Max on top position value.