### PR TITLE
Do not simplify generic methods calls if type argument nullability would change (attempt1)

### DIFF
--- a/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// #define LOG
-
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -17,11 +15,6 @@ using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-#if LOG
-using System.IO;
-using System.Text.RegularExpressions;
-#endif
-
 namespace Microsoft.CodeAnalysis.SimplifyTypeNames;
 
 internal abstract class SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnum, TSimplifierOptions>
@@ -29,29 +22,23 @@ internal abstract class SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnu
     where TLanguageKindEnum : struct
     where TSimplifierOptions : SimplifierOptions
 {
-#if LOG
-    private static string _logFile = @"c:\temp\simplifytypenames.txt";
-    private static object _logGate = new object();
-    private static readonly Regex s_newlinePattern = new Regex(@"[\r\n]+");
-#endif
-
     private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(AnalyzersResources.Name_can_be_simplified), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
 
     private static readonly LocalizableString s_localizableTitleSimplifyNames = new LocalizableResourceString(nameof(AnalyzersResources.Simplify_Names), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
     private static readonly DiagnosticDescriptor s_descriptorSimplifyNames = CreateDescriptorWithId(IDEDiagnosticIds.SimplifyNamesDiagnosticId,
-                                                                EnforceOnBuildValues.SimplifyNames,
-                                                                hasAnyCodeStyleOption: false,
-                                                                s_localizableTitleSimplifyNames,
-                                                                s_localizableMessage,
-                                                                isUnnecessary: true);
+        EnforceOnBuildValues.SimplifyNames,
+        hasAnyCodeStyleOption: false,
+        s_localizableTitleSimplifyNames,
+        s_localizableMessage,
+        isUnnecessary: true);
 
     private static readonly LocalizableString s_localizableTitleSimplifyMemberAccess = new LocalizableResourceString(nameof(AnalyzersResources.Simplify_Member_Access), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
     private static readonly DiagnosticDescriptor s_descriptorSimplifyMemberAccess = CreateDescriptorWithId(IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId,
-                                                                EnforceOnBuildValues.SimplifyMemberAccess,
-                                                                hasAnyCodeStyleOption: false,
-                                                                s_localizableTitleSimplifyMemberAccess,
-                                                                s_localizableMessage,
-                                                                isUnnecessary: true);
+        EnforceOnBuildValues.SimplifyMemberAccess,
+        hasAnyCodeStyleOption: false,
+        s_localizableTitleSimplifyMemberAccess,
+        s_localizableMessage,
+        isUnnecessary: true);
 
     private static readonly DiagnosticDescriptor s_descriptorPreferBuiltinOrFrameworkType = CreateDescriptorWithId(IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId,
         EnforceOnBuildValues.PreferBuiltInOrFrameworkType,

--- a/src/Features/CSharpTest/Diagnostics/AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/CSharpTest/Diagnostics/AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;

--- a/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/Features/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -6832,6 +6832,32 @@ new TestParameters(Options.Script));
             }
             """);
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75570")]
+    public Task GenericMethodArgsWithNullabilityDifference()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            #nullable enable
+
+            using System.Collections.Generic;
+            using System.Diagnostics.CodeAnalysis;
+            using System.Linq;
+
+            class C1 { }
+
+            class C2 { }
+
+            class D
+            {
+                public static C2[] ConvertAll(IEnumerable<C1> values)
+                {
+                    return values.[|Select<C1, C2>|](Convert).ToArray();
+                }
+
+                [return: NotNullIfNotNull(nameof(value))]
+                private static C2? Convert(C1? value) => value is null ? null : new C2();
+            }
+            """);
+
     private async Task TestWithPredefinedTypeOptionsAsync(string code, string expected, int index = 0)
         => await TestInRegularAndScript1Async(code, expected, index, new TestParameters(options: PreferIntrinsicTypeEverywhere));
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -374,12 +374,12 @@ internal abstract class AbstractSpeculationAnalyzer<
             return false;
         }
 
-        if (symbol.IsReducedExtension())
+        if (symbol.IsReducedExtension() && !newSymbol.IsReducedExtension())
         {
             symbol = ((IMethodSymbol)symbol).GetConstructedReducedFrom()!;
         }
 
-        if (newSymbol.IsReducedExtension())
+        if (newSymbol.IsReducedExtension() && !symbol.IsReducedExtension())
         {
             newSymbol = ((IMethodSymbol)newSymbol).GetConstructedReducedFrom()!;
         }
@@ -401,7 +401,8 @@ internal abstract class AbstractSpeculationAnalyzer<
         if (s_includeNullabilityComparer.Equals(symbol, newSymbol))
             return true;
 
-        if (symbol is IMethodSymbol methodSymbol && newSymbol is IMethodSymbol newMethodSymbol)
+        if (symbol is IMethodSymbol methodSymbol &&
+            newSymbol is IMethodSymbol newMethodSymbol)
         {
             // If we have local functions, we can't use normal symbol equality for them (since that checks locations).
             // Have to defer to SymbolEquivalence instead.


### PR DESCRIPTION
https://github.com/dotnet/roslyn/issues/75570

Would prefer to take https://github.com/dotnet/roslyn/pull/79400 instead.