### PR TITLE
Razor span mapping in LSP for cohosting

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -1015,6 +1015,20 @@ internal static partial class ProtocolConversions
             return null;
         }
 
+        if (textDocument is SourceGeneratedDocument sourceGeneratedDocument &&
+            textDocument.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } sourceGeneratedSpanMappingService)
+        {
+            var result = await sourceGeneratedSpanMappingService.MapSpansAsync(sourceGeneratedDocument, textSpans, cancellationToken).ConfigureAwait(false);
+            if (result.IsDefaultOrEmpty)
+            {
+                return null;
+            }
+
+            Contract.ThrowIfFalse(textSpans.Length == result.Length,
+                $"The number of input spans {textSpans.Length} should match the number of mapped spans returned {result.Length}");
+            return result;
+        }
+
         var spanMappingService = document.DocumentServiceProvider.GetService<ISpanMappingService>();
         if (spanMappingService == null)
         {

--- a/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratedDocumentSpanMappingService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     internal interface IRazorSourceGeneratedDocumentSpanMappingService
     {
-        Task<ImmutableArray<RazorMappedEditResult>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, Document newDocument, CancellationToken cancellationToken);
+        Task<ImmutableArray<RazorMappedEditResult>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken);
         Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratedDocumentSpanMappingService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     internal interface IRazorSourceGeneratedDocumentSpanMappingService
     {
-        Task<ImmutableArray<RazorMappedEditResult>> GetMappedTextChangesAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken);
-        Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(Document document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);
+        Task<ImmutableArray<RazorMappedEditResult>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, Document newDocument, CancellationToken cancellationToken);
+        Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Features/RazorGeneratedDocumentIdentity.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorGeneratedDocumentIdentity.cs
@@ -9,4 +9,17 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
 /// <summary>
 /// Wrapper for <see cref="SourceGeneratedDocumentIdentity" /> and <see cref="SourceGeneratorIdentity" />
 /// </summary>
-internal record struct RazorGeneratedDocumentIdentity(DocumentId DocumentId, string HintName, string FilePath, string GeneratorAssemblyName, string? GeneratorAssemblyPath, Version GeneratorAssemblyVersion, string GeneratorTypeName);
+internal record struct RazorGeneratedDocumentIdentity(DocumentId DocumentId, string HintName, string FilePath, string GeneratorAssemblyName, string? GeneratorAssemblyPath, Version GeneratorAssemblyVersion, string GeneratorTypeName)
+{
+    internal static RazorGeneratedDocumentIdentity Create(SourceGeneratedDocument document)
+        => Create(document.Identity);
+
+    internal static RazorGeneratedDocumentIdentity Create(SourceGeneratedDocumentIdentity identity)
+        => new(identity.DocumentId,
+            identity.HintName,
+            identity.FilePath,
+            identity.Generator.AssemblyName,
+            identity.Generator.AssemblyPath,
+            identity.Generator.AssemblyVersion,
+            identity.Generator.TypeName);
+}

--- a/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingService.cs
@@ -24,7 +24,7 @@ internal sealed class RazorSourceGeneratedDocumentSpanMappingService(
 {
     private readonly IRazorSourceGeneratedDocumentSpanMappingService? _implementation = implementation;
 
-    public async Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken)
     {
         if (_implementation is null ||
             !oldDocument.IsRazorSourceGeneratedDocument() ||
@@ -56,7 +56,7 @@ internal sealed class RazorSourceGeneratedDocumentSpanMappingService(
         return changesBuilder.ToImmutableAndClear();
     }
 
-    public async Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(Document document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)
     {
         if (_implementation is null ||
             !document.IsRazorSourceGeneratedDocument())
@@ -65,7 +65,7 @@ internal sealed class RazorSourceGeneratedDocumentSpanMappingService(
         }
 
         var mappedSpans = await _implementation.MapSpansAsync(document, spans, cancellationToken).ConfigureAwait(false);
-        if (mappedSpans.IsDefaultOrEmpty)
+        if (mappedSpans.Length != spans.Length)
         {
             return [];
         }
@@ -73,10 +73,9 @@ internal sealed class RazorSourceGeneratedDocumentSpanMappingService(
         using var _ = ArrayBuilder<MappedSpanResult>.GetInstance(out var spansBuilder);
         foreach (var span in mappedSpans)
         {
-            if (!span.IsDefault)
-            {
-                spansBuilder.Add(new MappedSpanResult(span.FilePath, span.LinePositionSpan, span.Span));
-            }
+            spansBuilder.Add(span.IsDefault
+                ? default
+                : new MappedSpanResult(span.FilePath, span.LinePositionSpan, span.Span));
         }
 
         return spansBuilder.ToImmutableAndClear();

--- a/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingServiceWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingServiceWrapper.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
@@ -19,7 +18,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
 [ExportWorkspaceService(typeof(ISourceGeneratedDocumentSpanMappingService)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class RazorSourceGeneratedDocumentSpanMappingService(
+internal sealed class RazorSourceGeneratedDocumentSpanMappingServiceWrapper(
     [Import(AllowDefault = true)] IRazorSourceGeneratedDocumentSpanMappingService? implementation) : ISourceGeneratedDocumentSpanMappingService
 {
     private readonly IRazorSourceGeneratedDocumentSpanMappingService? _implementation = implementation;

--- a/src/Tools/ExternalAccess/Razor/Features/RazorUri.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorUri.cs
@@ -35,13 +35,6 @@ internal static class RazorUri
 
         // Razor only cares about documents from its own generator, but it's better to just send them back the info they
         // need to check on their side, so we can avoid dual insertions if anything changes.
-        return new RazorGeneratedDocumentIdentity(
-            identity.DocumentId,
-            identity.HintName,
-            identity.FilePath,
-            identity.Generator.AssemblyName,
-            identity.Generator.AssemblyPath,
-            identity.Generator.AssemblyVersion,
-            identity.Generator.TypeName);
+        return RazorGeneratedDocumentIdentity.Create(identity);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentSpanMappingService.cs
@@ -11,9 +11,9 @@ namespace Microsoft.CodeAnalysis.Host;
 
 internal interface ISourceGeneratedDocumentSpanMappingService : IWorkspaceService
 {
-    Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken);
+    Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken);
 
-    Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(Document document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);
+    Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);
 }
 
 internal record struct MappedTextChange(string MappedFilePath, TextChange TextChange);


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/79604
Part of https://github.com/dotnet/razor/issues/9519

This is the follow up to the above PR to support rename in LSP, but thought I'd make the API slightly stronger while I was here since we haven't consumed it on Razor yet. I also misunderstood the span mapping API, and it needing to return an array of the same length as the input.