### PR TITLE
Trap on-the-fly-doc exceptions in quick info

### DIFF
--- a/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
@@ -198,7 +198,8 @@ internal sealed class CSharpSemanticQuickInfoProvider() : CommonSemanticQuickInf
         }
     }
 
-    protected override async Task<OnTheFlyDocsInfo?> GetOnTheFlyDocsInfoAsync(QuickInfoContext context, CancellationToken cancellationToken)
+    protected override async Task<OnTheFlyDocsInfo?> GetOnTheFlyDocsInfoAsync(
+        QuickInfoContext context, CancellationToken cancellationToken)
     {
         try
         {
@@ -210,7 +211,8 @@ internal sealed class CSharpSemanticQuickInfoProvider() : CommonSemanticQuickInf
         }
     }
 
-    private static async Task<OnTheFlyDocsInfo?> GetOnTheFlyDocsInfoWorkerAsync(QuickInfoContext context, CancellationToken cancellationToken)
+    private static async Task<OnTheFlyDocsInfo?> GetOnTheFlyDocsInfoWorkerAsync(
+        QuickInfoContext context, CancellationToken cancellationToken)
     {
         var document = context.Document;
         var position = context.Position;
@@ -249,9 +251,7 @@ internal sealed class CSharpSemanticQuickInfoProvider() : CommonSemanticQuickInf
         }
 
         if (symbol.DeclaringSyntaxReferences.Length == 0)
-        {
             return null;
-        }
 
         // Checks to see if any of the files containing the symbol are excluded.
         var hasContentExcluded = false;
@@ -267,17 +267,12 @@ internal sealed class CSharpSemanticQuickInfoProvider() : CommonSemanticQuickInf
         }
 
         var solution = document.Project.Solution;
-        var declarationCode = symbol.DeclaringSyntaxReferences.Select(reference =>
+        var declarationCode = symbol.DeclaringSyntaxReferences.SelectAsArray(reference =>
         {
             var span = reference.Span;
             var syntaxReferenceDocument = solution.GetDocument(reference.SyntaxTree);
-            if (syntaxReferenceDocument is not null)
-            {
-                return new OnTheFlyDocsRelevantFileInfo(syntaxReferenceDocument, span);
-            }
-
-            return null;
-        }).ToImmutableArray();
+            return syntaxReferenceDocument is null ? null : new OnTheFlyDocsRelevantFileInfo(syntaxReferenceDocument, span);
+        });
 
         var additionalContext = OnTheFlyDocsUtilities.GetAdditionalOnTheFlyDocsContext(solution, symbol);
 

--- a/src/Features/Core/Portable/QuickInfo/OnTheFlyDocsInfo.cs
+++ b/src/Features/Core/Portable/QuickInfo/OnTheFlyDocsInfo.cs
@@ -18,7 +18,7 @@ internal sealed class OnTheFlyDocsInfo(string symbolSignature, ImmutableArray<On
     public string SymbolSignature { get; } = symbolSignature;
     public ImmutableArray<OnTheFlyDocsRelevantFileInfo?> DeclarationCode { get; } = declarationCode;
     public string Language { get; } = language;
-    public bool IsContentExcluded { get; set; } = isContentExcluded;
+    public bool IsContentExcluded { get; } = isContentExcluded;
     public ImmutableArray<OnTheFlyDocsRelevantFileInfo?> AdditionalContext { get; } = additionalContext;
 
     // Added for telemetry collection purposes.


### PR DESCRIPTION
Possible fix for https://github.com/dotnet/roslyn/issues/79663

Looking at the history of reports, the only thing i can see we changed in quick info was the introduction of on-the-fly-docs.  This calls into copilot services, and has a lot of complexity (as well as naked throws in it).  I've wrapped these to at least report back to us when something goes wrong.  but to also be tolerant and non-blocking of normal quick info in that case.