### PR TITLE
Fix name qualification when moving a using alias outside of a file scoped namespace

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
@@ -36,7 +36,7 @@ using static SyntaxFactory;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.MoveMisplacedUsingDirectives), Shared]
 [method: ImportingConstructor]
 [method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFixProvider
+internal sealed class MisplacedUsingDirectivesCodeFixProvider() : CodeFixProvider
 {
     private static readonly SyntaxAnnotation s_usingPlacementCodeFixAnnotation = new(nameof(s_usingPlacementCodeFixAnnotation));
 
@@ -73,10 +73,9 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
 
         foreach (var diagnostic in context.Diagnostics)
         {
-            context.RegisterCodeFix(
-                CodeAction.Create(
+            context.RegisterCodeFix(CodeAction.Create(
                     CSharpAnalyzersResources.Move_misplaced_using_directives,
-                    token => GetTransformedDocumentAsync(document, compilationUnit, GetAllUsingDirectives(compilationUnit), placement, simplifierOptions, token),
+                    cancellationToken => GetTransformedDocumentAsync(document, compilationUnit, placement, simplifierOptions, cancellationToken),
                     nameof(CSharpAnalyzersResources.Move_misplaced_using_directives)),
                 diagnostic);
         }
@@ -101,7 +100,7 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
             return document;
 
         return await GetTransformedDocumentAsync(
-            document, compilationUnit, allUsingDirectives, placement, simplifierOptions, cancellationToken).ConfigureAwait(false);
+            document, compilationUnit, placement, simplifierOptions, cancellationToken).ConfigureAwait(false);
     }
 
     private static ImmutableArray<UsingDirectiveSyntax> GetAllUsingDirectives(CompilationUnitSyntax compilationUnit)
@@ -123,7 +122,7 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
         {
             foreach (var member in members)
             {
-                if (member is NamespaceDeclarationSyntax namespaceDeclaration)
+                if (member is BaseNamespaceDeclarationSyntax namespaceDeclaration)
                 {
                     result.AddRange(namespaceDeclaration.Usings);
                     Recurse(namespaceDeclaration.Members);
@@ -135,12 +134,13 @@ internal sealed partial class MisplacedUsingDirectivesCodeFixProvider() : CodeFi
     private static async Task<Document> GetTransformedDocumentAsync(
         Document document,
         CompilationUnitSyntax compilationUnit,
-        ImmutableArray<UsingDirectiveSyntax> allUsingDirectives,
         AddImportPlacement placement,
         SimplifierOptions simplifierOptions,
         CancellationToken cancellationToken)
     {
         var bannerService = document.GetRequiredLanguageService<IFileBannerFactsService>();
+
+        var allUsingDirectives = GetAllUsingDirectives(compilationUnit);
 
         // Expand usings so that they can be properly simplified after they are relocated.
         var compilationUnitWithExpandedUsings = await ExpandUsingDirectivesAsync(

--- a/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
+++ b/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
@@ -69,7 +69,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     private const string DelegateDefinition = @"public delegate void TestDelegate();";
 
     private TestParameters GetTestParameters(CodeStyleOption2<AddImportPlacement> preferredPlacementOption)
-        => new(options: new OptionsCollection(GetLanguage()) { { CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, preferredPlacementOption } });
+        => new(options: new(GetLanguage()) { { CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, preferredPlacementOption } });
 
     private Task TestDiagnosticMissingAsync(
         [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
@@ -653,6 +653,44 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
 
             namespace N1
             {
+            }
+            """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75961")]
+    public Task WhenOutsidePreferred_AliasToLocalType_FileScopedNamespace()
+    {
+        return TestInRegularAndScriptAsync("""
+            namespace Goo;
+
+            [|using Alias = C;|]
+
+            class C;
+            """, """
+
+            {|Warning:using Alias = Goo.C;|}
+
+            namespace Goo;
+            class C;
+            """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75961")]
+    public Task WhenOutsidePreferred_AliasToLocalType_BlockNamespace()
+    {
+        return TestInRegularAndScriptAsync("""
+            namespace Goo
+            {
+                [|using Alias = C;|]
+
+                class C;
+            }
+            """, """
+            {|Warning:using Alias = Goo.C;|}
+
+            namespace Goo
+            {
+                class C;
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/72782
Fixes https://github.com/dotnet/roslyn/issues/75961