### PR TITLE
Projects to deploy

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -210,8 +210,9 @@ public sealed class EditAndContinueLanguageServiceTests : EditAndContinueWorkspa
                         ])
                 ],
                 SyntaxError = syntaxError,
-                ProjectsToRebuild = [project.Id],
-                ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty.Add(project.Id, [])
+                ProjectsToRebuild = [projectId],
+                ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty.Add(projectId, []),
+                ProjectsToRedeploy = [projectId],
             };
         };
 
@@ -276,6 +277,7 @@ public sealed class EditAndContinueLanguageServiceTests : EditAndContinueWorkspa
                 SyntaxError = null,
                 ProjectsToRebuild = [],
                 ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
+                ProjectsToRedeploy = [],
             };
         };
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -343,6 +343,11 @@ internal sealed class EditSession
             return false;
         }
 
+        if (HasProjectLevelDifferences(oldProject, newProject, differences) && differences == null)
+        {
+            return true;
+        }
+
         foreach (var documentId in newProject.State.DocumentStates.GetChangedStateIds(oldProject.State.DocumentStates, ignoreUnchangedContent: true))
         {
             var document = newProject.GetRequiredDocument(documentId);
@@ -361,7 +366,7 @@ internal sealed class EditSession
                 return true;
             }
 
-            differences.Value.ChangedOrAddedDocuments.Add(document);
+            differences.ChangedOrAddedDocuments.Add(document);
         }
 
         foreach (var documentId in newProject.State.DocumentStates.GetAddedStateIds(oldProject.State.DocumentStates))
@@ -377,7 +382,7 @@ internal sealed class EditSession
                 return true;
             }
 
-            differences.Value.ChangedOrAddedDocuments.Add(document);
+            differences.ChangedOrAddedDocuments.Add(document);
         }
 
         foreach (var documentId in newProject.State.DocumentStates.GetRemovedStateIds(oldProject.State.DocumentStates))
@@ -393,7 +398,7 @@ internal sealed class EditSession
                 return true;
             }
 
-            differences.Value.DeletedDocuments.Add(document);
+            differences.DeletedDocuments.Add(document);
         }
 
         // The following will check for any changes in non-generated document content (editorconfig, additional docs).
@@ -436,9 +441,50 @@ internal sealed class EditSession
         return false;
     }
 
-    internal static async Task GetProjectDifferencesAsync(TraceLog log, Project oldProject, Project newProject, ProjectDifferences documentDifferences, ArrayBuilder<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    /// <summary>
+    /// Return true if projects might have differences in state other than document content that migth affect EnC.
+    /// The checks need to be fast. May return true even if the changes don't actually affect the behavior.
+    /// </summary>
+    internal static bool HasProjectLevelDifferences(Project oldProject, Project newProject, ProjectDifferences? differences)
+    {
+        if (oldProject.ParseOptions != newProject.ParseOptions ||
+            oldProject.CompilationOptions != newProject.CompilationOptions ||
+            oldProject.AssemblyName != newProject.AssemblyName)
+        {
+            if (differences != null)
+            {
+                differences.HasSettingChange = true;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        if (!oldProject.MetadataReferences.SequenceEqual(newProject.MetadataReferences) ||
+            !oldProject.ProjectReferences.SequenceEqual(newProject.ProjectReferences))
+        {
+            if (differences != null)
+            {
+                differences.HasReferenceChange = true;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static async Task GetProjectDifferencesAsync(TraceLog log, Project? oldProject, Project newProject, ProjectDifferences documentDifferences, ArrayBuilder<Diagnostic> diagnostics, CancellationToken cancellationToken)
     {
         documentDifferences.Clear();
+
+        if (oldProject == null)
+        {
+            return;
+        }
 
         if (!await HasDifferencesAsync(oldProject, newProject, documentDifferences, cancellationToken).ConfigureAwait(false))
         {
@@ -697,6 +743,16 @@ internal sealed class EditSession
         return hasRudeEdit;
     }
 
+    private static bool HasAddedReference(Compilation oldCompilation, Compilation newCompilation)
+    {
+        using var pooledOldNames = SharedPools.StringIgnoreCaseHashSet.GetPooledObject();
+        var oldNames = pooledOldNames.Object;
+        Debug.Assert(oldNames.Comparer == AssemblyIdentityComparer.SimpleNameComparer);
+
+        oldNames.AddRange(oldCompilation.ReferencedAssemblyNames.Select(static r => r.Name));
+        return newCompilation.ReferencedAssemblyNames.Any(static (newReference, oldNames) => !oldNames.Contains(newReference.Name), oldNames);
+    }
+
     internal static async ValueTask<ProjectChanges> GetProjectChangesAsync(
         ActiveStatementsMap baseActiveStatements,
         Compilation oldCompilation,
@@ -900,9 +956,11 @@ internal sealed class EditSession
             using var _1 = ArrayBuilder<ManagedHotReloadUpdate>.GetInstance(out var deltas);
             using var _2 = ArrayBuilder<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)>.GetInstance(out var nonRemappableRegions);
             using var _3 = ArrayBuilder<ProjectBaseline>.GetInstance(out var newProjectBaselines);
-            using var _4 = ArrayBuilder<(ProjectId id, Guid mvid)>.GetInstance(out var projectsToStale);
-            using var _5 = ArrayBuilder<ProjectId>.GetInstance(out var projectsToUnstale);
+            using var _4 = ArrayBuilder<ProjectId>.GetInstance(out var addedUnbuiltProjects);
+            using var _5 = ArrayBuilder<ProjectId>.GetInstance(out var projectsToRedeploy);
             using var _6 = PooledDictionary<ProjectId, ArrayBuilder<Diagnostic>>.GetInstance(out var diagnosticBuilders);
+
+            // Project differences for currently analyzed project. Reused and cleared.
             using var projectDifferences = new ProjectDifferences();
 
             // After all projects have been analyzed "true" value indicates changed document that is only included in stale projects.
@@ -945,39 +1003,16 @@ internal sealed class EditSession
                     }
 
                     var oldProject = oldSolution.GetProject(newProject.Id);
-                    if (oldProject == null)
-                    {
-                        Log.Write($"EnC state of {newProject.GetLogDisplay()} queried: project not loaded");
-
-                        // TODO (https://github.com/dotnet/roslyn/issues/1204):
-                        //
-                        // When debugging session is started some projects might not have been loaded to the workspace yet (may be explicitly unloaded by the user).
-                        // We capture the base solution. Edits in files that are in projects that haven't been loaded won't be applied
-                        // and will result in source mismatch when the user steps into them.
-                        //
-                        // We can allow project to be added by including all its documents here.
-                        // When we analyze these documents later on we'll check if they match the PDB.
-                        // If so we can add them to the committed solution and detect further changes.
-                        // It might be more efficient though to track added projects separately.
-
-                        continue;
-                    }
-
-                    Debug.Assert(oldProject.SupportsEditAndContinue());
-
-                    if (!oldProject.ProjectSettingsSupportEditAndContinue(Log))
-                    {
-                        // reason alrady reported
-                        continue;
-                    }
+                    Debug.Assert(oldProject == null || oldProject.SupportsEditAndContinue());
 
                     projectDiagnostics = ArrayBuilder<Diagnostic>.GetInstance();
 
                     await GetProjectDifferencesAsync(Log, oldProject, newProject, projectDifferences, projectDiagnostics, cancellationToken).ConfigureAwait(false);
+                    projectDifferences.Log(Log, newProject);
 
-                    if (projectDifferences.HasDocumentChanges)
+                    if (projectDifferences.IsEmpty)
                     {
-                        Log.Write($"Found {projectDifferences.ChangedOrAddedDocuments.Count} potentially changed, {projectDifferences.DeletedDocuments.Count} deleted document(s) in project {newProject.GetLogDisplay()}");
+                        continue;
                     }
 
                     var (mvid, mvidReadError) = await DebuggingSession.GetProjectModuleIdAsync(newProject, cancellationToken).ConfigureAwait(false);
@@ -989,8 +1024,9 @@ internal sealed class EditSession
                         if (mvid == staleModuleId || mvidReadError != null)
                         {
                             Log.Write($"EnC state of {newProject.GetLogDisplay()} queried: project is stale");
-                            UpdateChangedDocumentsStaleness(isStale: true);
 
+                            // Track changed documents that are only included in stale or unbuilt projects:
+                            UpdateChangedDocumentsStaleness(isStale: true);
                             continue;
                         }
 
@@ -1003,14 +1039,29 @@ internal sealed class EditSession
                         // The MVID is required for emit so we consider the error permanent and report it here.
                         // Bail before analyzing documents as the analysis needs to read the PDB which will likely fail if we can't even read the MVID.
                         projectDiagnostics.Add(mvidReadError);
-                        projectSummaryToReport = ProjectAnalysisSummary.ValidChanges;
                         continue;
                     }
 
                     if (mvid == Guid.Empty)
                     {
-                        Log.Write($"Changes not applied to {newProject.GetLogDisplay()}: project not built");
+                        // If the project has been added to the solution, ask the project system to build it.
+                        if (oldProject == null)
+                        {
+                            Log.Write($"Project build requested for {newProject.GetLogDisplay()}");
+                            addedUnbuiltProjects.Add(newProject.Id);
+                        }
+                        else
+                        {
+                            Log.Write($"Changes not applied to {newProject.GetLogDisplay()}: project not built");
+                        }
+
+                        // Track changed documents that are only included in stale or unbuilt projects:
                         UpdateChangedDocumentsStaleness(isStale: true);
+                        continue;
+                    }
+
+                    if (oldProject == null)
+                    {
                         continue;
                     }
 
@@ -1079,8 +1130,7 @@ internal sealed class EditSession
 
                     // Unsupported changes in referenced assemblies will be reported below.
                     if (projectSummary is ProjectAnalysisSummary.NoChanges or ProjectAnalysisSummary.ValidInsignificantChanges &&
-                        oldProject.MetadataReferences.SequenceEqual(newProject.MetadataReferences) &&
-                        oldProject.ProjectReferences.SequenceEqual(newProject.ProjectReferences))
+                        !projectDifferences.HasReferenceChange)
                     {
                         continue;
                     }
@@ -1138,6 +1188,14 @@ internal sealed class EditSession
                     if (projectBaselines.Any(baseline => HasReferenceRudeEdits(baseline.InitiallyReferencedAssemblies, newCompilation, projectDiagnostics)))
                     {
                         continue;
+                    }
+
+                    // If the project references new dependencies, the host needs to invoke ReferenceCopyLocalPathsOutputGroup target on this project
+                    // to deploy these dependencies to the projects output directory. The deployment shouldn't overwrite existing files.
+                    // It should only happen if the project has no rude edits (especially not rude edits related to references) -- we bailed above if so.
+                    if (HasAddedReference(oldCompilation, newCompilation))
+                    {
+                        projectsToRedeploy.Add(newProject.Id);
                     }
 
                     if (projectSummary is ProjectAnalysisSummary.NoChanges or ProjectAnalysisSummary.ValidInsignificantChanges)
@@ -1338,6 +1396,7 @@ internal sealed class EditSession
                 solution,
                 updates,
                 diagnostics,
+                addedUnbuiltProjects,
                 runningProjects,
                 out var projectsToRestart,
                 out var projectsToRebuild);
@@ -1352,7 +1411,8 @@ internal sealed class EditSession
                 diagnostics,
                 syntaxError: null,
                 projectsToRestart,
-                projectsToRebuild);
+                projectsToRebuild,
+                projectsToRedeploy.ToImmutable());
         }
         catch (Exception e) when (LogException(e) && FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
         {

--- a/src/Features/Core/Portable/EditAndContinue/EditSessionTelemetry.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSessionTelemetry.cs
@@ -87,7 +87,7 @@ internal sealed class EditSessionTelemetry
     public void LogSyntaxError()
         => _hadSyntaxErrors = true;
 
-    public void LogProjectAnalysisSummary(ProjectAnalysisSummary summary, Guid projectTelemetryId, IEnumerable<Diagnostic> diagnostics)
+    public void LogProjectAnalysisSummary(ProjectAnalysisSummary? summary, Guid projectTelemetryId, IEnumerable<Diagnostic> diagnostics)
     {
         lock (_guard)
         {
@@ -110,6 +110,10 @@ internal sealed class EditSessionTelemetry
 
             switch (summary)
             {
+                case null:
+                    // report diagnostics only
+                    break;
+
                 case ProjectAnalysisSummary.NoChanges:
                     break;
 

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -185,7 +185,7 @@ internal readonly struct EmitSolutionUpdateResults
     /// <summary>
     /// Returns projects that need to be rebuilt and/or restarted due to blocking rude edits in order to apply changes.
     /// </summary>
-    /// ]<param name="addedUnbuiltProjects">Projects that were added to the solution and not built yet.</param>
+    /// <param name="addedUnbuiltProjects">Projects that were added to the solution and not built yet.</param>
     /// <param name="runningProjects">Identifies projects that have been launched.</param>
     /// <param name="projectsToRestart">
     /// Running projects that have to be restarted and a list of projects with rude edits that caused the restart.

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -11,6 +12,7 @@ using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -35,6 +37,9 @@ internal readonly struct EmitSolutionUpdateResults
 
         [DataMember]
         public required ImmutableArray<ProjectId> ProjectsToRebuild { get; init; }
+
+        [DataMember]
+        public required ImmutableArray<ProjectId> ProjectsToRedeploy { get; init; }
 
         internal ImmutableArray<ManagedHotReloadDiagnostic> GetAllDiagnostics()
         {
@@ -90,7 +95,8 @@ internal readonly struct EmitSolutionUpdateResults
                 Diagnostics = [DiagnosticData.Create(diagnostic, firstProject)],
                 SyntaxError = null,
                 ProjectsToRebuild = [.. runningProjects.Keys],
-                ProjectsToRestart = runningProjects.Keys.ToImmutableDictionary(keySelector: static p => p, elementSelector: static p => ImmutableArray.Create(p))
+                ProjectsToRedeploy = [],
+                ProjectsToRestart = runningProjects.Keys.ToImmutableDictionary(keySelector: static p => p, elementSelector: static p => ImmutableArray.Create(p)),
             };
         }
     }
@@ -103,6 +109,7 @@ internal readonly struct EmitSolutionUpdateResults
         SyntaxError = null,
         ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
         ProjectsToRebuild = [],
+        ProjectsToRedeploy = [],
     };
 
     /// <summary>
@@ -136,6 +143,12 @@ internal readonly struct EmitSolutionUpdateResults
     /// </summary>
     public required ImmutableArray<ProjectId> ProjectsToRebuild { get; init; }
 
+    /// <summary>
+    /// Projects whose dependencies need to be deployed to their output directory, if not already present.
+    /// Unordered set.
+    /// </summary>
+    public required ImmutableArray<ProjectId> ProjectsToRedeploy { get; init; }
+
     public Data Dehydrate()
         => Solution == null
         ? new()
@@ -145,6 +158,7 @@ internal readonly struct EmitSolutionUpdateResults
             SyntaxError = null,
             ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
             ProjectsToRebuild = [],
+            ProjectsToRedeploy = [],
         }
         : new()
         {
@@ -153,6 +167,7 @@ internal readonly struct EmitSolutionUpdateResults
             SyntaxError = GetSyntaxErrorData(),
             ProjectsToRestart = ProjectsToRestart,
             ProjectsToRebuild = ProjectsToRebuild,
+            ProjectsToRedeploy = ProjectsToRedeploy,
         };
 
     private DiagnosticData? GetSyntaxErrorData()
@@ -170,6 +185,7 @@ internal readonly struct EmitSolutionUpdateResults
     /// <summary>
     /// Returns projects that need to be rebuilt and/or restarted due to blocking rude edits in order to apply changes.
     /// </summary>
+    /// ]<param name="addedUnbuiltProjects">Projects that were added to the solution and not built yet.</param>
     /// <param name="runningProjects">Identifies projects that have been launched.</param>
     /// <param name="projectsToRestart">
     /// Running projects that have to be restarted and a list of projects with rude edits that caused the restart.
@@ -183,6 +199,7 @@ internal readonly struct EmitSolutionUpdateResults
         Solution solution,
         ImmutableArray<ManagedHotReloadUpdate> moduleUpdates,
         ImmutableArray<ProjectDiagnostics> diagnostics,
+        IReadOnlyCollection<ProjectId> addedUnbuiltProjects,
         ImmutableDictionary<ProjectId, RunningProjectInfo> runningProjects,
         out ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> projectsToRestart,
         out ImmutableArray<ProjectId> projectsToRebuild)
@@ -215,11 +232,10 @@ internal readonly struct EmitSolutionUpdateResults
         using var _1 = ArrayBuilder<ProjectId>.GetInstance(out var traversalStack);
 
         // Maps project to restart to all projects with rude edits that caused the restart:
-        var projectsToRestartBuilder = PooledDictionary<ProjectId, ArrayBuilder<ProjectId>>.GetInstance();
+        using var _2 = PooledHashSet<ProjectId>.GetInstance(out var projectsToRestartBuilder);
+        var projectsToRebuildBuilder = PooledDictionary<ProjectId, ArrayBuilder<ProjectId>>.GetInstance();
 
-        using var _3 = PooledHashSet<ProjectId>.GetInstance(out var projectsToRebuildBuilder);
-        using var _4 = ArrayBuilder<(ProjectId projectWithRudeEdits, ImmutableArray<ProjectId> impactedRunningProjects)>.GetInstance(out var impactedRunningProjectMap);
-        using var _5 = ArrayBuilder<ProjectId>.GetInstance(out var impactedRunningProjects);
+        using var _3 = ArrayBuilder<(ProjectId projectWithRudeEdits, ImmutableArray<ProjectId> impactedRunningProjects)>.GetInstance(out var impactedRunningProjectMap);
 
         foreach (var (projectId, projectDiagnostics) in diagnostics)
         {
@@ -229,21 +245,35 @@ internal readonly struct EmitSolutionUpdateResults
                 continue;
             }
 
-            AddImpactedRunningProjects(impactedRunningProjects, projectId, hasBlocking);
-
-            foreach (var impactedRunningProject in impactedRunningProjects)
+            var hasImpactedRunningProjects = false;
+            foreach (var ancestor in GetAncestorsAndSelf(projectId))
             {
-                projectsToRestartBuilder.MultiAdd(impactedRunningProject, projectId);
+                if (runningProjects.TryGetValue(ancestor, out var runningProject) &&
+                    (hasBlocking || runningProject.RestartWhenChangesHaveNoEffect))
+                {
+                    projectsToRebuildBuilder.MultiAdd(ancestor, projectId);
+                    projectsToRestartBuilder.Add(ancestor);
+
+                    hasImpactedRunningProjects = true;
+                }
             }
 
-            if (hasBlocking && impactedRunningProjects is [])
+            if (hasBlocking && !hasImpactedRunningProjects)
             {
                 // Projects with rude edits that do not impact running projects has to be rebuilt,
                 // so that the change takes effect if it is loaded in future.
-                projectsToRebuildBuilder.Add(projectId);
+                projectsToRebuildBuilder.MultiAdd(projectId, projectId);
             }
+        }
 
-            impactedRunningProjects.Clear();
+        // Rebuild unbuilt projects that have been added and impact a running project
+        // (a project reference was added).
+        foreach (var projectId in addedUnbuiltProjects)
+        {
+            if (GetAncestorsAndSelf(projectId).Where(runningProjects.ContainsKey).Any())
+            {
+                projectsToRebuildBuilder.MultiAdd(projectId, projectId);
+            }
         }
 
         // At this point the restart set contains all running projects transitively affected by rude edits.
@@ -257,69 +287,79 @@ internal readonly struct EmitSolutionUpdateResults
             {
                 foreach (var update in moduleUpdates)
                 {
-                    AddImpactedRunningProjects(impactedRunningProjects, update.ProjectId, isBlocking: true);
-
-                    foreach (var impactedRunningProject in impactedRunningProjects)
+                    foreach (var ancestor in GetAncestorsAndSelf(update.ProjectId))
                     {
-                        projectsToRestartBuilder.TryAdd(impactedRunningProject, []);
+                        if (runningProjects.ContainsKey(ancestor))
+                        {
+                            projectsToRebuildBuilder.TryAdd(ancestor, []);
+                            projectsToRestartBuilder.Add(ancestor);
+                        }
                     }
-
-                    impactedRunningProjects.Clear();
                 }
             }
         }
-        else if (!moduleUpdates.IsEmpty && projectsToRestartBuilder.Count > 0)
+        else if (!moduleUpdates.IsEmpty && projectsToRebuildBuilder.Count > 0)
         {
             // The set of updated projects is usually much smaller than the number of all projects in the solution.
-            // We iterate over this set updating the reset set until no new project is added to the reset set.
+            // We iterate over this set updating the restart set until no new project is added to the restart set.
             // Once a project is determined to affect a running process, all running processes that
-            // reference this project are added to the reset set. The project is then removed from updated
-            // project set as it can't contribute any more running projects to the reset set.
-            // If an updated project does not affect reset set in a given iteration, it stays in the set
-            // because it may affect reset set later on, after another running project is added to it.
+            // reference this project are added to the restart set. The project is then removed from updated
+            // project set as it can't contribute any more running projects to the restart set.
+            // If an updated project does not affect restart set in a given iteration, it stays in the set
+            // because it may affect restart set later on, after another running project is added to it.
 
             using var _6 = PooledHashSet<ProjectId>.GetInstance(out var updatedProjects);
             using var _7 = ArrayBuilder<ProjectId>.GetInstance(out var updatedProjectsToRemove);
-            using var _8 = PooledHashSet<ProjectId>.GetInstance(out var projectsThatCausedRestart);
+            using var _8 = PooledHashSet<ProjectId>.GetInstance(out var projectsThatCausedRebuild);
 
             updatedProjects.AddRange(moduleUpdates.Select(static u => u.ProjectId));
 
             while (true)
             {
-                Debug.Assert(updatedProjectsToRemove.IsEmpty);
+                updatedProjectsToRemove.Clear();
 
                 foreach (var updatedProjectId in updatedProjects)
                 {
-                    AddImpactedRunningProjects(impactedRunningProjects, updatedProjectId, isBlocking: true);
+                    projectsThatCausedRebuild.Clear();
 
-                    Debug.Assert(projectsThatCausedRestart.Count == 0);
+                    // A project being updated that is a transitive dependency of a running project and
+                    // also transitive dependency of a project that needs to be rebuilt
+                    // causes the running project to be restarted.
 
-                    // collect all projects that caused restart of any of the impacted running projects:
-                    foreach (var impactedRunningProject in impactedRunningProjects)
+                    foreach (var ancestor in GetAncestorsAndSelf(updatedProjectId))
                     {
-                        if (projectsToRestartBuilder.TryGetValue(impactedRunningProject, out var causes))
+                        if (projectsToRebuildBuilder.TryGetValue(ancestor, out var causes))
                         {
-                            projectsThatCausedRestart.AddRange(causes);
+                            projectsThatCausedRebuild.AddRange(causes);
                         }
                     }
 
-                    if (projectsThatCausedRestart.Any())
+                    if (!projectsThatCausedRebuild.Any())
                     {
-                        // The projects that caused the impacted running project to be restarted
-                        // indirectly cause the running project that depends on the updated project to be restarted.
-                        foreach (var impactedRunningProject in impactedRunningProjects)
+                        continue;
+                    }
+
+                    var hasImpactOnRestartSet = false;
+                    foreach (var ancestor in GetAncestorsAndSelf(updatedProjectId))
+                    {
+                        if (!runningProjects.ContainsKey(ancestor))
                         {
-                            if (!projectsToRestartBuilder.ContainsKey(impactedRunningProject))
-                            {
-                                projectsToRestartBuilder.MultiAddRange(impactedRunningProject, projectsThatCausedRestart);
-                            }
+                            continue;
                         }
 
+                        if (!projectsToRebuildBuilder.ContainsKey(ancestor))
+                        {
+                            projectsToRebuildBuilder.MultiAddRange(ancestor, projectsThatCausedRebuild);
+                            projectsToRestartBuilder.Add(ancestor);
+
+                            hasImpactOnRestartSet = true;
+                        }
+                    }
+
+                    if (hasImpactOnRestartSet)
+                    {
                         updatedProjectsToRemove.Add(updatedProjectId);
                     }
-
-                    impactedRunningProjects.Clear();
-                    projectsThatCausedRestart.Clear();
                 }
 
                 if (updatedProjectsToRemove is [])
@@ -329,35 +369,31 @@ internal readonly struct EmitSolutionUpdateResults
                 }
 
                 updatedProjects.RemoveAll(updatedProjectsToRemove);
-                updatedProjectsToRemove.Clear();
             }
         }
 
-        foreach (var (_, causes) in projectsToRestartBuilder)
+        foreach (var (_, causes) in projectsToRebuildBuilder)
         {
             causes.SortAndRemoveDuplicates();
         }
 
-        projectsToRebuildBuilder.AddRange(projectsToRestartBuilder.Keys);
-        projectsToRestart = projectsToRestartBuilder.ToImmutableMultiDictionaryAndFree();
-        projectsToRebuild = [.. projectsToRebuildBuilder];
+        projectsToRebuild = [.. projectsToRebuildBuilder.Keys];
+
+        projectsToRestart = projectsToRebuildBuilder.ToImmutableMultiDictionaryAndFree(
+            where: static (id, projectsToRestartBuilder) => projectsToRestartBuilder.Contains(id),
+            projectsToRestartBuilder);
+
         return;
 
-        void AddImpactedRunningProjects(ArrayBuilder<ProjectId> impactedProjects, ProjectId initialProject, bool isBlocking)
+        IEnumerable<ProjectId> GetAncestorsAndSelf(ProjectId initialProject)
         {
-            Debug.Assert(impactedProjects.IsEmpty);
-
-            Debug.Assert(traversalStack.Count == 0);
+            traversalStack.Clear();
             traversalStack.Push(initialProject);
 
             while (traversalStack.Count > 0)
             {
                 var projectId = traversalStack.Pop();
-                if (runningProjects.TryGetValue(projectId, out var runningProject) &&
-                    (isBlocking || runningProject.RestartWhenChangesHaveNoEffect))
-                {
-                    impactedProjects.Add(projectId);
-                }
+                yield return projectId;
 
                 foreach (var referencingProjectId in graph.GetProjectsThatDirectlyDependOnThisProject(projectId))
                 {

--- a/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
@@ -17,7 +17,8 @@ internal readonly struct SolutionUpdate(
     ImmutableArray<ProjectDiagnostics> diagnostics,
     Diagnostic? syntaxError,
     ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> projectsToRestart,
-    ImmutableArray<ProjectId> projectsToRebuild)
+    ImmutableArray<ProjectId> projectsToRebuild,
+    ImmutableArray<ProjectId> projectsToRedeploy)
 {
     public readonly ModuleUpdates ModuleUpdates = moduleUpdates;
     public readonly ImmutableDictionary<ProjectId, Guid> StaleProjects = staleProjects;
@@ -29,6 +30,7 @@ internal readonly struct SolutionUpdate(
     public readonly Diagnostic? SyntaxError = syntaxError;
     public readonly ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> ProjectsToRestart = projectsToRestart;
     public readonly ImmutableArray<ProjectId> ProjectsToRebuild = projectsToRebuild;
+    public readonly ImmutableArray<ProjectId> ProjectsToRedeploy = projectsToRedeploy;
 
     public static SolutionUpdate Empty(
         ImmutableArray<ProjectDiagnostics> diagnostics,
@@ -43,7 +45,8 @@ internal readonly struct SolutionUpdate(
             diagnostics,
             syntaxError,
             projectsToRestart: ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty,
-            projectsToRebuild: []);
+            projectsToRebuild: [],
+            projectsToRedeploy: []);
 
     internal void Log(TraceLog log, UpdateId updateId)
     {

--- a/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -68,26 +69,6 @@ internal static partial class Extensions
 
         void LogReason(string message)
             => log?.Write($"Project '{project.GetLogDisplay()}' doesn't support EnC: {message}");
-
-        return true;
-    }
-
-    /// <summary>
-    /// True if project settings are compatible with Edit and Continue.
-    /// </summary>
-    public static bool ProjectSettingsSupportEditAndContinue(this Project project, TraceLog? log = null)
-    {
-        Contract.ThrowIfFalse(project.SupportsEditAndContinue());
-        Contract.ThrowIfNull(project.CompilationOptions);
-
-        if (project.CompilationOptions.OptimizationLevel != OptimizationLevel.Debug)
-        {
-            LogReason(nameof(ProjectSettingKind.OptimizationLevel), project.CompilationOptions.OptimizationLevel.ToString());
-            return false;
-        }
-
-        void LogReason(string settingName, string value)
-            => log?.Write($"Project '{project.GetLogDisplay()}' setting '{settingName}' value '{value}' is not compatible with EnC");
 
         return true;
     }

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -114,17 +114,22 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
         /// Updates to be applied to modules. Empty if there are blocking rude edits.
         /// Only updates to projects that are not included in <see cref="ProjectsToRebuild"/> are listed.
         /// </summary>
-        public ImmutableArray<Update> ProjectUpdates { get; init; }
+        public required ImmutableArray<Update> ProjectUpdates { get; init; }
 
         /// <summary>
         /// Running projects that need to be restarted due to rude edits in order to apply changes.
         /// </summary>
-        public ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> ProjectsToRestart { get; init; }
+        public required ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> ProjectsToRestart { get; init; }
 
         /// <summary>
         /// Projects with changes that need to be rebuilt in order to apply changes.
         /// </summary>
-        public ImmutableArray<ProjectId> ProjectsToRebuild { get; init; }
+        public required ImmutableArray<ProjectId> ProjectsToRebuild { get; init; }
+
+        /// <summary>
+        /// Projects whose dependencies need to be deployed to their output directory, if not already present.
+        /// </summary>
+        public required ImmutableArray<ProjectId> ProjectsToRedeploy { get; init; }
     }
 
     private static readonly ActiveStatementSpanProvider s_solutionActiveStatementSpanProvider =
@@ -241,7 +246,8 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
                 update.UpdatedTypes,
                 update.RequiredCapabilities)),
             ProjectsToRestart = results.ProjectsToRestart,
-            ProjectsToRebuild = results.ProjectsToRebuild
+            ProjectsToRebuild = results.ProjectsToRebuild,
+            ProjectsToRedeploy = results.ProjectsToRedeploy,
         };
     }
 

--- a/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -34,6 +34,9 @@ public sealed class RemoteEditAndContinueServiceTests
             (!string.IsNullOrWhiteSpace(d.DataLocation.UnmappedFileSpan.Path) ? $" {d.DataLocation.UnmappedFileSpan.Path}({d.DataLocation.UnmappedFileSpan.StartLinePosition.Line}, {d.DataLocation.UnmappedFileSpan.StartLinePosition.Character}, {d.DataLocation.UnmappedFileSpan.EndLinePosition.Line}, {d.DataLocation.UnmappedFileSpan.EndLinePosition.Character}):" : "") +
             $" {d.Message}";
 
+    private static IEnumerable<string> Inspect(ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>> projects)
+        => projects.Select(kvp => $"{kvp.Key}: [{string.Join(", ", kvp.Value.Select(p => p.ToString()))}]");
+
     [Theory, CombinatorialData]
     public async Task Proxy(TestHost testHost)
     {
@@ -244,7 +247,7 @@ public sealed class RemoteEditAndContinueServiceTests
         Assert.Equal(span1, activeStatements.NewSpan.ToLinePositionSpan());
 
         AssertEx.SequenceEqual([projectId], results.ProjectsToRebuild);
-        AssertEx.SequenceEqual([KeyValuePair.Create<ProjectId, ImmutableArray<ProjectId>>(projectId, [projectId])], results.ProjectsToRestart);
+        AssertEx.SequenceEqual([$"{projectId}: [{projectId}]"], Inspect(results.ProjectsToRestart));
         AssertEx.SequenceEqual([projectId], results.ProjectsToRedeploy);
 
         // CommitSolutionUpdate

--- a/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -214,8 +214,9 @@ public sealed class RemoteEditAndContinueServiceTests
                 ModuleUpdates = updates,
                 Diagnostics = diagnostics,
                 SyntaxError = syntaxError,
-                ProjectsToRebuild = [project.Id],
-                ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty.Add(project.Id, []),
+                ProjectsToRebuild = [projectId],
+                ProjectsToRestart = ImmutableDictionary<ProjectId, ImmutableArray<ProjectId>>.Empty.Add(projectId, [projectId]),
+                ProjectsToRedeploy = [projectId]
             };
         };
 
@@ -241,6 +242,10 @@ public sealed class RemoteEditAndContinueServiceTests
         Assert.Equal(instructionId1.Method.Method, activeStatements.Method);
         Assert.Equal(instructionId1.ILOffset, activeStatements.ILOffset);
         Assert.Equal(span1, activeStatements.NewSpan.ToLinePositionSpan());
+
+        AssertEx.SequenceEqual([projectId], results.ProjectsToRebuild);
+        AssertEx.SequenceEqual([KeyValuePair.Create<ProjectId, ImmutableArray<ProjectId>>(projectId, [projectId])], results.ProjectsToRestart);
+        AssertEx.SequenceEqual([projectId], results.ProjectsToRedeploy);
 
         // CommitSolutionUpdate
 

--- a/src/Features/TestUtilities/EditAndContinue/Extensions.cs
+++ b/src/Features/TestUtilities/EditAndContinue/Extensions.cs
@@ -93,6 +93,10 @@ internal static class Extensions
                 ? path : Path.Combine(Path.GetDirectoryName(solution.GetRequiredProject(projectId).FilePath!)!, path))
         .GetRequiredDocument(id);
 
+    public static Project WithCompilationOptions<TCompilationOptions>(this Project project, Func<TCompilationOptions, TCompilationOptions> transform)
+        where TCompilationOptions : CompilationOptions
+        => project.WithCompilationOptions(transform((TCompilationOptions)(project.CompilationOptions ?? throw ExceptionUtilities.Unreachable())));
+
     public static Guid CreateProjectTelemetryId(string projectName)
     {
         Assert.True(Encoding.UTF8.GetByteCount(projectName) <= 20, "Use shorter project names in tests");


### PR DESCRIPTION
Calculate projects to redeploy. When a project reference is added we need to deploy the target project to the output directory of the referencing project (if the project copies dependencies to the output directory). This is performed by evaluating `ReferenceCopyLocalPathsOutputGroup` in the host (dotnet-watch/project system). EnC service now returns set of project to invoke the target on in `ProjectsToRedeploy`.

Also updates `HasChangesAsync` to account for changes in project settings, metadata and project references. Skips further analysis during emit solution updates if there are no project changes. Avoids hitting the disk for reading MVID for all projects in the solution.

Adds tests.

Enables https://github.com/dotnet/sdk/pull/49611
Implements https://github.com/dotnet/roslyn/issues/49015 (Roslyn's part)