### PR TITLE
Fix creating skeleton cross-language references

### DIFF
--- a/src/Workspaces/Core/Portable/TemporaryStorage/TrivialTemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TrivialTemporaryStorageService.cs
@@ -21,6 +21,7 @@ internal sealed class TrivialTemporaryStorageService : ITemporaryStorageServiceI
 
     public ITemporaryStorageStreamHandle WriteToTemporaryStorage(Stream stream, CancellationToken cancellationToken)
     {
+        stream.Position = 0;
         var newStream = new MemoryStream();
         stream.CopyTo(newStream);
         return new StreamStorage(newStream);

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -592,4 +592,18 @@ language: LanguageNames.CSharp);
         // rooted within the export provider instance.
         GC.KeepAlive(exportProvider);
     }
+
+    [Fact]
+    public async Task VbReferencingCSharp()
+    {
+        var workspace = new AdhocWorkspace();
+        var csProj = workspace.AddProject("CsProj", LanguageNames.CSharp);
+        csProj = csProj.WithCompilationOptions(csProj.CompilationOptions.WithOutputKind(OutputKind.DynamicallyLinkedLibrary));
+        var vbProj = csProj.Solution.AddProject("VbProj", "VbProj", LanguageNames.VisualBasic)
+            .AddProjectReference(new ProjectReference(csProj.Id));
+        vbProj = vbProj.WithCompilationOptions(vbProj.CompilationOptions.WithOutputKind(OutputKind.DynamicallyLinkedLibrary));
+        var comp = (await vbProj.GetCompilationAsync())!;
+        var diagnostics = comp.GetDiagnostics();
+        Assert.Empty(diagnostics);
+    }
 }


### PR DESCRIPTION
Fixes failures discovered when updating Roslyn in https://github.com/dotnet/roslyn-analyzers/pull/7739.