### PR TITLE
Simplify determination of live vs. build diagnostics

### DIFF
--- a/src/Compilers/Core/Portable/Diagnostic/WellKnownDiagnosticTags.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/WellKnownDiagnosticTags.cs
@@ -21,6 +21,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Indicates that the diagnostic is related to build.
         /// </summary>
+        /// <remarks>
+        /// Build errors are recognized to potentially represent stale results from a point in the past when the computation occurred.
+        /// An example of when Roslyn produces non-live errors is with an explicit user gesture to "run code analysis".
+        /// Because these representerrors from the past, we do want them to be superseded by a more recent live run,
+        /// or a more recent build from another source.
+        /// </remarks>
         public const string Build = nameof(Build);
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/WellKnownDiagnosticTags.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/WellKnownDiagnosticTags.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Build errors are recognized to potentially represent stale results from a point in the past when the computation occurred.
         /// An example of when Roslyn produces non-live errors is with an explicit user gesture to "run code analysis".
-        /// Because these representerrors from the past, we do want them to be superseded by a more recent live run,
+        /// Because these represent errors from the past, we do want them to be superseded by a more recent live run,
         /// or a more recent build from another source.
         /// </remarks>
         public const string Build = nameof(Build);

--- a/src/LanguageServer/ExternalAccess/VisualDiagnostics/Internal/HotReloadDiagnosticSource.cs
+++ b/src/LanguageServer/ExternalAccess/VisualDiagnostics/Internal/HotReloadDiagnosticSource.cs
@@ -27,6 +27,5 @@ internal sealed class HotReloadDiagnosticSource(IHotReloadDiagnosticSource sourc
     public TextDocumentIdentifier? GetDocumentIdentifier() => new() { DocumentUri = textDocument.GetURI() };
     public ProjectOrDocumentId GetId() => new(textDocument.Id);
     public Project GetProject() => textDocument.Project;
-    public bool IsLiveSource() => true;
     public string ToDisplayString() => $"{this.GetType().Name}: {textDocument.FilePath ?? textDocument.Name} in {textDocument.Project.Name}";
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlDiagnosticSourceProvider.cs
@@ -58,7 +58,8 @@ internal sealed class VirtualProjectXmlDiagnosticSourceProvider(VirtualProjectXm
                     isEnabledByDefault: true,
                     // Warning level 0 is used as a placeholder when the diagnostic has error severity
                     warningLevel: 0,
-                    customTags: ImmutableArray<string>.Empty,
+                    // Mark these diagnostics as build errors so they can be overridden by diagnostics from an explicit build.
+                    customTags: [WellKnownDiagnosticTags.Build],
                     properties: ImmutableDictionary<string, string?>.Empty,
                     projectId: document.Project.Id,
                     location: new DiagnosticDataLocation(location, document.Id)
@@ -84,13 +85,6 @@ internal sealed class VirtualProjectXmlDiagnosticSourceProvider(VirtualProjectXm
         {
             return document.Project;
         }
-
-        /// <summary>
-        /// These diagnostics are from the last time 'dotnet run-api' was invoked, which only occurs when a design time build is performed.
-        /// <seealso cref="IDiagnosticSource.IsLiveSource"/>.
-        /// </summary>
-        /// <returns></returns>
-        public bool IsLiveSource() => false;
 
         public string ToDisplayString() => nameof(VirtualProjectXmlDiagnosticSource);
     }

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
@@ -23,17 +23,16 @@ internal static partial class ProtocolConversions
     /// <param name="diagnosticData">The diagnostic to convert</param>
     /// <param name="supportsVisualStudioExtensions">Whether the client is Visual Studio</param>
     /// <param name="project">The project the diagnostic is relevant to</param>
-    /// <param name="isLiveSource">Whether the diagnostic is considered "live" and should supersede others</param>
     /// <param name="potentialDuplicate">Whether the diagnostic is potentially a duplicate to a build diagnostic</param>
     /// <param name="globalOptionService">The global options service</param>
-    public static ImmutableArray<LSP.Diagnostic> ConvertDiagnostic(DiagnosticData diagnosticData, bool supportsVisualStudioExtensions, Project project, bool isLiveSource, bool potentialDuplicate, IGlobalOptionService globalOptionService)
+    public static ImmutableArray<LSP.Diagnostic> ConvertDiagnostic(DiagnosticData diagnosticData, bool supportsVisualStudioExtensions, Project project, bool potentialDuplicate, IGlobalOptionService globalOptionService)
     {
         if (!ShouldIncludeHiddenDiagnostic(diagnosticData, supportsVisualStudioExtensions))
         {
             return [];
         }
 
-        var diagnostic = CreateLspDiagnostic(diagnosticData, project, isLiveSource, potentialDuplicate, supportsVisualStudioExtensions);
+        var diagnostic = CreateLspDiagnostic(diagnosticData, project, potentialDuplicate, supportsVisualStudioExtensions);
 
         // Check if we need to handle the unnecessary tag (fading).
         if (!diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary))
@@ -65,7 +64,7 @@ internal static partial class ProtocolConversions
             diagnosticsBuilder.Add(diagnostic);
             foreach (var location in unnecessaryLocations)
             {
-                var additionalDiagnostic = CreateLspDiagnostic(diagnosticData, project, isLiveSource, potentialDuplicate, supportsVisualStudioExtensions);
+                var additionalDiagnostic = CreateLspDiagnostic(diagnosticData, project, potentialDuplicate, supportsVisualStudioExtensions);
                 additionalDiagnostic.Severity = LSP.DiagnosticSeverity.Hint;
                 additionalDiagnostic.Range = GetRange(location);
                 additionalDiagnostic.Tags = [DiagnosticTag.Unnecessary, VSDiagnosticTags.HiddenInEditor, VSDiagnosticTags.HiddenInErrorList, VSDiagnosticTags.SuppressEditorToolTip];
@@ -94,7 +93,6 @@ internal static partial class ProtocolConversions
     private static LSP.VSDiagnostic CreateLspDiagnostic(
         DiagnosticData diagnosticData,
         Project project,
-        bool isLiveSource,
         bool potentialDuplicate,
         bool supportsVisualStudioExtensions)
     {
@@ -108,7 +106,7 @@ internal static partial class ProtocolConversions
             CodeDescription = ProtocolConversions.HelpLinkToCodeDescription(diagnosticData.GetValidHelpLinkUri()),
             Message = diagnosticData.Message,
             Severity = ConvertDiagnosticSeverity(diagnosticData.Severity),
-            Tags = ConvertTags(diagnosticData, isLiveSource, potentialDuplicate),
+            Tags = ConvertTags(diagnosticData, potentialDuplicate),
             DiagnosticRank = ConvertRank(diagnosticData),
             Range = GetRange(diagnosticData.DataLocation)
         };
@@ -223,7 +221,7 @@ internal static partial class ProtocolConversions
     /// If you make change in this method, please also update the corresponding file in
     /// src\VisualStudio\Xaml\Impl\Implementation\LanguageServer\Handler\Diagnostics\AbstractPullDiagnosticHandler.cs
     /// </summary>
-    private static DiagnosticTag[] ConvertTags(DiagnosticData diagnosticData, bool isLiveSource, bool potentialDuplicate)
+    private static DiagnosticTag[] ConvertTags(DiagnosticData diagnosticData, bool potentialDuplicate)
     {
         using var _ = ArrayBuilder<DiagnosticTag>.GetInstance(out var result);
 
@@ -246,11 +244,8 @@ internal static partial class ProtocolConversions
         if (potentialDuplicate)
             result.Add(VSDiagnosticTags.PotentialDuplicate);
 
-        // Mark this also as a build error.  That way an explicitly kicked off build from a source like CPS can
+        // If tagged as build, mark this also as a build error.  That way an explicitly kicked off build from a source like CPS can
         // override it.
-        if (!isLiveSource)
-            result.Add(VSDiagnosticTags.BuildError);
-
         result.Add(diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.Build)
             ? VSDiagnosticTags.BuildError
             : VSDiagnosticTags.IntellisenseError);

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.Diagnostics.cs
@@ -17,6 +17,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer;
 
 internal static partial class ProtocolConversions
 {
+    internal static ImmutableArray<DiagnosticData> AddBuildTagIfNotPresent(ImmutableArray<DiagnosticData> diagnostics)
+    {
+        return diagnostics.SelectAsArray(static d =>
+        {
+            if (d.CustomTags.Contains(WellKnownDiagnosticTags.Build))
+                return d;
+
+            return d.WithCustomTags(d.CustomTags.Add(WellKnownDiagnosticTags.Build));
+        });
+    }
+
     /// <summary>
     /// Converts from <see cref="DiagnosticData"/> to <see cref="LSP.Diagnostic"/>
     /// </summary>

--- a/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_OpenDocument.cs
+++ b/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_OpenDocument.cs
@@ -18,9 +18,6 @@ internal static partial class EditAndContinueDiagnosticSource
 {
     private sealed class OpenDocumentSource(Document document) : AbstractDocumentDiagnosticSource<Document>(document)
     {
-        public override bool IsLiveSource()
-            => true;
-
         public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, CancellationToken cancellationToken)
         {
             var designTimeDocument = Document;

--- a/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_Workspace.cs
+++ b/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_Workspace.cs
@@ -19,8 +19,6 @@ internal static partial class EditAndContinueDiagnosticSource
 {
     private sealed class ProjectSource(Project project, ImmutableArray<DiagnosticData> diagnostics) : AbstractProjectDiagnosticSource(project)
     {
-        public override bool IsLiveSource()
-            => true;
 
         public override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, CancellationToken cancellationToken)
             => Task.FromResult(diagnostics);
@@ -28,8 +26,6 @@ internal static partial class EditAndContinueDiagnosticSource
 
     private sealed class ClosedDocumentSource(TextDocument document, ImmutableArray<DiagnosticData> diagnostics) : AbstractWorkspaceDocumentDiagnosticSource(document)
     {
-        public override bool IsLiveSource()
-            => true;
 
         public override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, CancellationToken cancellationToken)
             => Task.FromResult(diagnostics);

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -313,7 +313,6 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
             diagnosticData,
             capabilities.HasVisualStudioLspCapability(),
             diagnosticSource.GetProject(),
-            diagnosticSource.IsLiveSource(),
             PotentialDuplicate,
             GlobalOptions);
     }

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSourceProviders/DiagnosticSourceManager.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSourceProviders/DiagnosticSourceManager.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,7 +77,7 @@ internal sealed class DiagnosticSourceManager : IDiagnosticSourceManager
         }
         else
         {
-            // VS Code (and legacy VS ?) pass null sourceName when requesting all sources.
+            // Some clients (legacy VS/VSCode, Razor) do not support multiple sources - a null source indicates that diagnostics from all sources should be returned.
             using var _ = ArrayBuilder<IDiagnosticSource>.GetInstance(out var sourcesBuilder);
             foreach (var (name, provider) in nameToProviderMap)
             {
@@ -106,7 +105,6 @@ internal sealed class DiagnosticSourceManager : IDiagnosticSourceManager
         if (isDocument)
         {
             // Group all document sources into a single source.
-            Debug.Assert(sources.All(s => s.IsLiveSource()), "All document sources should be live");
             sources = [new AggregatedDocumentDiagnosticSource(sources)];
         }
         else
@@ -115,7 +113,7 @@ internal sealed class DiagnosticSourceManager : IDiagnosticSourceManager
             // will have same value for GetDocumentIdentifier and GetProject(). Thus can be
             // aggregated in a single source which will return same values. See
             // AggregatedDocumentDiagnosticSource implementation for more details.
-            sources = [.. sources.GroupBy(s => (s.GetId(), s.IsLiveSource()), s => s).SelectMany(g => AggregatedDocumentDiagnosticSource.AggregateIfNeeded(g))];
+            sources = [.. sources.GroupBy(s => s.GetId(), s => s).SelectMany(g => AggregatedDocumentDiagnosticSource.AggregateIfNeeded(g))];
         }
 
         return sources;
@@ -141,7 +139,6 @@ internal sealed class DiagnosticSourceManager : IDiagnosticSourceManager
             return result;
         }
 
-        public bool IsLiveSource() => true;
         public Project GetProject() => sources[0].GetProject();
         public ProjectOrDocumentId GetId() => sources[0].GetId();
         public TextDocumentIdentifier? GetDocumentIdentifier() => sources[0].GetDocumentIdentifier();

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
@@ -16,8 +16,6 @@ internal abstract class AbstractDocumentDiagnosticSource<TDocument>(TDocument do
     public TDocument Document { get; } = document;
     public Solution Solution => this.Document.Project.Solution;
 
-    public abstract bool IsLiveSource();
-
     public abstract Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         RequestContext context, CancellationToken cancellationToken);
 

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractProjectDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractProjectDiagnosticSource.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -23,7 +24,6 @@ internal abstract class AbstractProjectDiagnosticSource(Project project)
     public static AbstractProjectDiagnosticSource CreateForCodeAnalysisDiagnostics(Project project, ICodeAnalysisDiagnosticAnalyzerService codeAnalysisService)
         => new CodeAnalysisDiagnosticSource(project, codeAnalysisService);
 
-    public abstract bool IsLiveSource();
     public abstract Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, CancellationToken cancellationToken);
 
     public ProjectOrDocumentId GetId() => new(Project.Id);
@@ -37,12 +37,6 @@ internal abstract class AbstractProjectDiagnosticSource(Project project)
     private sealed class FullSolutionAnalysisDiagnosticSource(Project project, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer)
         : AbstractProjectDiagnosticSource(project)
     {
-        /// <summary>
-        /// This is a normal project source that represents live/fresh diagnostics that should supersede everything else.
-        /// </summary>
-        public override bool IsLiveSource()
-            => true;
-
         public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
             RequestContext context,
             CancellationToken cancellationToken)
@@ -64,19 +58,17 @@ internal abstract class AbstractProjectDiagnosticSource(Project project)
     private sealed class CodeAnalysisDiagnosticSource(Project project, ICodeAnalysisDiagnosticAnalyzerService codeAnalysisService)
         : AbstractProjectDiagnosticSource(project)
     {
-        /// <summary>
-        /// This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
-        /// user.  As such, it is definitely not "live" data, and it should be overridden by any subsequent fresh data
-        /// that has been produced.
-        /// </summary>
-        public override bool IsLiveSource()
-            => false;
-
         public override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
             RequestContext context,
             CancellationToken cancellationToken)
         {
-            return Task.FromResult(codeAnalysisService.GetLastComputedProjectDiagnostics(Project.Id));
+            var diagnostics = codeAnalysisService.GetLastComputedProjectDiagnostics(Project.Id);
+
+            //This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
+            // user.  As such, it is definitely not "live" data, and it should be overridden by any subsequent fresh data
+            // that has been produced.
+            diagnostics = [.. diagnostics.Select(d => d.WithCustomTags(d.CustomTags.Add(WellKnownDiagnosticTags.Build)))];
+            return Task.FromResult(diagnostics);
         }
     }
 }

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractProjectDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractProjectDiagnosticSource.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
@@ -64,10 +64,10 @@ internal abstract class AbstractProjectDiagnosticSource(Project project)
         {
             var diagnostics = codeAnalysisService.GetLastComputedProjectDiagnostics(Project.Id);
 
-            //This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
+            // This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
             // user.  As such, it is definitely not "live" data, and it should be overridden by any subsequent fresh data
             // that has been produced.
-            diagnostics = [.. diagnostics.Select(d => d.WithCustomTags(d.CustomTags.Add(WellKnownDiagnosticTags.Build)))];
+            diagnostics = ProtocolConversions.AddBuildTagIfNotPresent(diagnostics);
             return Task.FromResult(diagnostics);
         }
     }

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractWorkspaceDocumentDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractWorkspaceDocumentDiagnosticSource.cs
@@ -92,10 +92,10 @@ internal abstract class AbstractWorkspaceDocumentDiagnosticSource(TextDocument d
         {
             var diagnostics = codeAnalysisService.GetLastComputedDocumentDiagnostics(Document.Id);
 
-            //This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
+            // This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
             // user.  As such, it is definitely not "live" data, and it should be overridden by any subsequent fresh data
             // that has been produced.
-            diagnostics = [.. diagnostics.Select(d => d.WithCustomTags(d.CustomTags.Add(WellKnownDiagnosticTags.Build)))];
+            diagnostics = ProtocolConversions.AddBuildTagIfNotPresent(diagnostics);
             return Task.FromResult(diagnostics);
         }
     }

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractWorkspaceDocumentDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractWorkspaceDocumentDiagnosticSource.cs
@@ -32,12 +32,6 @@ internal abstract class AbstractWorkspaceDocumentDiagnosticSource(TextDocument d
         /// </summary>
         private static readonly ConditionalWeakTable<Project, AsyncLazy<ILookup<DocumentId, DiagnosticData>>> s_projectToDiagnostics = new();
 
-        /// <summary>
-        /// This is a normal document source that represents live/fresh diagnostics that should supersede everything else.
-        /// </summary>
-        public override bool IsLiveSource()
-            => true;
-
         public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
             RequestContext context,
             CancellationToken cancellationToken)
@@ -92,19 +86,17 @@ internal abstract class AbstractWorkspaceDocumentDiagnosticSource(TextDocument d
     private sealed class CodeAnalysisDiagnosticSource(TextDocument document, ICodeAnalysisDiagnosticAnalyzerService codeAnalysisService)
         : AbstractWorkspaceDocumentDiagnosticSource(document)
     {
-        /// <summary>
-        /// This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
-        /// user.  As such, it is definitely not "live" data, and it should be overridden by any subsequent fresh data
-        /// that has been produced.
-        /// </summary>
-        public override bool IsLiveSource()
-            => false;
-
         public override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
             RequestContext context,
             CancellationToken cancellationToken)
         {
-            return Task.FromResult(codeAnalysisService.GetLastComputedDocumentDiagnostics(Document.Id));
+            var diagnostics = codeAnalysisService.GetLastComputedDocumentDiagnostics(Document.Id);
+
+            //This source provides the results of the *last* explicitly kicked off "run code analysis" command from the
+            // user.  As such, it is definitely not "live" data, and it should be overridden by any subsequent fresh data
+            // that has been produced.
+            diagnostics = [.. diagnostics.Select(d => d.WithCustomTags(d.CustomTags.Add(WellKnownDiagnosticTags.Build)))];
+            return Task.FromResult(diagnostics);
         }
     }
 }

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
@@ -15,12 +15,6 @@ internal sealed class DocumentDiagnosticSource(DiagnosticKind diagnosticKind, Te
 {
     public DiagnosticKind DiagnosticKind { get; } = diagnosticKind;
 
-    /// <summary>
-    /// This is a normal document source that represents live/fresh diagnostics that should supersede everything else.
-    /// </summary>
-    public override bool IsLiveSource()
-        => true;
-
     public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         RequestContext context, CancellationToken cancellationToken)
     {

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
@@ -29,7 +29,6 @@ internal interface IDiagnosticSource
     /// errors from the past, we do want them to be superseded by a more recent live run, or a more recent build from
     /// another source.
     /// </summary>
-    bool IsLiveSource();
 
     Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         RequestContext context,

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
@@ -20,16 +20,6 @@ internal interface IDiagnosticSource
     ProjectOrDocumentId GetId();
     TextDocumentIdentifier? GetDocumentIdentifier();
     string ToDisplayString();
-
-    /// <summary>
-    /// True if this source produces diagnostics that are considered 'live' or not.  Live errors represent up to date
-    /// information that should supersede other sources.  Non 'live' errors (aka "build errors") are recognized to
-    /// potentially represent stale results from a point in the past when the computation occurred.  An example of when
-    /// Roslyn produces non-live errors is with an explicit user gesture to "run code analysis". Because these represent
-    /// errors from the past, we do want them to be superseded by a more recent live run, or a more recent build from
-    /// another source.
-    /// </summary>
-
     Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         RequestContext context,
         CancellationToken cancellationToken);

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/NonLocalDocumentDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/NonLocalDocumentDiagnosticSource.cs
@@ -16,9 +16,6 @@ internal sealed class NonLocalDocumentDiagnosticSource(
 {
     private readonly Func<DiagnosticAnalyzer, bool>? _shouldIncludeAnalyzer = shouldIncludeAnalyzer;
 
-    public override bool IsLiveSource()
-        => true;
-
     public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         RequestContext context,
         CancellationToken cancellationToken)

--- a/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/TaskListDiagnosticSource.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/TaskListDiagnosticSource.cs
@@ -29,9 +29,6 @@ internal sealed class TaskListDiagnosticSource(Document document, IGlobalOptionS
 
     private readonly IGlobalOptionService _globalOptions = globalOptions;
 
-    public override bool IsLiveSource()
-        => true;
-
     public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         RequestContext context, CancellationToken cancellationToken)
     {

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -217,8 +217,6 @@ public sealed class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTests
 
             public Project GetProject() => textDocument.Project;
 
-            public bool IsLiveSource() => true;
-
             public string ToDisplayString() => textDocument.ToString()!;
         }
     }

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/DiagnosticsPullCacheTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/DiagnosticsPullCacheTests.cs
@@ -125,11 +125,6 @@ public sealed class DiagnosticsPullCacheTests(ITestOutputHelper testOutputHelper
                 isEnabledByDefault: true, warningLevel: 0, [], ImmutableDictionary<string, string?>.Empty,context.Document!.Project.Id,
                 new DiagnosticDataLocation(new FileLinePositionSpan(context.Document!.FilePath!, new Text.LinePosition(0, 0), new Text.LinePosition(0, 0))))]);
         }
-
-        public override bool IsLiveSource()
-        {
-            return true;
-        }
     }
 
     [Export(typeof(IDiagnosticSourceProvider)), Shared, PartNotDiscoverable]

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Diagnostics.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Diagnostics.cs
@@ -25,8 +25,6 @@ internal static class Diagnostics
             document, range: null, DiagnosticKind.All, cancellationToken).ConfigureAwait(false);
 
         var project = document.Project;
-        // isLiveSource means build might override a diagnostics, but this method is only used by tooling, so builds aren't relevant
-        const bool IsLiveSource = false;
         // Potential duplicate is only set for workspace diagnostics
         const bool PotentialDuplicate = false;
 
@@ -34,7 +32,7 @@ internal static class Diagnostics
         foreach (var diagnostic in diagnostics)
         {
             if (!diagnostic.IsSuppressed)
-                result.AddRange(ProtocolConversions.ConvertDiagnostic(diagnostic, supportsVisualStudioExtensions, project, IsLiveSource, PotentialDuplicate, globalOptionsService));
+                result.AddRange(ProtocolConversions.ConvertDiagnostic(diagnostic, supportsVisualStudioExtensions, project, PotentialDuplicate, globalOptionsService));
         }
 
         return result.ToImmutableAndFree();

--- a/src/Tools/ExternalAccess/Xaml/Internal/XamlDiagnosticSource.cs
+++ b/src/Tools/ExternalAccess/Xaml/Internal/XamlDiagnosticSource.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
 
 internal sealed class XamlDiagnosticSource(IXamlDiagnosticSource xamlDiagnosticSource, TextDocument document) : IDiagnosticSource
 {
-    bool IDiagnosticSource.IsLiveSource() => true;
     Project IDiagnosticSource.GetProject() => document.Project;
     ProjectOrDocumentId IDiagnosticSource.GetId() => new(document.Id);
     TextDocumentIdentifier? IDiagnosticSource.GetDocumentIdentifier() => new() { DocumentUri = document.GetURI() };

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -102,6 +102,11 @@ internal sealed class DiagnosticData(
             WarningLevel, CustomTags, Properties, ProjectId, location, additionalLocations,
             Language, Title, Description, HelpLink, IsSuppressed);
 
+    public DiagnosticData WithCustomTags(ImmutableArray<string> customTags)
+        => new(Id, Category, Message, Severity, DefaultSeverity, IsEnabledByDefault,
+            WarningLevel, customTags, Properties, ProjectId, DataLocation, AdditionalLocations,
+            Language, Title, Description, HelpLink, IsSuppressed);
+
     public DocumentId? DocumentId => DataLocation.DocumentId;
 
     public override bool Equals(object? obj)


### PR DESCRIPTION
Removes IsLive from the diagnostic source, and relies on diagnostic tags to correctly set the `Build` diagnostic tag.

This fixes a debug assert crash when using Razor with the latest main changes

```
2025-07-30 14:46:02.141 [error] [stderr] Process terminated. Assertion failed.
All document sources should be live
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.DiagnosticSourceManager.AggregateSourcesIfNeeded(ImmutableArray`1 sources, Boolean isDocument) in C:\Users\xiaoyuz\source\repo\roslyn\src\LanguageServer\Protocol\Handler\Diagnostics\DiagnosticSourceProviders\DiagnosticSourceManager.cs:line 109
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.DiagnosticSourceManager.CreateDiagnosticSourcesAsync(RequestContext context, String providerName, ImmutableDictionary`2 nameToProviderMap, Boolean isDocument, CancellationToken cancellationToken) in C:\Users\xiaoyuz\source\repo\roslyn\src\LanguageServer\Protocol\Handler\Diagnostics\DiagnosticSourceProviders\DiagnosticSourceManager.cs:line 95
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.DiagnosticSourceManager.CreateDiagnosticSourcesAsync(RequestContext context, String providerName, ImmutableDictionary`2 nameToProviderMap, Boolean isDocument, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.DiagnosticSourceManager.CreateDocumentDiagnosticSourcesAsync(RequestContext context, String providerName, CancellationToken cancellationToken) in C:\Users\xiaoyuz\source\repo\roslyn\src\LanguageServer\Protocol\Handler\Diagnostics\DiagnosticSourceProviders\DiagnosticSourceManager.cs:line 55
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.AbstractDocumentPullDiagnosticHandler`3.GetOrderedDiagnosticSourcesAsync(TDiagnosticsParams diagnosticsParams, String requestDiagnosticCategory, RequestContext context, CancellationToken cancellationToken) in C:\Users\xiaoyuz\source\repo\roslyn\src\LanguageServer\Protocol\Handler\Diagnostics\AbstractDocumentPullDiagnosticHandler.cs:line 50
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.AbstractPullDiagnosticHandler`3.HandleRequestAsync(TDiagnosticsParams diagnosticsParams, RequestContext context, CancellationToken cancellationToken) in C:\Users\xiaoyuz\source\repo\roslyn\src\LanguageServer\Protocol\Handler\Diagnostics\AbstractPullDiagnosticHandler.cs:line 142
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.AbstractPullDiagnosticHandler`3.HandleRequestAsync(TDiagnosticsParams diagnosticsParams, RequestContext context, CancellationToken cancellationToken)
   at Microsoft.CommonLanguageServerProtocol.Framework.QueueItem`1.StartRequestAsync[TRequest,TResponse](TRequest request, TRequestContext context, IMethodHandler handler, String language, CancellationToken cancellationToken) in C:\Users\xiaoyuz\source\repo\roslyn\src\LanguageServer\Microsoft.CommonLanguageServerProtocol.Framework\QueueItem.cs:line 191
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.CommonLanguageServerProtocol.Framework.QueueItem`1.StartRequestAsync[TRequest,TResponse](TRequest request, TRequestContext context, IMethodHandler handler, String language, CancellationToken cancellationToken)
   at Microsoft.CommonLanguageServerProtocol.Framework.RequestExecutionQueue`1.<>c__DisplayClass18_0`2.<ProcessQueueCoreAsync>b__2() in C:\Users\xiaoyuz\source\repo\roslyn\src\LanguageServer\Microsoft.CommonLanguageServerProtocol.Framework\RequestExecutionQueue.cs:line 378
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```

this bug was revealed in https://github.com/dotnet/roslyn/pull/79421 when a non-live doc diagnostic source was added