### PR TITLE
Reduce allocations in CSharpVirtualCharService.TryConvertStringToVirtualChars

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
@@ -245,6 +245,14 @@ internal class CSharpVirtualCharService : AbstractVirtualCharService
 
         var startIndexInclusive = startDelimiter.Length;
         var endIndexExclusive = tokenText.Length - endDelimiter.Length;
+        var offset = token.SpanStart;
+
+        // Avoid creating and processsing the runes if there are no escapes or surrogates in the string.
+        if (!ContainsEscapeOrSurrogate(tokenText.AsSpan(startIndexInclusive, endIndexExclusive - startIndexInclusive), escapeBraces))
+        {
+            var sequence = VirtualCharSequence.Create(offset, tokenText);
+            return sequence.GetSubSequence(TextSpan.FromBounds(startIndexInclusive, endIndexExclusive));
+        }
 
         // Do things in two passes.  First, convert everything in the string to a 16-bit-char+span.  Then walk
         // again, trying to create Runes from the 16-bit-chars. We do this to simplify complex cases where we may
@@ -253,7 +261,6 @@ internal class CSharpVirtualCharService : AbstractVirtualCharService
         using var _ = ArrayBuilder<(char ch, TextSpan span)>.GetInstance(out var charResults);
 
         // First pass, just convert everything in the string (i.e. escapes) to plain 16-bit characters.
-        var offset = token.SpanStart;
         for (var index = startIndexInclusive; index < endIndexExclusive;)
         {
             var ch = tokenText[index];
@@ -280,6 +287,21 @@ internal class CSharpVirtualCharService : AbstractVirtualCharService
         }
 
         return CreateVirtualCharSequence(tokenText, offset, startIndexInclusive, endIndexExclusive, charResults);
+    }
+
+    private static bool ContainsEscapeOrSurrogate(ReadOnlySpan<char> tokenText, bool escapeBraces)
+    {
+        foreach (var ch in tokenText)
+        {
+            if (ch == '\\')
+                return true;
+            else if (escapeBraces && IsOpenOrCloseBrace(ch))
+                return true;
+            else if (char.IsSurrogate(ch))
+                return true;
+        }
+
+        return false;
     }
 
     private static VirtualCharSequence CreateVirtualCharSequence(


### PR DESCRIPTION
This method is accounting for 1.4% of allocations in the OOP process in a completion scenario in the RazorEditing.CompletionInCohosting speedometer test I am looking at.

Instead of doing all the work and hitting the pools, we can just handle the normal case of there not being any surrogates or escape characters and just create a VirtualCharSequence wrapper around the existing string.

Locally, I see about 75% of strings that come through hit this optimization.

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/656486

Original allocations:
<img width="1540" height="278" alt="image" src="https://github.com/user-attachments/assets/316db875-61d9-45b1-91c6-028f599b642e" />

Test insertion allocations:
<img width="1378" height="351" alt="image" src="https://github.com/user-attachments/assets/2d2cc4a2-cf17-4956-91e5-642b7c52aac0" />
