### PR TITLE
Fix inline hints font size for monospaced alignment

### DIFF
--- a/src/EditorFeatures/Core/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsTag.cs
@@ -124,12 +124,11 @@ internal sealed class InlineHintsTag : IntraTextAdornmentTag
         bool classify)
     {
         // Constructs the hint block which gets assigned parameter name and FontStyles according to the options
-        // page. Calculates a inline tag that will be 3/4s the size of a normal line. This shrink size tends to work
-        // well with VS at any zoom level or font size.
+        // page. For better monospaced alignment, we use the same font size as the editor text.
         var block = new TextBlock
         {
             FontFamily = format.Typeface.FontFamily,
-            FontSize = 0.75 * format.FontRenderingEmSize,
+            FontSize = format.FontRenderingEmSize, // Use same font size as editor for proper baseline alignment
             FontStyle = FontStyles.Normal,
             Foreground = format.ForegroundBrush,
             // Adds a little bit of padding to the left of the text relative to the border to make the text seem


### PR DESCRIPTION
#73649 
fixed the issue: monospaced code is not always laid out nicely in a grid
by: having the inline hint text use the same font family and font size as the other code.

Before: 
<img width="555" height="554" alt="Screenshot 2025-07-23 042538" src="https://github.com/user-attachments/assets/56abe030-6cee-4746-ad8d-6a509cb425d8" />

After:
<img width="1247" height="818" alt="Screenshot 2025-07-23 043405" src="https://github.com/user-attachments/assets/b6572b8f-33de-4612-9219-c4dfeee57cf8" />