### PR TITLE
Reduce path length of Roslyn ServiceHub Services folder

### DIFF
--- a/src/VisualStudio/Setup.ServiceHub/arm64/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.ServiceHub/arm64/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="35B9F49B-CC6A-4102-923E-2A41C179BF1F" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Roslyn Services for .NET ServiceHub Host (arm64)</DisplayName>
-    <Description xml:space="preserve">Roslyn Services for .NET ServiceHub Host</Description>
+    <DisplayName>Roslyn ServiceHub Services (arm64)</DisplayName>
+    <Description xml:space="preserve">Roslyn ServiceHub Services</Description>
     <PackageId>Microsoft.CodeAnalysis.VisualStudio.ServiceHub.Setup.arm64</PackageId>
     <License>EULA.rtf</License>
     <AllowClientRole>true</AllowClientRole>

--- a/src/VisualStudio/Setup.ServiceHub/x64/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.ServiceHub/x64/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="77E1B4B1-51C4-4B24-9CA2-3CFAC4943DFF" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Roslyn Services for .NET ServiceHub Host</DisplayName>
-    <Description xml:space="preserve">Roslyn Services for .NET ServiceHub Host</Description>
+    <DisplayName>Roslyn ServiceHub Services</DisplayName>
+    <Description xml:space="preserve">Roslyn ServiceHub Services</Description>
     <PackageId>Microsoft.CodeAnalysis.VisualStudio.ServiceHub.Setup.x64</PackageId>
     <License>EULA.rtf</License>
     <AllowClientRole>true</AllowClientRole>


### PR DESCRIPTION
I've been hitting lots of gold bars in VS indicating various features are unavailable when F5'ing the Roslyn project. I finally spent some time digging into why this happens on my machine, and it turns out that out service hub service paths are just a bit too long. This PR just reduces that path length by 14 characters, which is enough for all the services to be under the 260 character long path limit for my machine.

<img width="2345" height="468" alt="image" src="https://github.com/user-attachments/assets/7bbb10f6-42ae-474f-b202-69ba5d1fd9e5" />

Example path causing issues (267 chars)
```
C:\Users\toddgrun.REDMOND\AppData\Local\Microsoft\VisualStudio\18.0_daab5064RoslynDev\Extensions\Microsoft\Roslyn Services for .NET ServiceHub Host\42.42.42.4242424\Microsoft.VisualStudio.LanguageServices.LegacySolutionEventsAggregationCore64.servicehub.service.json
```