### PR TITLE
Workaround VSCode's lack of support for case sorting in completion

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -119,7 +119,7 @@ internal sealed class CompletionResolveHandler : ILspServiceRequestHandler<LSP.C
         // but from different namespaces. However, VSCode doesn't include labelDetails in the resolve request, so we 
         // compare SortText instead when it's set (which is when label != SortText)
         return lspCompletionItem.Label == completionItem.GetEntireDisplayText()
-            && (lspCompletionItem.SortText is null || lspCompletionItem.SortText == completionItem.SortText);
+            && (lspCompletionItem.Label == completionItem.SortText || lspCompletionItem.SortText?.EndsWith(completionItem.SortText) == true);
     }
 
     private static LSP.TextDocumentIdentifier? GetTextDocumentCacheEntry(LSP.CompletionItem request)

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -145,9 +145,8 @@ internal static class CompletionResultFactory
             {
                 // VSCode doesn't handle casing very well, but we do, and we already sorted the list
                 // Add sort text to ensure that items are sorted by their position in the list.
-                // The max length of sort text is 100 characters, so we only need 4 characters to represent the index.
-                var listOrderSortPrefix = index.ToString("D4");
-                lspItem.SortText = $"{listOrderSortPrefix}{lspItem.SortText}";
+                // The max length of the list is 1000 items, so we only need 4 characters to represent the index.
+                lspItem.SortText = $"{index:D4}{lspItem.SortText}";
             }
 
             if (!lspItem.Label.Equals(item.FilterText, StringComparison.Ordinal))

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -73,10 +73,11 @@ internal static class CompletionResultFactory
 
         var defaultSpan = list.Span;
         var typedText = documentText.GetSubText(defaultSpan).ToString();
-        foreach (var item in list.ItemsList)
+        for (var i = 0; i < list.ItemsList.Count; i++)
         {
+            var item = list.ItemsList[i];
             item.Span = defaultSpan; // item.Span will be used to generate change, adjust it if needed
-            lspCompletionItems.Add(await CreateLSPCompletionItemAsync(item, typedText).ConfigureAwait(false));
+            lspCompletionItems.Add(await CreateLSPCompletionItemAsync(item, typedText, i).ConfigureAwait(false));
         }
 
         var completionList = new LSP.VSInternalCompletionList
@@ -113,7 +114,7 @@ internal static class CompletionResultFactory
             ? new LSP.OptimizedVSCompletionList(completionList)
             : completionList;
 
-        async Task<LSP.CompletionItem> CreateLSPCompletionItemAsync(CompletionItem item, string typedText)
+        async Task<LSP.CompletionItem> CreateLSPCompletionItemAsync(CompletionItem item, string typedText, int index)
         {
             // Defer to host to create the actual completion item (including potential subclasses),
             // and add any custom information.
@@ -136,7 +137,18 @@ internal static class CompletionResultFactory
             lspItem.Data = completionItemResolveData;
 
             if (!lspItem.Label.Equals(item.SortText, StringComparison.Ordinal))
+            {
                 lspItem.SortText = item.SortText;
+            }
+
+            if (!capabilityHelper.SupportVSInternalClientCapabilities)
+            {
+                // VSCode doesn't handle casing very well, but we do, and we already sorted the list
+                // Add sort text to ensure that items are sorted by their position in the list.
+                // The max length of sort text is 100 characters, so we only need 4 characters to represent the index.
+                var listOrderSortPrefix = index.ToString("D4");
+                lspItem.SortText = $"{listOrderSortPrefix}{lspItem.SortText}";
+            }
 
             if (!lspItem.Label.Equals(item.FilterText, StringComparison.Ordinal))
                 lspItem.FilterText = item.FilterText;

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -132,7 +132,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var actualItem = completionResult.Items.First(i => i.Label == "Task");
         Assert.Equal("System.Threading.Tasks", actualItem.LabelDetails.Description);
-        Assert.Equal("~Task  System.Threading.Tasks", actualItem.SortText);
+        Assert.Equal("0000~Task  System.Threading.Tasks", actualItem.SortText);
         Assert.Equal(CompletionItemKind.Class, actualItem.Kind);
         Assert.Null(actualItem.LabelDetails.Detail);
         Assert.Null(actualItem.FilterText);
@@ -149,7 +149,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var resolvedItem = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, actualItem, CancellationToken.None).ConfigureAwait(false);
         Assert.Equal("System.Threading.Tasks", resolvedItem.LabelDetails.Description);
-        Assert.Equal("~Task  System.Threading.Tasks", resolvedItem.SortText);
+        Assert.Equal("0000~Task  System.Threading.Tasks", resolvedItem.SortText);
         Assert.Equal(CompletionItemKind.Class, resolvedItem.Kind);
 
         TextEdit expectedAdditionalEdit = isInUsingStatement
@@ -219,7 +219,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var actualItem = completionResult.Items.First(i => i.Label == "ExtensionMethod");
         Assert.Equal("NS2", actualItem.LabelDetails.Description);
-        Assert.Equal("~ExtensionMethod NS2", actualItem.SortText);
+        Assert.Equal("0004~ExtensionMethod NS2", actualItem.SortText);
         Assert.Equal(CompletionItemKind.Method, actualItem.Kind);
         Assert.Null(actualItem.LabelDetails.Detail);
         Assert.Null(actualItem.FilterText);
@@ -236,7 +236,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var resolvedItem = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, actualItem, CancellationToken.None).ConfigureAwait(false);
         Assert.Equal("NS2", resolvedItem.LabelDetails.Description);
-        Assert.Equal("~ExtensionMethod NS2", resolvedItem.SortText);
+        Assert.Equal("0004~ExtensionMethod NS2", resolvedItem.SortText);
         Assert.Equal(CompletionItemKind.Method, resolvedItem.Kind);
 
         var expectedAdditionalEdit = new TextEdit() { NewText = "using NS2;\r\n\r\n", Range = new() { Start = new(1, 0), End = new(1, 0) } };
@@ -285,7 +285,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
         Assert.Equal(CompletionItemKind.Keyword, actualItem.Kind);
         Assert.Equal("summ", actualItem.TextEditText);
         Assert.Null(actualItem.LabelDetails);
-        Assert.Null(actualItem.SortText);
+        Assert.Equal("0011", actualItem.SortText);
         Assert.Null(actualItem.FilterText);
         Assert.Null(actualItem.TextEdit);
         Assert.Null(actualItem.AdditionalTextEdits);
@@ -544,7 +544,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var actualItem = completionResult.Items.First(i => i.Label == "ObsoleteType");
         Assert.Null(actualItem.LabelDetails);
-        Assert.Null(actualItem.SortText);
+        Assert.Equal("0000", actualItem.SortText);
         Assert.Equal(CompletionItemKind.Class, actualItem.Kind);
         Assert.Equal([CompletionItemTag.Deprecated], actualItem.Tags);
         Assert.Null(actualItem.FilterText);
@@ -561,7 +561,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var resolvedItem = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, actualItem, CancellationToken.None).ConfigureAwait(false);
         Assert.Null(resolvedItem.LabelDetails);
-        Assert.Null(resolvedItem.SortText);
+        Assert.Equal("0000", actualItem.SortText);
         Assert.Equal(CompletionItemKind.Class, resolvedItem.Kind);
         Assert.Equal([CompletionItemTag.Deprecated], resolvedItem.Tags);
 
@@ -577,7 +577,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
             Kind = LSP.MarkupKind.PlainText,
             Value = "[deprecated] class ObsoleteType"
         };
-        AssertJsonEquals(resolvedItem.Documentation, expectedDocumentation);
+        AssertJsonEquals(expectedDocumentation, resolvedItem.Documentation);
     }
 
     private sealed class CSharpLspMockCompletionService : CompletionService
@@ -724,7 +724,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var resolvedItem1 = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, itemFromNS1, CancellationToken.None).ConfigureAwait(false);
         Assert.Equal("Namespace1", resolvedItem1.LabelDetails.Description);
-        Assert.Equal("~MyClass Namespace1", resolvedItem1.SortText);
+        Assert.Equal("0000~MyClass Namespace1", resolvedItem1.SortText);
         Assert.Equal(CompletionItemKind.Class, resolvedItem1.Kind);
 
         var expectedAdditionalEdit1 = new TextEdit() { NewText = "using Namespace1;\r\n\r\n", Range = new() { Start = new(1, 0), End = new(1, 0) } };
@@ -732,7 +732,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var resolvedItem2 = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, itemFromNS2, CancellationToken.None).ConfigureAwait(false);
         Assert.Equal("Namespace2", resolvedItem2.LabelDetails.Description);
-        Assert.Equal("~MyClass Namespace2", resolvedItem2.SortText);
+        Assert.Equal("0001~MyClass Namespace2", resolvedItem2.SortText);
         Assert.Equal(CompletionItemKind.Class, resolvedItem2.Kind);
 
         var expectedAdditionalEdit2 = new TextEdit() { NewText = "using Namespace2;\r\n\r\n", Range = new() { Start = new(1, 0), End = new(1, 0) } };


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6170

![completion_case_sort](https://github.com/user-attachments/assets/363bf102-0363-4b02-9b2e-4978f61d831c)
