### PR TITLE
Compute solution explorer diagnostic descriptors in OOP process.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
@@ -58,4 +58,17 @@ internal static class DiagnosticAnalyzerExtensions
 
     public static IEnumerable<AnalyzerPerformanceInfo> ToAnalyzerPerformanceInfo(this IDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo> analysisResult, DiagnosticAnalyzerInfoCache analyzerInfo)
         => analysisResult.Select(kv => new AnalyzerPerformanceInfo(kv.Key.GetAnalyzerId(), analyzerInfo.IsTelemetryCollectionAllowed(kv.Key), kv.Value.ExecutionTime));
+
+    public static ImmutableArray<DiagnosticDescriptor> GetDiagnosticDescriptors(
+        this Project project,
+        AnalyzerReference analyzerReference)
+    {
+        var diagnosticAnalyzerService = project.Solution.Services.GetRequiredService<IDiagnosticAnalyzerService>();
+
+        var descriptors = analyzerReference
+            .GetAnalyzers(project.Language)
+            .SelectManyAsArray(a => diagnosticAnalyzerService.AnalyzerInfoCache.GetDiagnosticDescriptors(a));
+
+        return descriptors;
+    }
 }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
@@ -179,6 +179,7 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
             // in tests), we'll just fall back to loading these in process.
             if (analyzerReference is AnalyzerFileReference analyzerFileReference)
             {
+                var client = await RemoteHostClient.TryGetClientAsync(this.Workspace, cancellationToken).ConfigureAwait(false);
                 if (client is not null)
                 {
                     var result = await client.TryInvokeAsync<IRemoteSourceGenerationService, ImmutableArray<SourceGeneratorIdentity>>(

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Threading;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell;
 using Roslyn.Utilities;
+using VSLangProj140;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer;
 
@@ -115,12 +116,11 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
             return;
         }
 
-        var newDiagnosticItems = GenerateDiagnosticItems(project, analyzerReference);
-        var newSourceGeneratorItems = await GenerateSourceGeneratorItemsAsync(
-            project, analyzerReference).ConfigureAwait(false);
+        var (latestDiagnosticItems, latestSourceGeneratorItems) = await GetLatestItemsAsync(
+            project, analyzerReference, cancellationToken).ConfigureAwait(false);
 
         // If we computed the same set of items as the last time, we can bail out now.
-        if (_items.SequenceEqual([.. newDiagnosticItems, .. newSourceGeneratorItems]))
+        if (_items.SequenceEqual([.. latestDiagnosticItems, .. latestSourceGeneratorItems]))
             return;
 
         // Go back to UI thread to update the observable collection.  Otherwise, it enqueue its own UI work that we cannot track.
@@ -130,27 +130,36 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
         try
         {
             _items.Clear();
-            _items.AddRange(newDiagnosticItems);
-            _items.AddRange(newSourceGeneratorItems);
+            _items.AddRange(latestDiagnosticItems);
+            _items.AddRange(latestSourceGeneratorItems);
         }
         finally
         {
             _items.EndBulkOperation();
         }
+    }
 
-        return;
+    private async Task<(ImmutableArray<BaseItem>, ImmutableArray<BaseItem>)> GetLatestItemsAsync(
+        Project project,
+        AnalyzerReference analyzerReference,
+        CancellationToken cancellationToken)
+    {
+        var client = await RemoteHostClient.TryGetClientAsync(this.Workspace, cancellationToken).ConfigureAwait(false);
 
-        ImmutableArray<BaseItem> GenerateDiagnosticItems(
-            Project project,
-            AnalyzerReference analyzerReference)
+        var latestDiagnosticItems = await GenerateDiagnosticItemsAsync().ConfigureAwait(false);
+        var latestSourceGeneratorItems = await GenerateSourceGeneratorItemsAsync().ConfigureAwait(false);
+
+        return (latestDiagnosticItems, latestSourceGeneratorItems);
+
+        async Task<ImmutableArray<BaseItem>> GenerateDiagnosticItemsAsync()
         {
             var generalDiagnosticOption = project.CompilationOptions!.GeneralDiagnosticOption;
             var specificDiagnosticOptions = project.CompilationOptions!.SpecificDiagnosticOptions;
             var analyzerConfigOptions = project.GetAnalyzerConfigOptions();
 
-            var diagnosticAnalyzerService = this.Workspace.Services.GetRequiredService<IDiagnosticAnalyzerService>();
-            return analyzerReference.GetAnalyzers(project.Language)
-                .SelectMany(a => diagnosticAnalyzerService.AnalyzerInfoCache.GetDiagnosticDescriptors(a))
+            var descriptors = await GetDiagnosticDescriptorsAsync().ConfigureAwait(false);
+
+            return descriptors
                 .GroupBy(d => d.Id)
                 .OrderBy(g => g.Key, StringComparer.CurrentCulture)
                 .SelectAsArray(g =>
@@ -164,9 +173,34 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
                 });
         }
 
-        async Task<ImmutableArray<BaseItem>> GenerateSourceGeneratorItemsAsync(
-            Project project,
-            AnalyzerReference analyzerReference)
+        async ValueTask<ImmutableArray<DiagnosticDescriptor>> GetDiagnosticDescriptorsAsync()
+        {
+            // Call out to oop to do this if possible.  This way we don't actually load the analyzers in proc.
+            // this also allows 
+            if (client is not null &&
+                analyzerReference is AnalyzerFileReference analyzerFileReference)
+            {
+                var result = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableArray<DiagnosticDescriptorData>>(
+                    project,
+                    (service, solutionChecksum, cancellationToken) => service.GetDiagnosticDescriptorsAsync(
+                        solutionChecksum, project.Id, analyzerFileReference.FullPath, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
+
+                // If the call fails, the OOP substrate will have already reported an error
+                if (!result.HasValue)
+                    return [];
+
+                return result.Value.SelectAsArray(d => d.ToDiagnosticDescriptor());
+            }
+
+            // Otherwise, do the work in process.
+            var diagnosticAnalyzerService = this.Workspace.Services.GetRequiredService<IDiagnosticAnalyzerService>();
+            return analyzerReference
+                .GetAnalyzers(project.Language)
+                .SelectManyAsArray(a => diagnosticAnalyzerService.AnalyzerInfoCache.GetDiagnosticDescriptors(a));
+        }
+
+        async Task<ImmutableArray<BaseItem>> GenerateSourceGeneratorItemsAsync()
         {
             var identifies = await GetIdentitiesAsync().ConfigureAwait(false);
             return identifies.SelectAsArray(
@@ -177,23 +211,20 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
         {
             // Can only remote AnalyzerFileReferences over to the oop side.  If we have another form of reference (like
             // in tests), we'll just fall back to loading these in process.
-            if (analyzerReference is AnalyzerFileReference analyzerFileReference)
+            if (client is not null &&
+                analyzerReference is AnalyzerFileReference analyzerFileReference)
             {
-                var client = await RemoteHostClient.TryGetClientAsync(this.Workspace, cancellationToken).ConfigureAwait(false);
-                if (client is not null)
-                {
-                    var result = await client.TryInvokeAsync<IRemoteSourceGenerationService, ImmutableArray<SourceGeneratorIdentity>>(
-                        project,
-                        (service, solutionChecksum, cancellationToken) => service.GetSourceGeneratorIdentitiesAsync(
-                            solutionChecksum, project.Id, analyzerFileReference.FullPath, cancellationToken),
-                        cancellationToken).ConfigureAwait(false);
+                var result = await client.TryInvokeAsync<IRemoteSourceGenerationService, ImmutableArray<SourceGeneratorIdentity>>(
+                    project,
+                    (service, solutionChecksum, cancellationToken) => service.GetSourceGeneratorIdentitiesAsync(
+                        solutionChecksum, project.Id, analyzerFileReference.FullPath, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
 
-                    // If the call fails, the OOP substrate will have already reported an error
-                    if (!result.HasValue)
-                        return [];
+                // If the call fails, the OOP substrate will have already reported an error
+                if (!result.HasValue)
+                    return [];
 
-                    return result.Value;
-                }
+                return result.Value;
             }
 
             // Do the work in process.

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Threading;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell;
 using Roslyn.Utilities;
-using VSLangProj140;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer;
 

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/BaseDiagnosticAndGeneratorItemSource.cs
@@ -194,10 +194,7 @@ internal abstract partial class BaseDiagnosticAndGeneratorItemSource : IAttached
             }
 
             // Otherwise, do the work in process.
-            var diagnosticAnalyzerService = this.Workspace.Services.GetRequiredService<IDiagnosticAnalyzerService>();
-            return analyzerReference
-                .GetAnalyzers(project.Language)
-                .SelectManyAsArray(a => diagnosticAnalyzerService.AnalyzerInfoCache.GetDiagnosticDescriptors(a));
+            return project.GetDiagnosticDescriptors(analyzerReference);
         }
 
         async Task<ImmutableArray<BaseItem>> GenerateSourceGeneratorItemsAsync()

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDescriptorData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDescriptorData.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.Diagnostics;
+
+[DataContract]
+internal sealed class DiagnosticDescriptorData(
+    string id,
+    string title,
+    string messageFormat,
+    string category,
+    DiagnosticSeverity defaultSeverity,
+    bool isEnabledByDefault,
+    string? description,
+    string? helpLinkUri,
+    ImmutableArray<string> customTags)
+{
+    [DataMember(Order = 0)]
+    public readonly string Id = id;
+    [DataMember(Order = 1)]
+    public readonly string Title = title;
+    [DataMember(Order = 2)]
+    public readonly string MessageFormat = messageFormat;
+    [DataMember(Order = 3)]
+    public readonly string Category = category;
+    [DataMember(Order = 4)]
+    public readonly DiagnosticSeverity DefaultSeverity = defaultSeverity;
+    [DataMember(Order = 5)]
+    public readonly bool IsEnabledByDefault = isEnabledByDefault;
+    [DataMember(Order = 6)]
+    public readonly string? Description = description;
+    [DataMember(Order = 7)]
+    public readonly string? HelpLinkUri = helpLinkUri;
+    [DataMember(Order = 8)]
+    public readonly ImmutableArray<string> CustomTags = customTags;
+
+    public static DiagnosticDescriptorData Create(DiagnosticDescriptor descriptor)
+    {
+        return new DiagnosticDescriptorData(
+            descriptor.Id,
+            descriptor.Title.ToString(CultureInfo.CurrentUICulture),
+            descriptor.MessageFormat.ToString(CultureInfo.CurrentUICulture),
+            descriptor.Category,
+            descriptor.DefaultSeverity,
+            descriptor.IsEnabledByDefault,
+            descriptor.Description?.ToString(CultureInfo.CurrentUICulture),
+            descriptor.HelpLinkUri,
+            customTags: descriptor.CustomTags.AsImmutableOrEmpty());
+    }
+
+    public DiagnosticDescriptor ToDiagnosticDescriptor()
+    {
+        return new DiagnosticDescriptor(
+            Id,
+            Title,
+            MessageFormat,
+            Category,
+            DefaultSeverity,
+            IsEnabledByDefault,
+            Description,
+            HelpLinkUri,
+            ImmutableCollectionsMarshal.AsArray(CustomTags)!);
+    }
+}

--- a/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -15,6 +15,8 @@ internal interface IRemoteDiagnosticAnalyzerService
     ValueTask<SerializableDiagnosticAnalysisResults> CalculateDiagnosticsAsync(Checksum solutionChecksum, DiagnosticArguments arguments, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<DiagnosticData>> GetSourceGeneratorDiagnosticsAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
     ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<DiagnosticDescriptorData>> GetDiagnosticDescriptorsAsync(
+        Checksum solutionChecksum, ProjectId projectId, string analyzerReferenceFullPath, CancellationToken cancellationToken);
 }
 
 [DataContract]

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -129,12 +129,9 @@ internal sealed class RemoteDiagnosticAnalyzerService(in BrokeredServiceBase.Ser
                 var analyzerReference = project.AnalyzerReferences
                     .First(r => r.FullPath == analyzerReferenceFullPath);
 
-                var diagnosticAnalyzerService = solution.Services.GetRequiredService<IDiagnosticAnalyzerService>();
-
-                var descriptors = analyzerReference
-                    .GetAnalyzers(project.Language)
-                    .SelectMany(a => diagnosticAnalyzerService.AnalyzerInfoCache.GetDiagnosticDescriptors(a))
-                    .SelectAsArray(d => DiagnosticDescriptorData.Create(d));
+                var descriptors = project
+                .GetDiagnosticDescriptors(analyzerReference)
+                .SelectAsArray(DiagnosticDescriptorData.Create);
 
                 return ValueTask.FromResult(descriptors);
             },

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -130,8 +130,8 @@ internal sealed class RemoteDiagnosticAnalyzerService(in BrokeredServiceBase.Ser
                     .First(r => r.FullPath == analyzerReferenceFullPath);
 
                 var descriptors = project
-                .GetDiagnosticDescriptors(analyzerReference)
-                .SelectAsArray(DiagnosticDescriptorData.Create);
+                    .GetDiagnosticDescriptors(analyzerReference)
+                    .SelectAsArray(DiagnosticDescriptorData.Create);
 
                 return ValueTask.FromResult(descriptors);
             },


### PR DESCRIPTION
This is needed so that hte VS ui properly updates when analyzers change on disk.