### PR TITLE
Delete unnecessary GetServiceAsync calls

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -146,12 +146,6 @@ internal sealed class RoslynPackage : AbstractPackage
     {
         await TaskScheduler.Default;
 
-        await GetServiceAsync(typeof(SVsErrorList)).ConfigureAwait(false);
-        await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(false);
-        await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(false);
-        await GetServiceAsync(typeof(SVsRunningDocumentTable)).ConfigureAwait(false);
-        await GetServiceAsync(typeof(SVsTextManager)).ConfigureAwait(false);
-
         // we need to load it as early as possible since we can have errors from
         // package from each language very early
         await this.ComponentModel.GetService<VisualStudioSuppressionFixService>().InitializeAsync(this, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
It's not entirely clear to me why these were added; the intent may have been to create them asynchronously before we had a later GetService() call, but these services are likely to be created when we're loaded (like IVsShell), so these won't do anything. Some of the other ones we've now all moved to GetServiceAsync() at the actual use sites so there's no reason to have that either.

Closes https://github.com/dotnet/roslyn/issues/29598