### PR TITLE
Remove obsolete API the project system was using

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/AbstractEntryPointFinderService.cs
@@ -10,9 +10,4 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 internal abstract class AbstractEntryPointFinderService : IEntryPointFinderService
 {
     public abstract IEnumerable<INamedTypeSymbol> FindEntryPoints(Compilation compilation, bool findFormsOnly);
-
-    public IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly)
-        => symbol is { ContainingCompilation: Compilation compilation }
-            ? FindEntryPoints(compilation, findFormsOnly)
-            : [];
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/IEntryPointFinderService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/IEntryPointFinderService.cs
@@ -14,13 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 internal interface IEntryPointFinderService : ILanguageService
 {
     /// <summary>
-    /// Finds the types that contain entry points like the Main method in a give namespace.
-    /// </summary>
-    /// <param name="symbol">The namespace to search.</param>
-    /// <param name="findFormsOnly">Restrict the search to only Windows Forms classes. Note that this is only implemented for VisualBasic</param>
-    IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly);
-
-    /// <summary>
     /// Finds the types that contain entry points like the Main method in a given compilation.
     /// </summary>
     /// <param name="compilation">The compilation to search.</param>


### PR DESCRIPTION
We offered a replacement API for them to call; this was consumed in https://github.com/dotnet/project-system/pull/9689 so we can delete this now.