### PR TITLE
Set RoslynCompilerType=Custom in all toolset package flavors

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Framework/build/Microsoft.Net.Compilers.Toolset.Framework.Core.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Framework/build/Microsoft.Net.Compilers.Toolset.Framework.Core.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <_RoslynTargetDirectoryName>net472</_RoslynTargetDirectoryName>   
     <_RoslynTasksDirectory>$(MSBuildThisFileDirectory)..\tasks\$(_RoslynTargetDirectoryName)\</_RoslynTasksDirectory>
+    <RoslynCompilerType>Custom</RoslynCompilerType>
     <RoslynTasksAssembly>$(_RoslynTasksDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll</RoslynTasksAssembly> 
     <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">true</UseSharedCompilation>
     <CSharpCoreTargetsPath>$(_RoslynTasksDirectory)Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/arm64/build/Microsoft.Net.Compilers.Toolset.Arm64.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/arm64/build/Microsoft.Net.Compilers.Toolset.Arm64.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <_RoslynTasksDirectory>$(MSBuildThisFileDirectory)..\tasks\net472\</_RoslynTasksDirectory>
+    <RoslynCompilerType>Custom</RoslynCompilerType>
     <RoslynTasksAssembly>$(_RoslynTasksDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll</RoslynTasksAssembly> 
     <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">true</UseSharedCompilation>
     <CSharpCoreTargetsPath>$(_RoslynTasksDirectory)Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>


### PR DESCRIPTION
Follow up on https://github.com/dotnet/roslyn/pull/78584 where this was set only for the core toolset package.

Fixes broken bootstrap framework CI legs in [full roslyn-CI](https://dev.azure.com/dnceng-public/public/_build?definitionId=95&_a=summary&branchFilter=319). They have been broken by updating to .NET 10 (https://github.com/dotnet/roslyn/pull/78925) because that brings in the new logic to use Core compiler even on Framework MSBuild. The Framework toolset package should have overridden that but since it didn't set RoslynCompilerType=Custom, it didn't and so the build tried to load the ValidateBootstrap task from the SDK's build tasks (Microsoft.Build.Tasks.CodeAnalysis.Sdk.dll) but the ValidateBootstrap task is only available in build tasks from the local bootstrap build.

Full CI run of this PR (including the bootstrap framework leg): [20250710.8](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1090854&view=results)