### PR TITLE
Fix flow analysis of extern local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1403,7 +1403,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxNode syntax,
             bool isCall)
         {
-            if (isCall)
+            // Extern local function bodies are not visited, so ignore their state.
+            if (isCall && !symbol.IsExtern)
             {
                 Join(ref State, ref localFunctionState.StateFromBottom);
 

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/LocalFunctions.cs
@@ -706,6 +706,25 @@ class C
         }
 
         [Fact]
+        public void UnusedLocalFunc_Extern()
+        {
+            var comp = CreateCompilation("""
+                using System.Runtime.InteropServices;
+                class C
+                {
+                    public static void Main()
+                    {
+                        [DllImport("test")] static extern bool Local();
+                    }
+                }
+                """);
+            comp.VerifyDiagnostics(
+                // (6,48): warning CS8321: The local function 'Local' is declared but never used
+                //         [DllImport("test")] static extern bool Local();
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local").WithArguments("Local").WithLocation(6, 48));
+        }
+
+        [Fact]
         public void UnassignedInStruct()
         {
             var source = @"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/79437.

The problem was that each local function starts in unreachable state and `extern` local functions are never visited, hence the local function call also ends up marked as unreachable and so no definite assignment errors are reported.