### PR TITLE
Improve error reporting from RemoteInitializationService

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
@@ -90,13 +90,13 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
         return base.CreateExportProviderAsync(cancellationToken);
     }
 
-    protected override bool ContainsUnexpectedErrors(IEnumerable<string> erroredParts, ImmutableList<PartDiscoveryException> partDiscoveryExceptions)
+    protected override bool ContainsUnexpectedErrors(IEnumerable<string> erroredParts)
     {
         // Verify that we have exactly the MEF errors that we expect.  If we have less or more this needs to be updated to assert the expected behavior.
         var expectedErrorPartsSet = new HashSet<string>(["CSharpMapCodeService", "PythiaSignatureHelpProvider", "CopilotSemanticSearchQueryExecutor"]);
         var hasUnexpectedErroredParts = erroredParts.Any(part => !expectedErrorPartsSet.Contains(part));
 
-        return hasUnexpectedErroredParts || !partDiscoveryExceptions.IsEmpty;
+        return hasUnexpectedErroredParts;
     }
 
     protected override Task WriteCompositionCacheAsync(string compositionCacheFile, CompositionConfiguration config, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/ExportProviderBuilder.cs
+++ b/src/Workspaces/Remote/Core/ExportProviderBuilder.cs
@@ -89,7 +89,7 @@ internal abstract class ExportProviderBuilder(
 
         // Verify we only have expected errors.
 
-        ThrowOnUnexpectedErrors(config, catalog);
+        ReportCompositionErrors(config, catalog);
 
         // Try to cache the composition.
         _ = WriteCompositionCacheAsync(compositionCacheFile, config, cancellationToken).ReportNonFatalErrorAsync();
@@ -180,25 +180,28 @@ internal abstract class ExportProviderBuilder(
         }
     }
 
-    protected abstract bool ContainsUnexpectedErrors(IEnumerable<string> erroredParts, ImmutableList<PartDiscoveryException> partDiscoveryExceptions);
+    protected abstract bool ContainsUnexpectedErrors(IEnumerable<string> erroredParts);
 
-    private void ThrowOnUnexpectedErrors(CompositionConfiguration configuration, ComposableCatalog catalog)
+    private void ReportCompositionErrors(CompositionConfiguration configuration, ComposableCatalog catalog)
     {
+        foreach (var exception in catalog.DiscoveredParts.DiscoveryErrors)
+        {
+            LogError($"Encountered exception in the MEF composition: {exception.Message}");
+        }
+
         // Verify that we have exactly the MEF errors that we expect.  If we have less or more this needs to be updated to assert the expected behavior.
         var erroredParts = configuration.CompositionErrors.FirstOrDefault()?.SelectMany(error => error.Parts).Select(part => part.Definition.Type.Name) ?? [];
 
-        if (ContainsUnexpectedErrors(erroredParts, catalog.DiscoveredParts.DiscoveryErrors))
+        if (ContainsUnexpectedErrors(erroredParts))
         {
             try
             {
-                catalog.DiscoveredParts.ThrowOnErrors();
                 configuration.ThrowOnErrors();
             }
             catch (CompositionFailedException ex)
             {
                 // The ToString for the composition failed exception doesn't output a nice set of errors by default, so log it separately
-                LogError($"Encountered errors in the MEF composition:{Environment.NewLine}{ex.ErrorsAsString}");
-                throw new CompositionFailedException(ex.Message + Environment.NewLine + ex.ErrorsAsString);
+                LogError($"Encountered errors in the MEF composition: {ex.Message}{Environment.NewLine}{ex.ErrorsAsString}");
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteExportProviderBuilder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteExportProviderBuilder.cs
@@ -73,16 +73,11 @@ internal sealed class RemoteExportProviderBuilder : ExportProviderBuilder
     {
     }
 
-    protected override bool ContainsUnexpectedErrors(IEnumerable<string> erroredParts, ImmutableList<PartDiscoveryException> partDiscoveryExceptions)
+    protected override bool ContainsUnexpectedErrors(IEnumerable<string> erroredParts)
     {
         // Verify that we have exactly the MEF errors that we expect.  If we have less or more this needs to be updated to assert the expected behavior.
         var expectedErrorPartsSet = new HashSet<string>(["PythiaSignatureHelpProvider", "VSTypeScriptAnalyzerService", "CodeFixService", "CSharpMapCodeService", "CopilotSemanticSearchQueryExecutor"]);
-        var hasUnexpectedErroredParts = erroredParts.Any(part => !expectedErrorPartsSet.Contains(part));
-
-        if (hasUnexpectedErroredParts)
-            return true;
-
-        return partDiscoveryExceptions.Count > 0;
+        return erroredParts.Any(part => !expectedErrorPartsSet.Contains(part));
     }
 
     private sealed class SimpleAssemblyLoader : IAssemblyLoader


### PR DESCRIPTION
Avoid throwing CompositionException. Instead, report all composition errors via LogError and display them in the VS info-bar.
Not throwing an exception also allows OOP to function in cases when one service fails to compose but other services are fine.