### PR TITLE
Reduce allocations during CommonCompletionItem.Create

### DIFF
--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -103,6 +103,9 @@ internal static class TaggedTextExtensions
                 includeNavigationHints && d.Kind != SymbolDisplayPartKind.NamespaceName ? getNavigationHint(d.Symbol) : null));
     }
 
+    public static ImmutableArray<(string tag, string text)> ToTagsAndText(this ImmutableArray<SymbolDisplayPart> displayParts)
+        => displayParts.SelectAsArray(static d => (GetTag(d), d.ToString()));
+
     private static string GetTag(SymbolDisplayPart part)
     {
         // We don't actually have any specific classifications for aliases.  So if the compiler passed us that kind,

--- a/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Tags;
 using Roslyn.Utilities;
 
@@ -44,7 +45,7 @@ internal static class CommonCompletionItem
 
         if (!description.IsDefault && description.Length > 0)
         {
-            properties = properties.NullToEmpty().Add(KeyValuePair.Create(DescriptionProperty, EncodeDescription(description.ToTaggedText())));
+            properties = properties.NullToEmpty().Add(KeyValuePair.Create(DescriptionProperty, EncodeDescription(description.ToTagsAndText())));
         }
 
         return CompletionItem.CreateInternal(
@@ -77,8 +78,25 @@ internal static class CommonCompletionItem
 
     private static readonly char[] s_descriptionSeparators = ['|'];
 
-    private static string EncodeDescription(ImmutableArray<TaggedText> description)
-        => string.Join("|", description.SelectMany(d => new[] { d.Tag, d.Text }).Select(t => t.Escape('\\', s_descriptionSeparators)));
+    private static string EncodeDescription(ImmutableArray<(string tag, string text)> description)
+    {
+        using var _ = PooledStringBuilder.GetInstance(out var builder);
+
+        foreach (var (tag, text) in description)
+        {
+            var escapedTag = tag.Escape('\\', s_descriptionSeparators);
+            var escapedText = text.Escape('\\', s_descriptionSeparators);
+
+            if (builder.Length > 0)
+                builder.Append('|');
+
+            builder.Append(escapedTag);
+            builder.Append('|');
+            builder.Append(escapedText);
+        }
+
+        return builder.ToString();
+    }
 
     private static CompletionDescription DecodeDescription(string encoded)
     {


### PR DESCRIPTION
I noticed this when looking at a ManagedLangsVS64.Typing test profile. CommonCompletionItem.Create accounts for about 1.4% of allocations in the test, about 1/3 of which is due to some linq usage. This change just expands that linq out and reduces the amount of data the method needs generated for it.

<img width="1212" height="1161" alt="image" src="https://github.com/user-attachments/assets/0e0f4bcd-4f71-4d87-8ca2-bfa0fe4b3820" />
