### PR TITLE
Modify LSP folding ranges to account for AutoCollapse

### DIFF
--- a/src/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -111,7 +111,7 @@ internal sealed class FoldingRangesHandler : ILspServiceDocumentRequestHandler<F
                 BlockTypes.Imports => FoldingRangeKind.Imports,
                 BlockTypes.PreprocessorRegion => FoldingRangeKind.Region,
                 BlockTypes.Member => VSFoldingRangeKind.Implementation,
-                _ => null,
+                _ => span.AutoCollapse ? VSFoldingRangeKind.Implementation : null,
             };
 
             foldingRanges.Add(new FoldingRange()

--- a/src/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
@@ -70,6 +70,7 @@ public sealed class FoldingRangesTests : AbstractLanguageServerProtocolTests
         var expected = testLspServer.GetLocations()
             .SelectMany(kvp => kvp.Value.Select(location => CreateFoldingRange(kvp.Key, location.Range, collapsedText ?? "...")))
             .OrderByDescending(range => range.StartLine)
+            .ThenByDescending(range => range.StartCharacter)
             .ToArray();
 
         var results = await RunGetFoldingRangeAsync(testLspServer);

--- a/src/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
@@ -53,6 +53,17 @@ public sealed class FoldingRangesTests : AbstractLanguageServerProtocolTests
             }|}
             """);
 
+    [Theory, CombinatorialData]
+    public Task TestGetFoldingRangeAsync_AutoCollapse(bool mutatingLspWorkspace)
+        => AssertFoldingRanges(mutatingLspWorkspace, """
+            class C{|foldingRange:
+            {
+                private Action<int> Foo(){|implementation: => i =>{|foldingRange:
+                {
+                };|}|}
+            }|}
+            """);
+
     private async Task AssertFoldingRanges(bool mutatingLspWorkspace, string markup, string collapsedText = null)
     {
         var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);


### PR DESCRIPTION
VS editor uses VSFoldingRangeKind.Implementation to determine which regions need to be collapsed during it's [CollapseToDefinitions implementation](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VSEditor?path=/src/Editor/VisualStudio/Impl/ViewAdapter/IOleCommandTarget.cs&version=GBmain&line=2454&lineEnd=2455&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents)

This commit ensures that we set this flag when [BlockSpan.AutoCollapse](https://github.com/dotnet/roslyn/blob/5f51f252332bd2bff80831c2c95f119aab9bb768/src/Features/Core/Portable/Structure/BlockSpan.cs#L64) is set, indicating this block should be collapsed when Collapse to Definitions is invoked.

Addresses the C# LSP equivalent of [this community ticket](https://developercommunity.visualstudio.com/t/Blazor:-Ctrl--M-O-not-working-for-ra/10857833#T-ND10941241)