### PR TITLE
Add helper method

### DIFF
--- a/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
@@ -199,3 +199,19 @@ namespace Roslyn.Test.Utilities.TestGenerators
         public void Initialize(IncrementalGeneratorInitializationContext context) => _onInit(context);
     }
 }
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    /// <summary>
+    /// We check for the presence of the razor SG by full name
+    /// so we have to make sure this is the right name in the right namespace.
+    /// </summary>
+    internal sealed class RazorSourceGenerator(Action<GeneratorExecutionContext> execute) : ISourceGenerator
+    {
+        private readonly Action<GeneratorExecutionContext> _execute = execute;
+
+        public void Initialize(GeneratorInitializationContext context) { }
+
+        public void Execute(GeneratorExecutionContext context) => _execute(context);
+    }
+}

--- a/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -47,6 +48,8 @@ internal abstract partial class AbstractEditorInlineRenameService
         private static async ValueTask<InlineRenameLocation> ConvertLocationAsync(Solution solution, RenameLocation location, CancellationToken cancellationToken)
         {
             var document = await solution.GetRequiredDocumentAsync(location.DocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+
+            Contract.ThrowIfTrue(location.DocumentId.IsSourceGenerated && !document.IsRazorSourceGeneratedDocument());
             return new InlineRenameLocation(document, location.Location.SourceSpan);
         }
 

--- a/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.InlineRenameLocationSet.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
 
@@ -16,26 +17,37 @@ internal abstract partial class AbstractEditorInlineRenameService
 {
     private sealed class InlineRenameLocationSet : IInlineRenameLocationSet
     {
+        public static async Task<InlineRenameLocationSet> CreateAsync(
+            SymbolInlineRenameInfo renameInfo,
+            LightweightRenameLocations renameLocationSet,
+            CancellationToken cancellationToken)
+        {
+            var solution = renameLocationSet.Solution;
+            var validLocations = renameLocationSet.Locations.Where(RenameLocation.ShouldRename);
+            var locations = await validLocations.SelectAsArrayAsync(static (loc, solution, ct) => ConvertLocationAsync(solution, loc, ct), solution, cancellationToken).ConfigureAwait(false);
+
+            return new InlineRenameLocationSet(renameInfo, renameLocationSet, locations);
+        }
+
         private readonly LightweightRenameLocations _renameLocationSet;
         private readonly SymbolInlineRenameInfo _renameInfo;
 
         public IList<InlineRenameLocation> Locations { get; }
 
-        public InlineRenameLocationSet(
+        private InlineRenameLocationSet(
             SymbolInlineRenameInfo renameInfo,
-            LightweightRenameLocations renameLocationSet)
+            LightweightRenameLocations renameLocationSet,
+            ImmutableArray<InlineRenameLocation> locations)
         {
             _renameInfo = renameInfo;
             _renameLocationSet = renameLocationSet;
-            this.Locations = renameLocationSet.Locations.Where(RenameLocation.ShouldRename)
-                                                        .Select(ConvertLocation)
-                                                        .ToImmutableArray();
+            this.Locations = locations;
         }
 
-        private InlineRenameLocation ConvertLocation(RenameLocation location)
+        private static async ValueTask<InlineRenameLocation> ConvertLocationAsync(Solution solution, RenameLocation location, CancellationToken cancellationToken)
         {
-            return new InlineRenameLocation(
-                _renameLocationSet.Solution.GetRequiredDocument(location.DocumentId), location.Location.SourceSpan);
+            var document = await solution.GetRequiredDocumentAsync(location.DocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            return new InlineRenameLocation(document, location.Location.SourceSpan);
         }
 
         public async Task<IInlineRenameReplacementInfo> GetReplacementsAsync(

--- a/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Utilities;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
 
@@ -135,7 +134,7 @@ internal abstract partial class AbstractEditorInlineRenameService
             var locations = await Renamer.FindRenameLocationsAsync(
                 solution, this.RenameSymbol, options, cancellationToken).ConfigureAwait(false);
 
-            return new InlineRenameLocationSet(this, locations);
+            return await InlineRenameLocationSet.CreateAsync(this, locations, cancellationToken).ConfigureAwait(false);
         }
 
         public bool TryOnBeforeGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText)

--- a/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.cs
@@ -24,7 +24,7 @@ internal abstract partial class AbstractEditorInlineRenameService : IEditorInlin
 
     public async Task<IInlineRenameInfo> GetRenameInfoAsync(Document document, int position, CancellationToken cancellationToken)
     {
-        var symbolicInfo = await SymbolicRenameInfo.GetRenameInfoAsync(document, position, includeSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+        var symbolicInfo = await SymbolicRenameInfo.GetRenameInfoAsync(document, position, cancellationToken).ConfigureAwait(false);
         if (symbolicInfo.LocalizedErrorMessage != null)
             return new FailureInlineRenameInfo(symbolicInfo.LocalizedErrorMessage);
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -859,7 +859,7 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
         async Task<ImmutableArray<(DocumentId documentId, string newName, SyntaxNode newRoot, SourceText newText)>> CalculateFinalDocumentChangesAsync(
             Solution newSolution, CancellationToken cancellationToken)
         {
-            var changes = _baseSolution.GetChanges(newSolution);
+            var changes = newSolution.GetChanges(_baseSolution);
             var changedDocumentIDs = changes.GetProjectChanges().SelectManyAsArray(c => c.GetChangedDocuments());
 
             using var _ = PooledObjects.ArrayBuilder<(DocumentId documentId, string newName, SyntaxNode newRoot, SourceText newText)>.GetInstance(out var result);
@@ -877,6 +877,12 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
                     : (documentId, newDocument.Name, newRoot: null, await newDocument.GetTextAsync(cancellationToken).ConfigureAwait(false)));
             }
 
+            foreach (var documentId in changes.GetExplicitlyChangedSourceGeneratedDocuments())
+            {
+                var newDocument = newSolution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(documentId);
+                result.Add((documentId, newDocument.Name, newRoot: null, await newDocument.GetTextAsync(cancellationToken).ConfigureAwait(false)));
+            }
+
             return result.ToImmutableAndClear();
         }
     }
@@ -892,16 +898,7 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
         if (!RenameInfo.TryOnBeforeGlobalSymbolRenamed(Workspace, documentChanges.SelectAsArray(t => t.documentId), this.ReplacementText))
             return (NotificationSeverity.Error, EditorFeaturesResources.Rename_operation_was_cancelled_or_is_not_valid);
 
-        // Grab the workspace's current solution, and make the document changes to it we computed.
-        var finalSolution = Workspace.CurrentSolution;
-        foreach (var (documentId, newName, newRoot, newText) in documentChanges)
-        {
-            finalSolution = newRoot != null
-                ? finalSolution.WithDocumentSyntaxRoot(documentId, newRoot)
-                : finalSolution.WithDocumentText(documentId, newText);
-
-            finalSolution = finalSolution.WithDocumentName(documentId, newName);
-        }
+        var finalSolution = _threadingContext.JoinableTaskFactory.Run(() => GetFinalSolutionAsync(documentChanges));
 
         // Now actually go and apply the changes to the workspace.  We expect this to succeed as we're on the UI
         // thread, and nothing else should have been able to make a change to workspace since we we grabbed its
@@ -932,6 +929,30 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
             // always able to undo anything any other external listener did.
             undoTransaction.Commit();
         }
+    }
+
+    private async Task<Solution> GetFinalSolutionAsync(ImmutableArray<(DocumentId, string, SyntaxNode, SourceText)> documentChanges)
+    {
+        // Grab the workspace's current solution, and make the document changes to it we computed.
+        var finalSolution = Workspace.CurrentSolution;
+        foreach (var (documentId, newName, newRoot, newText) in documentChanges)
+        {
+            if (documentId.IsSourceGenerated)
+            {
+                _ = await finalSolution.GetDocumentAsync(documentId, includeSourceGenerated: true, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            finalSolution = newRoot != null
+                ? finalSolution.WithDocumentSyntaxRoot(documentId, newRoot)
+                : finalSolution.WithDocumentText(documentId, newText);
+
+            if (!documentId.IsSourceGenerated)
+            {
+                finalSolution = finalSolution.WithDocumentName(documentId, newName);
+            }
+        }
+
+        return finalSolution;
     }
 
     internal bool TryGetContainingEditableSpan(SnapshotPoint point, out SnapshotSpan editableSpan)

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -939,7 +939,8 @@ internal sealed partial class InlineRenameSession : IInlineRenameSession, IFeatu
         {
             if (documentId.IsSourceGenerated)
             {
-                _ = await finalSolution.GetDocumentAsync(documentId, includeSourceGenerated: true, CancellationToken.None).ConfigureAwait(false);
+                var document = await finalSolution.GetDocumentAsync(documentId, includeSourceGenerated: true, CancellationToken.None).ConfigureAwait(false);
+                Contract.ThrowIfFalse(document.IsRazorSourceGeneratedDocument());
             }
 
             finalSolution = newRoot != null

--- a/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
@@ -2,6 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
+Imports Microsoft.CodeAnalysis.Testing
+Imports Microsoft.CodeAnalysis.Text
+
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     <[UseExportProvider]>
     <Trait(Traits.Feature, Traits.Features.Rename)>
@@ -55,6 +60,39 @@ public class GeneratedClass
 
             End Using
         End Sub
+
+        <Theory, CombinatorialData>
+        Public Async Function RenameWithReferenceInRazorGeneratedFile(host As RenameTestHost) As Task
+            Dim generatedMarkup = "
+public class GeneratedClass
+{
+    public void M([|RegularClass|] c) { }
+}
+"
+            Dim generatedCode As String = ""
+            Dim span As TextSpan
+            TestFileMarkupParser.GetSpan(generatedMarkup, generatedCode, span)
+            Dim sourceGenerator = New Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator(Sub(c) c.AddSource("generated_file.cs", generatedCode))
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+public class [|$$RegularClass|]
+{
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, sourceGenerator:=sourceGenerator, renameTo:="A")
+
+                Dim project = result.ConflictResolution.OldSolution.Projects.Single()
+                Dim generatedDocuments = Await project.GetSourceGeneratedDocumentsAsync(CancellationToken.None)
+                Dim generatedTree = Await generatedDocuments.Single().GetSyntaxTreeAsync(CancellationToken.None)
+                Dim location = CodeAnalysis.Location.Create(generatedTree, span)
+                'Manually assert the generated location, because the test workspace doesn't know about it
+                result.AssertLocationReferencedAs(location, RelatedLocationType.NoConflict)
+
+            End Using
+        End Function
 
         <Theory, CombinatorialData>
         <WorkItem("https://github.com/dotnet/roslyn/issues/51537")>

--- a/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
@@ -219,7 +219,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             Return locations
         End Function
 
-        Private Sub AssertLocationReplacedWith(location As Location, replacementText As String, Optional isRenameWithinStringOrComment As Boolean = False)
+        Public Sub AssertLocationReplacedWith(location As Location, replacementText As String, Optional isRenameWithinStringOrComment As Boolean = False)
             Try
                 Dim documentId = ConflictResolution.OldSolution.GetDocumentId(location.SourceTree)
                 Dim newLocation = ConflictResolution.GetResolutionTextSpan(location.SourceSpan, documentId)
@@ -242,7 +242,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             End Try
         End Sub
 
-        Private Sub AssertLocationReferencedAs(location As Location, type As RelatedLocationType)
+        Public Sub AssertLocationReferencedAs(location As Location, type As RelatedLocationType)
             Try
                 Dim documentId = ConflictResolution.OldSolution.GetDocumentId(location.SourceTree)
                 Dim reference = _unassertedRelatedLocations.SingleOrDefault(

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -81,6 +81,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             Next
         End Function
 
+        Public Async Function VerifyChangedSourceGeneratedDocumentFileNames(workspace As EditorTestWorkspace, ParamArray mappedFiles As String()) As Task
+            Await WaitForRename(workspace)
+
+            Assert.Equal(workspace.ChangedSourceGeneratedDocumentFileNames, mappedFiles)
+        End Function
+
         Public Sub VerifyFileName(document As Document, newIdentifierName As String)
             Dim expectedName = Path.ChangeExtension(newIdentifierName, Path.GetExtension(document.Name))
             Assert.Equal(expectedName, document.Name)

--- a/src/Features/Core/Portable/Rename/SymbolicRenameInfo.cs
+++ b/src/Features/Core/Portable/Rename/SymbolicRenameInfo.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -111,13 +112,13 @@ internal sealed class SymbolicRenameInfo
     }
 
     public static async Task<SymbolicRenameInfo> GetRenameInfoAsync(
-        Document document, int position, bool includeSourceGenerated, CancellationToken cancellationToken)
+        Document document, int position, CancellationToken cancellationToken)
     {
         var triggerToken = await GetTriggerTokenAsync(document, position, cancellationToken).ConfigureAwait(false);
         if (triggerToken == default)
             return new SymbolicRenameInfo(FeaturesResources.You_must_rename_an_identifier);
 
-        return await GetRenameInfoAsync(document, triggerToken, includeSourceGenerated, cancellationToken).ConfigureAwait(false);
+        return await GetRenameInfoAsync(document, triggerToken, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<SyntaxToken> GetTriggerTokenAsync(Document document, int position, CancellationToken cancellationToken)
@@ -131,7 +132,6 @@ internal sealed class SymbolicRenameInfo
     private static async Task<SymbolicRenameInfo> GetRenameInfoAsync(
         Document document,
         SyntaxToken triggerToken,
-        bool includeSourceGenerated,
         CancellationToken cancellationToken)
     {
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();

--- a/src/Features/Core/Portable/Rename/SymbolicRenameInfo.cs
+++ b/src/Features/Core/Portable/Rename/SymbolicRenameInfo.cs
@@ -222,7 +222,7 @@ internal sealed class SymbolicRenameInfo
                 var solution = document.Project.Solution;
                 var sourceDocument = solution.GetRequiredDocument(location.SourceTree);
 
-                if (!includeSourceGenerated && sourceDocument is SourceGeneratedDocument)
+                if (sourceDocument is SourceGeneratedDocument && !sourceDocument.IsRazorSourceGeneratedDocument())
                 {
                     // The file is generated so doesn't count towards valid spans 
                     // we can edit.

--- a/src/LanguageServer/Protocol/Handler/Rename/PrepareRenameHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Rename/PrepareRenameHandler.cs
@@ -33,7 +33,7 @@ internal sealed class PrepareRenameHandler() : ILspServiceDocumentRequestHandler
         var position = await document.GetPositionFromLinePositionAsync(linePosition, cancellationToken).ConfigureAwait(false);
 
         var symbolicRenameInfo = await SymbolicRenameInfo.GetRenameInfoAsync(
-            document, position, includeSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+            document, position, cancellationToken).ConfigureAwait(false);
         if (symbolicRenameInfo.IsError)
             return null;
 

--- a/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -28,24 +28,23 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
     public TextDocumentIdentifier GetTextDocumentIdentifier(RenameParams request) => request.TextDocument;
 
     public Task<WorkspaceEdit?> HandleRequestAsync(RenameParams request, RequestContext context, CancellationToken cancellationToken)
-        => GetRenameEditAsync(context.GetRequiredDocument(), ProtocolConversions.PositionToLinePosition(request.Position), request.NewName, includeSourceGenerated: false, cancellationToken);
+        => GetRenameEditAsync(context.GetRequiredDocument(), ProtocolConversions.PositionToLinePosition(request.Position), request.NewName, cancellationToken);
 
-    internal static async Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, bool includeSourceGenerated, CancellationToken cancellationToken)
+    internal static async Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, CancellationToken cancellationToken)
     {
         var oldSolution = document.Project.Solution;
         var position = await document.GetPositionFromLinePositionAsync(linePosition, cancellationToken).ConfigureAwait(false);
 
         var symbolicRenameInfo = await SymbolicRenameInfo.GetRenameInfoAsync(
-            document, position, includeSourceGenerated, cancellationToken).ConfigureAwait(false);
+            document, position, cancellationToken).ConfigureAwait(false);
         if (symbolicRenameInfo.IsError)
             return null;
 
         var options = new SymbolRenameOptions(
-            renameOverloads: false,
-            renameInStrings: false,
-            renameInComments: false,
-            renameFile: false,
-            renameInSourceGeneratedDocuments: includeSourceGenerated);
+            RenameOverloads: false,
+            RenameInStrings: false,
+            RenameInComments: false,
+            RenameFile: false);
 
         var renameLocationSet = await Renamer.FindRenameLocationsAsync(
             oldSolution,
@@ -69,8 +68,6 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
         // Then we can just take the text changes from the first document to avoid returning duplicate edits.
         renamedSolution = await renamedSolution.WithMergedLinkedFileChangesAsync(oldSolution, solutionChanges, cancellationToken: cancellationToken).ConfigureAwait(false);
         solutionChanges = renamedSolution.GetChanges(oldSolution);
-
-        Contract.ThrowIfTrue(!includeSourceGenerated && !renamedSolution.CompilationState.FrozenSourceGeneratedDocumentStates.IsEmpty, "Renaming in generated documents is not allowed, but there are changes in source generated documents.");
 
         var changedDocuments = solutionChanges
             .GetProjectChanges()

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Rename.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Rename.cs
@@ -16,5 +16,5 @@ internal static class Rename
         => PrepareRenameHandler.GetRenameRangeAsync(document, linePosition, cancellationToken);
 
     public static Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, CancellationToken cancellationToken)
-        => RenameHandler.GetRenameEditAsync(document, linePosition, newName, includeSourceGenerated: true, cancellationToken);
+        => RenameHandler.GetRenameEditAsync(document, linePosition, newName, cancellationToken);
 }

--- a/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratedDocumentSpanMappingService.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal interface IRazorSourceGeneratedDocumentSpanMappingService
+    {
+        Task<ImmutableArray<RazorMappedEditResult>> GetMappedTextChangesAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken);
+        Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(Document document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/Features/RazorMappedSpanResult.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorMappedSpanResult.cs
@@ -3,16 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
 
+[DataContract]
 internal readonly struct RazorMappedSpanResult
 {
+    [DataMember(Order = 0)]
     public readonly string FilePath;
 
+    [DataMember(Order = 1)]
     public readonly LinePositionSpan LinePositionSpan;
 
+    [DataMember(Order = 2)]
     public readonly TextSpan Span;
 
     public RazorMappedSpanResult(string filePath, LinePositionSpan linePositionSpan, TextSpan span)
@@ -30,7 +35,10 @@ internal readonly struct RazorMappedSpanResult
     public bool IsDefault => FilePath == null;
 }
 
-internal readonly record struct RazorMappedEditResult(string FilePath, TextChange[] TextChanges)
+[DataContract]
+internal readonly record struct RazorMappedEditResult(
+    [property: DataMember(Order = 0)] string FilePath,
+    [property: DataMember(Order = 1)] TextChange[] TextChanges)
 {
     public bool IsDefault => FilePath == null || TextChanges == null;
 }

--- a/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingService.cs
@@ -1,0 +1,85 @@
+﻿
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+[ExportWorkspaceService(typeof(ISourceGeneratedDocumentSpanMappingService)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class RazorSourceGeneratedDocumentSpanMappingService(
+    [Import(AllowDefault = true)] IRazorSourceGeneratedDocumentSpanMappingService? implementation) : ISourceGeneratedDocumentSpanMappingService
+{
+    private readonly IRazorSourceGeneratedDocumentSpanMappingService? _implementation = implementation;
+
+    public async Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)
+    {
+        if (_implementation is null ||
+            !oldDocument.IsRazorSourceGeneratedDocument() ||
+            !newDocument.IsRazorSourceGeneratedDocument())
+        {
+            return [];
+        }
+
+        var mappedChanges = await _implementation.GetMappedTextChangesAsync(oldDocument, newDocument, cancellationToken).ConfigureAwait(false);
+        if (mappedChanges.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        using var _ = ArrayBuilder<MappedTextChange>.GetInstance(out var changesBuilder);
+        foreach (var change in mappedChanges)
+        {
+            if (change.IsDefault)
+            {
+                continue;
+            }
+
+            foreach (var textChange in change.TextChanges)
+            {
+                changesBuilder.Add(new MappedTextChange(change.FilePath, textChange));
+            }
+        }
+
+        return changesBuilder.ToImmutableAndClear();
+
+    }
+
+    public async Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(Document document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)
+    {
+        if (_implementation is null ||
+            !document.IsRazorSourceGeneratedDocument())
+        {
+            return [];
+        }
+
+        var mappedSpans = await _implementation.MapSpansAsync(document, spans, cancellationToken).ConfigureAwait(false);
+        if (mappedSpans.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        using var _ = ArrayBuilder<MappedSpanResult>.GetInstance(out var spansBuilder);
+        foreach (var span in mappedSpans)
+        {
+            if (!span.IsDefault)
+            {
+                spansBuilder.Add(new MappedSpanResult(span.FilePath, span.LinePositionSpan, span.Span));
+            }
+        }
+
+        return spansBuilder.ToImmutableAndClear();
+    }
+}

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -626,7 +627,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
         // Instead, we invoke this in JTF run which will mitigate deadlocks when the ConfigureAwait(true)
         // tries to switch back to the main thread in the LSP client.
         // Link to LSP client bug for ConfigureAwait(true) - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1216657
-        var mappedChanges = _threadingContext.JoinableTaskFactory.Run(() => GetMappedTextChangesAsync(solutionChanges));
+        var mappedChanges = _threadingContext.JoinableTaskFactory.Run(() => GetMappedTextChangesAsync(solutionChanges, CancellationToken.None));
 
         // Group the mapped text changes by file, then apply all mapped text changes for the file.
         foreach (var changesForFile in mappedChanges)
@@ -641,7 +642,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
 
         return;
 
-        async Task<MultiDictionary<string, (TextChange TextChange, ProjectId ProjectId)>> GetMappedTextChangesAsync(SolutionChanges solutionChanges)
+        async Task<MultiDictionary<string, (TextChange TextChange, ProjectId ProjectId)>> GetMappedTextChangesAsync(SolutionChanges solutionChanges, CancellationToken cancellationToken)
         {
             var filePathToMappedTextChanges = new MultiDictionary<string, (TextChange TextChange, ProjectId ProjectId)>();
             foreach (var projectChanges in solutionChanges.GetProjectChanges())
@@ -656,10 +657,32 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
 
                     var newDocument = projectChanges.NewProject.GetRequiredDocument(changedDocumentId);
                     var mappedTextChanges = await mappingService.GetMappedTextChangesAsync(
-                        oldDocument, newDocument, CancellationToken.None).ConfigureAwait(false);
+                        oldDocument, newDocument, cancellationToken).ConfigureAwait(false);
                     foreach (var (filePath, textChange) in mappedTextChanges)
                     {
                         filePathToMappedTextChanges.Add(filePath, (textChange, projectChanges.ProjectId));
+                    }
+                }
+            }
+
+            var sourceGeneratedDocumentMappingService = Services.GetService<ISourceGeneratedDocumentSpanMappingService>();
+            if (sourceGeneratedDocumentMappingService is not null)
+            {
+                // Since we're mapping changes to source generated documents, we have to ensure the old solution has run the generators
+                // so the mapper has something to compare to.
+                foreach (var (docId, state) in solutionChanges.NewSolution.CompilationState.FrozenSourceGeneratedDocumentStates.States)
+                {
+                    _ = await solutionChanges.OldSolution.GetRequiredDocumentAsync(docId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                }
+
+                foreach (var docId in solutionChanges.GetExplicitlyChangedSourceGeneratedDocuments())
+                {
+                    var oldDocument = solutionChanges.OldSolution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(docId);
+                    var newDocument = solutionChanges.NewSolution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(docId);
+                    var mappedTextChanges = await sourceGeneratedDocumentMappingService.GetMappedTextChangesAsync(oldDocument, newDocument, cancellationToken).ConfigureAwait(false);
+                    foreach (var (filePath, textChange) in mappedTextChanges)
+                    {
+                        filePathToMappedTextChanges.Add(filePath, (textChange, docId.ProjectId));
                     }
                 }
             }

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -672,7 +672,8 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
                 // so the mapper has something to compare to.
                 foreach (var (docId, state) in solutionChanges.NewSolution.CompilationState.FrozenSourceGeneratedDocumentStates.States)
                 {
-                    _ = await solutionChanges.OldSolution.GetRequiredDocumentAsync(docId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                    var document = await solutionChanges.OldSolution.GetRequiredDocumentAsync(docId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                    Contract.ThrowIfFalse(document.IsRazorSourceGeneratedDocument());
                 }
 
                 foreach (var docId in solutionChanges.GetExplicitlyChangedSourceGeneratedDocuments())

--- a/src/Workspaces/Core/Portable/Remote/RemoteUtilities.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteUtilities.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -65,6 +66,8 @@ internal static class RemoteUtilities
             .SelectAsArrayAsync(async (tuple, cancellationToken) =>
             {
                 var document = await oldSolution.GetDocumentAsync(tuple.documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfTrue(tuple.documentId.IsSourceGenerated && !document.IsRazorSourceGeneratedDocument());
+
                 var oldText = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 var newText = oldText.WithChanges(tuple.textChanges);
                 return (tuple.documentId, newText);

--- a/src/Workspaces/Core/Portable/Remote/RemoteUtilities.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteUtilities.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Remote;
@@ -38,6 +39,14 @@ internal static class RemoteUtilities
             }
         }
 
+        foreach (var docId in solutionChanges.GetExplicitlyChangedSourceGeneratedDocuments())
+        {
+            var oldDoc = oldSolution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(docId);
+            var newDoc = newSolution.GetRequiredSourceGeneratedDocumentForAlreadyGeneratedId(docId);
+            var textChanges = await newDoc.GetTextChangesAsync(oldDoc, cancellationToken).ConfigureAwait(false);
+            builder.Add((docId, textChanges.ToImmutableArray()));
+        }
+
         return builder.ToImmutableAndClear();
     }
 
@@ -55,7 +64,8 @@ internal static class RemoteUtilities
         var documentIdsAndTexts = await documentTextChanges
             .SelectAsArrayAsync(async (tuple, cancellationToken) =>
             {
-                var oldText = await oldSolution.GetDocument(tuple.documentId).GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+                var document = await oldSolution.GetDocumentAsync(tuple.documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                var oldText = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 var newText = oldText.WithChanges(tuple.textChanges);
                 return (tuple.documentId, newText);
             }, cancellationToken)

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -104,7 +104,7 @@ internal static partial class ConflictResolver
                 _replacementTextValid = IsIdentifierValid_Worker(baseSolution, _replacementText, documentsGroupedByTopologicallySortedProjectId.Select(g => g.Key));
                 var renamedSpansTracker = new RenamedSpansTracker();
                 var conflictResolution = new MutableConflictResolution(
-                    baseSolution, renamedSpansTracker, _replacementText, _replacementTextValid, this.RenameOptions);
+                    baseSolution, renamedSpansTracker, _replacementText, _replacementTextValid);
 
                 var intermediateSolution = conflictResolution.OldSolution;
                 foreach (var documentsByProject in documentsGroupedByTopologicallySortedProjectId)
@@ -198,7 +198,7 @@ internal static partial class ConflictResolver
 
                     // Step 3: Simplify the project
                     conflictResolution.UpdateCurrentSolution(await renamedSpansTracker.SimplifyAsync(
-                        conflictResolution.CurrentSolution, documentsByProject, _replacementTextValid, _renameAnnotations, this.RenameOptions, _cancellationToken).ConfigureAwait(false));
+                        conflictResolution.CurrentSolution, documentsByProject, _replacementTextValid, _renameAnnotations, _cancellationToken).ConfigureAwait(false));
                     intermediateSolution = await conflictResolution.RemoveAllRenameAnnotationsAsync(
                         intermediateSolution, documentsByProject, _renameAnnotations, _cancellationToken).ConfigureAwait(false);
                     conflictResolution.UpdateCurrentSolution(intermediateSolution);
@@ -353,7 +353,7 @@ internal static partial class ConflictResolver
                         documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                     var syntaxRoot = await newDocument.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
                     var baseDocument = await conflictResolution.OldSolution.GetRequiredDocumentAsync(
-                        documentId, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);
+                        documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                     var baseSyntaxTree = await baseDocument.GetRequiredSyntaxTreeAsync(_cancellationToken).ConfigureAwait(false);
                     var baseRoot = await baseDocument.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
                     SemanticModel? newDocumentSemanticModel = null;
@@ -661,7 +661,7 @@ internal static partial class ConflictResolver
                     : _renameSymbolDeclarationLocation.SourceSpan.Start;
 
                 var document = await conflictResolution.CurrentSolution.GetRequiredDocumentAsync(
-                    _documentIdOfRenameSymbolDeclaration, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);
+                    _documentIdOfRenameSymbolDeclaration, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                 var newSymbol = await SymbolFinder.FindSymbolAtPositionAsync(document, start, cancellationToken: _cancellationToken).ConfigureAwait(false);
                 return newSymbol;
             }
@@ -770,7 +770,7 @@ internal static partial class ConflictResolver
                     _cancellationToken.ThrowIfCancellationRequested();
 
                     var document = await originalSolution.GetRequiredDocumentAsync(
-                        documentId, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);
+                        documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                     var semanticModel = await document.GetRequiredSemanticModelAsync(_cancellationToken).ConfigureAwait(false);
                     var originalSyntaxRoot = await semanticModel.SyntaxTree.GetRootAsync(_cancellationToken).ConfigureAwait(false);
 
@@ -825,7 +825,7 @@ internal static partial class ConflictResolver
                     }
                     else
                     {
-                        partiallyRenamedSolution = await conflictResolution.WithDocumentSyntaxRootAsync(partiallyRenamedSolution, documentId, newRoot, _cancellationToken).ConfigureAwait(false);
+                        partiallyRenamedSolution = await MutableConflictResolution.WithDocumentSyntaxRootAsync(partiallyRenamedSolution, documentId, newRoot, _cancellationToken).ConfigureAwait(false);
                     }
                 }
 

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -211,7 +211,7 @@ internal static partial class ConflictResolver
                 if (IsRenameValid(conflictResolution, renamedSymbolInNewSolution))
                 {
                     var declarationDocument = await conflictResolution.CurrentSolution.GetRequiredDocumentAsync(
-                        _documentIdOfRenameSymbolDeclaration, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);
+                        _documentIdOfRenameSymbolDeclaration, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                     var semanticModel = await declarationDocument.GetRequiredSemanticModelAsync(_cancellationToken).ConfigureAwait(false);
                     await AddImplicitConflictsAsync(
                         renamedSymbolInNewSolution,
@@ -269,7 +269,7 @@ internal static partial class ConflictResolver
             {
                 // remember if there were issues in the document prior to renaming it.
                 var originalDoc = await conflictResolution.OldSolution.GetRequiredDocumentAsync(
-                    documentId, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);
+                    documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                 documentIdErrorStateLookup.Add(documentId, await originalDoc.HasAnyErrorsAsync(_cancellationToken).ConfigureAwait(false));
             }
 
@@ -292,7 +292,7 @@ internal static partial class ConflictResolver
                     if (!documentIdErrorStateLookup[documentId])
                     {
                         var changeDoc = await conflictResolution.CurrentSolution.GetRequiredDocumentAsync(
-                            documentId, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);
+                            documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                         await changeDoc.VerifyNoErrorsAsync("Rename introduced errors in error-free code", _cancellationToken, ignoreErrorCodes).ConfigureAwait(false);
                     }
                 }
@@ -350,7 +350,7 @@ internal static partial class ConflictResolver
                 foreach (var documentId in documentIdsForConflictResolution)
                 {
                     var newDocument = await conflictResolution.CurrentSolution.GetRequiredDocumentAsync(
-                        documentId, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);
+                        documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                     var syntaxRoot = await newDocument.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
                     var baseDocument = await conflictResolution.OldSolution.GetRequiredDocumentAsync(
                         documentId, RenameOptions.RenameInSourceGeneratedDocuments, _cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/MutableConflictResolution.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/MutableConflictResolution.cs
@@ -73,7 +73,7 @@ internal sealed class MutableConflictResolution(
             if (renamedSpansTracker.IsDocumentChanged(documentId))
             {
                 var document = await CurrentSolution.GetRequiredDocumentAsync(
-                    documentId, _options.RenameInSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
+                    documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                 var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
                 // For the computeReplacementToken and computeReplacementNode functions, use 
@@ -185,7 +185,7 @@ internal sealed class MutableConflictResolution(
         {
             Contract.ThrowIfFalse(_options.RenameInSourceGeneratedDocuments);
 
-            _ = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: _options.RenameInSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
+            _ = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
         }
 
         return solution.WithDocumentSyntaxRoot(documentId, newRoot, PreservationMode.PreserveIdentity);

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/MutableConflictResolution.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/MutableConflictResolution.cs
@@ -22,8 +22,7 @@ internal sealed class MutableConflictResolution(
     Solution oldSolution,
     RenamedSpansTracker renamedSpansTracker,
     string replacementText,
-    bool replacementTextValid,
-    SymbolRenameOptions options)
+    bool replacementTextValid)
 {
     // List of All the Locations that were renamed and conflict-complexified
     public readonly List<RelatedLocation> RelatedLocations = [];
@@ -48,8 +47,6 @@ internal sealed class MutableConflictResolution(
     /// The solution snapshot as it is being updated with specific rename steps.
     /// </summary>
     public Solution CurrentSolution { get; private set; } = oldSolution;
-
-    private readonly SymbolRenameOptions _options = options;
 
     private (DocumentId documentId, string newName) _renamedDocument;
 
@@ -176,15 +173,13 @@ internal sealed class MutableConflictResolution(
     /// work before calling the normal WithDocumentSyntaxRoot method. If the option is not set, there should be no source generated
     /// documents, and the method will complete synchronously.
     /// </remarks>
-    internal async ValueTask<Solution> WithDocumentSyntaxRootAsync(Solution solution, DocumentId documentId, SyntaxNode newRoot, CancellationToken cancellationToken)
+    internal static async ValueTask<Solution> WithDocumentSyntaxRootAsync(Solution solution, DocumentId documentId, SyntaxNode newRoot, CancellationToken cancellationToken)
     {
         // In a source generated document, we have to ensure we've realized the "old" tree in the modified solution or WithDocumentSyntaxRoot
         // won't work. Performing a rename in a source generated document is opt-in, so we can assume that we only hit this condition in
         // scenarios that wanted it.
         if (documentId.IsSourceGenerated)
         {
-            Contract.ThrowIfFalse(_options.RenameInSourceGeneratedDocuments);
-
             _ = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
@@ -148,7 +148,6 @@ internal sealed class RenamedSpansTracker
         IEnumerable<DocumentId> documentIds,
         bool replacementTextValid,
         AnnotationTable<RenameAnnotation> renameAnnotations,
-        SymbolRenameOptions options,
         CancellationToken cancellationToken)
     {
         foreach (var documentId in documentIds)

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
@@ -158,7 +158,7 @@ internal sealed class RenamedSpansTracker
                 // It's possible that rename will have found locations in generated documents, so we have to make sure to allow that. We assume that the
                 // entry point to rename will only process source generated documents if it needed to.
                 var document = await solution.GetRequiredDocumentAsync(
-                    documentId, options.RenameInSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
+                    documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
 
                 if (replacementTextValid)
                 {

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Rename.ConflictEngine;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -86,6 +87,8 @@ internal readonly struct SerializableRenameLocation(
     public async ValueTask<RenameLocation> RehydrateAsync(Solution solution, CancellationToken cancellation)
     {
         var document = await solution.GetRequiredDocumentAsync(DocumentId, includeSourceGenerated: true, cancellation).ConfigureAwait(false);
+        Contract.ThrowIfTrue(DocumentId.IsSourceGenerated && !document.IsRazorSourceGeneratedDocument());
+
         var tree = await document.GetRequiredSyntaxTreeAsync(cancellation).ConfigureAwait(false);
 
         return new RenameLocation(

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -85,7 +85,7 @@ internal readonly struct SerializableRenameLocation(
 
     public async ValueTask<RenameLocation> RehydrateAsync(Solution solution, CancellationToken cancellation)
     {
-        var document = solution.GetRequiredDocument(DocumentId);
+        var document = await solution.GetRequiredDocumentAsync(DocumentId, includeSourceGenerated: true, cancellation).ConfigureAwait(false);
         var tree = await document.GetRequiredSyntaxTreeAsync(cancellation).ConfigureAwait(false);
 
         return new RenameLocation(

--- a/src/Workspaces/Core/Portable/Rename/RenameOptions.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameOptions.cs
@@ -34,22 +34,7 @@ public readonly record struct SymbolRenameOptions(
     [property: DataMember(Order = 0)] bool RenameOverloads = false,
     [property: DataMember(Order = 1)] bool RenameInStrings = false,
     [property: DataMember(Order = 2)] bool RenameInComments = false,
-    [property: DataMember(Order = 3)] bool RenameFile = false)
-{
-    internal SymbolRenameOptions(
-        bool renameOverloads,
-        bool renameInStrings,
-        bool renameInComments,
-        bool renameFile,
-        bool renameInSourceGeneratedDocuments)
-        : this(renameOverloads, renameInStrings, renameInComments, renameFile)
-    {
-        RenameInSourceGeneratedDocuments = renameInSourceGeneratedDocuments;
-    }
-
-    [DataMember(Order = 4)]
-    internal bool RenameInSourceGeneratedDocuments { get; init; } = false;
-}
+    [property: DataMember(Order = 3)] bool RenameFile = false);
 
 /// <summary>
 /// Options for renaming a document.

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -236,7 +237,7 @@ internal sealed partial class SymbolicRenameLocations
                 // If the location is in a source generated file, we won't rename it. Our assumption in this case is we
                 // have cascaded to this symbol from our original source symbol, and the generator will update this file
                 // based on the renamed symbol.
-                if (options.RenameInSourceGeneratedDocuments || document is not SourceGeneratedDocument)
+                if (document is not SourceGeneratedDocument || document.IsRazorSourceGeneratedDocument())
                     results.Add(new RenameLocation(location, document.Id, isRenamableAccessor: isRenamableAccessor));
             }
         }
@@ -246,7 +247,7 @@ internal sealed partial class SymbolicRenameLocations
         {
             // We won't try to update references in source generated files; we'll assume the generator will rerun
             // and produce an updated document with the new name.
-            if (!options.RenameInSourceGeneratedDocuments && location.Document is SourceGeneratedDocument)
+            if (location.Document is SourceGeneratedDocument && !location.Document.IsRazorSourceGeneratedDocument())
                 return [];
 
             var shouldIncludeSymbol = await ShouldIncludeSymbolAsync(referencedSymbol, originalSymbol, solution, true, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -159,7 +159,7 @@ internal sealed partial class SymbolicRenameLocations
         /// Given a ISymbol, returns the renameable locations for a given symbol.
         /// </summary>
         public static async Task<ImmutableArray<RenameLocation>> GetRenamableDefinitionLocationsAsync(
-            ISymbol referencedSymbol, ISymbol originalSymbol, Solution solution, SymbolRenameOptions options, CancellationToken cancellationToken)
+            ISymbol referencedSymbol, ISymbol originalSymbol, Solution solution, CancellationToken cancellationToken)
         {
             var shouldIncludeSymbol = await ShouldIncludeSymbolAsync(referencedSymbol, originalSymbol, solution, false, cancellationToken).ConfigureAwait(false);
             if (!shouldIncludeSymbol)
@@ -243,7 +243,7 @@ internal sealed partial class SymbolicRenameLocations
         }
 
         internal static async Task<IEnumerable<RenameLocation>> GetRenamableReferenceLocationsAsync(
-            ISymbol referencedSymbol, ISymbol originalSymbol, ReferenceLocation location, Solution solution, SymbolRenameOptions options, CancellationToken cancellationToken)
+            ISymbol referencedSymbol, ISymbol originalSymbol, ReferenceLocation location, Solution solution, CancellationToken cancellationToken)
         {
             // We won't try to update references in source generated files; we'll assume the generator will rerun
             // and produce an updated document with the new name.

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.cs
@@ -63,10 +63,10 @@ internal sealed partial class SymbolicRenameLocations
             symbol = await RenameUtilities.FindDefinitionSymbolAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
 
             // First, find the direct references just to the symbol being renamed.
-            var originalSymbolResult = await AddLocationsReferenceSymbolsAsync(symbol, solution, options, cancellationToken).ConfigureAwait(false);
+            var originalSymbolResult = await AddLocationsReferenceSymbolsAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
 
             // Next, find references to overloads, if the user has asked to rename those as well.
-            var overloadsResult = options.RenameOverloads ? await GetOverloadsAsync(symbol, solution, options, cancellationToken).ConfigureAwait(false) :
+            var overloadsResult = options.RenameOverloads ? await GetOverloadsAsync(symbol, solution, cancellationToken).ConfigureAwait(false) :
                 [];
 
             // Finally, include strings/comments if that's what the user wants.
@@ -111,12 +111,12 @@ internal sealed partial class SymbolicRenameLocations
     }
 
     private static async Task<ImmutableArray<SearchResult>> GetOverloadsAsync(
-        ISymbol symbol, Solution solution, SymbolRenameOptions options, CancellationToken cancellationToken)
+        ISymbol symbol, Solution solution, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<SearchResult>.GetInstance(out var overloadsResult);
 
         foreach (var overloadedSymbol in RenameUtilities.GetOverloadedSymbols(symbol))
-            overloadsResult.Add(await AddLocationsReferenceSymbolsAsync(overloadedSymbol, solution, options, cancellationToken).ConfigureAwait(false));
+            overloadsResult.Add(await AddLocationsReferenceSymbolsAsync(overloadedSymbol, solution, cancellationToken).ConfigureAwait(false));
 
         return overloadsResult.ToImmutableAndClear();
     }
@@ -124,7 +124,6 @@ internal sealed partial class SymbolicRenameLocations
     private static async Task<SearchResult> AddLocationsReferenceSymbolsAsync(
         ISymbol symbol,
         Solution solution,
-        SymbolRenameOptions options,
         CancellationToken cancellationToken)
     {
         var locations = ImmutableHashSet.CreateBuilder<RenameLocation>();
@@ -134,12 +133,12 @@ internal sealed partial class SymbolicRenameLocations
         foreach (var referencedSymbol in referenceSymbols)
         {
             locations.AddAll(
-                await ReferenceProcessing.GetRenamableDefinitionLocationsAsync(referencedSymbol.Definition, symbol, solution, options, cancellationToken).ConfigureAwait(false));
+                await ReferenceProcessing.GetRenamableDefinitionLocationsAsync(referencedSymbol.Definition, symbol, solution, cancellationToken).ConfigureAwait(false));
 
             locations.AddAll(
                 await referencedSymbol.Locations.SelectManyInParallelAsync(
                     (l, c) => ReferenceProcessing.GetRenamableReferenceLocationsAsync(
-                        referencedSymbol.Definition, symbol, l, solution, options, c),
+                        referencedSymbol.Definition, symbol, l, solution, c),
                     cancellationToken).ConfigureAwait(false));
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
@@ -27,4 +27,7 @@ internal static class Extensions
 
     public static bool IsRazorDocument(this TextDocumentState documentState)
         => documentState.DocumentServiceProvider.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName == RazorCSharpLspClientName;
+
+    public static bool IsRazorSourceGeneratedDocument(this Document document)
+        => document is SourceGeneratedDocument { Identity.Generator.TypeName: "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator" };
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentSpanMappingService.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Host;
+
+internal interface ISourceGeneratedDocumentSpanMappingService : IWorkspaceService
+{
+    Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken);
+
+    Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(Document document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);
+}
+
+internal record struct MappedTextChange(string MappedFilePath, TextChange TextChange);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionChanges.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionChanges.cs
@@ -16,6 +16,9 @@ public readonly struct SolutionChanges
     private readonly Solution _newSolution;
     private readonly Solution _oldSolution;
 
+    internal Solution OldSolution => _oldSolution;
+    internal Solution NewSolution => _newSolution;
+
     internal SolutionChanges(Solution newSolution, Solution oldSolution)
     {
         _newSolution = newSolution;


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/9519
Half of the fix for https://github.com/dotnet/razor/issues/12054

Previously I allowed rename to work on any source generated document, but made it only opt in for when the rename request came from Razor. Now that we have a little more time for development, it's time to finish the feature off properly. This PR:

* Rename will only consider source generated documents if they're from Razor
* Any rename operation will automatically do so, without opt in
* Before applying changes to the workspace, we call in to Razor to map edits
	* This matches the behaviour of non-cohosting, but that does edit mapping via a document service. Since with cohosting Razor doesn't control the document creation, there is no way to set up a document service, so there is just a workspace service that does the same thing.

There will still need to be more PRs to make this work in VS Code, and to hook up the span mapping aspect of the service, but I didn't want this PR to get too big.