### PR TITLE
*** WIP: Reduce allocations in DeclataionComputer

### DIFF
--- a/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
+++ b/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
@@ -8,36 +8,56 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis
 {
     internal class DeclarationComputer
     {
-        internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, IEnumerable<SyntaxNode>? executableCodeBlocks, CancellationToken cancellationToken)
+        internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, ArrayBuilder<SyntaxNode>? executableCodeBlocks, CancellationToken cancellationToken)
         {
             var declaredSymbol = GetDeclaredSymbol(model, node, getSymbol, cancellationToken);
             return GetDeclarationInfo(node, declaredSymbol, executableCodeBlocks);
         }
 
-        internal static DeclarationInfo GetDeclarationInfo(SyntaxNode node, ISymbol? declaredSymbol, IEnumerable<SyntaxNode>? executableCodeBlocks)
+        internal static DeclarationInfo GetDeclarationInfo(SyntaxNode node, ISymbol? declaredSymbol, ArrayBuilder<SyntaxNode>? executableCodeBlocks)
         {
-            var codeBlocks = executableCodeBlocks?.Where(c => c != null).AsImmutableOrEmpty() ?? ImmutableArray<SyntaxNode>.Empty;
+            var codeBlocks = ImmutableArray<SyntaxNode>.Empty;
+            if (executableCodeBlocks != null)
+            {
+                executableCodeBlocks.RemoveAll(c => c == null);
+
+                codeBlocks = executableCodeBlocks.ToImmutable();
+            }
+
             return new DeclarationInfo(node, codeBlocks, declaredSymbol);
         }
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken)
         {
-            return GetDeclarationInfo(model, node, getSymbol, (IEnumerable<SyntaxNode>?)null, cancellationToken);
+            return GetDeclarationInfo(model, node, getSymbol, (ArrayBuilder<SyntaxNode>?)null, cancellationToken);
         }
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, SyntaxNode executableCodeBlock, CancellationToken cancellationToken)
         {
-            return GetDeclarationInfo(model, node, getSymbol, SpecializedCollections.SingletonEnumerable(executableCodeBlock), cancellationToken);
+            var builder = ArrayBuilder<SyntaxNode>.GetInstance();
+            builder.Add(executableCodeBlock);
+
+            var result = GetDeclarationInfo(model, node, getSymbol, builder, cancellationToken);
+
+            builder.Free();
+            return result;
         }
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken, params SyntaxNode[] executableCodeBlocks)
         {
-            return GetDeclarationInfo(model, node, getSymbol, executableCodeBlocks.AsEnumerable(), cancellationToken);
+            var builder = ArrayBuilder<SyntaxNode>.GetInstance();
+            builder.AddRange(executableCodeBlocks);
+
+            var result = GetDeclarationInfo(model, node, getSymbol, builder, cancellationToken);
+
+            builder.Free();
+            return result;
         }
 
         private static ISymbol? GetDeclaredSymbol(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken)


### PR DESCRIPTION
This is a draft until I get back numbers from a speedometer run.

CSharpDeclarationComputer.ComputeDeclarations shows up as 1.0% of Roslyn OOP allocations during a completion scenario in the RazorEditingTests.CompletionInCohosting speedometer test. The majority of the allocations under this method appear to be linq related, so switching to the model where we use a pooled collection to collect the items rather than linq enumerables.