### PR TITLE
Introduce helper to ensure span mapping is consistent everywhere

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -417,7 +417,7 @@ internal static partial class ProtocolConversions
             }
 
             // Map all the text changes' spans for this document.
-            var mappedResults = await oldDocument.TryGetMappedSpanResultAsync([.. textChanges.Select(tc => tc.Span)], cancellationToken).ConfigureAwait(false);
+            var mappedResults = await SpanMappingHelper.TryGetMappedSpanResultAsync(oldDocument, [.. textChanges.Select(tc => tc.Span)], cancellationToken).ConfigureAwait(false);
             if (mappedResults == null)
             {
                 // There's no span mapping available, just create text edits from the original text changes.
@@ -473,7 +473,7 @@ internal static partial class ProtocolConversions
         Debug.Assert(document.FilePath != null);
 
         var result = document is Document d
-            ? await d.TryGetMappedSpanResultAsync([textSpan], cancellationToken).ConfigureAwait(false)
+            ? await SpanMappingHelper.TryGetMappedSpanResultAsync(d, [textSpan], cancellationToken).ConfigureAwait(false)
             : null;
         if (result == null)
             return await ConvertTextSpanToLocationAsync(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -417,7 +417,7 @@ internal static partial class ProtocolConversions
             }
 
             // Map all the text changes' spans for this document.
-            var mappedResults = await GetMappedSpanResultAsync(oldDocument, [.. textChanges.Select(tc => tc.Span)], cancellationToken).ConfigureAwait(false);
+            var mappedResults = await oldDocument.TryGetMappedSpanResultAsync([.. textChanges.Select(tc => tc.Span)], cancellationToken).ConfigureAwait(false);
             if (mappedResults == null)
             {
                 // There's no span mapping available, just create text edits from the original text changes.
@@ -472,7 +472,9 @@ internal static partial class ProtocolConversions
     {
         Debug.Assert(document.FilePath != null);
 
-        var result = await GetMappedSpanResultAsync(document, [textSpan], cancellationToken).ConfigureAwait(false);
+        var result = document is Document d
+            ? await d.TryGetMappedSpanResultAsync([textSpan], cancellationToken).ConfigureAwait(false)
+            : null;
         if (result == null)
             return await ConvertTextSpanToLocationAsync(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);
 
@@ -1006,39 +1008,6 @@ internal static partial class ProtocolConversions
                 _ => text,
             };
         }
-    }
-
-    private static async Task<ImmutableArray<MappedSpanResult>?> GetMappedSpanResultAsync(TextDocument textDocument, ImmutableArray<TextSpan> textSpans, CancellationToken cancellationToken)
-    {
-        if (textDocument is not Document document)
-        {
-            return null;
-        }
-
-        if (textDocument is SourceGeneratedDocument sourceGeneratedDocument &&
-            textDocument.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } sourceGeneratedSpanMappingService)
-        {
-            var result = await sourceGeneratedSpanMappingService.MapSpansAsync(sourceGeneratedDocument, textSpans, cancellationToken).ConfigureAwait(false);
-            if (result.IsDefaultOrEmpty)
-            {
-                return null;
-            }
-
-            Contract.ThrowIfFalse(textSpans.Length == result.Length,
-                $"The number of input spans {textSpans.Length} should match the number of mapped spans returned {result.Length}");
-            return result;
-        }
-
-        var spanMappingService = document.DocumentServiceProvider.GetService<ISpanMappingService>();
-        if (spanMappingService == null)
-        {
-            return null;
-        }
-
-        var mappedSpanResult = await spanMappingService.MapSpansAsync(document, textSpans, cancellationToken).ConfigureAwait(false);
-        Contract.ThrowIfFalse(textSpans.Length == mappedSpanResult.Length,
-            $"The number of input spans {textSpans.Length} should match the number of mapped spans returned {mappedSpanResult.Length}");
-        return mappedSpanResult;
     }
 
     private static LSP.Range MappedSpanResultToRange(MappedSpanResult mappedSpanResult)

--- a/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -351,9 +350,14 @@ public sealed class RenameTests(ITestOutputHelper testOutputHelper) : AbstractLa
     {
         public bool DidMapSpans { get; private set; }
 
+        public bool CanMapSpans(SourceGeneratedDocument sourceGeneratedDocument)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken)
         {
-            throw new System.NotImplementedException();
+            throw new NotImplementedException();
         }
 
         public Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)

--- a/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingServiceWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorSourceGeneratedDocumentSpanMappingServiceWrapper.cs
@@ -23,6 +23,11 @@ internal sealed class RazorSourceGeneratedDocumentSpanMappingServiceWrapper(
 {
     private readonly IRazorSourceGeneratedDocumentSpanMappingService? _implementation = implementation;
 
+    public bool CanMapSpans(SourceGeneratedDocument document)
+    {
+        return _implementation is not null && document.IsRazorSourceGeneratedDocument();
+    }
+
     public async Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken)
     {
         if (_implementation is null ||

--- a/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
@@ -155,7 +155,7 @@ internal sealed class RemoteCodeLensReferencesService : ICodeLensReferencesServi
             }
 
             var span = new TextSpan(descriptor.SpanStart, descriptor.SpanLength);
-            var results = await document.TryGetMappedSpanResultAsync([span], cancellationToken).ConfigureAwait(false);
+            var results = await SpanMappingHelper.TryGetMappedSpanResultAsync(document, [span], cancellationToken).ConfigureAwait(false);
             if (results is null)
             {
                 // for normal document, just add one as they are

--- a/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
@@ -142,11 +142,7 @@ internal sealed class RemoteCodeLensReferencesService : ICodeLensReferencesServi
         foreach (var descriptor in descriptors)
         {
             var referencedDocumentId = DocumentId.CreateFromSerialized(
-                ProjectId.CreateFromSerialized(descriptor.ProjectGuid),
-                descriptor.DocumentGuid,
-                // HACK: work around https://github.com/dotnet/roslyn/issues/79699
-                isSourceGenerated: !File.Exists(descriptor.FilePath),
-                debugName: null);
+                ProjectId.CreateFromSerialized(descriptor.ProjectGuid), descriptor.DocumentGuid);
 
             var document = await solution.GetDocumentAsync(referencedDocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             if (document == null)
@@ -182,7 +178,9 @@ internal sealed class RemoteCodeLensReferencesService : ICodeLensReferencesServi
             {
                 if (document.IsRazorSourceGeneratedDocument())
                 {
-                    // HACK: Until Razor has a workspace level excerpt service, we'll just display the result as best we can
+                    // HACK: Razor doesn't have has a workspace level excerpt service, but if we just return a simple descriptor here,
+                    // the user at least sees something, can navigate, and Razor can improve this later if necessary. Until
+                    // https://github.com/dotnet/roslyn/issues/79699 is fixed this won't get hit anyway.
                     list.Add(new ReferenceLocationDescriptor(
                         descriptor.LongDescription,
                         descriptor.Language,

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -80,23 +80,15 @@ internal partial class StreamingFindUsagesPresenter
 
         public static async Task<MappedSpanResult?> TryMapAndGetFirstAsync(DocumentSpan documentSpan, SourceText sourceText, CancellationToken cancellationToken)
         {
-            var service = documentSpan.Document.DocumentServiceProvider.GetService<ISpanMappingService>();
-            if (service == null)
-            {
-                return new MappedSpanResult(documentSpan.Document.FilePath!, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);
-            }
-
-            var results = await service.MapSpansAsync(
-                documentSpan.Document, [documentSpan.SourceSpan], cancellationToken).ConfigureAwait(false);
-
-            if (results.IsDefaultOrEmpty)
+            var results = await documentSpan.Document.TryGetMappedSpanResultAsync([documentSpan.SourceSpan], cancellationToken).ConfigureAwait(false);
+            if (results is not { } mappedSpans || mappedSpans.IsDefaultOrEmpty)
             {
                 return new MappedSpanResult(documentSpan.Document.FilePath!, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);
             }
 
             // if span mapping service filtered out the span, make sure
             // to return null so that we remove the span from the result
-            return results.FirstOrNull(r => !r.IsDefault);
+            return mappedSpans.FirstOrNull(r => !r.IsDefault);
         }
 
         public static SourceText GetLineContainingPosition(SourceText text, int position)

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -80,7 +80,7 @@ internal partial class StreamingFindUsagesPresenter
 
         public static async Task<MappedSpanResult?> TryMapAndGetFirstAsync(DocumentSpan documentSpan, SourceText sourceText, CancellationToken cancellationToken)
         {
-            var results = await documentSpan.Document.TryGetMappedSpanResultAsync([documentSpan.SourceSpan], cancellationToken).ConfigureAwait(false);
+            var results = await SpanMappingHelper.TryGetMappedSpanResultAsync(documentSpan.Document, [documentSpan.SourceSpan], cancellationToken).ConfigureAwait(false);
             if (results is not { } mappedSpans || mappedSpans.IsDefaultOrEmpty)
             {
                 return new MappedSpanResult(documentSpan.Document.FilePath!, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
@@ -197,7 +197,7 @@ internal sealed class VisualStudioDocumentNavigationService(
 
         // Before attempting to open the document, check if the location maps to a different file that should be opened instead.
         if (textDocument is Document document &&
-            document.CanMapSpans())
+            SpanMappingHelper.CanMapSpans(document))
         {
             var mappedSpanResult = await GetMappedSpanAsync(
                 document,
@@ -314,7 +314,7 @@ internal sealed class VisualStudioDocumentNavigationService(
 
     private static async Task<MappedSpanResult?> GetMappedSpanAsync(Document generatedDocument, TextSpan textSpan, CancellationToken cancellationToken)
     {
-        var results = await generatedDocument.TryGetMappedSpanResultAsync([textSpan], cancellationToken).ConfigureAwait(false);
+        var results = await SpanMappingHelper.TryGetMappedSpanResultAsync(generatedDocument, [textSpan], cancellationToken).ConfigureAwait(false);
 
         if (results == null)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Host;
 
@@ -30,6 +34,17 @@ internal static class Extensions
 
     public static bool IsRazorSourceGeneratedDocument(this Document document)
         => document is SourceGeneratedDocument { Identity.Generator.TypeName: "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator" };
+
+    public static bool CanMapSpans(this Document document)
+    {
+        if (document is SourceGeneratedDocument sourceGeneratedDocument &&
+            document.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } sourceGeneratedSpanMappingService)
+        {
+            return sourceGeneratedSpanMappingService.CanMapSpans(sourceGeneratedDocument);
+        }
+
+        return document.DocumentServiceProvider.GetService<ISpanMappingService>() is not null;
+    }
 
     public static async Task<ImmutableArray<MappedSpanResult>?> TryGetMappedSpanResultAsync(this Document document, ImmutableArray<TextSpan> textSpans, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentSpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentSpanMappingService.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Host;
 
 internal interface ISourceGeneratedDocumentSpanMappingService : IWorkspaceService
 {
+    bool CanMapSpans(SourceGeneratedDocument sourceGeneratedDocument);
+
     Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken);
 
     Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/SpanMappingHelper.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/SpanMappingHelper.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Host;
+
+internal static class SpanMappingHelper
+{
+    public static bool CanMapSpans(Document document)
+    {
+        if (document is SourceGeneratedDocument sourceGeneratedDocument &&
+            document.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } sourceGeneratedSpanMappingService)
+        {
+            return sourceGeneratedSpanMappingService.CanMapSpans(sourceGeneratedDocument);
+        }
+
+        return document.DocumentServiceProvider.GetService<ISpanMappingService>() is not null;
+    }
+
+    public static async Task<ImmutableArray<MappedSpanResult>?> TryGetMappedSpanResultAsync(Document document, ImmutableArray<TextSpan> textSpans, CancellationToken cancellationToken)
+    {
+        if (document is SourceGeneratedDocument sourceGeneratedDocument &&
+            document.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } sourceGeneratedSpanMappingService)
+        {
+            var result = await sourceGeneratedSpanMappingService.MapSpansAsync(sourceGeneratedDocument, textSpans, cancellationToken).ConfigureAwait(false);
+            if (result.IsDefaultOrEmpty)
+            {
+                return null;
+            }
+
+            Contract.ThrowIfFalse(textSpans.Length == result.Length,
+                $"The number of input spans {textSpans.Length} should match the number of mapped spans returned {result.Length}");
+            return result;
+        }
+
+        var spanMappingService = document.DocumentServiceProvider.GetService<ISpanMappingService>();
+        if (spanMappingService == null)
+        {
+            return null;
+        }
+
+        var mappedSpanResult = await spanMappingService.MapSpansAsync(document, textSpans, cancellationToken).ConfigureAwait(false);
+        Contract.ThrowIfFalse(textSpans.Length == mappedSpanResult.Length,
+            $"The number of input spans {textSpans.Length} should match the number of mapped spans returned {mappedSpanResult.Length}");
+        return mappedSpanResult;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/72136
Part of https://github.com/dotnet/razor/issues/9519

Recent PRs introduced a cohost-compatible span mapping service, this PR rolls it out everywhere. No excerpt service, and honestly the FAR results look better without it, so hoping to avoid needing that for now :)