### PR TITLE
Include comments written above local variables when getting quick info for them.

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -9815,4 +9815,99 @@ AnonymousTypes(
             }
             """,
             MainDescription($"Extensions.extension(System.String)"));
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
+    public Task TestLocalVariableComment1()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    // Comment on i
+                    int i;
+                    Console.WriteLine($$i);
+                }
+            }
+            """,
+            MainDescription($"({FeaturesResources.local_variable}) int i"),
+            Documentation("Comment on i"));
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
+    public Task TestLocalVariableComment2()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    // Comment unrelated to i
+
+                    int i;
+                    Console.WriteLine($$i);
+                }
+            }
+            """,
+            MainDescription($"({FeaturesResources.local_variable}) int i"));
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
+    public Task TestLocalVariableComment3()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    // Multi
+                    // line
+                    // comment for i
+                    int i;
+                    Console.WriteLine($$i);
+                }
+            }
+            """,
+            MainDescription($"({FeaturesResources.local_variable}) int i"),
+            Documentation("Multi line comment for i"));
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
+    public Task TestLocalVariableComment4()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    // Comment for i.  It is > 0
+                    int i;
+                    Console.WriteLine($$i);
+                }
+            }
+            """,
+            MainDescription($"({FeaturesResources.local_variable}) int i"),
+            Documentation("Comment for i. It is > 0"));
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
+    public Task TestLocalVariableComment5()
+        => TestWithOptionsAsync(
+            Options.Regular,
+            """
+            // Comment for i.  It is > 0
+            int i;
+            Console.WriteLine($$i);
+            """,
+            MainDescription($"({FeaturesResources.local_variable}) int i"),
+            Documentation("Comment for i. It is > 0"));
+
+    [Fact]
+    public Task TestLocalVariableComment6()
+        => TestWithOptionsAsync(
+            Options.Regular,
+            """
+            // <summary>Comment for i. 
+            // It is &gt; 0</summary>
+            int i;
+            Console.WriteLine($$i);
+            """,
+            MainDescription($"({FeaturesResources.local_variable}) int i"),
+            Documentation("Comment for i. It is > 0"));
 }

--- a/src/EditorFeatures/TestUtilities/QuickInfo/AbstractQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/TestUtilities/QuickInfo/AbstractQuickInfoSourceTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
@@ -25,23 +23,23 @@ public abstract class AbstractQuickInfoSourceTests
         return string.Concat(System.Environment.NewLine, formattedCode);
     }
 
-    protected async Task TestInMethodAndScriptAsync(string code, string expectedContent, string expectedDocumentationComment = null)
+    protected async Task TestInMethodAndScriptAsync(string code, string expectedContent, string? expectedDocumentationComment = null)
     {
         await TestInMethodAsync(code, expectedContent, expectedDocumentationComment);
         await TestInScriptAsync(code, expectedContent, expectedDocumentationComment);
     }
 
-    protected abstract Task TestInClassAsync(string code, string expectedContent, string expectedDocumentationComment = null);
+    protected abstract Task TestInClassAsync(string code, string expectedContent, string? expectedDocumentationComment = null);
 
-    protected abstract Task TestInMethodAsync(string code, string expectedContent, string expectedDocumentationComment = null);
+    protected abstract Task TestInMethodAsync(string code, string expectedContent, string? expectedDocumentationComment = null);
 
-    protected abstract Task TestInScriptAsync(string code, string expectedContent, string expectedDocumentationComment = null);
+    protected abstract Task TestInScriptAsync(string code, string expectedContent, string? expectedDocumentationComment = null);
 
     protected abstract Task TestAsync(
         string code,
         string expectedContent,
-        string expectedDocumentationComment = null,
-        CSharpParseOptions parseOptions = null);
+        string? expectedDocumentationComment = null,
+        CSharpParseOptions? parseOptions = null);
 
     protected abstract Task AssertNoContentAsync(
         EditorTestWorkspace workspace,
@@ -53,5 +51,5 @@ public abstract class AbstractQuickInfoSourceTests
         Document document,
         int position,
         string expectedContent,
-        string expectedDocumentationComment = null);
+        string? expectedDocumentationComment = null);
 }

--- a/src/EditorFeatures/TestUtilities/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/TestUtilities/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
@@ -36,12 +36,7 @@ public abstract class AbstractSemanticQuickInfoSourceTests
         => null;
 
     internal static Action<QuickInfoItem> SymbolGlyph(Glyph expectedGlyph)
-    {
-        return qi =>
-        {
-            Assert.Contains(expectedGlyph, qi.Tags.GetGlyphs());
-        };
-    }
+        => qi => Assert.Contains(expectedGlyph, qi.Tags.GetGlyphs());
 
     internal static Action<QuickInfoItem> WarningGlyph(Glyph expectedGlyph)
         => SymbolGlyph(expectedGlyph);

--- a/src/Features/CSharp/Portable/DocumentationComments/CSharpDocumentationCommentFormattingService.cs
+++ b/src/Features/CSharp/Portable/DocumentationComments/CSharpDocumentationCommentFormattingService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.DocumentationComments;
@@ -12,11 +10,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 
 [ExportLanguageService(typeof(IDocumentationCommentFormattingService), LanguageNames.CSharp), Shared]
-internal sealed class CSharpDocumentationCommentFormattingService : AbstractDocumentationCommentFormattingService
-{
-    [ImportingConstructor]
-    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-    public CSharpDocumentationCommentFormattingService()
-    {
-    }
-}
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class CSharpDocumentationCommentFormattingService() : AbstractDocumentationCommentFormattingService;

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
@@ -251,14 +251,15 @@ internal sealed partial class CSharpSymbolDisplayService
 
         protected override void AddCaptures(ISymbol symbol)
         {
-            if (symbol is IMethodSymbol method && method.ContainingSymbol.IsKind(SymbolKind.Method))
+            if (symbol is IMethodSymbol { ContainingSymbol.Kind: SymbolKind.Method } method)
             {
                 var syntax = method.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
-                if (syntax.IsKind(SyntaxKind.LocalFunctionStatement) || syntax is AnonymousFunctionExpressionSyntax)
-                {
+                if (syntax is LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax)
                     AddCaptures(syntax);
-                }
             }
         }
+
+        protected override string GetCommentText(SyntaxTrivia trivia)
+            => trivia.ToFullString()["//".Length..];
     }
 }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageService;
 
@@ -31,15 +32,13 @@ internal abstract partial class AbstractSymbolDisplayService : ISymbolDisplaySer
         return parts.ToDisplayString();
     }
 
-    public async Task<ImmutableArray<SymbolDisplayPart>> ToDescriptionPartsAsync(SemanticModel semanticModel, int position, ImmutableArray<ISymbol> symbols, SymbolDescriptionOptions options, SymbolDescriptionGroups groups, CancellationToken cancellationToken)
+    public Task<ImmutableArray<SymbolDisplayPart>> ToDescriptionPartsAsync(SemanticModel semanticModel, int position, ImmutableArray<ISymbol> symbols, SymbolDescriptionOptions options, SymbolDescriptionGroups groups, CancellationToken cancellationToken)
     {
         if (symbols.Length == 0)
-        {
-            return [];
-        }
+            return SpecializedTasks.EmptyImmutableArray<SymbolDisplayPart>();
 
         var builder = CreateDescriptionBuilder(semanticModel, position, options, cancellationToken);
-        return await builder.BuildDescriptionAsync(symbols, groups).ConfigureAwait(false);
+        return builder.BuildDescriptionAsync(symbols, groups);
     }
 
     public async Task<IDictionary<SymbolDescriptionGroups, ImmutableArray<TaggedText>>> ToDescriptionGroupsAsync(

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
@@ -5,8 +5,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.DocumentationComments;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Features/VisualBasic/Portable/DocumentationComments/VisualBasicDocumentationCommentFormattingService.vb
+++ b/src/Features/VisualBasic/Portable/DocumentationComments/VisualBasicDocumentationCommentFormattingService.vb
@@ -4,6 +4,7 @@
 
 Imports System.Composition
 Imports System.Diagnostics.CodeAnalysis
+Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.Host.Mef
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.DocumentationComments

--- a/src/Features/VisualBasic/Portable/DocumentationComments/VisualBasicDocumentationCommentFormattingService.vb
+++ b/src/Features/VisualBasic/Portable/DocumentationComments/VisualBasicDocumentationCommentFormattingService.vb
@@ -4,13 +4,11 @@
 
 Imports System.Composition
 Imports System.Diagnostics.CodeAnalysis
-Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.Host.Mef
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.DocumentationComments
-
     <ExportLanguageService(GetType(IDocumentationCommentFormattingService), LanguageNames.VisualBasic), [Shared]>
-    Friend Class VisualBasicDocumentationCommentFormattingService
+    Friend NotInheritable Class VisualBasicDocumentationCommentFormattingService
         Inherits AbstractDocumentationCommentFormattingService
 
         <ImportingConstructor>

--- a/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
+++ b/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
@@ -11,7 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
     Partial Friend Class VisualBasicSymbolDisplayService
-        Protected Class SymbolDescriptionBuilder
+        Protected NotInheritable Class SymbolDescriptionBuilder
             Inherits AbstractSymbolDescriptionBuilder
 
             Private Shared ReadOnly s_minimallyQualifiedFormat As SymbolDisplayFormat = SymbolDisplayFormat.MinimallyQualifiedFormat _
@@ -171,6 +171,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
                     AddCaptures(syntax)
                 End If
             End Sub
+
+            Protected Overrides Function GetCommentText(trivia As SyntaxTrivia) As String
+                Return trivia.ToFullString().Substring(1)
+            End Function
 
             Protected Overrides ReadOnly Property MinimallyQualifiedFormat As SymbolDisplayFormat = s_minimallyQualifiedFormat
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/72780