### PR TITLE
Allow captured primary constructor parameters to be still used in base-list

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -11931,6 +11931,27 @@ public class C(int x) : Base(x)
             End Using
         End Function
 
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/78917")>
+        Public Async Function FilterPrimaryConstructorParameters_AllowInBaseTypeWhenCapturedAsMember() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document><![CDATA[
+public sealed class Derived(
+    string value)
+    : Base($"{val$$}")
+{
+    public string Value { get; } = value;
+}
+
+public abstract class Base(string value);
+]]>
+                </Document>,
+                languageVersion:=LanguageVersion.CSharp12)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("value", displayTextSuffix:="")
+            End Using
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestItemsSorted() As Task
             Using state = TestStateFactory.CreateCSharpTestState(

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -443,7 +443,7 @@ internal partial class CSharpRecommendationService
                 CancellationToken cancellationToken)
             {
                 // Fine to offer primary constructor parameters in field/property initializers 
-                var initializer = context.TargetToken.GetAncestors<EqualsValueClauseSyntax>().FirstOrDefault();
+                var initializer = context.TargetToken.GetAncestor<EqualsValueClauseSyntax>();
                 if (initializer is
                     {
                         Parent: PropertyDeclarationSyntax or
@@ -452,6 +452,11 @@ internal partial class CSharpRecommendationService
                 {
                     return false;
                 }
+
+                // Also fine to offer primary constructor parameters in the base type list of that type.
+                var baseTypeSyntax = context.TargetToken.GetAncestor<PrimaryConstructorBaseTypeSyntax>();
+                if (baseTypeSyntax != null)
+                    return false;
 
                 // We're not in an initializer.  Filter out this primary constructor parameter if it's already been
                 // captured by an existing field or property initializer.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/78917