### PR TITLE
Use Append overload for repeating chars

### DIFF
--- a/src/EditorFeatures/CSharp/StringCopyPaste/KnownSourcePasteProcessor.cs
+++ b/src/EditorFeatures/CSharp/StringCopyPaste/KnownSourcePasteProcessor.cs
@@ -306,7 +306,7 @@ internal sealed class KnownSourcePasteProcessor(
                 }
                 else
                 {
-                    builder.Append(new string('{', dollarSignCount));
+                    builder.Append('{', dollarSignCount);
                     builder.Append(content.InterpolationExpression);
                     builder.Append(content.InterpolationAlignmentClause);
 
@@ -316,7 +316,7 @@ internal sealed class KnownSourcePasteProcessor(
                         builder.Append(content.InterpolationFormatClause);
                     }
 
-                    builder.Append(new string('}', dollarSignCount));
+                    builder.Append('}', dollarSignCount);
                 }
             }
             else


### PR DESCRIPTION
This is a minor change to adopt the (info level) analyzer warning coming as part of this suggestion (marked as api-approved): https://github.com/dotnet/runtime/issues/117643