### PR TITLE
Get rid of an unnecessary image list load

### DIFF
--- a/src/VisualStudio/Core/Def/Library/AbstractLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/AbstractLibraryManager.cs
@@ -5,7 +5,6 @@
 using System;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library;
@@ -13,7 +12,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library;
 internal abstract partial class AbstractLibraryManager : IVsCoTaskMemFreeMyStrings
 {
     internal readonly Guid LibraryGuid;
-    private readonly IntPtr _imageListPtr;
 
     public readonly IThreadingContext ThreadingContext;
     public readonly IComponentModel ComponentModel;
@@ -25,13 +23,5 @@ internal abstract partial class AbstractLibraryManager : IVsCoTaskMemFreeMyStrin
         ComponentModel = componentModel;
         ServiceProvider = serviceProvider;
         ThreadingContext = componentModel.GetService<IThreadingContext>();
-
-        var vsShell = serviceProvider.GetService(typeof(SVsShell)) as IVsShell;
-        vsShell?.TryGetPropertyValue(__VSSPROPID.VSSPROPID_ObjectMgrTypesImgList, out _imageListPtr);
-    }
-
-    public IntPtr ImageListPtr
-    {
-        get { return _imageListPtr; }
     }
 }

--- a/src/VisualStudio/Core/Def/Library/AbstractObjectList.cs
+++ b/src/VisualStudio/Core/Def/Library/AbstractObjectList.cs
@@ -199,7 +199,8 @@ internal abstract class AbstractObjectList<TLibraryManager> : IVsCoTaskMemFreeMy
             return VSConstants.E_INVALIDARG;
         }
 
-        pData[0].hImageList = this.LibraryManager.ImageListPtr;
+        // Just return zero for the hImageList, which allows the object browser to use the default image list with no DPI issues.
+        pData[0].hImageList = IntPtr.Zero;
         GetDisplayData(index, ref pData[0]);
 
         return VSConstants.S_OK;


### PR DESCRIPTION
We were fetching an image list on the UI thread during the registration of our library manager for the Object Browser. This is surprisingly expensive (50ms), and it turns out seems to be entirely unnecessary. Returning zero means the default list is used, which works just fine. In fact -- better than fine! This also fixes some fuzzy icons in High DPI settings.