### PR TITLE
Reenable analyzer that was disabled when we moved to .Net 10 Preview 5

### DIFF
--- a/src/Compilers/.editorconfig
+++ b/src/Compilers/.editorconfig
@@ -12,9 +12,6 @@ dotnet_diagnostic.RS0100.severity = none
 # RS0102: Braces must not have blank lines between them
 dotnet_diagnostic.RS0102.severity = none
 
-# IDE0051: Unused member
-dotnet_diagnostic.IDE0051.severity = none
-
 # IDE0170: Prefer extended property pattern
 dotnet_diagnostic.IDE0170.severity = suggestion
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/79306