### PR TITLE
Allow add using to work on Razor generated documents

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -39,7 +39,7 @@ internal sealed class RemoteMissingImportDiscoveryService(
     {
         return RunServiceAsync(solutionChecksum, async solution =>
         {
-            var document = solution.GetDocument(documentId);
+            var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             if (document is null)
                 return [];
 
@@ -68,7 +68,7 @@ internal sealed class RemoteMissingImportDiscoveryService(
     {
         return RunServiceAsync(solutionChecksum, async solution =>
         {
-            var document = solution.GetDocument(documentId);
+            var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             if (document is null)
                 return [];
 


### PR DESCRIPTION
Completely missed this because Razor cohosting tests don't use the Roslyn OOP.