### PR TITLE
Remove untriaged label automation

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -277,34 +277,6 @@ configuration:
       then:
       - closeIssue
 
-    - description: Add "untriaged" label on new issues
-      triggerOnOwnActions: false
-      if:
-      - payloadType: Issues
-      - not:
-          hasLabel:
-            label: untriaged
-      - and:
-          - isAction:
-              action: Opened
-      then:
-      - addLabel:
-          label: untriaged
-
-    - description: Remove "untriaged" label from issues when closed or added to a milestone
-      triggerOnOwnActions: false
-      if:
-      - payloadType: Issues
-      - or:
-        - isAction:
-            action: Closed
-        - isPartOfAnyMilestone
-      - hasLabel:
-          label: untriaged
-      then:
-      - removeLabel:
-          label: untriaged
-          
     - description: Add breaking change doc instructions to issue
       if:
       - payloadType: Issues


### PR DESCRIPTION
The `Status` field on our project board supercedes this label. Removing it since it's no longer used.