### PR TITLE
ExtensionGroupingInfo - reduce consumed memory and delay creation of Cci adapter instances until emit

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExtensionGroupingInfo.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExtensionGroupingInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // Extension block symbols declared in a class are grouped by their corresponding grouping type metadata name (top level key),
             // then grouped by their corresponding extension marker type metadata name (the secondary key used by MultiDictionary).
-            // <see cref="SourceNamedTypeSymbol"/>s are the extension blocks.
+            // SourceNamedTypeSymbols are the extension blocks.
             var groupingMap = new Dictionary<string, MultiDictionary<string, SourceNamedTypeSymbol>>(EqualityComparer<string>.Default);
 
             foreach (var type in container.GetTypeMembers(""))


### PR DESCRIPTION
Relates to test plan https://github.com/dotnet/roslyn/issues/76130