### PR TITLE
Make attachdebugger flag work on non-Windows

### DIFF
--- a/src/Compilers/CSharp/Portable/Utilities/EnvironmentExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/EnvironmentExtensions.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+internal static class EnvironmentExtensions
+{
+    extension(Environment)
+    {
+        public static int ProcessId
+        {
+            get
+            {
+#if NET
+                return Environment.ProcessId;
+#else
+                return System.Diagnostics.Process.GetCurrentProcess().Id;
+#endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
These compiler flags used Debugger.Launch, which only works on windows. I borrowed the equivalent code from the LSP launcher, which already has this functionality (https://github.com/dotnet/roslyn/blob/cf34acbc5d0f64ff87013cdd02ae61cff562daaf/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs#L75-L89).
