### PR TITLE
Make 'convert to raw string' a syntax-only refactoring

### DIFF
--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertStringToRawStringCodeRefactoringProvider.cs
@@ -36,9 +36,12 @@ internal sealed partial class ConvertStringToRawStringCodeRefactoringProvider() 
             s_kindToEquivalenceKeyMap[i] = i.ToString(CultureInfo.InvariantCulture);
     }
 
-    private static readonly ImmutableArray<IConvertStringProvider> s_convertStringProviders = [ConvertRegularStringToRawStringProvider.Instance, ConvertInterpolatedStringToRawStringProvider.Instance];
+    private static readonly ImmutableArray<IConvertStringProvider> s_convertStringProviders =
+        [ConvertRegularStringToRawStringProvider.Instance, ConvertInterpolatedStringToRawStringProvider.Instance];
 
     protected override ImmutableArray<FixAllScope> SupportedFixAllScopes => AllFixAllScopes;
+
+    protected override CodeActionCleanup Cleanup => CodeActionCleanup.SyntaxOnly;
 
     private static bool CanConvert(
         ParsedDocument parsedDocument,


### PR DESCRIPTION
This ensures that during the automatic cleanup portion of this refactoring, that we don't bother doing semantic processing (like trying simplify type names) as they just do not apply.

This allows much better parallelization and avoids pointless passes that do nothing.