### PR TITLE
Fix extension-method add-import completion in syntactically ambiguous scenarios

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/ExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/ExtensionMethodImportCompletionProvider.cs
@@ -64,6 +64,14 @@ internal sealed class ExtensionMethodImportCompletionProvider() : AbstractExtens
         CancellationToken cancellationToken,
         [NotNullWhen(true)] out ITypeSymbol? receiverTypeSymbol)
     {
+        // If we have:
+        //
+        //      X.Y.$$
+        //      var v = ...
+        //
+        // Then this will seem as if we're asking for completion inside the error qualified type symbol 'X.Y.var' in
+        // a qualified type name context (i.e. "types only"). To address that, we call into our helper which checks and
+        // reinterprets that case as if we have `X.Y.` in an expression context instead.
         if (node is ExpressionSyntax expression &&
             expression.ShouldNameExpressionBeTreatedAsExpressionInsteadOfType(semanticModel, out _, out var container) &&
             container is not null and not IErrorTypeSymbol)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/ExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/ExtensionMethodImportCompletionProvider.cs
@@ -10,10 +10,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/79096