### PR TITLE
Add back in helpers that were removed in #79559

### DIFF
--- a/src/Features/CSharpTest/CodeActions/AbstractCSharpCodeActionTest_NoEditor.cs
+++ b/src/Features/CSharpTest/CodeActions/AbstractCSharpCodeActionTest_NoEditor.cs
@@ -28,4 +28,12 @@ public abstract class AbstractCSharpCodeActionTest_NoEditor : AbstractCodeAction
     {
         return base.TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, index, parameters);
     }
+
+    internal new Task TestInRegularAndScriptAsync(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string expectedMarkup,
+        TestParameters parameters)
+    {
+        return base.TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, parameters);
+    }
 }

--- a/src/Features/CSharpTest/CodeActions/AbstractCSharpCodeActionTest_NoEditor.cs
+++ b/src/Features/CSharpTest/CodeActions/AbstractCSharpCodeActionTest_NoEditor.cs
@@ -20,12 +20,12 @@ public abstract class AbstractCSharpCodeActionTest_NoEditor : AbstractCodeAction
 
     protected internal override string GetLanguage() => LanguageNames.CSharp;
 
-    internal new Task TestInRegularAndScript1Async(
+    internal new Task TestInRegularAndScriptAsync(
         [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
         [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string expectedMarkup,
         int index = 0,
         TestParameters? parameters = null)
     {
-        return base.TestInRegularAndScript1Async(initialMarkup, expectedMarkup, index, parameters);
+        return base.TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, index, parameters);
     }
 }

--- a/src/Features/CSharpTest/CodeActions/AbstractCSharpCodeActionTest_NoEditor.cs
+++ b/src/Features/CSharpTest/CodeActions/AbstractCSharpCodeActionTest_NoEditor.cs
@@ -19,4 +19,13 @@ public abstract class AbstractCSharpCodeActionTest_NoEditor : AbstractCodeAction
     protected override ParseOptions GetScriptOptions() => TestOptions.Script;
 
     protected internal override string GetLanguage() => LanguageNames.CSharp;
+
+    internal new Task TestInRegularAndScript1Async(
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string initialMarkup,
+        [StringSyntax(PredefinedEmbeddedLanguageNames.CSharpTest)] string expectedMarkup,
+        int index = 0,
+        TestParameters? parameters = null)
+    {
+        return base.TestInRegularAndScript1Async(initialMarkup, expectedMarkup, index, parameters);
+    }
 }

--- a/src/Features/CSharpTest/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
+++ b/src/Features/CSharpTest/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
@@ -1099,7 +1099,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters1()
-        => TestInRegularAndScriptAsync(
+        => TestInRegularAndScript1Async(
             """
             class C
             {
@@ -1135,7 +1135,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters2()
-        => TestInRegularAndScriptAsync(
+        => TestInRegularAndScript1Async(
             """
             class C
             {
@@ -1171,7 +1171,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters3()
-        => TestInRegularAndScriptAsync(
+        => TestInRegularAndScript1Async(
             """
             class C
             {
@@ -1207,7 +1207,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters4()
-        => TestInRegularAndScriptAsync(
+        => TestInRegularAndScript1Async(
             """
             class C
             {

--- a/src/Features/CSharpTest/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
+++ b/src/Features/CSharpTest/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
@@ -1099,7 +1099,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters1()
-        => TestInRegularAndScript1Async(
+        => TestInRegularAndScriptAsync(
             """
             class C
             {
@@ -1135,7 +1135,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters2()
-        => TestInRegularAndScript1Async(
+        => TestInRegularAndScriptAsync(
             """
             class C
             {
@@ -1171,7 +1171,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters3()
-        => TestInRegularAndScript1Async(
+        => TestInRegularAndScriptAsync(
             """
             class C
             {
@@ -1207,7 +1207,7 @@ class C
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76562")]
     public Task TestOptionalParameters4()
-        => TestInRegularAndScript1Async(
+        => TestInRegularAndScriptAsync(
             """
             class C
             {


### PR DESCRIPTION
This allows tests to be classified in C#.