### PR TITLE
Generate complogs on build failure

### DIFF
--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -14,7 +14,7 @@ steps:
       script: |
         Set-Location -Path "$(Build.SourcesDirectory)\artifacts\log\${{ parameters.configuration }}\"
         Get-ChildItem -Filter "*.binlog" | ForEach-Object {
-          dnx complog create $_.FullName
+          dnx --yes complog create $_.FullName
         }
     continueOnError: true
     condition: failed()

--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -7,6 +7,18 @@ parameters:
   default: 'Debug'
 
 steps:
+  - task: PowerShell@2
+    displayName: Generate Complog on Build Failure
+    inputs:
+      targetType: 'inline'
+      script: |
+        Set-Location -Path "$(Build.SourcesDirectory)\artifacts\log\${{ parameters.configuration }}\"
+        Get-ChildItem -Filter "*.binlog" | ForEach-Object {
+          dnx complog create $_.FullName
+        }
+    continueOnError: true
+    condition: failed()
+
   - task: CopyFiles@2
     displayName: Copy Test Artifacts to Logs
     inputs:

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1852,11 +1852,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool prependedDefaultValueTypeConstructorInitializer,
             out MethodBodySemanticModel.InitialState forSemanticModel)
         {
-            if ((bool)(object)true)
-            {
-                Debug.Assert(false, "Testing");
-            }
-
             originalBodyNested = false;
             prependedDefaultValueTypeConstructorInitializer = false;
             importChain = null;

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1852,6 +1852,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool prependedDefaultValueTypeConstructorInitializer,
             out MethodBodySemanticModel.InitialState forSemanticModel)
         {
+            if ((bool)(object)true)
+            {
+                Debug.Assert(false, "Testing");
+            }
+
             originalBodyNested = false;
             prependedDefaultValueTypeConstructorInitializer = false;
             importChain = null;

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -499,10 +499,10 @@ namespace Microsoft.CodeAnalysis
                 switch (e.ErrorCode)
                 {
                     case AnalyzerLoadFailureEventArgs.FailureErrorCode.UnableToLoadAnalyzer:
-                        diagnostic = new DiagnosticInfo(messageProvider, messageProvider.WRN_UnableToLoadAnalyzer, analyzerReference.FullPath, e.Message);
+                        diagnostic = new DiagnosticInfo(messageProvider, messageProvider.WRN_UnableToLoadAnalyzer, analyzerReference.FullPath, e.Exception?.ToString() ?? e.Message);
                         break;
                     case AnalyzerLoadFailureEventArgs.FailureErrorCode.UnableToCreateAnalyzer:
-                        diagnostic = new DiagnosticInfo(messageProvider, messageProvider.WRN_AnalyzerCannotBeCreated, e.TypeName ?? "", analyzerReference.FullPath, e.Message);
+                        diagnostic = new DiagnosticInfo(messageProvider, messageProvider.WRN_AnalyzerCannotBeCreated, e.TypeName ?? "", analyzerReference.FullPath, e.Exception?.ToString() ?? e.Message);
                         break;
                     case AnalyzerLoadFailureEventArgs.FailureErrorCode.NoAnalyzers:
                         diagnostic = new DiagnosticInfo(messageProvider, messageProvider.WRN_NoAnalyzerInAssembly, analyzerReference.FullPath);


### PR DESCRIPTION
This should make it easier to reproduce CI compiler failures locally.