### PR TITLE
Fix out of bounds when creating structure guides for types without bodies

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/TypeDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/TypeDeclarationStructureTests.cs
@@ -109,21 +109,4 @@ public sealed class TypeDeclarationStructureTests : AbstractCSharpSyntaxNodeStru
                 """,
             Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
             Region("textspan2", "#0", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
-
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/62506")]
-    public Task TestTypeDeclarationNoBraces1()
-        => VerifyBlockSpansAsync("""
-                {|textspan1:// comment
-                {|hint1:$$struct S|}|}
-                """,
-            Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
-
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/62506")]
-    public Task TestTypeDeclarationNoBraces2()
-        => VerifyBlockSpansAsync("""
-                {|hint1:$${|comment:// comment
-                |}struct S{|textspan1:;|}|}
-                """,
-            Region("comment", "// comment ...", autoCollapse: true),
-            Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
 }

--- a/src/EditorFeatures/CSharpTest/Structure/TypeDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/TypeDeclarationStructureTests.cs
@@ -245,7 +245,7 @@ public sealed class TypeDeclarationStructureTests : AbstractCSharpSyntaxNodeStru
     public Task TestTypeDeclarationNoBraces2()
         => VerifyBlockSpansAsync("""
                 {|comment:// comment|}
-                {|textspan1:{|hint1:$$struct S;|}|}
+                {|hint1:$$struct S{|textspan1:;|}|}
                 """,
             Region("comment", "// comment ...", autoCollapse: true),
             Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: false));


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/62506