### PR TITLE
Add a few tests to ensure Razor span mapping is hooked up

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
@@ -341,31 +341,4 @@ public sealed class RenameTests(ITestOutputHelper testOutputHelper) : AbstractLa
     {
         return await testLspServer.ExecuteRequestAsync<LSP.RenameParams, LSP.WorkspaceEdit>(LSP.Methods.TextDocumentRenameName, renameParams, CancellationToken.None);
     }
-
-    [ExportWorkspaceService(typeof(ISourceGeneratedDocumentSpanMappingService))]
-    [Shared]
-    [method: ImportingConstructor]
-    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    private class TestSourceGeneratedDocumentSpanMappingService() : ISourceGeneratedDocumentSpanMappingService
-    {
-        public bool DidMapSpans { get; private set; }
-
-        public bool CanMapSpans(SourceGeneratedDocument sourceGeneratedDocument)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)
-        {
-            DidMapSpans = true;
-            Assert.True(document.IsRazorSourceGeneratedDocument());
-
-            return Task.FromResult(ImmutableArray<MappedSpanResult>.Empty);
-        }
-    }
 }

--- a/src/LanguageServer/ProtocolUnitTests/TestSourceGeneratedDocumentSpanMappingService.cs
+++ b/src/LanguageServer/ProtocolUnitTests/TestSourceGeneratedDocumentSpanMappingService.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+[ExportWorkspaceService(typeof(ISourceGeneratedDocumentSpanMappingService))]
+[Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class TestSourceGeneratedDocumentSpanMappingService() : ISourceGeneratedDocumentSpanMappingService
+{
+    public bool DidMapSpans { get; private set; }
+
+    public bool CanMapSpans(SourceGeneratedDocument sourceGeneratedDocument)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ImmutableArray<MappedTextChange>> GetMappedTextChangesAsync(SourceGeneratedDocument oldDocument, SourceGeneratedDocument newDocument, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ImmutableArray<MappedSpanResult>> MapSpansAsync(SourceGeneratedDocument document, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)
+    {
+        if (document.IsRazorSourceGeneratedDocument())
+        {
+            DidMapSpans = true;
+        }
+
+        return Task.FromResult(ImmutableArray<MappedSpanResult>.Empty);
+    }
+}


### PR DESCRIPTION
I started this with the intention of supporting span mapping in the LSP server in more places, only to find out I didn't need to because it was already supported. May as well keep the tests I wrote at least.