### PR TITLE
 Prevent Edit and Continue failure when an F# project is present in the solution but not touched during the editing session.

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -726,7 +726,12 @@ internal sealed class DebuggingSession : IDisposable
 
         foreach (var projectId in rebuiltProjects)
         {
-            _editSessionTelemetry.LogUpdatedBaseline(solution.GetRequiredProject(projectId).State.ProjectInfo.Attributes.TelemetryId);
+            var project = solution.GetProject(projectId);
+            if (project == null)
+            {
+                continue;
+            }
+            _editSessionTelemetry.LogUpdatedBaseline(project.State.ProjectInfo.Attributes.TelemetryId);
         }
 
         // Restart edit session reusing previous non-remappable regions and break state:


### PR DESCRIPTION

**Root Cause:**  
`solution.GetRequiredProject(projectId)` throws if the project is not available (e.g., F#), even if the project wasn't modified.

**Exception (user and project details masked):**
```
StreamJsonRpc.RemoteInvocationException: Project of ID (ProjectId, #05dff083-7e2b-4f7f-93b5-f1ce391de888 - C:\Users\[REDACTED]\[REDACTED]) is required to accomplish the task but is not available from the solution
   at StreamJsonRpc.JsonRpc.<InvokeCoreAsync>d__156`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Remote.BrokeredServiceConnection`1.<TryInvokeAsync>d__17.MoveNext() in C:\Users\[REDACTED]\DevArchive\roslyn\src\Workspaces\Remote\Core\BrokeredServiceConnection.cs:line 170
RPC server exception:
System.InvalidOperationException: Project of ID (ProjectId, #05dff083-7e2b-4f7f-93b5-f1ce391de888 - C:\Users\[REDACTED]\[REDACTED]) is required to accomplish the task but is not available from the solution
      at Microsoft.CodeAnalysis.Shared.Extensions.ISolutionExtensions.GetRequiredProject(Solution solution, ProjectId projectId) in C:\Users\[REDACTED]\DevArchive\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\Extensions\ISolutionExtensions.cs:line 43
      at Microsoft.CodeAnalysis.EditAndContinue.DebuggingSession.UpdateBaselines(Solution solution, ImmutableArray`1 rebuiltProjects) in C:\Users\[REDACTED]\DevArchive\roslyn\src\Features\Core\Portable\EditAndContinue\DebuggingSession.cs:line 729
      at Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueService.UpdateBaselines(DebuggingSessionId sessionId, Solution solution, ImmutableArray`1 rebuiltProjects) in C:\Users\[REDACTED]\DevArchive\roslyn\src\Features\Core\Portable\EditAndContinue\EditAndContinueService.cs:line 257
      at Microsoft.CodeAnalysis.EditAndContinue.RemoteEditAndContinueService.<>c__DisplayClass14_0.<UpdateBaselinesAsync>b__0(Solution solution) in C:\Users\[REDACTED]\DevArchive\roslyn\src\Workspaces\Remote\ServiceHub\Services\EditAndContinue\RemoteEditAndContinueService.cs:line 192
```

**Change:**  
Use a simple `(project != null)` check to skip unavailable projects in baseline update logic and avoid exceptions on untouched F# projects.