### PR TITLE
Allow using `/main` with top-level statements

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6575,9 +6575,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TopLevelStatementAfterNamespaceOrType" xml:space="preserve">
     <value>Top-level statements must precede namespace and type declarations.</value>
   </data>
-  <data name="ERR_SimpleProgramDisallowsMainType" xml:space="preserve">
-    <value>Cannot specify /main if there is a compilation unit with top-level statements.</value>
-  </data>
   <data name="ERR_SimpleProgramNotAnExecutable" xml:space="preserve">
     <value>Program using top-level statements must be an executable.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1899,15 +1899,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var entryPointMethod = FindEntryPoint(simpleProgramEntryPointSymbol, cancellationToken, out diagnostics);
                         entryPoint = new EntryPoint(entryPointMethod, diagnostics);
                     }
-
-                    if (this.Options.MainTypeName != null && simpleProgramEntryPointSymbol is object)
-                    {
-                        var diagnostics = DiagnosticBag.GetInstance();
-                        diagnostics.Add(ErrorCode.ERR_SimpleProgramDisallowsMainType, NoLocation.Singleton);
-                        entryPoint = new EntryPoint(entryPoint.MethodSymbol,
-                                                    new ReadOnlyBindingDiagnostic<AssemblySymbol>(
-                                                        entryPoint.Diagnostics.Diagnostics.Concat(diagnostics.ToReadOnlyAndFree()), entryPoint.Diagnostics.Dependencies));
-                    }
                 }
 
                 Interlocked.CompareExchange(ref _lazyEntryPoint, entryPoint, null);

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1815,7 +1815,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_SimpleProgramLocalIsReferencedOutsideOfTopLevelStatement = 8801,
         ERR_SimpleProgramMultipleUnitsWithTopLevelStatements = 8802,
         ERR_TopLevelStatementAfterNamespaceOrType = 8803,
-        ERR_SimpleProgramDisallowsMainType = 8804,
+        // ERR_SimpleProgramDisallowsMainType = 8804,
         ERR_SimpleProgramNotAnExecutable = 8805,
 
         ERR_UnsupportedCallingConvention = 8806,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2074,7 +2074,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_SimpleProgramLocalIsReferencedOutsideOfTopLevelStatement
                 or ErrorCode.ERR_SimpleProgramMultipleUnitsWithTopLevelStatements
                 or ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType
-                or ErrorCode.ERR_SimpleProgramDisallowsMainType
                 or ErrorCode.ERR_SimpleProgramNotAnExecutable
                 or ErrorCode.ERR_UnsupportedCallingConvention
                 or ErrorCode.ERR_InvalidFunctionPointerCallingConvention

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">Člen záznamu {0} musí vracet {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">Pokud existuje jednotka kompilace s příkazy nejvyšší úrovně, nedá se zadat /main.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">Musíte zadat aspoň jeden příkaz nejvyšší úrovně.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">Der Datensatzmember "{0}" muss "{1}" zurückgeben.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">"/main" kann nicht angegeben werden, wenn eine Kompilierungseinheit mit Anweisungen der obersten Ebene vorhanden ist.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">Mindestens eine Anweisung der obersten Ebene darf nicht leer sein.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">El miembro del registro "{0}" debe devolver "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">No se puede especificar /main si hay una unidad de compilación con instrucciones de nivel superior.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">Al menos una instrucción de nivel superior no debe estar vacía.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">Le membre d'enregistrement '{0}' doit retourner '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">Impossible de spécifier /main s'il existe une unité de compilation avec des instructions de niveau supérieur.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">Au moins une instruction de niveau supérieur ne doit pas être vide.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">Il membro di record '{0}' deve restituire '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">Non è possibile specificare /main se è presente un'unità di compilazione con istruzioni di primo livello.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">Almeno un'istruzione di primo livello deve essere non vuota.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">レコード メンバー '{0}' は '{1}' を返す必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">トップレベルのステートメントを含むコンパイル ユニットがある場合、/main を指定することはできません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">少なくとも 1 つの最上位のステートメントを空以外にする必要があります。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">레코드 멤버 '{0}'은(는) '{1}'을(를) 반환해야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">최상위 문이 포함된 컴파일 단위가 있으면 /main을 지정할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">최소한 하나의 최상위 문은 비어 있지 않아야 합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">Składowa rekordu „{0}” musi zwracać wartość „{1}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">Nie można określić opcji /main, jeśli istnieje jednostka kompilacji z instrukcjami najwyższego poziomu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">Co najmniej jedna instrukcja najwyższego poziomu nie może być pusta.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">O membro do registro '{0}' precisa retornar '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">Não é possível especificar /main quando há uma unidade de compilação com instruções de nível superior.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">Pelo menos uma instrução de nível superior não pode estar vazia.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">Элемент записи "{0}" должен возвращать "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">Невозможно указать параметр /main, если существует единица компиляции с инструкциями верхнего уровня.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">По крайней мере один оператор верхнего уровня не должен быть пустым.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">'{0}' kayıt üyesi '{1}' döndürmelidir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">Üst düzey deyimleri olan bir derleme birimi varsa /main belirtilemez.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">En az birüst düzey deyim boş olmamalıdır.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">记录成员“{0}”必须返回“{1}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">如果存在包含顶级语句的编译单元，则不能指定 /main。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">至少一个顶级语句必须为非空。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2332,11 +2332,6 @@
         <target state="translated">記錄成員 '{0}' 必須傳回 '{1}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_SimpleProgramDisallowsMainType">
-        <source>Cannot specify /main if there is a compilation unit with top-level statements.</source>
-        <target state="translated">如果有編譯單位包含最上層陳述式，就無法指定 /main。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SimpleProgramIsEmpty">
         <source>At least one top-level statement must be non-empty.</source>
         <target state="translated">至少一個最上層陳述式必須是非空白。</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -5318,8 +5318,6 @@ class Program3
             var comp = CreateCompilation(text, options: TestOptions.DebugExe.WithMainTypeName("Program2"), parseOptions: DefaultParseOptions);
 
             comp.VerifyEmitDiagnostics(
-                // error CS8804: Cannot specify /main if there is a compilation unit with top-level statements.
-                Diagnostic(ErrorCode.ERR_SimpleProgramDisallowsMainType).WithLocation(1, 1),
                 // (12,23): warning CS8892: Method 'Program2.Main(string[])' will not be used as an entry point because a synchronous entry point 'Program2.Main()' was found.
                 //     static async Task Main(string[] args)
                 Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("Program2.Main(string[])", "Program2.Main()").WithLocation(12, 23)
@@ -5346,9 +5344,7 @@ partial class Program
 
             comp.VerifyEmitDiagnostics(
                 // error CS7088: Invalid 'MainTypeName' value: ''.
-                Diagnostic(ErrorCode.ERR_BadCompilationOptionValue).WithArguments("MainTypeName", "").WithLocation(1, 1),
-                // error CS8804: Cannot specify /main if there is a compilation unit with top-level statements.
-                Diagnostic(ErrorCode.ERR_SimpleProgramDisallowsMainType).WithLocation(1, 1)
+                Diagnostic(ErrorCode.ERR_BadCompilationOptionValue).WithArguments("MainTypeName", "").WithLocation(1, 1)
                 );
         }
 
@@ -5656,6 +5652,63 @@ partial class Program
             var comp = CreateCompilation(text);
             var verifier = CompileAndVerify(comp, expectedOutput: "42");
             verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ExplicitMain_25()
+        {
+            string source = """
+                System.Console.WriteLine("tls");
+
+                class C
+                {
+                    static void Main()
+                    {
+                        System.Console.WriteLine("main");
+                    }
+                }
+                """;
+
+            CompileAndVerify(source,
+                expectedOutput: "main",
+                options: TestOptions.DebugExe.WithMainTypeName("C"),
+                parseOptions: DefaultParseOptions);
+        }
+
+        [Fact]
+        public void ExplicitMain_26()
+        {
+            string source = """
+                System.Console.WriteLine("tls");
+
+                partial class Program
+                {
+                    static void Main()
+                    {
+                        System.Console.WriteLine("main");
+                    }
+                }
+                """;
+
+            CompileAndVerify(source,
+                expectedOutput: "main",
+                options: TestOptions.DebugExe.WithMainTypeName("Program"),
+                parseOptions: DefaultParseOptions);
+        }
+
+        [Fact]
+        public void ExplicitMain_27()
+        {
+            string source = """
+                System.Console.WriteLine("tls");
+                """;
+
+            CreateCompilation(source,
+                options: TestOptions.DebugExe.WithMainTypeName("Program"),
+                parseOptions: DefaultParseOptions).VerifyDiagnostics(
+                // (1,1): error CS1558: 'Program' does not have a suitable static 'Main' method
+                // System.Console.WriteLine("tls");
+                Diagnostic(ErrorCode.ERR_NoMainInClass, "System").WithArguments("Program").WithLocation(1, 1));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -5299,10 +5299,12 @@ class Program2
 {
     static void Main()
     {
+        System.Console.Write(""Program2"");
     }
 
     static async Task Main(string[] args)
     {
+        System.Console.Write(""Program2Async"");
         await Task.Factory.StartNew(() => 5);
     }
 }
@@ -5311,16 +5313,15 @@ class Program3
 {
     static void Main(string[] args)
     {
+        System.Console.Write(""Program3"");
     }
 }
 ";
 
-            var comp = CreateCompilation(text, options: TestOptions.DebugExe.WithMainTypeName("Program2"), parseOptions: DefaultParseOptions);
-
-            comp.VerifyEmitDiagnostics(
-                // (12,23): warning CS8892: Method 'Program2.Main(string[])' will not be used as an entry point because a synchronous entry point 'Program2.Main()' was found.
+            CompileAndVerify(text, options: TestOptions.DebugExe.WithMainTypeName("Program2"), parseOptions: DefaultParseOptions, expectedOutput: "Program2").VerifyDiagnostics(
+                // (13,23): warning CS8892: Method 'Program2.Main(string[])' will not be used as an entry point because a synchronous entry point 'Program2.Main()' was found.
                 //     static async Task Main(string[] args)
-                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("Program2.Main(string[])", "Program2.Main()").WithLocation(12, 23)
+                Diagnostic(ErrorCode.WRN_SyncAndAsyncEntryPoints, "Main").WithArguments("Program2.Main(string[])", "Program2.Main()").WithLocation(13, 23)
                 );
         }
 


### PR DESCRIPTION
Speclet update: https://github.com/dotnet/csharplang/pull/9546
Resolves https://github.com/dotnet/csharplang/discussions/9544

LDM notes: https://github.com/dotnet/csharplang/blob/main/meetings/2025/LDM-2025-07-30.md#main-and-top-level-statements