### PR TITLE
Extensions: check for collisions

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8219,6 +8219,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Interpolated string handler arguments are not allowed in this context.</value>
   </data>
   <data name="ERR_ExtensionBlockCollision" xml:space="preserve">
-    <value>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</value>
+    <value>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8219,6 +8219,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Interpolated string handler arguments are not allowed in this context.</value>
   </data>
   <data name="ERR_ExtensionBlockCollision" xml:space="preserve">
-    <value>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</value>
+    <value>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8218,4 +8218,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_InterpolatedStringHandlerArgumentDisallowed" xml:space="preserve">
     <value>Interpolated string handler arguments are not allowed in this context.</value>
   </data>
+  <data name="ERR_ExtensionBlockCollision" xml:space="preserve">
+    <value>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2420,6 +2420,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InstanceOperatorExtensionWrongReceiverType = 9323,
         ERR_ExpressionTreeContainsExtensionBasedConditionalLogicalOperator = 9324,
         ERR_InterpolatedStringHandlerArgumentDisallowed = 9325,
+        ERR_ExtensionBlockCollision = 9326,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2532,6 +2532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_InstanceOperatorExtensionWrongReceiverType
                 or ErrorCode.ERR_ExpressionTreeContainsExtensionBasedConditionalLogicalOperator
                 or ErrorCode.ERR_InterpolatedStringHandlerArgumentDisallowed
+                or ErrorCode.ERR_ExtensionBlockCollision
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/ModuleCancellationInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/ModuleCancellationInstrumenter.cs
@@ -210,7 +210,8 @@ internal sealed class ModuleCancellationInstrumenter(
                         methodDefinition.TypeParameters,
                         typeMap1: null,
                         overload.TypeParameters,
-                        typeMap))
+                        typeMap,
+                        TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
                 {
                     var result = overload.AsMember(method.ContainingType);
                     return (result.Arity > 0) ? result.Construct(method.TypeArgumentsWithAnnotations) : result;

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/ModuleCancellationInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/ModuleCancellationInstrumenter.cs
@@ -199,7 +199,6 @@ internal sealed class ModuleCancellationInstrumenter(
                         typeMap,
                         MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
                         considerDefaultValues: false,
-                        considerScoped: false,
                         TypeComparisonKind) &&
                     MemberSignatureComparer.HaveSameReturnTypes(
                         methodDefinition,

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/ModuleCancellationInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/ModuleCancellationInstrumenter.cs
@@ -199,6 +199,7 @@ internal sealed class ModuleCancellationInstrumenter(
                         typeMap,
                         MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
                         considerDefaultValues: false,
+                        considerScoped: false,
                         TypeComparisonKind) &&
                     MemberSignatureComparer.HaveSameReturnTypes(
                         methodDefinition,

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// signatures, and we are disallowing similar overloads in source with function pointers.
         /// </summary>
         internal static bool RefKindEquals(TypeCompareKind compareKind, RefKind refKind1, RefKind refKind2)
-            => (compareKind & TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly) != 0
+            => (compareKind & TypeCompareKind.FunctionPointerRefOutInRefReadonlyMatch) != 0
                ? (refKind1 == RefKind.None) == (refKind2 == RefKind.None)
                : refKind1 == refKind2;
 

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -43,14 +43,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerCallingConvention: true,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -70,14 +64,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: true,
             considerReturnType: true,
-            considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -89,14 +77,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: true,
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions); //shouldn't actually matter for source members
 
         /// <summary>
@@ -111,14 +93,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: true,
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
+            refKindCompareMode: RefKindCompareMode.RefOutInRefReadonlyMatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -129,14 +105,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: true,
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -147,14 +117,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: true,
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -165,14 +129,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: true,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.ObliviousNullableModifierMatchesAny);
 
         /// <summary>
@@ -183,14 +141,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: false,
-            considerDefaultValues: false,
+            considerArity: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -202,14 +155,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: false,
-            considerDefaultValues: false,
+            considerArity: false,
             typeComparison: TypeCompareKind.AllNullableIgnoreOptions);
 
         /// <summary>
@@ -219,14 +167,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -237,14 +179,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
+            refKindCompareMode: RefKindCompareMode.RefOutInRefReadonlyMatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreTupleNames);
 
         /// <summary>
@@ -255,14 +191,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
+            refKindCompareMode: RefKindCompareMode.RefOutInRefReadonlyMatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -273,14 +203,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false, //Bug: DevDiv #15775
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -292,14 +216,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -310,14 +228,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
+            refKindCompareMode: RefKindCompareMode.RefOutInRefReadonlyMatch,
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -330,14 +242,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
+            refKindCompareMode: RefKindCompareMode.RefOutInRefReadonlyMatch,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -347,14 +253,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
+            refKindCompareMode: RefKindCompareMode.RefOutInRefReadonlyMatch,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -366,14 +266,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -384,14 +278,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: true,
             considerReturnType: true,
-            considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
+            refKindCompareMode: RefKindCompareMode.RefOutInRefReadonlyMatch,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -401,14 +289,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: true,
             considerExplicitlyImplementedInterfaces: false, //we'll be comparing interface members anyway
             considerReturnType: true,
-            considerTypeConstraints: false,
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers); //if it was a true explicit impl, we expect it to remain so after retargeting
 
         /// <summary>
@@ -419,14 +301,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false, //handled by lookup
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: false,
-            considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -436,13 +312,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
+            considerArity: true,
             considerDefaultValues: true,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -453,51 +325,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
-            considerTypeConstraints: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: false,
+            considerArity: false,
             considerDefaultValues: true,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
-
-        /// <summary>
-        /// This instance is used to determine if two source extension blocks match in IL sense and thus are allowed to share a grouping type.
-        /// It ignores parameter and type parameter names, parameter ref kind, C#-isms in type constraints, nullability and attributes.
-        /// </summary>
-        public static readonly MemberSignatureComparer ExtensionILSignatureComparer = new MemberSignatureComparer(
-            considerName: false,
-            considerExplicitlyImplementedInterfaces: false,
-            considerReturnType: false,
-            considerTypeConstraints: true,
-            considerCallingConvention: false,
-            refKindCompareMode: RefKindCompareMode.IgnoreRefKind,
-            considerTypeParameterAndParameterNames: false,
-            considerScoped: false,
-            considerAttributes: false,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
-            typeComparison: TypeCompareKind.AllIgnoreOptions);
-
-        /// <summary>
-        /// This instance is used to determine if two source extension blocks match in C# sense and thus are allowed to share a marker type.
-        /// It considers parameter and type parameter names, type constraints, nullability and attributes.
-        /// </summary>
-        public static readonly MemberSignatureComparer ExtensionCSharpSignatureComparer = new MemberSignatureComparer(
-            considerName: false,
-            considerExplicitlyImplementedInterfaces: false,
-            considerReturnType: false,
-            considerTypeConstraints: true,
-            considerCallingConvention: false,
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerTypeParameterAndParameterNames: true,
-            considerScoped: true,
-            considerAttributes: true,
-            considerTypeParameters: true,
-            considerDefaultValues: false,
-            typeComparison: TypeCompareKind.ConsiderEverything);
 
         // Compare the "unqualified" part of the member name (no explicit part)
         private readonly bool _considerName;
@@ -508,11 +340,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Compare the type symbols of the return types
         private readonly bool _considerReturnType;
 
-        // Compare the type constraints
-        private readonly bool _considerTypeConstraints;
-
-        // Compare the type parameters (arity, and potentially names, attributes and constraints, depending on other settings)
-        private readonly bool _considerTypeParameters;
+        // Compare the arity (type parameter count)
+        private readonly bool _considerArity;
 
         // Compare the full calling conventions.  Still compares varargs if false.
         private readonly bool _considerCallingConvention;
@@ -525,56 +354,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Equality options for parameter types and return types (if return is considered).
         private readonly TypeCompareKind _typeComparison;
 
-        // Compare parameter and type parameter names
-        private readonly bool _considerTypeParameterAndParameterNames;
-
-        // Compare declared scopedness of parameters (only valid on source symbols)
-        private readonly bool _considerScoped;
-
-        // Compare attributes too.
-        // Note: the order of named arguments is ignored
-        private readonly bool _considerAttributes;
-
         private MemberSignatureComparer(
             bool considerName,
             bool considerExplicitlyImplementedInterfaces,
             bool considerReturnType,
-            bool considerTypeConstraints,
             bool considerCallingConvention,
             RefKindCompareMode refKindCompareMode,
-            bool considerTypeParameterAndParameterNames,
-            bool considerScoped,
-            bool considerAttributes,
-            bool considerTypeParameters,
-            bool considerDefaultValues, TypeCompareKind typeComparison)
+            bool considerArity = true,
+            bool considerDefaultValues = false,
+            TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreNativeIntegers)
         {
             Debug.Assert(!considerExplicitlyImplementedInterfaces || considerName, "Doesn't make sense to consider interfaces separately from name.");
-            Debug.Assert(!considerTypeConstraints || considerTypeParameters, "If you consider type constraints, you must also consider type parameters");
 
             _considerName = considerName;
             _considerExplicitlyImplementedInterfaces = considerExplicitlyImplementedInterfaces;
             _considerReturnType = considerReturnType;
-            _considerTypeConstraints = considerTypeConstraints;
             _considerCallingConvention = considerCallingConvention;
             _refKindCompareMode = refKindCompareMode;
-            _considerTypeParameters = considerTypeParameters;
+            _considerArity = considerArity;
             _considerDefaultValues = considerDefaultValues;
             _typeComparison = typeComparison;
-            Debug.Assert((_typeComparison & TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly) == 0,
+            Debug.Assert((_typeComparison & TypeCompareKind.FunctionPointerRefOutInRefReadonlyMatch) == 0,
                          $"Rely on the {nameof(refKindCompareMode)} flag to set this to ensure all cases are handled.");
-            Debug.Assert(_refKindCompareMode == RefKindCompareMode.RefMatchesOutInRefReadonly ||
-                _refKindCompareMode == RefKindCompareMode.IgnoreRefKind ||
+            Debug.Assert(_refKindCompareMode == RefKindCompareMode.RefOutInRefReadonlyMatch ||
                 (_refKindCompareMode & RefKindCompareMode.ConsiderDifferences) != 0,
                 $"Cannot set {nameof(RefKindCompareMode)} flags without {nameof(RefKindCompareMode.ConsiderDifferences)}.");
-
-            if (refKindCompareMode == RefKindCompareMode.RefMatchesOutInRefReadonly)
+            if ((refKindCompareMode & RefKindCompareMode.ConsiderDifferences) == 0)
             {
-                _typeComparison |= TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly;
+                _typeComparison |= TypeCompareKind.FunctionPointerRefOutInRefReadonlyMatch;
             }
-
-            _considerTypeParameterAndParameterNames = considerTypeParameterAndParameterNames;
-            _considerScoped = considerScoped;
-            _considerAttributes = considerAttributes;
         }
 
         #region IEqualityComparer<Symbol> Members
@@ -591,227 +399,105 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            bool equals = equalsSlow(member1, member2);
-            Debug.Assert(!equals || GetHashCode(member1) == GetHashCode(member2), "If symbols are equal for some options, their hashes must be equal for those same options.");
-            return equals;
+            bool sawInterfaceInName1 = false;
+            bool sawInterfaceInName2 = false;
 
-            bool equalsSlow(Symbol member1, Symbol member2)
+            if (_considerName)
             {
-                bool sawInterfaceInName1 = false;
-                bool sawInterfaceInName2 = false;
+                string name1 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member1.Name);
+                string name2 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member2.Name);
 
-                if (_considerName)
+                sawInterfaceInName1 = name1 != member1.Name;
+                sawInterfaceInName2 = name2 != member2.Name;
+
+                if (name1 != name2)
                 {
-                    string name1 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member1.Name);
-                    string name2 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member2.Name);
-
-                    sawInterfaceInName1 = name1 != member1.Name;
-                    sawInterfaceInName2 = name2 != member2.Name;
-
-                    if (name1 != name2)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
+            }
 
-                // NB: up to, and including, this check, we have not actually forced the (type) parameters
-                // to be expanded - we're only using the counts.
-                if (_considerTypeParameters)
+            // NB: up to, and including, this check, we have not actually forced the (type) parameters
+            // to be expanded - we're only using the counts.
+            if (_considerArity && (member1.GetMemberArity() != member2.GetMemberArity()))
+            {
+                return false;
+            }
+
+            if (member1.GetParameterCount() != member2.GetParameterCount())
+            {
+                return false;
+            }
+
+            TypeMap? typeMap1 = GetTypeMap(member1);
+            TypeMap? typeMap2 = GetTypeMap(member2);
+
+            if (_considerReturnType && !HaveSameReturnTypes(member1, typeMap1, member2, typeMap2, _typeComparison))
+            {
+                return false;
+            }
+
+            if (member1.GetParameterCount() > 0 && !HaveSameParameterTypes(member1.GetParameters().AsSpan(), typeMap1, member2.GetParameters().AsSpan(), typeMap2,
+                                                                           _refKindCompareMode, considerDefaultValues: _considerDefaultValues, _typeComparison))
+            {
+                return false;
+            }
+
+            if (_considerCallingConvention)
+            {
+                if (GetCallingConvention(member1) != GetCallingConvention(member2))
                 {
-                    if (member1.GetMemberArity() != member2.GetMemberArity())
-                    {
-                        return false;
-                    }
-
-                    if (member1.GetMemberArity() > 0 && (_considerTypeParameterAndParameterNames || _considerAttributes))
-                    {
-                        ImmutableArray<TypeParameterSymbol> typeParams1 = member1.GetMemberTypeParameters();
-                        ImmutableArray<TypeParameterSymbol> typeParams2 = member2.GetMemberTypeParameters();
-
-                        if (_considerTypeParameterAndParameterNames && !haveSameTypeParameterNames(typeParams1, typeParams2))
-                        {
-                            return false;
-                        }
-
-                        if (_considerAttributes && !haveSameTypeParameterAttributes(typeParams1, typeParams2))
-                        {
-                            return false;
-                        }
-                    }
+                    return false;
                 }
+            }
+            else
+            {
+                if (IsVarargMethod(member1) != IsVarargMethod(member2))
+                {
+                    return false;
+                }
+            }
 
-                if (GetParameterCountIncludingParameterOfExtension(member1) != GetParameterCountIncludingParameterOfExtension(member2))
+            if (_considerExplicitlyImplementedInterfaces)
+            {
+                if (sawInterfaceInName1 != sawInterfaceInName2)
                 {
                     return false;
                 }
 
-                TypeMap? typeMap1 = GetTypeMap(member1);
-                TypeMap? typeMap2 = GetTypeMap(member2);
-
-                if (_considerReturnType && !HaveSameReturnTypes(member1, typeMap1, member2, typeMap2, _typeComparison))
+                // The purpose of this check is to determine whether the interface parts of the member names agree,
+                // but to do so using robust symbolic checks, rather than syntactic ones.  Therefore, if neither member
+                // name contains an interface name, this check is not relevant.  
+                // Phrased differently, the explicitly implemented interface is not part of the signature unless it's
+                // part of the name.
+                if (sawInterfaceInName1)
                 {
-                    return false;
-                }
+                    Debug.Assert(sawInterfaceInName2);
 
-                if (GetParameterCountIncludingParameterOfExtension(member1) > 0)
-                {
-                    var params1 = getParametersIncludingParameterOfExtension(member1);
-                    var params2 = getParametersIncludingParameterOfExtension(member2);
-                    if (!HaveSameParameterTypes(params1.AsSpan(), typeMap1, params2.AsSpan(), typeMap2,
-                        _refKindCompareMode, considerDefaultValues: _considerDefaultValues, considerScoped: _considerScoped, _typeComparison))
+                    // May avoid realizing interface members.
+                    if (member1.IsExplicitInterfaceImplementation() != member2.IsExplicitInterfaceImplementation())
                     {
                         return false;
                     }
 
-                    if (_considerTypeParameterAndParameterNames && !haveSameParameterNames(params1, params2))
-                    {
-                        return false;
-                    }
+                    // By comparing symbols, rather than syntax, we gain the flexibility of ignoring whitespace
+                    // and gracefully accepting multiple names for the same (or equivalent) types (e.g. "I<int>.M"
+                    // vs "I<System.Int32>.M"), but we lose the connection with the name.  For example, in metadata,
+                    // a method name "I.M" could have nothing to do with "I" but explicitly implement interface "I2".
+                    // We will behave as if the method was really named "I2.M".  Furthermore, in metadata, a method
+                    // can explicitly implement more than one interface method, in which case it doesn't really
+                    // make sense to pretend that all of them are part of the signature.
 
-                    if (_considerAttributes && !haveSameParameterAttributes(params1, params2))
-                    {
-                        return false;
-                    }
-                }
+                    var explicitInterfaceImplementations1 = member1.GetExplicitInterfaceImplementations();
+                    var explicitInterfaceImplementations2 = member2.GetExplicitInterfaceImplementations();
 
-                if (_considerCallingConvention)
-                {
-                    if (GetCallingConvention(member1) != GetCallingConvention(member2))
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    if (IsVarargMethod(member1) != IsVarargMethod(member2))
+                    if (!explicitInterfaceImplementations1.SetEquals(explicitInterfaceImplementations2, SymbolEqualityComparer.ConsiderEverything))
                     {
                         return false;
                     }
                 }
-
-                if (_considerExplicitlyImplementedInterfaces)
-                {
-                    if (sawInterfaceInName1 != sawInterfaceInName2)
-                    {
-                        return false;
-                    }
-
-                    // The purpose of this check is to determine whether the interface parts of the member names agree,
-                    // but to do so using robust symbolic checks, rather than syntactic ones.  Therefore, if neither member
-                    // name contains an interface name, this check is not relevant.  
-                    // Phrased differently, the explicitly implemented interface is not part of the signature unless it's
-                    // part of the name.
-                    if (sawInterfaceInName1)
-                    {
-                        Debug.Assert(sawInterfaceInName2);
-
-                        // May avoid realizing interface members.
-                        if (member1.IsExplicitInterfaceImplementation() != member2.IsExplicitInterfaceImplementation())
-                        {
-                            return false;
-                        }
-
-                        // By comparing symbols, rather than syntax, we gain the flexibility of ignoring whitespace
-                        // and gracefully accepting multiple names for the same (or equivalent) types (e.g. "I<int>.M"
-                        // vs "I<System.Int32>.M"), but we lose the connection with the name.  For example, in metadata,
-                        // a method name "I.M" could have nothing to do with "I" but explicitly implement interface "I2".
-                        // We will behave as if the method was really named "I2.M".  Furthermore, in metadata, a method
-                        // can explicitly implement more than one interface method, in which case it doesn't really
-                        // make sense to pretend that all of them are part of the signature.
-
-                        var explicitInterfaceImplementations1 = member1.GetExplicitInterfaceImplementations();
-                        var explicitInterfaceImplementations2 = member2.GetExplicitInterfaceImplementations();
-
-                        if (!explicitInterfaceImplementations1.SetEquals(explicitInterfaceImplementations2, SymbolEqualityComparer.ConsiderEverything))
-                        {
-                            return false;
-                        }
-                    }
-                }
-
-                return !_considerTypeConstraints || HaveSameConstraints(member1, typeMap1, member2, typeMap2, _typeComparison);
             }
 
-            static bool haveSameParameterNames(ImmutableArray<ParameterSymbol> params1, ImmutableArray<ParameterSymbol> params2)
-            {
-                return params1.SequenceEqual(params2, (p1, p2) => p1.Name == p2.Name);
-            }
-
-            static bool haveSameTypeParameterNames(ImmutableArray<TypeParameterSymbol> typeParams1, ImmutableArray<TypeParameterSymbol> typeParams2)
-            {
-                return typeParams1.SequenceEqual(typeParams2, (p1, p2) => p1.Name == p2.Name);
-            }
-
-            static bool haveSameParameterAttributes(ImmutableArray<ParameterSymbol> params1, ImmutableArray<ParameterSymbol> params2)
-            {
-                return params1.SequenceEqual(params2, (p1, p2) => hasSameAttribute(p1.GetAttributes(), p2.GetAttributes()));
-            }
-
-            static bool haveSameTypeParameterAttributes(ImmutableArray<TypeParameterSymbol> typeParams1, ImmutableArray<TypeParameterSymbol> typeParams2)
-            {
-                return typeParams1.SequenceEqual(typeParams2, (p1, p2) => hasSameAttribute(p1.GetAttributes(), p2.GetAttributes()));
-            }
-
-            static bool hasSameAttribute(ImmutableArray<CSharpAttributeData> attributes1, ImmutableArray<CSharpAttributeData> attributes2)
-            {
-                if (attributes1.IsEmpty && attributes2.IsEmpty)
-                {
-                    return true;
-                }
-
-                // Tracked by https://github.com/dotnet/roslyn/issues/78827 : optimization, consider using a pool
-                var comparer = CommonAttributeDataComparer.InstanceIgnoringNamedArgumentOrder;
-                var counts = new Dictionary<CSharpAttributeData, int>(comparer);
-
-                foreach (var attribute in attributes1)
-                {
-                    if (attribute.IsConditionallyOmitted)
-                    {
-                        continue;
-                    }
-
-                    counts[attribute] = counts.TryGetValue(attribute, out var foundCount) ? foundCount + 1 : 1;
-                }
-
-                foreach (var attribute in attributes2)
-                {
-                    if (attribute.IsConditionallyOmitted)
-                    {
-                        continue;
-                    }
-
-                    if (!counts.TryGetValue(attribute, out var foundCount) || foundCount == 0)
-                    {
-                        return false;
-                    }
-
-                    counts[attribute] = foundCount - 1;
-                }
-
-                return counts.Values.All(c => c == 0);
-            }
-
-            static ImmutableArray<ParameterSymbol> getParametersIncludingParameterOfExtension(Symbol member)
-            {
-                if (member is NamedTypeSymbol { IsExtension: true } namedType)
-                {
-                    return namedType.ExtensionParameter is not null
-                        ? [namedType.ExtensionParameter]
-                        : [];
-                }
-
-                return member.GetParameters();
-            }
-        }
-
-        private static int GetParameterCountIncludingParameterOfExtension(Symbol member)
-        {
-            if (member is NamedTypeSymbol { IsExtension: true } namedType)
-            {
-                return namedType.ExtensionParameter is not null ? 1 : 0;
-            }
-
-            return member.GetParameterCount();
+            return true;
         }
 
         public int GetHashCode(Symbol? member)
@@ -837,12 +523,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (member.Kind != SymbolKind.Field)
                 {
-                    if (_considerTypeParameters)
+                    if (_considerArity)
                     {
                         hash = Hash.Combine(member.GetMemberArity(), hash);
                     }
 
-                    hash = Hash.Combine(GetParameterCountIncludingParameterOfExtension(member), hash);
+                    hash = Hash.Combine(member.GetParameterCount(), hash);
                 }
             }
             return hash;
@@ -901,7 +587,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        private static TypeMap? GetTypeMap(Symbol member)
+        internal static TypeMap? GetTypeMap(Symbol member)
         {
             var typeParameters = member.GetMemberTypeParameters();
             return typeParameters.IsEmpty ?
@@ -910,21 +596,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     typeParameters,
                     IndexedTypeParameterSymbol.Take(member.GetMemberArity()),
                     true);
-        }
-
-        private static bool HaveSameConstraints(Symbol member1, TypeMap? typeMap1, Symbol member2, TypeMap? typeMap2, TypeCompareKind typeComparison)
-        {
-            Debug.Assert(member1.GetMemberArity() == member2.GetMemberArity());
-
-            int arity = member1.GetMemberArity();
-            if (arity == 0)
-            {
-                return true;
-            }
-
-            var typeParameters1 = member1.GetMemberTypeParameters();
-            var typeParameters2 = member2.GetMemberTypeParameters();
-            return HaveSameConstraints(typeParameters1, typeMap1, typeParameters2, typeMap2, typeComparison);
         }
 
         public static bool HaveSameConstraints(ImmutableArray<TypeParameterSymbol> typeParameters1, TypeMap? typeMap1, ImmutableArray<TypeParameterSymbol> typeParameters2, TypeMap? typeMap2, TypeCompareKind typeComparison)
@@ -953,12 +624,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool HaveSameConstraints(TypeParameterSymbol typeParameter1, TypeMap? typeMap1, TypeParameterSymbol typeParameter2, TypeMap? typeMap2, TypeCompareKind typeComparison)
         {
             // Spec 13.4.3: Implementation of generic methods.
-
-            if ((typeComparison & TypeCompareKind.IgnoreNullableModifiersForReferenceTypes) == 0 &&
-                typeParameter1.HasNotNullConstraint != typeParameter2.HasNotNullConstraint)
-            {
-                return false;
-            }
 
             if ((typeParameter1.HasConstructorConstraint != typeParameter2.HasConstructorConstraint) ||
                 (typeParameter1.HasReferenceTypeConstraint != typeParameter2.HasReferenceTypeConstraint) ||
@@ -1003,40 +668,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool HaveSameNullabilityInConstraints(TypeParameterSymbol typeParameter1, TypeMap? typeMap1, TypeParameterSymbol typeParameter2, TypeMap? typeMap2, TypeCompareKind typeComparison)
         {
             if (!typeParameter1.IsValueType
-                && !hasSameLevelNullability(typeParameter1, typeParameter2, typeComparison))
+                && !hasSameTopLevelNullability(typeParameter1, typeParameter2, typeComparison))
             {
                 return false;
             }
 
             return HaveSameTypeConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, SymbolEqualityComparer.Create(typeComparison));
 
-            static bool hasSameLevelNullability(TypeParameterSymbol typeParameter1, TypeParameterSymbol typeParameter2, TypeCompareKind typeComparison)
+            static bool hasSameTopLevelNullability(TypeParameterSymbol typeParameter1, TypeParameterSymbol typeParameter2, TypeCompareKind typeComparison)
             {
                 bool? isNotNullable1 = typeParameter1.IsNotNullable;
                 bool? isNotNullable2 = typeParameter2.IsNotNullable;
 
-                if ((typeComparison & TypeCompareKind.ObliviousNullableModifierMatchesAny) != 0)
+                bool isOblivious1 = !isNotNullable1.HasValue;
+                bool isOblivious2 = !isNotNullable2.HasValue;
+                if (isOblivious1 || isOblivious2)
                 {
-                    if (!isNotNullable1.HasValue || !isNotNullable2.HasValue)
+                    if ((typeComparison & TypeCompareKind.ObliviousNullableModifierMatchesAny) != 0)
                     {
                         return true;
                     }
-                }
-                else
-                {
-                    if (!isNotNullable1.HasValue || !isNotNullable2.HasValue)
+                    else
                     {
-                        return !isNotNullable1.HasValue && !isNotNullable2.HasValue;
+                        return isOblivious1 && isOblivious2;
                     }
                 }
 
-                if (isNotNullable1.HasValue && isNotNullable2.HasValue &&
-                    isNotNullable1.GetValueOrDefault() != isNotNullable2.GetValueOrDefault())
-                {
-                    return false;
-                }
-
-                return true;
+                Debug.Assert(isNotNullable1.HasValue && isNotNullable2.HasValue);
+                return isNotNullable1.GetValueOrDefault() == isNotNullable2.GetValueOrDefault();
             }
         }
 
@@ -1089,7 +748,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeMap? typeMap2,
             RefKindCompareMode refKindCompareMode,
             bool considerDefaultValues,
-            bool considerScoped,
             TypeCompareKind typeComparison)
         {
             Debug.Assert(params1.Length == params2.Length);
@@ -1098,7 +756,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int i = 0; i < numParams; i++)
             {
-                if (!HaveSameParameterType(params1[i], typeMap1, params2[i], typeMap2, refKindCompareMode, considerDefaultValues, considerScoped, typeComparison))
+                if (!HaveSameParameterType(params1[i], typeMap1, params2[i], typeMap2, refKindCompareMode, considerDefaultValues, typeComparison))
                 {
                     return false;
                 }
@@ -1114,7 +772,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeMap? typeMap2,
             RefKindCompareMode refKindCompareMode,
             bool considerDefaultValues,
-            bool considerScoped,
             TypeCompareKind typeComparison)
         {
             var type1 = SubstituteType(typeMap1, param1.TypeWithAnnotations);
@@ -1130,11 +787,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            if (considerScoped && param1.DeclaredScope != param2.DeclaredScope)
-            {
-                return false;
-            }
-
             if ((typeComparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) == 0 &&
                 !HaveSameCustomModifiers(param1.RefCustomModifiers, typeMap1, param2.RefCustomModifiers, typeMap2))
             {
@@ -1145,23 +797,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var refKind2 = param2.RefKind;
 
             // Metadata signatures don't distinguish ref/out, but C# does - even when comparing metadata method signatures.
-            if ((refKindCompareMode & RefKindCompareMode.ConsiderDifferences) != 0)
+            if (refKindCompareMode != RefKindCompareMode.IgnoreRefKind)
             {
-                if (!areRefKindsCompatible(refKindCompareMode, refKind1, refKind2))
+                if ((refKindCompareMode & RefKindCompareMode.ConsiderDifferences) != 0)
                 {
-                    return false;
+                    if (!areRefKindsCompatible(refKindCompareMode, refKind1, refKind2))
+                    {
+                        return false;
+                    }
                 }
-            }
-            else if (refKindCompareMode == RefKindCompareMode.RefMatchesOutInRefReadonly)
-            {
-                if ((refKind1 == RefKind.None) != (refKind2 == RefKind.None))
+                else
                 {
-                    return false;
+                    Debug.Assert(refKindCompareMode == RefKindCompareMode.RefOutInRefReadonlyMatch);
+                    if ((refKind1 == RefKind.None) != (refKind2 == RefKind.None))
+                    {
+                        return false;
+                    }
                 }
-            }
-            else
-            {
-                Debug.Assert(refKindCompareMode == RefKindCompareMode.IgnoreRefKind);
             }
 
             return true;
@@ -1242,7 +894,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             /// <summary>
             /// All ref modifiers are considered equivalent.
             /// </summary>
-            RefMatchesOutInRefReadonly = 0,
+            RefOutInRefReadonlyMatch = 0,
 
             /// <summary>
             /// Parameters with different ref modifiers are considered different.

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerCallingConvention: true,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -73,6 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -91,6 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -112,6 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -129,6 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -146,6 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -163,6 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -180,6 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: false,
             considerDefaultValues: false,
@@ -198,6 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: false,
             considerDefaultValues: false,
@@ -214,6 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -231,6 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -248,6 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -265,6 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -283,6 +296,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -300,6 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -319,6 +334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -335,6 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -353,6 +370,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -370,6 +388,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -386,6 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -403,6 +423,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -419,6 +440,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: true,
@@ -435,13 +457,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: false,
             considerDefaultValues: true,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
-        /// This instance is used to determine if two extension blocks match in IL sense and thus are allowed to share a grouping type.
+        /// This instance is used to determine if two source extension blocks match in IL sense and thus are allowed to share a grouping type.
         /// It ignores parameter and type parameter names, parameter ref kind, C#-isms in type constraints, nullability and attributes.
         /// </summary>
         public static readonly MemberSignatureComparer ExtensionILSignatureComparer = new MemberSignatureComparer(
@@ -452,13 +475,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.IgnoreRefKind,
             considerTypeParameterAndParameterNames: false,
+            considerScoped: false,
             considerAttributes: false,
             considerTypeParameters: true,
             considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
-        /// This instance is used to determine if two extension blocks match in C# sense and thus are allowed to share a marker type.
+        /// This instance is used to determine if two source extension blocks match in C# sense and thus are allowed to share a marker type.
         /// It considers parameter and type parameter names, type constraints, nullability and attributes.
         /// </summary>
         public static readonly MemberSignatureComparer ExtensionCSharpSignatureComparer = new MemberSignatureComparer(
@@ -469,6 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerTypeParameterAndParameterNames: true,
+            considerScoped: true,
             considerAttributes: true,
             considerTypeParameters: true,
             considerDefaultValues: false,
@@ -501,7 +526,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly TypeCompareKind _typeComparison;
 
         // Compare parameter and type parameter names
-        private readonly bool _considerParameterNames;
+        private readonly bool _considerTypeParameterAndParameterNames;
+
+        // Compare declared scopedness of parameters (only valid on source symbols)
+        private readonly bool _considerScoped;
 
         // Compare attributes too.
         // Note: the order of named arguments is ignored
@@ -515,10 +543,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool considerCallingConvention,
             RefKindCompareMode refKindCompareMode,
             bool considerTypeParameterAndParameterNames,
+            bool considerScoped,
             bool considerAttributes,
             bool considerTypeParameters,
-            bool considerDefaultValues,
-            TypeCompareKind typeComparison)
+            bool considerDefaultValues, TypeCompareKind typeComparison)
         {
             Debug.Assert(!considerExplicitlyImplementedInterfaces || considerName, "Doesn't make sense to consider interfaces separately from name.");
             Debug.Assert(!considerTypeConstraints || considerTypeParameters, "If you consider type constraints, you must also consider type parameters");
@@ -544,7 +572,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _typeComparison |= TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly;
             }
 
-            _considerParameterNames = considerTypeParameterAndParameterNames;
+            _considerTypeParameterAndParameterNames = considerTypeParameterAndParameterNames;
+            _considerScoped = considerScoped;
             _considerAttributes = considerAttributes;
         }
 
@@ -594,12 +623,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         return false;
                     }
 
-                    if (member1.GetMemberArity() > 0 && (_considerParameterNames || _considerAttributes))
+                    if (member1.GetMemberArity() > 0 && (_considerTypeParameterAndParameterNames || _considerAttributes))
                     {
                         ImmutableArray<TypeParameterSymbol> typeParams1 = member1.GetMemberTypeParameters();
                         ImmutableArray<TypeParameterSymbol> typeParams2 = member2.GetMemberTypeParameters();
 
-                        if (_considerParameterNames && !haveSameTypeParameterNames(typeParams1, typeParams2))
+                        if (_considerTypeParameterAndParameterNames && !haveSameTypeParameterNames(typeParams1, typeParams2))
                         {
                             return false;
                         }
@@ -629,12 +658,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var params1 = getParametersIncludingParameterOfExtension(member1);
                     var params2 = getParametersIncludingParameterOfExtension(member2);
                     if (!HaveSameParameterTypes(params1.AsSpan(), typeMap1, params2.AsSpan(), typeMap2,
-                        _refKindCompareMode, considerDefaultValues: _considerDefaultValues, _typeComparison))
+                        _refKindCompareMode, considerDefaultValues: _considerDefaultValues, considerScoped: _considerScoped, _typeComparison))
                     {
                         return false;
                     }
 
-                    if (_considerParameterNames && !haveSameParameterNames(params1, params2))
+                    if (_considerTypeParameterAndParameterNames && !haveSameParameterNames(params1, params2))
                     {
                         return false;
                     }
@@ -1060,6 +1089,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeMap? typeMap2,
             RefKindCompareMode refKindCompareMode,
             bool considerDefaultValues,
+            bool considerScoped,
             TypeCompareKind typeComparison)
         {
             Debug.Assert(params1.Length == params2.Length);
@@ -1068,7 +1098,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int i = 0; i < numParams; i++)
             {
-                if (!HaveSameParameterType(params1[i], typeMap1, params2[i], typeMap2, refKindCompareMode, considerDefaultValues, typeComparison))
+                if (!HaveSameParameterType(params1[i], typeMap1, params2[i], typeMap2, refKindCompareMode, considerDefaultValues, considerScoped, typeComparison))
                 {
                     return false;
                 }
@@ -1084,6 +1114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeMap? typeMap2,
             RefKindCompareMode refKindCompareMode,
             bool considerDefaultValues,
+            bool considerScoped,
             TypeCompareKind typeComparison)
         {
             var type1 = SubstituteType(typeMap1, param1.TypeWithAnnotations);
@@ -1095,6 +1126,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if (considerDefaultValues && param1.ExplicitDefaultConstantValue != param2.ExplicitDefaultConstantValue)
+            {
+                return false;
+            }
+
+            if (considerScoped && param1.DeclaredScope != param2.DeclaredScope)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -440,7 +440,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerDefaultValues: true,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
-
         /// <summary>
         /// This instance is used to determine if two extension blocks match in IL sense and thus are allowed to share a grouping type.
         /// It ignores parameter and type parameter names, parameter ref kind, C#-isms in type constraints, nullability and attributes.

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -600,7 +600,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         ImmutableArray<TypeParameterSymbol> typeParams1 = member1.GetMemberTypeParameters();
                         ImmutableArray<TypeParameterSymbol> typeParams2 = member2.GetMemberTypeParameters();
 
-                        if (_considerParameterNames && typeParams1.Length > 0 && !haveSameTypeParameterNames(typeParams1, typeParams2))
+                        if (_considerParameterNames && !haveSameTypeParameterNames(typeParams1, typeParams2))
                         {
                             return false;
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -46,6 +46,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerCallingConvention: true,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -68,6 +72,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -82,6 +90,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions); //shouldn't actually matter for source members
 
         /// <summary>
@@ -98,7 +110,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -112,6 +128,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -125,6 +145,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -138,6 +162,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.ObliviousNullableModifierMatchesAny);
 
         /// <summary>
@@ -151,7 +179,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerArity: false,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: false,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -166,7 +197,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            considerArity: false,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: false,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllNullableIgnoreOptions);
 
         /// <summary>
@@ -179,6 +213,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -191,7 +229,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreTupleNames);
 
         /// <summary>
@@ -204,7 +246,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -218,6 +264,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -232,6 +282,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -244,7 +298,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -259,7 +317,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -271,7 +333,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -286,6 +352,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -298,7 +368,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.RefMatchesOutInRefReadonly,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -311,6 +385,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers); //if it was a true explicit impl, we expect it to remain so after retargeting
 
         /// <summary>
@@ -324,6 +402,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -336,7 +418,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
-            considerArity: true,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
             considerDefaultValues: true,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -350,24 +434,46 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
-            considerArity: false,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: false,
             considerDefaultValues: true,
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
+
+
+        /// <summary>
+        /// This instance is used to determine if two extension blocks match in IL sense and thus are allowed to share a grouping type.
+        /// It ignores parameter and type parameter names, parameter ref kind, C#-isms in type constraints, nullability and attributes.
+        /// </summary>
+        public static readonly MemberSignatureComparer ExtensionILSignatureComparer = new MemberSignatureComparer(
+            considerName: false,
+            considerExplicitlyImplementedInterfaces: false,
+            considerReturnType: false,
+            considerTypeConstraints: true,
+            considerCallingConvention: false,
+            refKindCompareMode: RefKindCompareMode.IgnoreRefKind,
+            considerTypeParameterAndParameterNames: false,
+            considerAttributes: false,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
         /// This instance is used to determine if two extension blocks match in C# sense and thus are allowed to share a marker type.
         /// It considers parameter and type parameter names, type constraints, nullability and attributes.
         /// </summary>
-        public static readonly MemberSignatureComparer ExtensionSignatureComparer = new MemberSignatureComparer(
+        public static readonly MemberSignatureComparer ExtensionCSharpSignatureComparer = new MemberSignatureComparer(
             considerName: false,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: false,
             considerTypeConstraints: true,
             considerCallingConvention: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
-            typeComparison: TypeCompareKind.ConsiderEverything,
-            considerParameterNames: true,
-            considerAttributes: true);
+            considerTypeParameterAndParameterNames: true,
+            considerAttributes: true,
+            considerTypeParameters: true,
+            considerDefaultValues: false,
+            typeComparison: TypeCompareKind.ConsiderEverything);
 
         // Compare the "unqualified" part of the member name (no explicit part)
         private readonly bool _considerName;
@@ -381,8 +487,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Compare the type constraints
         private readonly bool _considerTypeConstraints;
 
-        // Compare the arity (type parameter count)
-        private readonly bool _considerArity;
+        // Compare the type parameters (arity, and potentially names, attributes and constraints, depending on other settings)
+        private readonly bool _considerTypeParameters;
 
         // Compare the full calling conventions.  Still compares varargs if false.
         private readonly bool _considerCallingConvention;
@@ -398,6 +504,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Compare parameter and type parameter names
         private readonly bool _considerParameterNames;
 
+        // Compare attributes too.
+        // Note: the order of named arguments is ignored
         private readonly bool _considerAttributes;
 
         private MemberSignatureComparer(
@@ -407,14 +515,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool considerTypeConstraints,
             bool considerCallingConvention,
             RefKindCompareMode refKindCompareMode,
-            bool considerArity = true,
-            bool considerDefaultValues = false,
-            TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreNativeIntegers,
-            bool considerParameterNames = false,
-            bool considerAttributes = false)
+            bool considerTypeParameterAndParameterNames,
+            bool considerAttributes,
+            bool considerTypeParameters,
+            bool considerDefaultValues,
+            TypeCompareKind typeComparison)
         {
             Debug.Assert(!considerExplicitlyImplementedInterfaces || considerName, "Doesn't make sense to consider interfaces separately from name.");
-            Debug.Assert(!considerTypeConstraints || considerArity, "If you consider type constraints, you must also consider arity");
+            Debug.Assert(!considerTypeConstraints || considerTypeParameters, "If you consider type constraints, you must also consider type parameters");
 
             _considerName = considerName;
             _considerExplicitlyImplementedInterfaces = considerExplicitlyImplementedInterfaces;
@@ -422,20 +530,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _considerTypeConstraints = considerTypeConstraints;
             _considerCallingConvention = considerCallingConvention;
             _refKindCompareMode = refKindCompareMode;
-            _considerArity = considerArity;
+            _considerTypeParameters = considerTypeParameters;
             _considerDefaultValues = considerDefaultValues;
             _typeComparison = typeComparison;
             Debug.Assert((_typeComparison & TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly) == 0,
                          $"Rely on the {nameof(refKindCompareMode)} flag to set this to ensure all cases are handled.");
-            Debug.Assert(_refKindCompareMode == RefKindCompareMode.DoNotConsiderDifferences ||
+            Debug.Assert(_refKindCompareMode == RefKindCompareMode.RefMatchesOutInRefReadonly ||
+                _refKindCompareMode == RefKindCompareMode.IgnoreRefKind ||
                 (_refKindCompareMode & RefKindCompareMode.ConsiderDifferences) != 0,
                 $"Cannot set {nameof(RefKindCompareMode)} flags without {nameof(RefKindCompareMode.ConsiderDifferences)}.");
-            if ((refKindCompareMode & RefKindCompareMode.ConsiderDifferences) == 0)
+
+            if (refKindCompareMode == RefKindCompareMode.RefMatchesOutInRefReadonly)
             {
                 _typeComparison |= TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly;
             }
 
-            _considerParameterNames = considerParameterNames;
+            _considerParameterNames = considerTypeParameterAndParameterNames;
             _considerAttributes = considerAttributes;
         }
 
@@ -453,139 +563,146 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            bool sawInterfaceInName1 = false;
-            bool sawInterfaceInName2 = false;
+            bool equals = equalsSlow(member1, member2);
+            Debug.Assert(!equals || GetHashCode(member1) == GetHashCode(member2), "If symbols are equal for some options, their hashes must be equal for those same options.");
+            return equals;
 
-            if (_considerName)
+            bool equalsSlow(Symbol member1, Symbol member2)
             {
-                string name1 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member1.Name);
-                string name2 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member2.Name);
+                bool sawInterfaceInName1 = false;
+                bool sawInterfaceInName2 = false;
 
-                sawInterfaceInName1 = name1 != member1.Name;
-                sawInterfaceInName2 = name2 != member2.Name;
-
-                if (name1 != name2)
+                if (_considerName)
                 {
-                    return false;
-                }
-            }
+                    string name1 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member1.Name);
+                    string name2 = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(member2.Name);
 
-            // NB: up to, and including, this check, we have not actually forced the (type) parameters
-            // to be expanded - we're only using the counts.
-            if (_considerArity)
-            {
-                if (member1.GetMemberArity() != member2.GetMemberArity())
-                {
-                    return false;
-                }
+                    sawInterfaceInName1 = name1 != member1.Name;
+                    sawInterfaceInName2 = name2 != member2.Name;
 
-                if (member1.GetMemberArity() > 0 && (_considerParameterNames || _considerAttributes))
-                {
-                    ImmutableArray<TypeParameterSymbol> typeParams1 = member1.GetMemberTypeParameters();
-                    ImmutableArray<TypeParameterSymbol> typeParams2 = member2.GetMemberTypeParameters();
-
-                    if (_considerParameterNames && typeParams1.Length > 0 && !haveSameTypeParameterNames(typeParams1, typeParams2))
-                    {
-                        return false;
-                    }
-
-                    if (_considerAttributes && !haveSameTypeParameterAttributes(typeParams1, typeParams2))
+                    if (name1 != name2)
                     {
                         return false;
                     }
                 }
-            }
 
-            if (member1.GetParameterCount() != member2.GetParameterCount())
-            {
-                return false;
-            }
-
-            TypeMap? typeMap1 = GetTypeMap(member1);
-            TypeMap? typeMap2 = GetTypeMap(member2);
-
-            if (_considerReturnType && !HaveSameReturnTypes(member1, typeMap1, member2, typeMap2, _typeComparison))
-            {
-                return false;
-            }
-
-            if (member1.GetParameterCount() > 0)
-            {
-                var params1 = member1.GetParameters();
-                var params2 = member2.GetParameters();
-                if (!HaveSameParameterTypes(params1.AsSpan(), typeMap1, params2.AsSpan(), typeMap2,
-                    _refKindCompareMode, considerDefaultValues: _considerDefaultValues, _typeComparison))
+                // NB: up to, and including, this check, we have not actually forced the (type) parameters
+                // to be expanded - we're only using the counts.
+                if (_considerTypeParameters)
                 {
-                    return false;
-                }
-
-                if (_considerParameterNames && !haveSameParameterNames(params1, params2))
-                {
-                    return false;
-                }
-
-                if (_considerAttributes && !haveSameParameterAttributes(params1, params2))
-                {
-                    return false;
-                }
-            }
-
-            if (_considerCallingConvention)
-            {
-                if (GetCallingConvention(member1) != GetCallingConvention(member2))
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                if (IsVarargMethod(member1) != IsVarargMethod(member2))
-                {
-                    return false;
-                }
-            }
-
-            if (_considerExplicitlyImplementedInterfaces)
-            {
-                if (sawInterfaceInName1 != sawInterfaceInName2)
-                {
-                    return false;
-                }
-
-                // The purpose of this check is to determine whether the interface parts of the member names agree,
-                // but to do so using robust symbolic checks, rather than syntactic ones.  Therefore, if neither member
-                // name contains an interface name, this check is not relevant.  
-                // Phrased differently, the explicitly implemented interface is not part of the signature unless it's
-                // part of the name.
-                if (sawInterfaceInName1)
-                {
-                    Debug.Assert(sawInterfaceInName2);
-
-                    // May avoid realizing interface members.
-                    if (member1.IsExplicitInterfaceImplementation() != member2.IsExplicitInterfaceImplementation())
+                    if (member1.GetMemberArity() != member2.GetMemberArity())
                     {
                         return false;
                     }
 
-                    // By comparing symbols, rather than syntax, we gain the flexibility of ignoring whitespace
-                    // and gracefully accepting multiple names for the same (or equivalent) types (e.g. "I<int>.M"
-                    // vs "I<System.Int32>.M"), but we lose the connection with the name.  For example, in metadata,
-                    // a method name "I.M" could have nothing to do with "I" but explicitly implement interface "I2".
-                    // We will behave as if the method was really named "I2.M".  Furthermore, in metadata, a method
-                    // can explicitly implement more than one interface method, in which case it doesn't really
-                    // make sense to pretend that all of them are part of the signature.
+                    if (member1.GetMemberArity() > 0 && (_considerParameterNames || _considerAttributes))
+                    {
+                        ImmutableArray<TypeParameterSymbol> typeParams1 = member1.GetMemberTypeParameters();
+                        ImmutableArray<TypeParameterSymbol> typeParams2 = member2.GetMemberTypeParameters();
 
-                    var explicitInterfaceImplementations1 = member1.GetExplicitInterfaceImplementations();
-                    var explicitInterfaceImplementations2 = member2.GetExplicitInterfaceImplementations();
+                        if (_considerParameterNames && typeParams1.Length > 0 && !haveSameTypeParameterNames(typeParams1, typeParams2))
+                        {
+                            return false;
+                        }
 
-                    if (!explicitInterfaceImplementations1.SetEquals(explicitInterfaceImplementations2, SymbolEqualityComparer.ConsiderEverything))
+                        if (_considerAttributes && !haveSameTypeParameterAttributes(typeParams1, typeParams2))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                if (GetParameterCountIncludingParameterOfExtension(member1) != GetParameterCountIncludingParameterOfExtension(member2))
+                {
+                    return false;
+                }
+
+                TypeMap? typeMap1 = GetTypeMap(member1);
+                TypeMap? typeMap2 = GetTypeMap(member2);
+
+                if (_considerReturnType && !HaveSameReturnTypes(member1, typeMap1, member2, typeMap2, _typeComparison))
+                {
+                    return false;
+                }
+
+                if (GetParameterCountIncludingParameterOfExtension(member1) > 0)
+                {
+                    var params1 = getParametersIncludingParameterOfExtension(member1);
+                    var params2 = getParametersIncludingParameterOfExtension(member2);
+                    if (!HaveSameParameterTypes(params1.AsSpan(), typeMap1, params2.AsSpan(), typeMap2,
+                        _refKindCompareMode, considerDefaultValues: _considerDefaultValues, _typeComparison))
+                    {
+                        return false;
+                    }
+
+                    if (_considerParameterNames && !haveSameParameterNames(params1, params2))
+                    {
+                        return false;
+                    }
+
+                    if (_considerAttributes && !haveSameParameterAttributes(params1, params2))
                     {
                         return false;
                     }
                 }
-            }
 
-            return !_considerTypeConstraints || HaveSameConstraints(member1, typeMap1, member2, typeMap2, ignoreNullability: (_typeComparison & TypeCompareKind.IgnoreNullableModifiersForReferenceTypes) != 0);
+                if (_considerCallingConvention)
+                {
+                    if (GetCallingConvention(member1) != GetCallingConvention(member2))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (IsVarargMethod(member1) != IsVarargMethod(member2))
+                    {
+                        return false;
+                    }
+                }
+
+                if (_considerExplicitlyImplementedInterfaces)
+                {
+                    if (sawInterfaceInName1 != sawInterfaceInName2)
+                    {
+                        return false;
+                    }
+
+                    // The purpose of this check is to determine whether the interface parts of the member names agree,
+                    // but to do so using robust symbolic checks, rather than syntactic ones.  Therefore, if neither member
+                    // name contains an interface name, this check is not relevant.  
+                    // Phrased differently, the explicitly implemented interface is not part of the signature unless it's
+                    // part of the name.
+                    if (sawInterfaceInName1)
+                    {
+                        Debug.Assert(sawInterfaceInName2);
+
+                        // May avoid realizing interface members.
+                        if (member1.IsExplicitInterfaceImplementation() != member2.IsExplicitInterfaceImplementation())
+                        {
+                            return false;
+                        }
+
+                        // By comparing symbols, rather than syntax, we gain the flexibility of ignoring whitespace
+                        // and gracefully accepting multiple names for the same (or equivalent) types (e.g. "I<int>.M"
+                        // vs "I<System.Int32>.M"), but we lose the connection with the name.  For example, in metadata,
+                        // a method name "I.M" could have nothing to do with "I" but explicitly implement interface "I2".
+                        // We will behave as if the method was really named "I2.M".  Furthermore, in metadata, a method
+                        // can explicitly implement more than one interface method, in which case it doesn't really
+                        // make sense to pretend that all of them are part of the signature.
+
+                        var explicitInterfaceImplementations1 = member1.GetExplicitInterfaceImplementations();
+                        var explicitInterfaceImplementations2 = member2.GetExplicitInterfaceImplementations();
+
+                        if (!explicitInterfaceImplementations1.SetEquals(explicitInterfaceImplementations2, SymbolEqualityComparer.ConsiderEverything))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return !_considerTypeConstraints || HaveSameConstraints(member1, typeMap1, member2, typeMap2, _typeComparison);
+            }
 
             static bool haveSameParameterNames(ImmutableArray<ParameterSymbol> params1, ImmutableArray<ParameterSymbol> params2)
             {
@@ -609,29 +726,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             static bool hasSameAttribute(ImmutableArray<CSharpAttributeData> attributes1, ImmutableArray<CSharpAttributeData> attributes2)
             {
-                if (attributes1.Length != attributes2.Length)
+                if (attributes1.IsEmpty && attributes2.IsEmpty)
                 {
-                    return false;
-                }
-
-                var comparer = CommonAttributeDataComparer.InstanceIgnoringNamedArgumentOrder;
-
-                if (attributes1 is [var single1] && attributes2 is [var single2])
-                {
-                    // Fast path for single attribute case
-                    return comparer.Equals(single1, single2);
+                    return true;
                 }
 
                 // Tracked by https://github.com/dotnet/roslyn/issues/78827 : optimization, consider using a pool
+                var comparer = CommonAttributeDataComparer.InstanceIgnoringNamedArgumentOrder;
                 var counts = new Dictionary<CSharpAttributeData, int>(comparer);
 
                 foreach (var attribute in attributes1)
                 {
+                    if (attribute.IsConditionallyOmitted)
+                    {
+                        continue;
+                    }
+
                     counts[attribute] = counts.TryGetValue(attribute, out var foundCount) ? foundCount + 1 : 1;
                 }
 
                 foreach (var attribute in attributes2)
                 {
+                    if (attribute.IsConditionallyOmitted)
+                    {
+                        continue;
+                    }
+
                     if (!counts.TryGetValue(attribute, out var foundCount) || foundCount == 0)
                     {
                         return false;
@@ -642,6 +762,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 return counts.Values.All(c => c == 0);
             }
+
+            static ImmutableArray<ParameterSymbol> getParametersIncludingParameterOfExtension(Symbol member)
+            {
+                if (member is NamedTypeSymbol { IsExtension: true } namedType)
+                {
+                    return namedType.ExtensionParameter is not null
+                        ? [namedType.ExtensionParameter]
+                        : [];
+                }
+
+                return member.GetParameters();
+            }
+        }
+
+        private static int GetParameterCountIncludingParameterOfExtension(Symbol member)
+        {
+            if (member is NamedTypeSymbol { IsExtension: true } namedType)
+            {
+                return namedType.ExtensionParameter is not null ? 1 : 0;
+            }
+
+            return member.GetParameterCount();
         }
 
         public int GetHashCode(Symbol? member)
@@ -667,8 +809,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (member.Kind != SymbolKind.Field)
                 {
-                    hash = Hash.Combine(member.GetMemberArity(), hash);
-                    hash = Hash.Combine(member.GetParameterCount(), hash);
+                    if (_considerTypeParameters)
+                    {
+                        hash = Hash.Combine(member.GetMemberArity(), hash);
+                    }
+
+                    hash = Hash.Combine(GetParameterCountIncludingParameterOfExtension(member), hash);
                 }
             }
             return hash;
@@ -738,7 +884,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     true);
         }
 
-        private static bool HaveSameConstraints(Symbol member1, TypeMap? typeMap1, Symbol member2, TypeMap? typeMap2, bool ignoreNullability = true)
+        private static bool HaveSameConstraints(Symbol member1, TypeMap? typeMap1, Symbol member2, TypeMap? typeMap2, TypeCompareKind typeComparison)
         {
             Debug.Assert(member1.GetMemberArity() == member2.GetMemberArity());
 
@@ -750,17 +896,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var typeParameters1 = member1.GetMemberTypeParameters();
             var typeParameters2 = member2.GetMemberTypeParameters();
-            return HaveSameConstraints(typeParameters1, typeMap1, typeParameters2, typeMap2, ignoreNullability);
+            return HaveSameConstraints(typeParameters1, typeMap1, typeParameters2, typeMap2, typeComparison);
         }
 
-        public static bool HaveSameConstraints(ImmutableArray<TypeParameterSymbol> typeParameters1, TypeMap? typeMap1, ImmutableArray<TypeParameterSymbol> typeParameters2, TypeMap? typeMap2, bool ignoreNullability = true)
+        public static bool HaveSameConstraints(ImmutableArray<TypeParameterSymbol> typeParameters1, TypeMap? typeMap1, ImmutableArray<TypeParameterSymbol> typeParameters2, TypeMap? typeMap2, TypeCompareKind typeComparison)
         {
             Debug.Assert(typeParameters1.Length == typeParameters2.Length);
 
             int arity = typeParameters1.Length;
             for (int i = 0; i < arity; i++)
             {
-                if (!HaveSameConstraints(typeParameters1[i], typeMap1, typeParameters2[i], typeMap2, ignoreNullability))
+                TypeParameterSymbol typeParameter1 = typeParameters1[i];
+                TypeParameterSymbol typeParameter2 = typeParameters2[i];
+                if (!HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, typeComparison))
+                {
+                    return false;
+                }
+                else if ((typeComparison & TypeCompareKind.IgnoreNullableModifiersForReferenceTypes) == 0
+                    && !HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, typeComparison))
                 {
                     return false;
                 }
@@ -769,11 +922,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        public static bool HaveSameConstraints(TypeParameterSymbol typeParameter1, TypeMap? typeMap1, TypeParameterSymbol typeParameter2, TypeMap? typeMap2, bool ignoreNullability = true)
+        public static bool HaveSameConstraints(TypeParameterSymbol typeParameter1, TypeMap? typeMap1, TypeParameterSymbol typeParameter2, TypeMap? typeMap2, TypeCompareKind typeComparison)
         {
             // Spec 13.4.3: Implementation of generic methods.
 
-            if (!ignoreNullability &&
+            if ((typeComparison & TypeCompareKind.IgnoreNullableModifiersForReferenceTypes) == 0 &&
                 typeParameter1.HasNotNullConstraint != typeParameter2.HasNotNullConstraint)
             {
                 return false;
@@ -789,7 +942,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            return HaveSameTypeConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, SymbolEqualityComparer.IgnoringDynamicTupleNamesAndNullability);
+            return HaveSameTypeConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, SymbolEqualityComparer.Create(typeComparison));
         }
 
         private static bool HaveSameTypeConstraints(TypeParameterSymbol typeParameter1, TypeMap? typeMap1, TypeParameterSymbol typeParameter2, TypeMap? typeMap2, IEqualityComparer<TypeSymbol> comparer)
@@ -819,20 +972,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AreConstraintTypesSubset(substitutedTypes2, substitutedTypes1, typeParameter1);
         }
 
-        public static bool HaveSameNullabilityInConstraints(TypeParameterSymbol typeParameter1, TypeMap typeMap1, TypeParameterSymbol typeParameter2, TypeMap typeMap2)
+        public static bool HaveSameNullabilityInConstraints(TypeParameterSymbol typeParameter1, TypeMap? typeMap1, TypeParameterSymbol typeParameter2, TypeMap? typeMap2, TypeCompareKind typeComparison)
         {
-            if (!typeParameter1.IsValueType)
+            if (!typeParameter1.IsValueType
+                && !hasSameLevelNullability(typeParameter1, typeParameter2, typeComparison))
+            {
+                return false;
+            }
+
+            return HaveSameTypeConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, SymbolEqualityComparer.Create(typeComparison));
+
+            static bool hasSameLevelNullability(TypeParameterSymbol typeParameter1, TypeParameterSymbol typeParameter2, TypeCompareKind typeComparison)
             {
                 bool? isNotNullable1 = typeParameter1.IsNotNullable;
                 bool? isNotNullable2 = typeParameter2.IsNotNullable;
+
+                if ((typeComparison & TypeCompareKind.ObliviousNullableModifierMatchesAny) != 0)
+                {
+                    if (!isNotNullable1.HasValue || !isNotNullable2.HasValue)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (!isNotNullable1.HasValue || !isNotNullable2.HasValue)
+                    {
+                        return !isNotNullable1.HasValue && !isNotNullable2.HasValue;
+                    }
+                }
+
                 if (isNotNullable1.HasValue && isNotNullable2.HasValue &&
                     isNotNullable1.GetValueOrDefault() != isNotNullable2.GetValueOrDefault())
                 {
                     return false;
                 }
-            }
 
-            return HaveSameTypeConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, SymbolEqualityComparer.AllIgnoreOptionsPlusNullableWithUnknownMatchesAny);
+                return true;
+            }
         }
 
         /// <summary>
@@ -940,12 +1117,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return false;
                 }
             }
-            else
+            else if (refKindCompareMode == RefKindCompareMode.RefMatchesOutInRefReadonly)
             {
                 if ((refKind1 == RefKind.None) != (refKind2 == RefKind.None))
                 {
                     return false;
                 }
+            }
+            else
+            {
+                Debug.Assert(refKindCompareMode == RefKindCompareMode.IgnoreRefKind);
             }
 
             return true;
@@ -1026,7 +1207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             /// <summary>
             /// All ref modifiers are considered equivalent.
             /// </summary>
-            DoNotConsiderDifferences = 0,
+            RefMatchesOutInRefReadonly = 0,
 
             /// <summary>
             /// Parameters with different ref modifiers are considered different.
@@ -1037,6 +1218,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             /// 'in'/'ref readonly' modifiers are considered equivalent.
             /// </summary>
             AllowRefReadonlyVsInMismatch = 1 << 1,
+
+            /// <summary>
+            /// Ignore ref kind differences.
+            /// </summary>
+            IgnoreRefKind = 1 << 2,
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -42,6 +42,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return ((PropertySymbol)member).Parameters;
                 case SymbolKind.Event:
                     return ImmutableArray<ParameterSymbol>.Empty;
+                case SymbolKind.NamedType:
+                    var namedType = (NamedTypeSymbol)member;
+                    if (namedType.IsExtension)
+                    {
+                        return namedType.ExtensionParameter is not null
+                            ? [namedType.ExtensionParameter]
+                            : [];
+                    }
+                    goto default;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(member.Kind);
             }
@@ -341,6 +350,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.Event:
                 case SymbolKind.Field:
                     return 0;
+                case SymbolKind.NamedType:
+                    var namedType = (NamedTypeSymbol)member;
+                    if (namedType.IsExtension)
+                    {
+                        return namedType.ExtensionParameter is not null ? 1 : 0;
+                    }
+                    goto default;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(member.Kind);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -42,15 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return ((PropertySymbol)member).Parameters;
                 case SymbolKind.Event:
                     return ImmutableArray<ParameterSymbol>.Empty;
-                case SymbolKind.NamedType:
-                    var namedType = (NamedTypeSymbol)member;
-                    if (namedType.IsExtension)
-                    {
-                        return namedType.ExtensionParameter is not null
-                            ? [namedType.ExtensionParameter]
-                            : [];
-                    }
-                    goto default;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(member.Kind);
             }
@@ -350,13 +341,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.Event:
                 case SymbolKind.Field:
                     return 0;
-                case SymbolKind.NamedType:
-                    var namedType = (NamedTypeSymbol)member;
-                    if (namedType.IsExtension)
-                    {
-                        return namedType.ExtensionParameter is not null ? 1 : 0;
-                    }
-                    goto default;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(member.Kind);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -3178,7 +3178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var containingTypeMap = new TypeMap(containingTypeParameters, IndexedTypeParameterSymbol.Take(n), allowAlpha: false);
                 var nestedTypeMap = new TypeMap(nestedTypeParameters, IndexedTypeParameterSymbol.Take(nestedTypeParameters.Length), allowAlpha: false);
 
-                var compareKind = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
+                const TypeCompareKind compareKind = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
                 for (int i = 0; i < n; i++)
                 {
                     var containingTypeParameter = containingTypeParameters[i];

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -534,7 +534,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             typeMap,
                             MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
                             considerDefaultValues: false,
-                            considerScoped: false,
                             TypeCompareKind.CLRSignatureCompareOptions))
                     {
                         continue;
@@ -547,7 +546,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             typeMap,
                             MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
                             considerDefaultValues: false,
-                            considerScoped: false,
                             TypeCompareKind.CLRSignatureCompareOptions))
                     {
                         continue;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -534,6 +534,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             typeMap,
                             MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
                             considerDefaultValues: false,
+                            considerScoped: false,
                             TypeCompareKind.CLRSignatureCompareOptions))
                     {
                         continue;
@@ -546,6 +547,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             typeMap,
                             MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
                             considerDefaultValues: false,
+                            considerScoped: false,
                             TypeCompareKind.CLRSignatureCompareOptions))
                     {
                         continue;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -555,7 +555,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             candidate.TypeParameters,
                             typeMap1: null,
                             combinedTypeParameters,
-                            typeMap))
+                            typeMap,
+                            TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
                     {
                         return candidate;
                     }
@@ -3177,11 +3178,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var containingTypeMap = new TypeMap(containingTypeParameters, IndexedTypeParameterSymbol.Take(n), allowAlpha: false);
                 var nestedTypeMap = new TypeMap(nestedTypeParameters, IndexedTypeParameterSymbol.Take(nestedTypeParameters.Length), allowAlpha: false);
 
+                var compareKind = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
                 for (int i = 0; i < n; i++)
                 {
                     var containingTypeParameter = containingTypeParameters[i];
                     var nestedTypeParameter = nestedTypeParameters[i];
-                    if (!MemberSignatureComparer.HaveSameConstraints(containingTypeParameter, containingTypeMap, nestedTypeParameter, nestedTypeMap))
+                    if (!MemberSignatureComparer.HaveSameConstraints(containingTypeParameter, containingTypeMap, nestedTypeParameter, nestedTypeMap, compareKind))
                     {
                         return false;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExtensionGroupingInfo.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExtensionGroupingInfo.cs
@@ -290,16 +290,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterSymbol? parameter1 = extension1.ExtensionParameter;
             ParameterSymbol? parameter2 = extension2.ExtensionParameter;
-            if (parameter1 is null || parameter2 is null)
+            if (parameter1 is null)
             {
-                return parameter1 is null && parameter2 is null;
+                return parameter2 is null;
             }
-
-            if (!MemberSignatureComparer.HaveSameParameterType(parameter1, typeMap1, parameter2, typeMap2,
-                refKindCompareMode: MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
-                considerDefaultValues: false, TypeCompareKind.ConsiderEverything))
+            else if (parameter2 is null)
             {
-                return false;
+                return parameter1 is null;
             }
 
             if (parameter1.DeclaredScope != parameter2.DeclaredScope)
@@ -308,6 +305,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if (parameter1.Name != parameter2.Name)
+            {
+                return false;
+            }
+
+            if (!MemberSignatureComparer.HaveSameParameterType(parameter1, typeMap1, parameter2, typeMap2,
+                refKindCompareMode: MemberSignatureComparer.RefKindCompareMode.ConsiderDifferences,
+                considerDefaultValues: false, TypeCompareKind.ConsiderEverything))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExtensionGroupingInfo.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExtensionGroupingInfo.cs
@@ -225,13 +225,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(extension1.IsExtension);
             Debug.Assert(extension2.IsExtension);
 
-            TypeMap? typeMap1 = MemberSignatureComparer.GetTypeMap(extension1);
-            TypeMap? typeMap2 = MemberSignatureComparer.GetTypeMap(extension2);
             if (extension1.Arity != extension2.Arity)
             {
                 return false;
             }
 
+            TypeMap? typeMap1 = MemberSignatureComparer.GetTypeMap(extension1);
+            TypeMap? typeMap2 = MemberSignatureComparer.GetTypeMap(extension2);
             if (extension1.Arity > 0
                 && !MemberSignatureComparer.HaveSameConstraints(extension1.TypeParameters, typeMap1, extension2.TypeParameters, typeMap2, TypeCompareKind.AllIgnoreOptions))
             {
@@ -260,13 +260,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(extension1.IsExtension);
             Debug.Assert(extension2.IsExtension);
 
-            TypeMap? typeMap1 = MemberSignatureComparer.GetTypeMap(extension1);
-            TypeMap? typeMap2 = MemberSignatureComparer.GetTypeMap(extension2);
             if (extension1.Arity != extension2.Arity)
             {
                 return false;
             }
 
+            TypeMap? typeMap1 = MemberSignatureComparer.GetTypeMap(extension1);
+            TypeMap? typeMap2 = MemberSignatureComparer.GetTypeMap(extension2);
             if (extension1.Arity > 0)
             {
                 ImmutableArray<TypeParameterSymbol> typeParams1 = extension1.TypeParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2362,6 +2362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (this.declaration.ContainsExtensionDeclarations)
             {
                 checkMemberNameConflictsInExtensions(diagnostics);
+                this.GetExtensionGroupingInfo().CheckSignatureCollisions(diagnostics);
             }
 
             checkMemberNameConflicts(GetMembersByName(), GetTypeMembersDictionary(), GetMembersUnordered(), diagnostics);
@@ -6000,7 +6001,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (_lazyExtensionGroupingInfo is null)
             {
-                // PROTOTYPE: Find the right place and perform checks for conflicting declarations getting into the same group or marker, and reporting appropriate errors.
                 Interlocked.CompareExchange(ref _lazyExtensionGroupingInfo, new ExtensionGroupingInfo(this), null);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
@@ -795,9 +795,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 foreach (CSharpAttributeData attribute in attributes)
                 {
-                    var stringBuilder = PooledStringBuilder.GetInstance();
-                    appendAttribute(attribute, stringBuilder.Builder);
-                    attributesBuilder.Add(stringBuilder.ToStringAndFree());
+                    if (!attribute.IsConditionallyOmitted)
+                    {
+                        var stringBuilder = PooledStringBuilder.GetInstance();
+                        appendAttribute(attribute, stringBuilder.Builder);
+                        attributesBuilder.Add(stringBuilder.ToStringAndFree());
+                    }
                 }
 
                 attributesBuilder.Sort(StringComparer.Ordinal); // Actual order doesn't matter - just want to be deterministic

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Extension.cs
@@ -626,19 +626,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     builder.Append("struct");
                     needComma = true;
                 }
-                else
+                else if (typeParam.HasNotNullConstraint)
                 {
-                    switch (typeParam.IsNotNullable)
-                    {
-                        case true:
-                            builder.Append("notnull");
-                            needComma = true;
-                            break;
-                        case false:
-                            builder.Append("maybenull");
-                            needComma = true;
-                            break;
-                    }
+                    builder.Append("notnull");
+                    needComma = true;
                 }
 
                 if (typeParam.ConstraintTypesNoUseSiteDiagnostics.Length > 0)
@@ -670,13 +661,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             static void appendTypeConstraints(TypeParameterSymbol typeParam, StringBuilder builder, ref bool needComma)
             {
-                ImmutableArray<TypeWithAnnotations> constraintTypes = typeParam.ConstraintTypesNoUseSiteDiagnostics;
-                var typeConstraintsBuilder = ArrayBuilder<string>.GetInstance(constraintTypes.Length);
-                for (int i = 0; i < constraintTypes.Length; i++)
+                ImmutableArray<TypeWithAnnotations> contraintTypes = typeParam.ConstraintTypesNoUseSiteDiagnostics;
+                var typeConstraintsBuilder = ArrayBuilder<string>.GetInstance(contraintTypes.Length);
+                for (int i = 0; i < contraintTypes.Length; i++)
                 {
                     var stringBuilder = PooledStringBuilder.GetInstance();
-                    appendType(constraintTypes[i].Type, stringBuilder.Builder);
-                    Debug.Assert(constraintTypes[i].CustomModifiers.IsEmpty);
+                    appendTypeWithAnnotation(contraintTypes[i], stringBuilder.Builder);
                     typeConstraintsBuilder.Add(stringBuilder.ToStringAndFree());
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -611,7 +611,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeMap2 = new TypeMap(typeParameters2, indexedTypeParameters, allowAlpha: true);
 
             // Report any mismatched method constraints.
-            var typeComparison = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
+            const TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
             for (int i = 0; i < arity; i++)
             {
                 var typeParameter1 = typeParameters1[i];

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -621,7 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentConstraints, implementation.GetFirstLocation(), implementation, typeParameter2.Name);
                 }
-                else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithUnknownMatchesAny))
+                else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithObliviousMatchesAny))
                 {
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInConstraintsOnPartialImplementation, implementation.GetFirstLocation(), implementation, typeParameter2.Name);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -621,7 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentConstraints, implementation.GetFirstLocation(), implementation, typeParameter2.Name);
                 }
-                else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithObliviousMatchesAny))
+                else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
                 {
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInConstraintsOnPartialImplementation, implementation.GetFirstLocation(), implementation, typeParameter2.Name);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -611,16 +611,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeMap2 = new TypeMap(typeParameters2, indexedTypeParameters, allowAlpha: true);
 
             // Report any mismatched method constraints.
+            var typeComparison = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
             for (int i = 0; i < arity; i++)
             {
                 var typeParameter1 = typeParameters1[i];
                 var typeParameter2 = typeParameters2[i];
 
-                if (!MemberSignatureComparer.HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
+                if (!MemberSignatureComparer.HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, typeComparison))
                 {
                     diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentConstraints, implementation.GetFirstLocation(), implementation, typeParameter2.Name);
                 }
-                else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
+                else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithUnknownMatchesAny))
                 {
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInConstraintsOnPartialImplementation, implementation.GetFirstLocation(), implementation, typeParameter2.Name);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolEqualityComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolEqualityComparer.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -38,6 +39,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private SymbolEqualityComparer(TypeCompareKind comparison)
         {
             _comparison = comparison;
+        }
+
+        internal static EqualityComparer<Symbol> Create(TypeCompareKind comparison)
+        {
+            if (comparison == (TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
+            {
+                return IgnoringDynamicTupleNamesAndNullability;
+            }
+            else if (comparison == TypeCompareKind.ConsiderEverything)
+            {
+                return ConsiderEverything;
+            }
+            else if (comparison == TypeCompareKind.AllIgnoreOptions)
+            {
+                return AllIgnoreOptions;
+            }
+            else if (comparison == TypeCompareKind.AllIgnoreOptionsPlusNullableWithUnknownMatchesAny)
+            {
+                return AllIgnoreOptionsPlusNullableWithUnknownMatchesAny;
+            }
+
+            Debug.Assert(false, "Consider optimizing as above when we need to handle a new type comparison kind.");
+            return new SymbolEqualityComparer(comparison);
         }
 
         public override int GetHashCode(Symbol obj)

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolEqualityComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolEqualityComparer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return AllIgnoreOptions;
             }
-            else if (comparison == TypeCompareKind.AllIgnoreOptionsPlusNullableWithUnknownMatchesAny)
+            else if (comparison == TypeCompareKind.AllIgnoreOptionsPlusNullableWithObliviousMatchesAny)
             {
                 return AllIgnoreOptionsPlusNullableWithUnknownMatchesAny;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2122,7 +2122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var typeMap2 = new TypeMap(typeParameters2, indexedTypeParameters, allowAlpha: true);
 
                 // Report any mismatched method constraints.
-                var compareKind = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
+                const TypeCompareKind compareKind = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
                 for (int i = 0; i < arity; i++)
                 {
                     var typeParameter1 = typeParameters1[i];

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2140,7 +2140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // error on B if the match to I.M is in a base class.)
                         diagnostics.Add(ErrorCode.ERR_ImplBadConstraints, GetImplicitImplementationDiagnosticLocation(interfaceMethod, implementingType, implicitImpl), typeParameter2.Name, implicitImpl, typeParameter1.Name, interfaceMethod);
                     }
-                    else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithObliviousMatchesAny))
+                    else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
                     {
                         diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInConstraintsOnImplicitImplementation, GetImplicitImplementationDiagnosticLocation(interfaceMethod, implementingType, implicitImpl),
                                         typeParameter2.Name, implicitImpl, typeParameter1.Name, interfaceMethod);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2122,12 +2122,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var typeMap2 = new TypeMap(typeParameters2, indexedTypeParameters, allowAlpha: true);
 
                 // Report any mismatched method constraints.
+                var compareKind = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
                 for (int i = 0; i < arity; i++)
                 {
                     var typeParameter1 = typeParameters1[i];
                     var typeParameter2 = typeParameters2[i];
 
-                    if (!MemberSignatureComparer.HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
+                    if (!MemberSignatureComparer.HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, compareKind))
                     {
                         // If the matching method for the interface member is defined on the implementing type,
                         // the matching method location is used for the error. Otherwise, the location of the
@@ -2139,7 +2140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // error on B if the match to I.M is in a base class.)
                         diagnostics.Add(ErrorCode.ERR_ImplBadConstraints, GetImplicitImplementationDiagnosticLocation(interfaceMethod, implementingType, implicitImpl), typeParameter2.Name, implicitImpl, typeParameter1.Name, interfaceMethod);
                     }
-                    else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
+                    else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithUnknownMatchesAny))
                     {
                         diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInConstraintsOnImplicitImplementation, GetImplicitImplementationDiagnosticLocation(interfaceMethod, implementingType, implicitImpl),
                                         typeParameter2.Name, implicitImpl, typeParameter1.Name, interfaceMethod);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2140,7 +2140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // error on B if the match to I.M is in a base class.)
                         diagnostics.Add(ErrorCode.ERR_ImplBadConstraints, GetImplicitImplementationDiagnosticLocation(interfaceMethod, implementingType, implicitImpl), typeParameter2.Name, implicitImpl, typeParameter1.Name, interfaceMethod);
                     }
-                    else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithUnknownMatchesAny))
+                    else if (!MemberSignatureComparer.HaveSameNullabilityInConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2, TypeCompareKind.AllIgnoreOptionsPlusNullableWithObliviousMatchesAny))
                     {
                         diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInConstraintsOnImplicitImplementation, GetImplicitImplementationDiagnosticLocation(interfaceMethod, implementingType, implicitImpl),
                                         typeParameter2.Name, implicitImpl, typeParameter1.Name, interfaceMethod);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             private readonly TypeCompareKind _compareKind;
 
-            public EqualsComparer(TypeCompareKind compareKind)
+            private EqualsComparer(TypeCompareKind compareKind)
             {
                 _compareKind = compareKind;
             }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Strom výrazů nesmí obsahovat výraz with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Eine Ausdrucksbaumstruktur darf keinen with-Ausdruck enthalten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Un árbol de expresión no puede contener una expresión with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Une arborescence de l'expression ne peut pas contenir d'expression with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Un albero delle espressioni non può contenere un'espressione with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -812,6 +812,11 @@
         <target state="translated">式ツリーは、with 式を含むことはできません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -812,6 +812,11 @@
         <target state="translated">식 트리에는 with 식이 포함될 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Drzewo wyrażeń nie może zawierać wyrażenia with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Uma árvore de expressão não pode conter uma expressão with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -812,6 +812,11 @@
         <target state="translated">Дерево выражения не может содержать выражение with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -812,6 +812,11 @@
         <target state="translated">İfade ağacı, with ifadesi içeremez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -812,6 +812,11 @@
         <target state="translated">表达式树不能包含 with 表达式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
-        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -812,6 +812,11 @@
         <target state="translated">運算式樹狀架構不得包含 with 運算式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExtensionBlockCollision">
+        <source>This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</source>
+        <target state="new">This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">
         <source>This member is not allowed in an extension block</source>
         <target state="new">This member is not allowed in an extension block</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -813,8 +813,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionBlockCollision">
-        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</source>
-        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata.</target>
+        <source>This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</source>
+        <target state="new">This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExtensionDisallowsMember">

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
@@ -12,8 +12,6 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Basic.Reference.Assemblies;
-using ICSharpCode.Decompiler.Metadata;
-using ICSharpCode.Decompiler.TypeSystem;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
@@ -11,13 +11,15 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using Basic.Reference.Assemblies;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -1579,6 +1581,60 @@ class Program
                expectedSrcAttrCount: 20,
                expectedDuplicateAttrCount: 5,
                attrTypeName: "UserDefinedAssemblyAttrAllowMultipleAttribute");
+        }
+
+        [Fact]
+        public void AssemblyDropIdenticalAttributes_01()
+        {
+            var src = """
+[assembly: A(typeof(object))]
+[assembly: A(typeof(object))]
+
+[assembly: A(typeof((int a, int b)))]
+[assembly: A(typeof((int notA, int notB)))]
+
+#nullable enable
+[assembly: A(typeof(I<object>))]
+[assembly: A(typeof(I<object?>))]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
+public class AAttribute : System.Attribute
+{
+    public AAttribute(System.Type type) { }
+}
+
+public interface I<T> { }
+""";
+            string assemblyName = GetUniqueName();
+            var netmoduleCompilation = CreateCompilation(src, options: TestOptions.ReleaseModule, assemblyName: assemblyName, targetFramework: TargetFramework.Net90);
+            MetadataReference netmoduleRef = ModuleMetadata.CreateFromImage(netmoduleCompilation.EmitToArray()).GetReference(display: assemblyName + ".netmodule");
+
+            var comp = CreateCompilation("", references: [netmoduleRef], targetFramework: TargetFramework.Net90);
+            CompileAndVerify(comp, symbolValidator: m => validate(m, hasDuplicate: false));
+
+            comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+            CompileAndVerify(comp, symbolValidator: m => validate(m, hasDuplicate: true));
+
+            static void validate(ModuleSymbol module, bool hasDuplicate)
+            {
+                var metadataAttributes = module.ContainingAssembly
+                    .GetAttributes()
+                    .Where(a => a.AttributeClass.Name == "AAttribute");
+
+                string[] expected = hasDuplicate ?
+                [
+                    "AAttribute(typeof(object))",
+                    "AAttribute(typeof((int, int)))",
+                    "AAttribute(typeof((int, int)))",
+                    "AAttribute(typeof(I<object>))"
+                ] : [
+                    "AAttribute(typeof(object))",
+                    "AAttribute(typeof((int, int)))",
+                    "AAttribute(typeof(I<object>))"
+                ];
+
+                AssertEx.Equal(expected, metadataAttributes.Select(a => a.ToString()));
+            }
         }
 
         [Fact, WorkItem(546939, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546939")]

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
@@ -1610,24 +1610,19 @@ public interface I<T> { }
             MetadataReference netmoduleRef = ModuleMetadata.CreateFromImage(netmoduleCompilation.EmitToArray()).GetReference(display: assemblyName + ".netmodule");
 
             var comp = CreateCompilation("", references: [netmoduleRef], targetFramework: TargetFramework.Net90);
-            CompileAndVerify(comp, symbolValidator: m => validate(m, hasDuplicate: false));
+            CompileAndVerify(comp, symbolValidator: validate);
 
             comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
-            CompileAndVerify(comp, symbolValidator: m => validate(m, hasDuplicate: true));
+            CompileAndVerify(comp, symbolValidator: validate);
 
-            static void validate(ModuleSymbol module, bool hasDuplicate)
+            static void validate(ModuleSymbol module)
             {
                 var metadataAttributes = module.ContainingAssembly
                     .GetAttributes()
                     .Where(a => a.AttributeClass.Name == "AAttribute");
 
-                string[] expected = hasDuplicate ?
+                string[] expected =
                 [
-                    "AAttribute(typeof(object))",
-                    "AAttribute(typeof((int, int)))",
-                    "AAttribute(typeof((int, int)))",
-                    "AAttribute(typeof(I<object>))"
-                ] : [
                     "AAttribute(typeof(object))",
                     "AAttribute(typeof((int, int)))",
                     "AAttribute(typeof(I<object>))"

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Assembly.cs
@@ -1608,10 +1608,10 @@ public interface I<T> { }
             MetadataReference netmoduleRef = ModuleMetadata.CreateFromImage(netmoduleCompilation.EmitToArray()).GetReference(display: assemblyName + ".netmodule");
 
             var comp = CreateCompilation("", references: [netmoduleRef], targetFramework: TargetFramework.Net90);
-            CompileAndVerify(comp, symbolValidator: validate);
+            CompileAndVerify(comp, symbolValidator: validate, verify: Verification.FailsPEVerify);
 
             comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
-            CompileAndVerify(comp, symbolValidator: validate);
+            CompileAndVerify(comp, symbolValidator: validate, verify: Verification.FailsPEVerify);
 
             static void validate(ModuleSymbol module)
             {

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public partial class ExtensionTests : CompilingTestBase
 {
-
     internal string ExtensionMarkerNameAttributeIL = """
 
 .class public auto ansi sealed beforefieldinit System.Runtime.CompilerServices.ExtensionMarkerNameAttribute

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -27916,5 +27916,29 @@ public static class E
         Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
         Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
+
+    [Fact]
+    public void Grouping_67()
+    {
+        var src = """
+public static class E
+{
+    extension(scoped ref RS s) { }
+    extension(ref RS s) { }
+}
+
+public ref struct RS { }
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
 }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -23156,7 +23156,7 @@ interface I { }
 
         var extension = (SourceNamedTypeSymbol)comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers().Single();
         AssertEx.Equal("extension<(I), (I), (I)>(System.Int32)", extension.ComputeExtensionGroupingRawName());
-        AssertEx.Equal("extension<T1, T2, T3>(System.Int32) where T1 : I! where T2 : I? where T3 : I", extension.ComputeExtensionMarkerRawName());
+        AssertEx.Equal("extension<T1, T2, T3>(System.Int32) where T1 : notnull, I where T2 : maybenull, I where T3 : I", extension.ComputeExtensionMarkerRawName());
 
         verifier.VerifyTypeIL("E", """
 .class private auto ansi abstract sealed beforefieldinit E
@@ -23173,7 +23173,7 @@ interface I { }
             01 00 00 00
         )
         // Nested Types
-        .class nested public auto ansi abstract sealed specialname '<Marker>$5B198AEBE2F597134BE1E94D84704187'<(I) T1, (I) T2, (I) T3>
+        .class nested public auto ansi abstract sealed specialname '<Marker>$A642A5031DDFF45A5478C1824AC1E939'<(I) T1, (I) T2, (I) T3>
             extends [mscorlib]System.Object
         {
             .param constraint T1, I
@@ -23197,8 +23197,8 @@ interface I { }
                 // Code size 1 (0x1)
                 .maxstack 8
                 IL_0000: ret
-            } // end of method '<Marker>$5B198AEBE2F597134BE1E94D84704187'::'<Extension>$'
-        } // end of class <Marker>$5B198AEBE2F597134BE1E94D84704187
+            } // end of method '<Marker>$A642A5031DDFF45A5478C1824AC1E939'::'<Extension>$'
+        } // end of class <Marker>$A642A5031DDFF45A5478C1824AC1E939
     } // end of class <Extension>$0AD8C3962A3C5E6BFA97E099F6F428C4
 } // end of class E
 """.Replace("[mscorlib]", ExecutionConditionUtil.IsMonoOrCoreClr ? "[netstandard]" : "[mscorlib]"));
@@ -25632,7 +25632,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25675,7 +25676,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25712,7 +25714,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25750,7 +25753,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25788,7 +25792,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25826,7 +25831,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25865,7 +25871,8 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
@@ -25892,7 +25899,8 @@ public class BAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25933,7 +25941,8 @@ public class AAttribute : System.Attribute
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25976,7 +25985,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26022,7 +26032,9 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.GetHashCode(extension1) == MemberSignatureComparer.ExtensionCSharpSignatureComparer.GetHashCode(extension2));
     }
 
     [Fact]
@@ -26086,7 +26098,8 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
@@ -26119,7 +26132,8 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
@@ -26152,12 +26166,13 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension([A2] int)
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26183,7 +26198,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26222,7 +26238,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26259,7 +26276,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26296,7 +26314,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26332,7 +26351,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26369,7 +26389,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26402,7 +26423,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
@@ -26424,7 +26446,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
@@ -26453,7 +26476,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension(A2)
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5),
             // (14,28): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
@@ -26469,7 +26492,8 @@ public static class E
         AssertEx.Equal("extension(A)", extension2.ComputeExtensionGroupingRawName());
         AssertEx.Equal("extension(A)", extension2.ComputeExtensionMarkerRawName());
 
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
@@ -26498,7 +26522,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension(A2)
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
     }
@@ -26529,12 +26553,13 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension<T>(T) where T : A2
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26563,12 +26588,13 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension<T, U>(T) where T : A2 where U : T
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26599,12 +26625,13 @@ public interface I { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension<T>(T) where T : I, A2
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26635,12 +26662,13 @@ public interface I { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension<T>(T) where T : I, A2
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26668,7 +26696,10 @@ public static class E
 }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
-        var verifier = CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension(ref A2 a)
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         var extension1 = (SourceNamedTypeSymbol)extensions[0];
@@ -26679,125 +26710,14 @@ public static class E
         AssertEx.Equal("extension(A)", extension2.ComputeExtensionGroupingRawName());
         AssertEx.Equal("extension(ref A a)", extension2.ComputeExtensionMarkerRawName());
 
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
-
-        verifier.VerifyTypeIL("E", """
-.class public auto ansi abstract sealed beforefieldinit E
-    extends [mscorlib]System.Object
-{
-    .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
-        01 00 00 00
-    )
-    // Nested Types
-    .class nested public auto ansi sealed specialname '<Extension>$43BB1C51423008731091E2D86C21895C'
-        extends [mscorlib]System.Object
-    {
-        .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
-            01 00 00 00
-        )
-        // Nested Types
-        .class nested public auto ansi abstract sealed specialname '<Marker>$ADCDF963FFE571676263A9D3587B316A'
-            extends [mscorlib]System.Object
-        {
-            // Methods
-            .method public hidebysig specialname static 
-                void '<Extension>$' (
-                    valuetype [assembly1]A a
-                ) cil managed 
-            {
-                .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-                    01 00 00 00
-                )
-                // Method begins at RVA 0x2067
-                // Code size 1 (0x1)
-                .maxstack 8
-                IL_0000: ret
-            } // end of method '<Marker>$ADCDF963FFE571676263A9D3587B316A'::'<Extension>$'
-        } // end of class <Marker>$ADCDF963FFE571676263A9D3587B316A
-        .class nested public auto ansi abstract sealed specialname '<Marker>$3ABF4F62890B47BCE5C28E8C145BB466'
-            extends [mscorlib]System.Object
-        {
-            // Methods
-            .method public hidebysig specialname static 
-                void '<Extension>$' (
-                    valuetype [assembly2]A& a
-                ) cil managed 
-            {
-                .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-                    01 00 00 00
-                )
-                // Method begins at RVA 0x2067
-                // Code size 1 (0x1)
-                .maxstack 8
-                IL_0000: ret
-            } // end of method '<Marker>$3ABF4F62890B47BCE5C28E8C145BB466'::'<Extension>$'
-        } // end of class <Marker>$3ABF4F62890B47BCE5C28E8C145BB466
-        // Methods
-        .method public hidebysig static 
-            void M () cil managed 
-        {
-            .custom instance void System.Runtime.CompilerServices.ExtensionMarkerNameAttribute::.ctor(string) = (
-                01 00 29 3c 4d 61 72 6b 65 72 3e 24 41 44 43 44
-                46 39 36 33 46 46 45 35 37 31 36 37 36 32 36 33
-                41 39 44 33 35 38 37 42 33 31 36 41 00 00
-            )
-            // Method begins at RVA 0x2069
-            // Code size 2 (0x2)
-            .maxstack 8
-            IL_0000: ldnull
-            IL_0001: throw
-        } // end of method '<Extension>$43BB1C51423008731091E2D86C21895C'::M
-        .method public hidebysig static 
-            void M2 () cil managed 
-        {
-            .custom instance void System.Runtime.CompilerServices.ExtensionMarkerNameAttribute::.ctor(string) = (
-                01 00 29 3c 4d 61 72 6b 65 72 3e 24 33 41 42 46
-                34 46 36 32 38 39 30 42 34 37 42 43 45 35 43 32
-                38 45 38 43 31 34 35 42 42 34 36 36 00 00
-            )
-            // Method begins at RVA 0x2069
-            // Code size 2 (0x2)
-            .maxstack 8
-            IL_0000: ldnull
-            IL_0001: throw
-        } // end of method '<Extension>$43BB1C51423008731091E2D86C21895C'::M2
-    } // end of class <Extension>$43BB1C51423008731091E2D86C21895C
-    // Methods
-    .method public hidebysig static 
-        void M () cil managed 
-    {
-        // Method begins at RVA 0x2067
-        // Code size 1 (0x1)
-        .maxstack 8
-        IL_0000: ret
-    } // end of method E::M
-    .method public hidebysig static 
-        void M2 () cil managed 
-    {
-        // Method begins at RVA 0x2067
-        // Code size 1 (0x1)
-        .maxstack 8
-        IL_0000: ret
-    } // end of method E::M2
-} // end of class E
-""".Replace("[mscorlib]", ExecutionConditionUtil.IsMonoOrCoreClr ? "[netstandard]" : "[mscorlib]"));
-
-        static void validate(ModuleSymbol module)
-        {
-            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
-            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
-            AssertEx.Equal([
-                "TypeDefinition:E",
-                "TypeDefinition:<Extension>$43BB1C51423008731091E2D86C21895C",
-                "TypeDefinition:<Marker>$ADCDF963FFE571676263A9D3587B316A",
-                "TypeDefinition:<Marker>$3ABF4F62890B47BCE5C28E8C145BB466"
-                ], reader.DumpNestedTypes(e.Handle));
-        }
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
     public void Grouping_31()
     {
+        // types from different assemblies in extension parameter
         var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
         var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
 
@@ -26821,6 +26741,9 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension(ref A2 a)
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5),
             // (14,28): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
             //         public static void M() { }
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "E").WithLocation(14, 28));
@@ -26828,6 +26751,360 @@ public static class E
 
     [Fact]
     public void Grouping_32()
+    {
+        // types from different assemblies in nested position in extension parameter
+        var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension(I<A1> a) { }
+    extension(I<A2> a) { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension(I<A2> a) { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+            () => Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_33()
+    {
+        // types from different assemblies in constraints
+        var libComp1 = CreateCompilation("public interface A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public interface A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension<T>(int i) where T : A1 { }
+    extension<T>(int i) where T : A2 { }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(int i) where T : I<A2> { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+            () => Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_34()
+    {
+        // types from different assemblies in nested position in constraints
+        var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension<T>(int i) where T : I<A1> { }
+    extension<T>(int i) where T : I<A2> { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(int i) where T : I<A2> { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => AssertEx.Equal("extension<(I`1<A>)>(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension<T>(System.Int32 i) where T : I<A>", extension1.ComputeExtensionMarkerRawName()),
+
+            () => AssertEx.Equal("extension<(I`1<A>)>(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension<T>(System.Int32 i) where T : I<A>", extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_35()
+    {
+        // types from different assemblies in typeof
+        var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension([A(typeof(A1))] int i) { }
+    extension([A(typeof(A2))] int i) { }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(System.Type t) { }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(int i) where T : I<A2> { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(A))] System.Int32 i)", extension1.ComputeExtensionMarkerRawName()),
+
+            () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(A))] System.Int32 i)", extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_36()
+    {
+        var src = """
+#nullable enable
+
+public static class E
+{
+    extension([A(typeof(I<object?>))] int) { }
+    extension([A(typeof(I<object>))] int) { }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(System.Type t) { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(I`1<System.Object>))] System.Int32)", extension1.ComputeExtensionMarkerRawName()),
+
+            () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(I`1<System.Object>))] System.Int32)", extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_37()
+    {
+        var src = """
+public static class E
+{
+    extension([A(typeof((int a, int b)))] int) { }
+    extension([A(typeof((int notA, int notB)))] int) { }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(System.Type t) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(System.ValueTuple`2<System.Int32, System.Int32>))] System.Int32)", extension1.ComputeExtensionMarkerRawName()),
+
+            () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(System.ValueTuple`2<System.Int32, System.Int32>))] System.Int32)", extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_38()
+    {
+        var src = """
+public static class E
+{
+    extension([A(typeof((int a, int b)))] int) { }
+    extension([A(typeof((int, int)))] int) { }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(System.Type t) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_39()
+    {
+        // types from different assemblies in nested position in typeof
+        var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension([A(typeof(I<A1>))] int i) { }
+    extension([A(typeof(I<A2>))] int i) { }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(System.Type t) { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(int i) where T : I<A2> { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(I`1<A>))] System.Int32 i)", extension1.ComputeExtensionMarkerRawName()),
+
+            () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(I`1<A>))] System.Int32 i)", extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_40()
+    {
+        // types from different assemblies in nested position in typeof
+        var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension([A([typeof(I<A1>)])] int i) { }
+    extension([A([typeof(I<A2>)])] int i) { }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(System.Type[] t) { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(int i) where T : I<A2> { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type[])*/([typeof(I`1<A>)])] System.Int32 i)", extension1.ComputeExtensionMarkerRawName()),
+
+            () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*(System.Type[])*/([typeof(I`1<A>)])] System.Int32 i)", extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_41()
     {
         // Function pointer type: ref vs. out
         var src = """
@@ -26845,11 +27122,12 @@ unsafe static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
-    public void Grouping_33()
+    public void Grouping_42()
     {
         // Constraints: new() vs. not
         var src = """
@@ -26867,11 +27145,12 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
-    public void Grouping_34()
+    public void Grouping_43()
     {
         // Constraints: class vs. not
         var src = """
@@ -26889,11 +27168,12 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
-    public void Grouping_35()
+    public void Grouping_44()
     {
         // Constraints: struct vs. not
         var src = """
@@ -26911,11 +27191,12 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
-    public void Grouping_36()
+    public void Grouping_45()
     {
         // Constraints: allows ref struct vs. not
         var src = """
@@ -26933,11 +27214,12 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
-    public void Grouping_37()
+    public void Grouping_46()
     {
         // Constraints: unmanaged vs. not
         var src = """
@@ -26955,11 +27237,12 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
-    public void Grouping_38()
+    public void Grouping_47()
     {
         // Constraints: variance difference
         var src = """
@@ -26974,7 +27257,7 @@ static class E
             // (3,15): error CS1960: Invalid variance modifier. Only interface and delegate type parameters can be specified as variant.
             //     extension<out T>(int) { }
             Diagnostic(ErrorCode.ERR_IllegalVarianceSyntax, "out").WithLocation(3, 15),
-            // (4,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            // (4,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
             //     extension<T>(int) { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(4, 5));
 
@@ -26983,11 +27266,14 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        // Note: the extension grouping raw name doesn't account for variance, but the IL-level comparer considers it.
+        // Consider ignoring variance in IL-level comparison too, to reduce a cascading diagnostic in this error scenario.
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 
     [Fact]
-    public void Grouping_39()
+    public void Grouping_48()
     {
         // difference in conditional attribute
         var src = """
@@ -27017,7 +27303,7 @@ public static partial class E
 [System.Diagnostics.Conditional("TEST")]
 public class AAttribute : System.Attribute { }
 """;
-        // attribute included
+        // attribute excluded
         var comp = CreateCompilation([src, src2, src3]);
         CompileAndVerify(comp).VerifyDiagnostics();
 
@@ -27028,9 +27314,10 @@ public class AAttribute : System.Attribute { }
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
         Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
         Assert.Equal("extension(System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
 
-        // attribute excluded by condition
+        // attribute included by condition
         comp = CreateCompilation([src, defineTestDirective + src2, src3]);
         comp.VerifyEmitDiagnostics();
 
@@ -27041,7 +27328,594 @@ public class AAttribute : System.Attribute { }
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
         Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
         AssertEx.Equal("extension([AAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_49()
+    {
+        // difference in conditional attribute
+        var src = """
+public static partial class E
+{
+    extension([A] int)
+    {
+        public static void M1() { }
+    }
+    extension(int)
+    {
+        public static void M2() { }
+    }
+}
+
+[System.Diagnostics.Conditional("TEST")]
+public class AAttribute : System.Attribute { }
+""";
+
+        var defineTestDirective = """
+#define TEST
+
+""";
+
+        // attribute excluded
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+            () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName()),
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+
+        // attribute included by condition
+        comp = CreateCompilation(defineTestDirective + src);
+        comp.VerifyEmitDiagnostics();
+
+        extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        extension1 = (SourceNamedTypeSymbol)extensions[0];
+        extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Multiple(
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+            () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+            () => AssertEx.Equal("extension([AAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName()),
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_50()
+    {
+        // difference in conditional attribute
+        var src = """
+public static partial class E
+{
+    extension([B] int) { }
+}
+""";
+        var defineTestDirective = """
+#define TEST
+
+""";
+
+        var src2 = """
+public static partial class E
+{
+    extension([A, B] int) { }
+}
+""";
+        var src3 = """
+[System.Diagnostics.Conditional("TEST")]
+public class AAttribute : System.Attribute { }
+
+public class BAttribute : System.Attribute { }
+""";
+        // attribute excluded
+        var comp = CreateCompilation([src, src2, src3]);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName());
+        Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+
+        // attribute included by condition
+        comp = CreateCompilation([src, defineTestDirective + src2, src3]);
+        comp.VerifyEmitDiagnostics();
+
+        extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        extension1 = (SourceNamedTypeSymbol)extensions[0];
+        extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName());
+        AssertEx.Equal("extension([AAttribute/*()*/] [BAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_51()
+    {
+        // difference in nullability in constraints: annotated vs. unannotated
+        var src = """
+#nullable enable
+
+public static partial class E
+{
+    extension<T>(int) where T : I { }
+    extension<T>(int) where T : I? { }
+}
+
+public interface I { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+
+        Assert.Multiple(
+            () => Assert.Equal("extension<(I)>(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
+            () => Assert.Equal("extension<(I)>(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+
+            () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I", extension1.ComputeExtensionMarkerRawName()),
+            () => Assert.Equal("extension<T>(System.Int32) where T : maybenull, I", extension2.ComputeExtensionMarkerRawName()),
+            () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_52()
+    {
+        // difference in nullability in constraints: annotated vs. oblivious
+        var src = """
+#nullable enable
+
+public static partial class E
+{
+    extension<T>(int) where T : I?
+    {
+    }
+
+    extension<T>(int) where T :
+#nullable disable
+        I
+#nullable enable
+    {
+    }
+}
+
+public interface I { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+
+        Assert.Multiple(
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+
+            () => Assert.Equal("extension<T>(System.Int32) where T : maybenull, I", extension1.ComputeExtensionMarkerRawName()),
+            () => Assert.Equal("extension<T>(System.Int32) where T : I", extension2.ComputeExtensionMarkerRawName()),
+            () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+        // TODO2 verify nullability of constraint after round-tripping in metadata
+    }
+
+    [Fact]
+    public void Grouping_53()
+    {
+        // difference in nullability in constraints: type constraints with different nullabilities
+        var src = """
+#nullable enable
+
+public static partial class E
+{
+    extension<T>(int) where T : I1?, I2 { }
+    extension<T>(int) where T : I1, I2?  { }
+}
+
+public interface I1 { }
+public interface I2 { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+
+        Assert.Multiple(
+            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
+
+            () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I1, I2", extension1.ComputeExtensionMarkerRawName()),
+            () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I1, I2", extension2.ComputeExtensionMarkerRawName()),
+            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
+
+            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
+            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+        );
+    }
+
+    [Fact]
+    public void Grouping_54()
+    {
+        // difference in nested nullability in constraints: annotated vs. unannotated
+        var src = """
+#nullable enable
+
+public static partial class E
+{
+    extension<T>(int) where T : I<object> { }
+    extension<T>(int) where T : I<object?> { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_55()
+    {
+        // difference in nested nullability in constraints: annotated vs. oblivious
+        var src = """
+#nullable enable
+
+public static partial class E
+{
+    extension<T>(int) where T : I<object?>
+    {
+        public static void M1() { }
+    }
+    extension<T>(int) where T : I<
+#nullable disable
+        object
+#nullable enable
+    >
+    {
+        public static void M2() { }
+    }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_56()
+    {
+        // difference in nested tuple names in constraints
+        var src = """
+#nullable enable
+
+public static partial class E
+{
+    extension<T>(int) where T : I<(int a, int b)>
+    {
+    }
+    extension<T>(int) where T : I<(int, int)>
+    {
+    }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_57()
+    {
+        // order of constraints
+        var src = """
+public static class E
+{
+    extension<T>(int) where T : I1, I2 { }
+    extension<T>(int) where T : I1, I2 { }
+}
+
+public interface I1 { }
+public interface I2 { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_58()
+    {
+        // order of constraints
+        var src = """
+public static class E
+{
+    extension<T>(int) where T : I1, I2 { }
+    extension<T>(int) where T : I2, I1 { }
+}
+
+public interface I1 { }
+public interface I2 { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_59()
+    {
+        // arglist
+        var src = """
+public static class E
+{
+    extension(__arglist) { }
+    extension(__arglist) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (3,15): error CS1669: __arglist is not valid in this context
+            //     extension(__arglist) { }
+            Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(3, 15),
+            // (4,15): error CS1669: __arglist is not valid in this context
+            //     extension(__arglist) { }
+            Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(4, 15));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_60()
+    {
+        // arglist vs. not
+        var src = """
+public static class E
+{
+    extension(__arglist) { }
+    extension(int) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (3,15): error CS1669: __arglist is not valid in this context
+            //     extension(__arglist) { }
+            Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(3, 15));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_61()
+    {
+        // default value
+        var src = """
+public static class E
+{
+    extension(int i = 0) { }
+    extension(int i = 1) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (3,15): error CS9284: The receiver parameter of an extension cannot have a default value
+            //     extension(int i = 0) { }
+            Diagnostic(ErrorCode.ERR_ExtensionParameterDisallowsDefaultValue, "int i = 0").WithLocation(3, 15),
+            // (4,15): error CS9284: The receiver parameter of an extension cannot have a default value
+            //     extension(int i = 1) { }
+            Diagnostic(ErrorCode.ERR_ExtensionParameterDisallowsDefaultValue, "int i = 1").WithLocation(4, 15));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_62()
+    {
+        var src = """
+public static class E
+{
+    extension<T>(int) { }
+    extension<T, T>(int) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (4,18): error CS0692: Duplicate type parameter 'T'
+            //     extension<T, T>(int) { }
+            Diagnostic(ErrorCode.ERR_DuplicateTypeParameter, "T").WithArguments("T").WithLocation(4, 18));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_63()
+    {
+        // function pointer in constraints: ref vs. ref readonly
+        var src = """
+public unsafe static class E
+{
+    extension<T>(int) where T : I<delegate*<ref int, void>[]> { }
+    extension<T>(int) where T : I<delegate*<ref readonly int, void>[]> { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
+        CompileAndVerify(comp, verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_64()
+    {
+        // function pointer in constraints: ref vs. out
+        var src = """
+public unsafe static class E
+{
+    extension<T>(int) where T : I<delegate*<ref int, void>[]> { }
+    extension<T>(int) where T : I<delegate*<out int, void>[]> { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_65()
+    {
+        // function pointer in constraints: calling convention difference
+        var src = """
+public unsafe static class E
+{
+    extension<T>(int) where T : I<delegate* unmanaged[Cdecl]<void>[]> { }
+    extension<T>(int) where T : I<delegate* unmanaged[Stdcall]<void>[]> { }
+}
+
+public interface I<T> { }
+""";
+        var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_66()
+    {
+        var src = """
+public static class E
+{
+    extension(error) { }
+    extension(error2) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (3,15): error CS0246: The type or namespace name 'error' could not be found (are you missing a using directive or an assembly reference?)
+            //     extension(error) { }
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "error").WithArguments("error").WithLocation(3, 15),
+            // (4,15): error CS0246: The type or namespace name 'error2' could not be found (are you missing a using directive or an assembly reference?)
+            //     extension(error2) { }
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "error2").WithArguments("error2").WithLocation(4, 15));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
     }
 }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -27305,6 +27305,12 @@ public interface I<T> { }
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
         VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.Multiple(
+            () => AssertEx.Equal("extension<T>(System.Int32) where T : notnull, I<System.Object!>", ((SourceNamedTypeSymbol)extensions[0]).ComputeExtensionMarkerRawName()),
+            () => AssertEx.Equal("extension<T>(System.Int32) where T : notnull, I<System.Object?>", ((SourceNamedTypeSymbol)extensions[1]).ComputeExtensionMarkerRawName())
+        );
     }
 
     [Fact]
@@ -27335,6 +27341,12 @@ public interface I<T> { }
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
         VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.Multiple(
+            () => AssertEx.Equal("extension<T>(System.Int32) where T : notnull, I<System.Object?>", ((SourceNamedTypeSymbol)extensions[0]).ComputeExtensionMarkerRawName()),
+            () => AssertEx.Equal("extension<T>(System.Int32) where T : notnull, I<System.Object>", ((SourceNamedTypeSymbol)extensions[1]).ComputeExtensionMarkerRawName())
+        );
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -27853,7 +27853,7 @@ public unsafe static class E
 public interface I<T> { }
 """;
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
-        CompileAndVerify(comp).VerifyDiagnostics();
+        CompileAndVerify(comp, verify: Verification.FailsPEVerify).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         var extension1 = (SourceNamedTypeSymbol)extensions[0];
@@ -27878,7 +27878,7 @@ public unsafe static class E
 public interface I<T> { }
 """;
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
-        CompileAndVerify(comp).VerifyDiagnostics();
+        CompileAndVerify(comp, verify: Verification.FailsPEVerify).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         var extension1 = (SourceNamedTypeSymbol)extensions[0];

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -25632,8 +25632,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25676,8 +25676,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25714,8 +25714,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25753,8 +25753,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25792,8 +25792,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25831,8 +25831,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25871,8 +25871,8 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -25899,8 +25899,8 @@ public class BAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25941,8 +25941,8 @@ public class AAttribute : System.Attribute
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -25985,8 +25985,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26032,9 +26032,8 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.GetHashCode(extension1) == MemberSignatureComparer.ExtensionCSharpSignatureComparer.GetHashCode(extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -26098,8 +26097,8 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -26132,8 +26131,8 @@ public class AAttribute : System.Attribute
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -26171,8 +26170,8 @@ public static class E
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26198,8 +26197,8 @@ public class AAttribute : System.Attribute { }
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26238,8 +26237,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26276,8 +26275,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26314,8 +26313,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26351,8 +26350,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26389,8 +26388,8 @@ public static class E
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
 
         static void validate(ModuleSymbol module)
         {
@@ -26423,8 +26422,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -26446,8 +26445,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -26492,8 +26491,8 @@ public static class E
         AssertEx.Equal("extension(A)", extension2.ComputeExtensionGroupingRawName());
         AssertEx.Equal("extension(A)", extension2.ComputeExtensionMarkerRawName());
 
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -26558,8 +26557,8 @@ public static class E
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26593,8 +26592,8 @@ public static class E
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26630,8 +26629,8 @@ public interface I { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26667,8 +26666,8 @@ public interface I { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
     }
 
     [Fact]
@@ -26710,8 +26709,8 @@ public static class E
         AssertEx.Equal("extension(A)", extension2.ComputeExtensionGroupingRawName());
         AssertEx.Equal("extension(ref A a)", extension2.ComputeExtensionMarkerRawName());
 
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -26782,8 +26781,8 @@ public interface I<T> { }
         Assert.Multiple(
             () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
             () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-            () => Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -26818,8 +26817,8 @@ public static class E
         Assert.Multiple(
             () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
             () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-            () => Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -26860,8 +26859,8 @@ public interface I<T> { }
             () => AssertEx.Equal("extension<(I`1<A>)>(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
             () => AssertEx.Equal("extension<T>(System.Int32 i) where T : I<A>", extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -26905,8 +26904,8 @@ public class AAttribute : System.Attribute
             () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
             () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(A))] System.Int32 i)", extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -26942,8 +26941,8 @@ public interface I<T> { }
             () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
             () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(I`1<System.Object>))] System.Int32)", extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -26975,8 +26974,8 @@ public class AAttribute : System.Attribute
             () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
             () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(System.ValueTuple`2<System.Int32, System.Int32>))] System.Int32)", extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27004,8 +27003,8 @@ public class AAttribute : System.Attribute
         Assert.Multiple(
             () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
             () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27051,8 +27050,8 @@ public interface I<T> { }
             () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
             () => AssertEx.Equal("extension([AAttribute/*(System.Type)*/(typeof(I`1<A>))] System.Int32 i)", extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27098,8 +27097,8 @@ public interface I<T> { }
             () => AssertEx.Equal("extension(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
             () => AssertEx.Equal("extension([AAttribute/*(System.Type[])*/([typeof(I`1<A>)])] System.Int32 i)", extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27122,8 +27121,8 @@ unsafe static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27145,8 +27144,8 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27168,8 +27167,8 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27191,8 +27190,8 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27214,8 +27213,8 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27237,8 +27236,8 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27268,8 +27267,8 @@ static class E
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
         // Note: the extension grouping raw name doesn't account for variance, but the IL-level comparer considers it.
         // Consider ignoring variance in IL-level comparison too, to reduce a cascading diagnostic in this error scenario.
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27314,8 +27313,8 @@ public class AAttribute : System.Attribute { }
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
         Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
         Assert.Equal("extension(System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
 
         // attribute included by condition
         comp = CreateCompilation([src, defineTestDirective + src2, src3]);
@@ -27328,8 +27327,8 @@ public class AAttribute : System.Attribute { }
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
         Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
         AssertEx.Equal("extension([AAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27369,8 +27368,8 @@ public class AAttribute : System.Attribute { }
             () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
             () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
             () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName()),
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
 
         // attribute included by condition
@@ -27384,8 +27383,8 @@ public class AAttribute : System.Attribute { }
             () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
             () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
             () => AssertEx.Equal("extension([AAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName()),
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27427,8 +27426,8 @@ public class BAttribute : System.Attribute { }
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
         Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName());
         Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
 
         // attribute included by condition
         comp = CreateCompilation([src, defineTestDirective + src2, src3]);
@@ -27441,8 +27440,8 @@ public class BAttribute : System.Attribute { }
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
         Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName());
         AssertEx.Equal("extension([AAttribute/*()*/] [BAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27476,8 +27475,8 @@ public interface I { }
             () => Assert.Equal("extension<T>(System.Int32) where T : maybenull, I", extension2.ComputeExtensionMarkerRawName()),
             () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27518,8 +27517,8 @@ public interface I { }
             () => Assert.Equal("extension<T>(System.Int32) where T : I", extension2.ComputeExtensionMarkerRawName()),
             () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27553,8 +27552,8 @@ public interface I2 { }
             () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I1, I2", extension2.ComputeExtensionMarkerRawName()),
             () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
 
-            () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
-            () => Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
+            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
+            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
         );
     }
 
@@ -27581,8 +27580,8 @@ public interface I<T> { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27618,8 +27617,8 @@ public interface I<T> { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27649,8 +27648,8 @@ public interface I<T> { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27675,8 +27674,8 @@ public interface I2 { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27701,8 +27700,8 @@ public interface I2 { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27730,8 +27729,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27756,8 +27755,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27785,8 +27784,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27810,8 +27809,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27835,8 +27834,8 @@ public interface I<T> { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27860,8 +27859,8 @@ public interface I<T> { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27885,8 +27884,8 @@ public interface I<T> { }
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27913,8 +27912,8 @@ public static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -27930,15 +27929,35 @@ public static class E
 public ref struct RS { }
 """;
         var comp = CreateCompilation(src);
-        comp.VerifyEmitDiagnostics();
+        //comp.VerifyEmitDiagnostics();
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         var extension1 = (SourceNamedTypeSymbol)extensions[0];
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_68()
+    {
+        var src = """
+public static class E
+{
+    extension<T>(T) { }
+    extension<T>(T) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -22566,7 +22566,7 @@ static class E
             // (3,15): error CS1960: Invalid variance modifier. Only interface and delegate type parameters can be specified as variant.
             //     extension<in T>(T t)
             Diagnostic(ErrorCode.ERR_IllegalVarianceSyntax, "in").WithLocation(3, 15),
-            // (7,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same grouping type identifier.
+            // (7,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(T t)
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(7, 5),
             // (9,21): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
@@ -22577,7 +22577,8 @@ static class E
             Diagnostic(ErrorCode.ERR_IllegalVarianceSyntax, "in").WithLocation(12, 27),
             // (13,24): error CS0111: Type 'E' already defines a member called 'M2' with the same parameter types
             //     public static void M2<T>(this T t) { }
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M2").WithArguments("M2", "E").WithLocation(13, 24));
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M2").WithArguments("M2", "E").WithLocation(13, 24)
+            );
     }
 
     [Fact]
@@ -25901,7 +25902,7 @@ public class BAttribute : System.Attribute { }
     [Fact]
     public void Grouping_09()
     {
-        // attribute on parameter vs. different attribute
+        // different attribute values on parameter
         var src = """
 public static class E
 {
@@ -26097,7 +26098,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension([A2] int) { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26375,7 +26376,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension(A2)
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5),
             // (14,28): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
@@ -26415,7 +26416,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension(A2) { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
     }
@@ -26440,7 +26441,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(T) where T : A2 { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26469,7 +26470,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T, U>(T) where T : A2 where U : T { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26500,7 +26501,7 @@ public interface I { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(T) where T : I, A2 { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26531,7 +26532,7 @@ public interface I { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(T) where T : I, A2 { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26560,7 +26561,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension(ref A2 a) { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26604,7 +26605,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension(ref A2 a)
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5),
             // (14,28): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
@@ -26635,7 +26636,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension(I<A2> a) { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26671,7 +26672,7 @@ public static class E
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(int i) where T : I<A2> { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26709,7 +26710,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(int i) where T : I<A2> { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26754,7 +26755,7 @@ public class AAttribute : System.Attribute
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(int i) where T : I<A2> { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26891,7 +26892,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(int i) where T : I<A2> { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -26938,7 +26939,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(int i) where T : I<A2> { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
@@ -27069,7 +27070,7 @@ static class E
             // (3,15): error CS1960: Invalid variance modifier. Only interface and delegate type parameters can be specified as variant.
             //     extension<out T>(int) { }
             Diagnostic(ErrorCode.ERR_IllegalVarianceSyntax, "out").WithLocation(3, 15),
-            // (4,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            // (4,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata, so must be in separate enclosing static classes.
             //     extension<T>(int) { }
             Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(4, 5));
 
@@ -27645,6 +27646,25 @@ public static class E1<T1>
             // (5,9): error CS9283: Extensions must be declared in a top-level, non-generic, static class
             //         extension((T1, T2)) { }
             Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Grouping_73()
+    {
+        var src = """
+public static class E
+{
+    extension(object) { }
+    extension(dynamic) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (4,15): error CS1103: The receiver parameter of an extension cannot be of type 'dynamic'
+            //     extension(dynamic) { }
+            Diagnostic(ErrorCode.ERR_BadTypeforThis, "dynamic").WithArguments("dynamic").WithLocation(4, 15));
+
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -27521,7 +27521,6 @@ public interface I { }
             () => Assert.True(MemberSignatureComparer.ExtensionILSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1])),
             () => Assert.False(MemberSignatureComparer.ExtensionCSharpSignatureComparer.Equals(extension1, extension2))
         );
-        // TODO2 verify nullability of constraint after round-tripping in metadata
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -22565,6 +22566,9 @@ static class E
             // (3,15): error CS1960: Invalid variance modifier. Only interface and delegate type parameters can be specified as variant.
             //     extension<in T>(T t)
             Diagnostic(ErrorCode.ERR_IllegalVarianceSyntax, "in").WithLocation(3, 15),
+            // (7,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same grouping type identifier.
+            //     extension<T>(T t)
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(7, 5),
             // (9,21): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
             //         public void M() { }
             Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "E").WithLocation(9, 21),
@@ -25608,7 +25612,7 @@ class C3<[ExtensionMarkerName("type parameter")] T> { }
     }
 
     [Fact]
-    public void GroupingType_01()
+    public void Grouping_01()
     {
         // extension blocks differing by tuple names are merged into a single grouping type
         var src = """
@@ -25627,6 +25631,9 @@ public static class E
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
         static void validate(ModuleSymbol module)
         {
             var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
@@ -25641,7 +25648,7 @@ public static class E
     }
 
     [Fact]
-    public void GroupingType_02()
+    public void Grouping_02()
     {
         // extension blocks differing by nullability are merged into a single grouping type
         var src = """
@@ -25667,6 +25674,9 @@ public static class E
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
         static void validate(ModuleSymbol module)
         {
             var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
@@ -25682,7 +25692,7 @@ public static class E
     }
 
     [Fact]
-    public void GroupingType_03()
+    public void Grouping_03()
     {
         // extension blocks differing by IL-level constraints each have a grouping type
         var src = """
@@ -25701,6 +25711,9 @@ public static class E
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
         static void validate(ModuleSymbol module)
         {
             var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
@@ -25716,7 +25729,7 @@ public static class E
     }
 
     [Fact]
-    public void GroupingType_04()
+    public void Grouping_04()
     {
         // extension blocks differing by C#-level constraints are merged into a single grouping type
         var src = """
@@ -25736,6 +25749,9 @@ public static class E
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
 
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
         static void validate(ModuleSymbol module)
         {
             var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
@@ -25747,6 +25763,1285 @@ public static class E
                 "TypeDefinition:<Marker>$2789E59A55056F0AD9E820EBD5BCDFBF"
                 ], reader.DumpNestedTypes(e.Handle));
         }
+    }
+
+    [Fact]
+    public void Grouping_05()
+    {
+        // attribute on parameter vs. no attribute
+        var src = """
+public static class E
+{
+    extension([A] int)
+    {
+        public static void M1() { }
+    }
+    extension(int)
+    {
+        public static void M2() { }
+    }
+}
+
+public class AAttribute : System.Attribute { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$BA41CFE2B5EDAEB8C1B9062F59ED4D69",
+                "TypeDefinition:<Marker>$E32A05FB502A840C00FE0EDD5BE96810",
+                "TypeDefinition:<Marker>$BA41CFE2B5EDAEB8C1B9062F59ED4D69"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_06()
+    {
+        // same attributes on parameter
+        var src = """
+public static class E
+{
+    extension([A] int)
+    {
+        public static void M1() { }
+    }
+    extension([A] int)
+    {
+        public static void M2() { }
+    }
+}
+
+public class AAttribute : System.Attribute { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$BA41CFE2B5EDAEB8C1B9062F59ED4D69",
+                "TypeDefinition:<Marker>$E32A05FB502A840C00FE0EDD5BE96810"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_07()
+    {
+        // different attributes constructors on parameter
+        var src = """
+public static class E
+{
+    extension([A] int) { }
+    extension([A(1)] int) { }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute() { }
+    public AAttribute(int i) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_08()
+    {
+        // attribute on parameter vs. different attribute
+        var src = """
+public static class E
+{
+    extension([A] int)
+    {
+        public static void M1() { }
+    }
+    extension([B] int)
+    {
+        public static void M2() { }
+    }
+}
+
+public class AAttribute : System.Attribute { }
+public class BAttribute : System.Attribute { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$BA41CFE2B5EDAEB8C1B9062F59ED4D69",
+                "TypeDefinition:<Marker>$E32A05FB502A840C00FE0EDD5BE96810",
+                "TypeDefinition:<Marker>$218F3E71AC85BD424B16D5E83C9E7F44"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_09()
+    {
+        // attribute on parameter vs. different attribute
+        var src = """
+public static class E
+{
+    extension([A(1)] int)
+    {
+        public static void M1() { }
+    }
+    extension([A(2)] int)
+    {
+        public static void M2() { }
+    }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(int value) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$BA41CFE2B5EDAEB8C1B9062F59ED4D69",
+                "TypeDefinition:<Marker>$B6EBDF480696A625FE9EDB09D32E1830",
+                "TypeDefinition:<Marker>$30F160891A3959D878D7B02360CC7D54"
+                ], reader.DumpNestedTypes(e.Handle));
+
+            var extensions = e.GetTypeMembers();
+            Assert.Equal(["AAttribute(1)"], extensions[0].ExtensionParameter.GetAttributes().Select(a => a.ToString()));
+            Assert.Equal(["AAttribute(2)"], extensions[1].ExtensionParameter.GetAttributes().Select(a => a.ToString()));
+        }
+    }
+
+    [Fact]
+    public void Grouping_10()
+    {
+        // duplicate attribute on parameter vs. single attribute
+        var src = """
+public static class E
+{
+    extension([A, A] int)
+    {
+        public static void M1() { }
+    }
+    extension([A] int)
+    {
+        public static void M2() { }
+    }
+}
+
+[System.AttributeUsage(System.AttributeTargets.All, AllowMultiple = true)]
+public class AAttribute : System.Attribute { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$BA41CFE2B5EDAEB8C1B9062F59ED4D69",
+                "TypeDefinition:<Marker>$F3C360580C2136B2A9F2154F91355898",
+                "TypeDefinition:<Marker>$E32A05FB502A840C00FE0EDD5BE96810"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_11()
+    {
+        // different attribute orders
+        var src = """
+public static class E
+{
+    extension([A(1), A(2)] int)
+    {
+        public static void M1() { }
+    }
+    extension([A(2), A(1)] int)
+    {
+        public static void M2() { }
+    }
+}
+
+[System.AttributeUsage(System.AttributeTargets.All, AllowMultiple = true)]
+public class AAttribute : System.Attribute
+{
+    public AAttribute(int value) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_12()
+    {
+        // different attribute orders
+        var src = """
+public static class E
+{
+    extension([A(1), A(2)] int)
+    {
+        public static void M() { }
+    }
+    extension([A(2), A(1)] int)
+    {
+        public static void M() { }
+    }
+}
+
+[System.AttributeUsage(System.AttributeTargets.All, AllowMultiple = true)]
+public class AAttribute : System.Attribute
+{
+    public AAttribute(int value) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (9,28): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
+            //         public static void M() { }
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "E").WithLocation(9, 28));
+    }
+
+    [Fact]
+    public void Grouping_13()
+    {
+        // different order of named arguments in attribute
+        var src = """
+public static class E
+{
+    extension([A(P1 = 0, P2 = 0)] int)
+    {
+        public static void M1() { }
+    }
+    extension([A(P2 = 0, P1 = 0)] int)
+    {
+        public static void M2() { }
+    }
+}
+
+public class AAttribute : System.Attribute
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_14()
+    {
+        // different order of arguments in attribute
+        var src = """
+public static class E
+{
+    extension([A(i1: 0, i2: 0)] int)
+    {
+        public static void M1() { }
+    }
+    extension([A(i2: 0, i1: 0)] int)
+    {
+        public static void M2() { }
+    }
+}
+
+public class AAttribute : System.Attribute
+{
+    public AAttribute(int i1, int i2) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_15()
+    {
+        // attribute on parameter from assembly vs. from another assembly
+        var libSrc = """
+public class AAttribute : System.Attribute { }
+""";
+        var libComp1 = CreateCompilation(libSrc, assemblyName: "assembly1");
+        var libComp2 = CreateCompilation(libSrc, assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::AAttribute;
+using A2 = alias2::AAttribute;
+
+public static class E
+{
+    extension([A1] int)
+    {
+        public static void M1() { }
+    }
+    extension([A2] int)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension([A2] int)
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+    }
+
+    [Fact]
+    public void Grouping_16()
+    {
+        // attributes on type parameter vs. no attribute
+        var src = """
+public static class E
+{
+    extension<[A] T>(int)
+    {
+        public static void M1() { }
+    }
+    extension<T>(int)
+    {
+        public static void M2() { }
+    }
+}
+
+public class AAttribute : System.Attribute { }
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$B8D310208B4544F25EEBACB9990FC73B",
+                "TypeDefinition:<Marker>$F167169D271C76FCF9FF858EA5CFC454",
+                "TypeDefinition:<Marker>$9D7BB308433678477E9C2F4392A27B18"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_17()
+    {
+        // notnull vs. oblivious type parameter
+        var src = """
+#nullable enable
+public static class E
+{
+    extension<T>(T) where T : notnull
+    {
+        public static void M1() { }
+    }
+
+#nullable disable
+    extension<T>(T)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$8048A6C8BE30A622530249B904B537EB",
+                "TypeDefinition:<Marker>$C7A07C3975E80DE5DBC93B5392C6C922",
+                "TypeDefinition:<Marker>$01CE3801593377B4E240F33E20D30D50"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_18()
+    {
+        // different type parameter names
+        var src = """
+public static class E
+{
+    extension<T1>(int)
+    {
+        public static void M1() { }
+    }
+
+    extension<T2>(int)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$B8D310208B4544F25EEBACB9990FC73B",
+                "TypeDefinition:<Marker>$A189EAA0A09C2534B53DBF86166AD56A",
+                "TypeDefinition:<Marker>$869530FF3C2454D7BCCC5A8D0E31052F"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_19()
+    {
+        // same type parameter names
+        var src = """
+public static class E
+{
+    extension<T>(int)
+    {
+        public static void M1() { }
+    }
+
+    extension<T>(int)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$B8D310208B4544F25EEBACB9990FC73B",
+                "TypeDefinition:<Marker>$9D7BB308433678477E9C2F4392A27B18"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_20()
+    {
+        // different parameter names
+        var src = """
+public static class E
+{
+    extension(int i1)
+    {
+        public static void M1() { }
+    }
+
+    extension(int i2)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$BA41CFE2B5EDAEB8C1B9062F59ED4D69",
+                "TypeDefinition:<Marker>$531E7AC45D443AE2243E7FFAB9455D60",
+                "TypeDefinition:<Marker>$032E02D1D6078965F7C2AFC8F27F2F81"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_21()
+    {
+        // same parameter names
+        var src = """
+public static class E
+{
+    extension(int i)
+    {
+        public static void M1() { }
+    }
+
+    extension(int i)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$BA41CFE2B5EDAEB8C1B9062F59ED4D69",
+                "TypeDefinition:<Marker>$F4B4FFE41AB49E80A4ECF390CF6EB372"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_22()
+    {
+        // ref vs. by value
+        var src = """
+public static class E
+{
+    extension(ref int i) { }
+    extension(int i) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_23()
+    {
+        // ref readonly vs. in
+        var src = """
+public static class E
+{
+    extension(ref readonly int i) { }
+    extension(in int i) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_24()
+    {
+        var libComp1 = CreateCompilation("public class A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public class A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension(A1)
+    {
+        public static void M() { }
+    }
+    extension(A2)
+    {
+        public static void M() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension(A2)
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5),
+            // (14,28): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
+            //         public static void M() { }
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "E").WithLocation(14, 28));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        AssertEx.Equal("extension(A)", extension1.ComputeExtensionGroupingRawName());
+        AssertEx.Equal("extension(A)", extension1.ComputeExtensionMarkerRawName());
+
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        AssertEx.Equal("extension(A)", extension2.ComputeExtensionGroupingRawName());
+        AssertEx.Equal("extension(A)", extension2.ComputeExtensionMarkerRawName());
+
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_25()
+    {
+        var libComp1 = CreateCompilation("public class A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public class A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension(A1)
+    {
+        public static void M1() { }
+    }
+    extension(A2)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension(A2)
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+    }
+
+    [Fact]
+    public void Grouping_26()
+    {
+        var libComp1 = CreateCompilation("public class A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public class A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension<T>(T) where T : A1
+    {
+        public static void M1() { }
+    }
+    extension<T>(T) where T : A2
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension<T>(T) where T : A2
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+    }
+
+    [Fact]
+    public void Grouping_27()
+    {
+        var libComp1 = CreateCompilation("public class A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public class A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension<T, U>(T) where T : A1 where U : T
+    {
+        public static void M1() { }
+    }
+    extension<T, U>(T) where T : A2 where U : T
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension<T, U>(T) where T : A2 where U : T
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+    }
+
+    [Fact]
+    public void Grouping_28()
+    {
+        var libComp1 = CreateCompilation("public interface A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public interface A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension<T>(T) where T : I, A1
+    {
+        public static void M1() { }
+    }
+    extension<T>(T) where T : I, A2
+    {
+        public static void M2() { }
+    }
+}
+
+public interface I { }
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension<T>(T) where T : I, A2
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+    }
+
+    [Fact]
+    public void Grouping_29()
+    {
+        var libComp1 = CreateCompilation("public interface A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public interface A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension<T>(T) where T : A1, I
+    {
+        public static void M1() { }
+    }
+    extension<T>(T) where T : I, A2
+    {
+        public static void M2() { }
+    }
+}
+
+public interface I { }
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (12,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension<T>(T) where T : I, A2
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+    }
+
+    [Fact]
+    public void Grouping_30()
+    {
+        var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension(A1 a)
+    {
+        public static void M() { }
+    }
+    extension(ref A2 a)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        var verifier = CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        AssertEx.Equal("extension(A)", extension1.ComputeExtensionGroupingRawName());
+        AssertEx.Equal("extension(A a)", extension1.ComputeExtensionMarkerRawName());
+
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        AssertEx.Equal("extension(A)", extension2.ComputeExtensionGroupingRawName());
+        AssertEx.Equal("extension(ref A a)", extension2.ComputeExtensionMarkerRawName());
+
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+
+        verifier.VerifyTypeIL("E", """
+.class public auto ansi abstract sealed beforefieldinit E
+    extends [mscorlib]System.Object
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
+        01 00 00 00
+    )
+    // Nested Types
+    .class nested public auto ansi sealed specialname '<Extension>$43BB1C51423008731091E2D86C21895C'
+        extends [mscorlib]System.Object
+    {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
+            01 00 00 00
+        )
+        // Nested Types
+        .class nested public auto ansi abstract sealed specialname '<Marker>$ADCDF963FFE571676263A9D3587B316A'
+            extends [mscorlib]System.Object
+        {
+            // Methods
+            .method public hidebysig specialname static 
+                void '<Extension>$' (
+                    valuetype [assembly1]A a
+                ) cil managed 
+            {
+                .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+                    01 00 00 00
+                )
+                // Method begins at RVA 0x2067
+                // Code size 1 (0x1)
+                .maxstack 8
+                IL_0000: ret
+            } // end of method '<Marker>$ADCDF963FFE571676263A9D3587B316A'::'<Extension>$'
+        } // end of class <Marker>$ADCDF963FFE571676263A9D3587B316A
+        .class nested public auto ansi abstract sealed specialname '<Marker>$3ABF4F62890B47BCE5C28E8C145BB466'
+            extends [mscorlib]System.Object
+        {
+            // Methods
+            .method public hidebysig specialname static 
+                void '<Extension>$' (
+                    valuetype [assembly2]A& a
+                ) cil managed 
+            {
+                .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+                    01 00 00 00
+                )
+                // Method begins at RVA 0x2067
+                // Code size 1 (0x1)
+                .maxstack 8
+                IL_0000: ret
+            } // end of method '<Marker>$3ABF4F62890B47BCE5C28E8C145BB466'::'<Extension>$'
+        } // end of class <Marker>$3ABF4F62890B47BCE5C28E8C145BB466
+        // Methods
+        .method public hidebysig static 
+            void M () cil managed 
+        {
+            .custom instance void System.Runtime.CompilerServices.ExtensionMarkerNameAttribute::.ctor(string) = (
+                01 00 29 3c 4d 61 72 6b 65 72 3e 24 41 44 43 44
+                46 39 36 33 46 46 45 35 37 31 36 37 36 32 36 33
+                41 39 44 33 35 38 37 42 33 31 36 41 00 00
+            )
+            // Method begins at RVA 0x2069
+            // Code size 2 (0x2)
+            .maxstack 8
+            IL_0000: ldnull
+            IL_0001: throw
+        } // end of method '<Extension>$43BB1C51423008731091E2D86C21895C'::M
+        .method public hidebysig static 
+            void M2 () cil managed 
+        {
+            .custom instance void System.Runtime.CompilerServices.ExtensionMarkerNameAttribute::.ctor(string) = (
+                01 00 29 3c 4d 61 72 6b 65 72 3e 24 33 41 42 46
+                34 46 36 32 38 39 30 42 34 37 42 43 45 35 43 32
+                38 45 38 43 31 34 35 42 42 34 36 36 00 00
+            )
+            // Method begins at RVA 0x2069
+            // Code size 2 (0x2)
+            .maxstack 8
+            IL_0000: ldnull
+            IL_0001: throw
+        } // end of method '<Extension>$43BB1C51423008731091E2D86C21895C'::M2
+    } // end of class <Extension>$43BB1C51423008731091E2D86C21895C
+    // Methods
+    .method public hidebysig static 
+        void M () cil managed 
+    {
+        // Method begins at RVA 0x2067
+        // Code size 1 (0x1)
+        .maxstack 8
+        IL_0000: ret
+    } // end of method E::M
+    .method public hidebysig static 
+        void M2 () cil managed 
+    {
+        // Method begins at RVA 0x2067
+        // Code size 1 (0x1)
+        .maxstack 8
+        IL_0000: ret
+    } // end of method E::M2
+} // end of class E
+""".Replace("[mscorlib]", ExecutionConditionUtil.IsMonoOrCoreClr ? "[netstandard]" : "[mscorlib]"));
+
+        static void validate(ModuleSymbol module)
+        {
+            var e = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMember("E");
+            var reader = ((PEModuleSymbol)module).Module.GetMetadataReader();
+            AssertEx.Equal([
+                "TypeDefinition:E",
+                "TypeDefinition:<Extension>$43BB1C51423008731091E2D86C21895C",
+                "TypeDefinition:<Marker>$ADCDF963FFE571676263A9D3587B316A",
+                "TypeDefinition:<Marker>$3ABF4F62890B47BCE5C28E8C145BB466"
+                ], reader.DumpNestedTypes(e.Handle));
+        }
+    }
+
+    [Fact]
+    public void Grouping_31()
+    {
+        var libComp1 = CreateCompilation("public struct A { }", assemblyName: "assembly1");
+        var libComp2 = CreateCompilation("public struct A { }", assemblyName: "assembly2");
+
+        var src = """
+extern alias alias1;
+extern alias alias2;
+using A1 = alias1::A;
+using A2 = alias2::A;
+
+public static class E
+{
+    extension(A1 a)
+    {
+        public static void M() { }
+    }
+    extension(ref A2 a)
+    {
+        public static void M() { }
+    }
+}
+""";
+        var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
+        comp.VerifyEmitDiagnostics(
+            // (14,28): error CS0111: Type 'E' already defines a member called 'M' with the same parameter types
+            //         public static void M() { }
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "E").WithLocation(14, 28));
+    }
+
+    [Fact]
+    public void Grouping_32()
+    {
+        // Function pointer type: ref vs. out
+        var src = """
+unsafe static class E
+{
+    extension(delegate*<ref int, void>[]) { }
+    extension(delegate*<out int, void>[]) { }
+}
+""";
+        var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_33()
+    {
+        // Constraints: new() vs. not
+        var src = """
+static class E
+{
+    extension<T>(int) where T : new() { }
+    extension<T>(int) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_34()
+    {
+        // Constraints: class vs. not
+        var src = """
+static class E
+{
+    extension<T>(int) where T : class { }
+    extension<T>(int) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_35()
+    {
+        // Constraints: struct vs. not
+        var src = """
+static class E
+{
+    extension<T>(int) where T : class { }
+    extension<T>(int) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_36()
+    {
+        // Constraints: allows ref struct vs. not
+        var src = """
+static class E
+{
+    extension<T>(int) where T : allows ref struct { }
+    extension<T>(int) { }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_37()
+    {
+        // Constraints: unmanaged vs. not
+        var src = """
+static class E
+{
+    extension<T>(int) where T : unmanaged { }
+    extension<T>(int) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_38()
+    {
+        // Constraints: variance difference
+        var src = """
+static class E
+{
+    extension<out T>(int) { }
+    extension<T>(int) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (3,15): error CS1960: Invalid variance modifier. Only interface and delegate type parameters can be specified as variant.
+            //     extension<out T>(int) { }
+            Diagnostic(ErrorCode.ERR_IllegalVarianceSyntax, "out").WithLocation(3, 15),
+            // (4,5): error CS9326: This extension block collides with another extension block. They have different signatures, but result in the same marker type identifier.
+            //     extension<T>(int) { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(4, 5));
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+    }
+
+    [Fact]
+    public void Grouping_39()
+    {
+        // difference in conditional attribute
+        var src = """
+public static partial class E
+{
+    extension([A] int)
+    {
+        public static void M1() { }
+    }
+}
+""";
+        var defineTestDirective = """
+#define TEST
+
+""";
+
+        var src2 = """
+public static partial class E
+{
+    extension([A] int)
+    {
+        public static void M2() { }
+    }
+}
+""";
+        var src3 = """
+[System.Diagnostics.Conditional("TEST")]
+public class AAttribute : System.Attribute { }
+""";
+        // attribute included
+        var comp = CreateCompilation([src, src2, src3]);
+        CompileAndVerify(comp).VerifyDiagnostics();
+
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
+        Assert.Equal("extension(System.Int32)", extension2.ComputeExtensionMarkerRawName());
+        Assert.True(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
+
+        // attribute excluded by condition
+        comp = CreateCompilation([src, defineTestDirective + src2, src3]);
+        comp.VerifyEmitDiagnostics();
+
+        extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        extension1 = (SourceNamedTypeSymbol)extensions[0];
+        extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
+        AssertEx.Equal("extension([AAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
+        Assert.False(MemberSignatureComparer.ExtensionSignatureComparer.Equals(extension1, extension2));
     }
 }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -25630,10 +25630,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -25646,6 +25643,17 @@ public static class E
                 "TypeDefinition:<Marker>$1F33B79C79D1C037CA6976EB16158758"
                 ], reader.DumpNestedTypes(e.Handle));
         }
+    }
+
+    private static void VerifyCollisions(CSharpCompilation comp, bool groupingMatch, bool markerMatch)
+    {
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        var extension1 = (SourceNamedTypeSymbol)extensions[0];
+        var extension2 = (SourceNamedTypeSymbol)extensions[1];
+        Assert.Equal(groupingMatch, extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
+        Assert.Equal(markerMatch, extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        Assert.Equal(groupingMatch, ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
+        Assert.Equal(markerMatch, ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
     }
 
     [Fact]
@@ -25674,10 +25682,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -25712,10 +25717,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -25751,10 +25753,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -25790,10 +25789,7 @@ public class AAttribute : System.Attribute { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -25829,10 +25825,7 @@ public class AAttribute : System.Attribute { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
 
         static void validate(ModuleSymbol module)
         {
@@ -25865,14 +25858,7 @@ public class AAttribute : System.Attribute
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -25897,10 +25883,7 @@ public class BAttribute : System.Attribute { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -25939,10 +25922,7 @@ public class AAttribute : System.Attribute
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -25983,10 +25963,7 @@ public class AAttribute : System.Attribute { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -26008,14 +25985,8 @@ public class AAttribute : System.Attribute { }
         var src = """
 public static class E
 {
-    extension([A(1), A(2)] int)
-    {
-        public static void M1() { }
-    }
-    extension([A(2), A(1)] int)
-    {
-        public static void M2() { }
-    }
+    extension([A(1), A(2)] int) { }
+    extension([A(2), A(1)] int) { }
 }
 
 [System.AttributeUsage(System.AttributeTargets.All, AllowMultiple = true)]
@@ -26026,14 +25997,7 @@ public class AAttribute : System.Attribute
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -26073,14 +26037,8 @@ public class AAttribute : System.Attribute
         var src = """
 public static class E
 {
-    extension([A(P1 = 0, P2 = 0)] int)
-    {
-        public static void M1() { }
-    }
-    extension([A(P2 = 0, P1 = 0)] int)
-    {
-        public static void M2() { }
-    }
+    extension([A(P1 = 0, P2 = 0)] int) { }
+    extension([A(P2 = 0, P1 = 0)] int) { }
 }
 
 public class AAttribute : System.Attribute
@@ -26091,14 +26049,7 @@ public class AAttribute : System.Attribute
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -26108,14 +26059,8 @@ public class AAttribute : System.Attribute
         var src = """
 public static class E
 {
-    extension([A(i1: 0, i2: 0)] int)
-    {
-        public static void M1() { }
-    }
-    extension([A(i2: 0, i1: 0)] int)
-    {
-        public static void M2() { }
-    }
+    extension([A(i1: 0, i2: 0)] int) { }
+    extension([A(i2: 0, i1: 0)] int) { }
 }
 
 public class AAttribute : System.Attribute
@@ -26125,14 +26070,7 @@ public class AAttribute : System.Attribute
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -26153,21 +26091,15 @@ using A2 = alias2::AAttribute;
 
 public static class E
 {
-    extension([A1] int)
-    {
-        public static void M1() { }
-    }
-    extension([A2] int)
-    {
-        public static void M2() { }
-    }
+    extension([A1] int) { }
+    extension([A2] int) { }
 }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
-            //     extension([A2] int)
-            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension([A2] int) { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
@@ -26195,10 +26127,7 @@ public class AAttribute : System.Attribute { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -26235,10 +26164,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -26273,10 +26199,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -26311,10 +26234,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
 
         static void validate(ModuleSymbol module)
         {
@@ -26348,10 +26268,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         static void validate(ModuleSymbol module)
         {
@@ -26386,10 +26303,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp, symbolValidator: validate).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
 
         static void validate(ModuleSymbol module)
         {
@@ -26416,14 +26330,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -26439,14 +26346,7 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -26509,21 +26409,15 @@ using A2 = alias2::A;
 
 public static class E
 {
-    extension(A1)
-    {
-        public static void M1() { }
-    }
-    extension(A2)
-    {
-        public static void M2() { }
-    }
+    extension(A1) { }
+    extension(A2) { }
 }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
-            //     extension(A2)
-            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension(A2) { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
     }
 
     [Fact]
@@ -26540,21 +26434,15 @@ using A2 = alias2::A;
 
 public static class E
 {
-    extension<T>(T) where T : A1
-    {
-        public static void M1() { }
-    }
-    extension<T>(T) where T : A2
-    {
-        public static void M2() { }
-    }
+    extension<T>(T) where T : A1 { }
+    extension<T>(T) where T : A2 { }
 }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
-            //     extension<T>(T) where T : A2
-            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(T) where T : A2 { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
@@ -26575,21 +26463,15 @@ using A2 = alias2::A;
 
 public static class E
 {
-    extension<T, U>(T) where T : A1 where U : T
-    {
-        public static void M1() { }
-    }
-    extension<T, U>(T) where T : A2 where U : T
-    {
-        public static void M2() { }
-    }
+    extension<T, U>(T) where T : A1 where U : T { }
+    extension<T, U>(T) where T : A2 where U : T { }
 }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
-            //     extension<T, U>(T) where T : A2 where U : T
-            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T, U>(T) where T : A2 where U : T { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
@@ -26610,23 +26492,17 @@ using A2 = alias2::A;
 
 public static class E
 {
-    extension<T>(T) where T : I, A1
-    {
-        public static void M1() { }
-    }
-    extension<T>(T) where T : I, A2
-    {
-        public static void M2() { }
-    }
+    extension<T>(T) where T : I, A1 { }
+    extension<T>(T) where T : I, A2 { }
 }
 
 public interface I { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
-            //     extension<T>(T) where T : I, A2
-            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(T) where T : I, A2 { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
@@ -26647,23 +26523,17 @@ using A2 = alias2::A;
 
 public static class E
 {
-    extension<T>(T) where T : A1, I
-    {
-        public static void M1() { }
-    }
-    extension<T>(T) where T : I, A2
-    {
-        public static void M2() { }
-    }
+    extension<T>(T) where T : A1, I { }
+    extension<T>(T) where T : I, A2 { }
 }
 
 public interface I { }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
-            //     extension<T>(T) where T : I, A2
-            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension<T>(T) where T : I, A2 { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         Assert.False(ExtensionGroupingInfo.HaveSameILSignature((SourceNamedTypeSymbol)extensions[0], (SourceNamedTypeSymbol)extensions[1]));
@@ -26684,21 +26554,15 @@ using A2 = alias2::A;
 
 public static class E
 {
-    extension(A1 a)
-    {
-        public static void M() { }
-    }
-    extension(ref A2 a)
-    {
-        public static void M2() { }
-    }
+    extension(A1 a) { }
+    extension(ref A2 a) { }
 }
 """;
         var comp = CreateCompilation(src, references: [libComp1.EmitToImageReference().WithAliases(["alias1"]), libComp2.EmitToImageReference().WithAliases(["alias2"])]);
         comp.VerifyEmitDiagnostics(
-            // (12,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
-            //     extension(ref A2 a)
-            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(12, 5));
+            // (9,5): error CS9326: This extension block collides with another extension block. They result in conflicting content-based type names in metadata.
+            //     extension(ref A2 a) { }
+            Diagnostic(ErrorCode.ERR_ExtensionBlockCollision, "extension").WithLocation(9, 5));
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         var extension1 = (SourceNamedTypeSymbol)extensions[0];
@@ -26996,16 +26860,7 @@ public class AAttribute : System.Attribute
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.Multiple(
-            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
-            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
-            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
-        );
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -27115,14 +26970,7 @@ unsafe static class E
 """;
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27138,14 +26986,7 @@ static class E
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27161,14 +27002,7 @@ static class E
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27184,14 +27018,7 @@ static class E
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27207,14 +27034,7 @@ static class E
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net90);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27230,14 +27050,7 @@ static class E
 """;
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27265,6 +27078,7 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
+        // TODO2
         // Note: the extension grouping raw name doesn't account for variance, but the IL-level comparer considers it.
         // Consider ignoring variance in IL-level comparison too, to reduce a cascading diagnostic in this error scenario.
         Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
@@ -27278,10 +27092,7 @@ static class E
         var src = """
 public static partial class E
 {
-    extension([A] int)
-    {
-        public static void M1() { }
-    }
+    extension([A] int) { }
 }
 """;
         var defineTestDirective = """
@@ -27292,10 +27103,7 @@ public static partial class E
         var src2 = """
 public static partial class E
 {
-    extension([A] int)
-    {
-        public static void M2() { }
-    }
+    extension([A] int) { }
 }
 """;
         var src3 = """
@@ -27305,30 +27113,12 @@ public class AAttribute : System.Attribute { }
         // attribute excluded
         var comp = CreateCompilation([src, src2, src3]);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
-        Assert.Equal("extension(System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
 
         // attribute included by condition
         comp = CreateCompilation([src, defineTestDirective + src2, src3]);
         comp.VerifyEmitDiagnostics();
-
-        extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        extension1 = (SourceNamedTypeSymbol)extensions[0];
-        extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName());
-        AssertEx.Equal("extension([AAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -27338,14 +27128,8 @@ public class AAttribute : System.Attribute { }
         var src = """
 public static partial class E
 {
-    extension([A] int)
-    {
-        public static void M1() { }
-    }
-    extension(int)
-    {
-        public static void M2() { }
-    }
+    extension([A] int) { }
+    extension(int) { }
 }
 
 [System.Diagnostics.Conditional("TEST")]
@@ -27360,32 +27144,12 @@ public class AAttribute : System.Attribute { }
         // attribute excluded
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.Multiple(
-            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
-            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-            () => AssertEx.Equal("extension(System.Int32)", extension1.ComputeExtensionMarkerRawName()),
-            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
-            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
-        );
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
 
         // attribute included by condition
         comp = CreateCompilation(defineTestDirective + src);
         comp.VerifyEmitDiagnostics();
-
-        extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        extension1 = (SourceNamedTypeSymbol)extensions[0];
-        extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.Multiple(
-            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
-            () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-            () => AssertEx.Equal("extension([AAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName()),
-            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
-            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
-        );
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -27418,30 +27182,16 @@ public class BAttribute : System.Attribute { }
         // attribute excluded
         var comp = CreateCompilation([src, src2, src3]);
         comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName());
-        Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
 
         // attribute included by condition
         comp = CreateCompilation([src, defineTestDirective + src2, src3]);
         comp.VerifyEmitDiagnostics();
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
-        extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        extension1 = (SourceNamedTypeSymbol)extensions[0];
-        extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.Equal("extension([BAttribute/*()*/] System.Int32)", extension1.ComputeExtensionMarkerRawName());
-        AssertEx.Equal("extension([AAttribute/*()*/] [BAttribute/*()*/] System.Int32)", extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
+        Assert.Equal("extension([BAttribute/*()*/] System.Int32)", ((SourceNamedTypeSymbol)extensions[0]).ComputeExtensionMarkerRawName());
+        AssertEx.Equal("extension([AAttribute/*()*/] [BAttribute/*()*/] System.Int32)", ((SourceNamedTypeSymbol)extensions[1]).ComputeExtensionMarkerRawName());
     }
 
     [Fact]
@@ -27461,6 +27211,7 @@ public interface I { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
         var extension1 = (SourceNamedTypeSymbol)extensions[0];
@@ -27469,14 +27220,9 @@ public interface I { }
         Assert.Multiple(
             () => Assert.Equal("extension<(I)>(System.Int32)", extension1.ComputeExtensionGroupingRawName()),
             () => Assert.Equal("extension<(I)>(System.Int32)", extension2.ComputeExtensionGroupingRawName()),
-            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
 
             () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I", extension1.ComputeExtensionMarkerRawName()),
-            () => Assert.Equal("extension<T>(System.Int32) where T : maybenull, I", extension2.ComputeExtensionMarkerRawName()),
-            () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-
-            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
-            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
+            () => Assert.Equal("extension<T>(System.Int32) where T : maybenull, I", extension2.ComputeExtensionMarkerRawName())
         );
     }
 
@@ -27505,20 +27251,12 @@ public interface I { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-
         Assert.Multiple(
-            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
-
-            () => Assert.Equal("extension<T>(System.Int32) where T : maybenull, I", extension1.ComputeExtensionMarkerRawName()),
-            () => Assert.Equal("extension<T>(System.Int32) where T : I", extension2.ComputeExtensionMarkerRawName()),
-            () => Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-
-            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
-            () => Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
+            () => Assert.Equal("extension<T>(System.Int32) where T : maybenull, I", ((SourceNamedTypeSymbol)extensions[0]).ComputeExtensionMarkerRawName()),
+            () => Assert.Equal("extension<T>(System.Int32) where T : I", ((SourceNamedTypeSymbol)extensions[1]).ComputeExtensionMarkerRawName())
         );
     }
 
@@ -27540,20 +27278,12 @@ public interface I2 { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
 
         var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-
         Assert.Multiple(
-            () => Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName()),
-
-            () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I1, I2", extension1.ComputeExtensionMarkerRawName()),
-            () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I1, I2", extension2.ComputeExtensionMarkerRawName()),
-            () => Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName()),
-
-            () => Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2)),
-            () => Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2))
+            () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I1, I2", ((SourceNamedTypeSymbol)extensions[0]).ComputeExtensionMarkerRawName()),
+            () => Assert.Equal("extension<T>(System.Int32) where T : notnull, I1, I2", ((SourceNamedTypeSymbol)extensions[1]).ComputeExtensionMarkerRawName())
         );
     }
 
@@ -27574,14 +27304,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -27611,14 +27334,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -27630,26 +27346,15 @@ public interface I<T> { }
 
 public static partial class E
 {
-    extension<T>(int) where T : I<(int a, int b)>
-    {
-    }
-    extension<T>(int) where T : I<(int, int)>
-    {
-    }
+    extension<T>(int) where T : I<(int a, int b)> { }
+    extension<T>(int) where T : I<(int, int)> { }
 }
 
 public interface I<T> { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -27668,14 +27373,7 @@ public interface I2 { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -27694,14 +27392,7 @@ public interface I2 { }
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -27724,13 +27415,7 @@ public static class E
             //     extension(__arglist) { }
             Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(4, 15));
 
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -27750,13 +27435,7 @@ public static class E
             //     extension(__arglist) { }
             Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(3, 15));
 
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27779,13 +27458,7 @@ public static class E
             //     extension(int i = 1) { }
             Diagnostic(ErrorCode.ERR_ExtensionParameterDisallowsDefaultValue, "int i = 1").WithLocation(4, 15));
 
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
     }
 
     [Fact]
@@ -27804,13 +27477,7 @@ public static class E
             //     extension<T, T>(int) { }
             Diagnostic(ErrorCode.ERR_DuplicateTypeParameter, "T").WithArguments("T").WithLocation(4, 18));
 
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27828,14 +27495,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
         CompileAndVerify(comp, verify: Verification.FailsPEVerify).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27853,14 +27513,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
         CompileAndVerify(comp, verify: Verification.FailsPEVerify).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27878,14 +27531,7 @@ public interface I<T> { }
 """;
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net90);
         CompileAndVerify(comp, verify: Verification.FailsPEVerify).VerifyDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27907,13 +27553,7 @@ public static class E
             //     extension(error2) { }
             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "error2").WithArguments("error2").WithLocation(4, 15));
 
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.False(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        VerifyCollisions(comp, groupingMatch: false, markerMatch: false);
     }
 
     [Fact]
@@ -27929,15 +27569,8 @@ public static class E
 public ref struct RS { }
 """;
         var comp = CreateCompilation(src);
-        //comp.VerifyEmitDiagnostics();
-
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
-        Assert.False(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.False(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+        comp.VerifyEmitDiagnostics();
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: false);
     }
 
     [Fact]
@@ -27952,12 +27585,67 @@ public static class E
 """;
         var comp = CreateCompilation(src);
         CompileAndVerify(comp).VerifyDiagnostics();
+        VerifyCollisions(comp, groupingMatch: true, markerMatch: true);
+    }
 
-        var extensions = comp.GetMember<NamedTypeSymbol>("E").GetTypeMembers();
-        var extension1 = (SourceNamedTypeSymbol)extensions[0];
-        var extension2 = (SourceNamedTypeSymbol)extensions[1];
-        Assert.True(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));
-        Assert.True(ExtensionGroupingInfo.HaveSameCSharpSignature(extension1, extension2));
+    [Fact]
+    public void Grouping_69()
+    {
+        var src = """
+public static class E<T>
+{
+    extension(T) { }
+    extension(T) { }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (4,5): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            //     extension(T) { }
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(4, 5),
+            // (3,5): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            //     extension(T) { }
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(3, 5));
+    }
+
+    [Fact]
+    public void Grouping_70()
+    {
+        var src = """
+extension<T>(T) { }
+extension<T>(T) { }
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,1): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            // extension<T>(T) { }
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(1, 1),
+            // (2,1): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            // extension<T>(T) { }
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(2, 1));
+    }
+
+    [Fact]
+    public void Grouping_72()
+    {
+        var src = """
+public static class E1<T1>
+{
+    public static class E2<T2>
+    {
+        extension((T1, T2)) { }
+        extension((T1, T2)) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (6,9): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            //         extension((T1, T2)) { }
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(6, 9),
+            // (5,9): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            //         extension((T1, T2)) { }
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(5, 9));
     }
 }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -27078,7 +27078,6 @@ static class E
         var extension2 = (SourceNamedTypeSymbol)extensions[1];
         Assert.True(extension1.ComputeExtensionGroupingRawName() == extension2.ComputeExtensionGroupingRawName());
         Assert.True(extension1.ComputeExtensionMarkerRawName() == extension2.ComputeExtensionMarkerRawName());
-        // TODO2
         // Note: the extension grouping raw name doesn't account for variance, but the IL-level comparer considers it.
         // Consider ignoring variance in IL-level comparison too, to reduce a cascading diagnostic in this error scenario.
         Assert.False(ExtensionGroupingInfo.HaveSameILSignature(extension1, extension2));

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -23161,21 +23161,21 @@ interface I { }
 
         verifier.VerifyTypeIL("E", """
 .class private auto ansi abstract sealed beforefieldinit E
-    extends [netstandard]System.Object
+    extends [mscorlib]System.Object
 {
-    .custom instance void [netstandard]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
         01 00 00 00
     )
     // Nested Types
     .class nested public auto ansi sealed specialname '<Extension>$0AD8C3962A3C5E6BFA97E099F6F428C4'<(I) $T0, (I) $T1, (I) $T2>
-        extends [netstandard]System.Object
+        extends [mscorlib]System.Object
     {
-        .custom instance void [netstandard]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = (
             01 00 00 00
         )
         // Nested Types
         .class nested public auto ansi abstract sealed specialname '<Marker>$5B198AEBE2F597134BE1E94D84704187'<(I) T1, (I) T2, (I) T3>
-            extends [netstandard]System.Object
+            extends [mscorlib]System.Object
         {
             .param constraint T1, I
                 .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = (
@@ -23191,7 +23191,7 @@ interface I { }
                     int32 ''
                 ) cil managed 
             {
-                .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+                .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
                     01 00 00 00
                 )
                 // Method begins at RVA 0x208e

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -981,7 +981,7 @@ unsafe class C
             var ptr2Out = comp.GetMember<FieldSymbol>("C.ptr2Out").Type;
 
             var symbolEqualityComparer = new SymbolEqualityComparer(
-                TypeCompareKind.ConsiderEverything | TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly | TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds);
+                TypeCompareKind.ConsiderEverything | TypeCompareKind.FunctionPointerRefOutInRefReadonlyMatch | TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds);
             Assert.Equal(ptr1Ref.GetPublicSymbol(), ptr1RefReadonly.GetPublicSymbol(), symbolEqualityComparer);
             Assert.Equal(ptr2Ref.GetPublicSymbol(), ptr2In.GetPublicSymbol(), symbolEqualityComparer);
             Assert.Equal(ptr2Ref.GetPublicSymbol(), ptr2Out.GetPublicSymbol(), symbolEqualityComparer);

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeDataComparer.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeDataComparer.cs
@@ -67,12 +67,7 @@ namespace Microsoft.CodeAnalysis
 
             foreach (var arg in constructorArguments)
             {
-                // We ignore type values because they contain information like tuple element names or nullability annotations,
-                // which are not relevant for this attribute comparison.
-                if (arg.Kind != TypedConstantKind.Type)
-                {
-                    hash = Hash.Combine(arg.GetHashCode(), hash);
-                }
+                hash = Hash.Combine(arg.GetHashCode(), hash);
             }
 
             return hash;
@@ -89,10 +84,7 @@ namespace Microsoft.CodeAnalysis
                     hash = hashCombine(arg.Key.GetHashCode(), hash, _considerNamedArgumentsOrder);
                 }
 
-                if (arg.Value.Kind != TypedConstantKind.Type)
-                {
-                    hash = hashCombine(arg.Value.GetHashCode(), hash, _considerNamedArgumentsOrder);
-                }
+                hash = hashCombine(arg.Value.GetHashCode(), hash, _considerNamedArgumentsOrder);
             }
 
             return hash;
@@ -136,11 +128,6 @@ namespace Microsoft.CodeAnalysis
 
             public int GetHashCode(TypedConstant obj)
             {
-                if (obj.Kind == TypedConstantKind.Type)
-                {
-                    return SymbolEqualityComparer.IgnoreAll.GetHashCode(obj.Value as ISymbol);
-                }
-
                 return obj.GetHashCode();
             }
         }
@@ -162,8 +149,7 @@ namespace Microsoft.CodeAnalysis
 
             public int GetHashCode(KeyValuePair<string, TypedConstant> pair)
             {
-                int hash = pair.Key.GetHashCode();
-                return Hash.Combine(TypedConstantComparer.IgnoreAll.GetHashCode(pair.Value), hash);
+                return pair.GetHashCode();
             }
         }
     }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeDataComparer.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeDataComparer.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -19,8 +18,14 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal sealed class CommonAttributeDataComparer : IEqualityComparer<AttributeData>
     {
-        public static CommonAttributeDataComparer Instance = new CommonAttributeDataComparer();
-        private CommonAttributeDataComparer() { }
+        public static CommonAttributeDataComparer Instance = new CommonAttributeDataComparer(considerNamedArgumentsOrder: true);
+        public static CommonAttributeDataComparer InstanceIgnoringNamedArgumentOrder = new CommonAttributeDataComparer(considerNamedArgumentsOrder: false);
+
+        private readonly bool _considerNamedArgumentsOrder;
+        private CommonAttributeDataComparer(bool considerNamedArgumentsOrder)
+        {
+            this._considerNamedArgumentsOrder = considerNamedArgumentsOrder;
+        }
 
         public bool Equals(AttributeData attr1, AttributeData attr2)
         {
@@ -32,7 +37,7 @@ namespace Microsoft.CodeAnalysis
                 attr1.HasErrors == attr2.HasErrors &&
                 attr1.IsConditionallyOmitted == attr2.IsConditionallyOmitted &&
                 attr1.CommonConstructorArguments.SequenceEqual(attr2.CommonConstructorArguments) &&
-                attr1.NamedArguments.SequenceEqual(attr2.NamedArguments);
+                (_considerNamedArgumentsOrder ? attr1.NamedArguments.SequenceEqual(attr2.NamedArguments) : attr1.NamedArguments.SetEquals(attr2.NamedArguments));
         }
 
         public int GetHashCode(AttributeData attr)

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -38,5 +38,7 @@ namespace Microsoft.CodeAnalysis
         AllIgnoreOptionsForVB = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreTupleNames,
 
         CLRSignatureCompareOptions = TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds,
+
+        AllIgnoreOptionsPlusNullableWithUnknownMatchesAny = TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes),
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
         // we could emit signatures overloaded on this distinction, because we must encode the type of ref in a modreq on the appropriate
         // parameter in metadata, which would change the type. However, this would be inconsistent with how ref vs out vs in works on
         // top-level signatures today, so we disallow it in source.
-        FunctionPointerRefMatchesOutInRefReadonly = 64,
+        FunctionPointerRefOutInRefReadonlyMatch = 64,
 
         AllNullableIgnoreOptions = IgnoreNullableModifiersForReferenceTypes | ObliviousNullableModifierMatchesAny,
         AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames | AllNullableIgnoreOptions | IgnoreNativeIntegers,
@@ -39,6 +39,6 @@ namespace Microsoft.CodeAnalysis
 
         CLRSignatureCompareOptions = TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds,
 
-        AllIgnoreOptionsPlusNullableWithUnknownMatchesAny = TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes),
+        AllIgnoreOptionsPlusNullableWithObliviousMatchesAny = TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes),
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1910,7 +1910,7 @@ REPARSE:
             var candidateTypeMap = new TypeMap(candidateTypeParameters, indexedTypeParameters, allowAlpha: true);
             var desiredTypeMap = new TypeMap(desiredTypeParameters, indexedTypeParameters, allowAlpha: true);
 
-            var typeComparison = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
+            const TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
             return MemberSignatureComparer.HaveSameConstraints(candidateTypeParameters, candidateTypeMap, desiredTypeParameters, desiredTypeMap, typeComparison);
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1910,7 +1910,8 @@ REPARSE:
             var candidateTypeMap = new TypeMap(candidateTypeParameters, indexedTypeParameters, allowAlpha: true);
             var desiredTypeMap = new TypeMap(desiredTypeParameters, indexedTypeParameters, allowAlpha: true);
 
-            return MemberSignatureComparer.HaveSameConstraints(candidateTypeParameters, candidateTypeMap, desiredTypeParameters, desiredTypeMap);
+            var typeComparison = TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes;
+            return MemberSignatureComparer.HaveSameConstraints(candidateTypeParameters, candidateTypeMap, desiredTypeParameters, desiredTypeMap, typeComparison);
         }
 
         [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]


### PR DESCRIPTION
Overview:
For extension blocks, we produce grouping and marker type names. They have content-based hashes.
There are two kinds of possible collisions:
1. Those (non-cryptographic) hashes theoretically could suffer some collisions. 
2. They also have known collisions due to information that is intentionally left out (such as the assembly identity where the types originate).

This PR implements a symbol-level check that ensures that we only allow extension blocks with identical IL-level signatures into a grouping type, and those with identical C#-level signatures into a marker type.
It is useful to look at `ComputeExtensionGroupingRawName()` and `ComputeExtensionMarkerRawName()` to see what information counts in IL-level vs. C#-level signature.

The only quirk (by design, but keeps surprising me) is that we decided that refkind doesn't count as part of IL-level signature.

Addresses one of the metadata follow-ups in https://github.com/dotnet/roslyn/issues/78963
Relates to test plan https://github.com/dotnet/roslyn/issues/76130