### PR TITLE
*** WIP: Reduce allocations in Assembly.GetTopLevelTypeByMetadataName

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1321,13 +1321,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///   2) /r:Goo=A.dll /r:B.dll -> B
         ///   3) /r:Goo=A.dll /r:A.dll -> A
         /// </summary>
-        internal void GetUnaliasedReferencedAssemblies(ArrayBuilder<AssemblySymbol> assemblies)
+        internal void GetUnaliasedReferencedAssemblies(List<AssemblySymbol> assemblies)
         {
             var referenceManager = GetBoundReferenceManager();
 
             int length = referenceManager.ReferencedAssemblies.Length;
-
-            assemblies.EnsureCapacity(assemblies.Count + length);
 
             for (int i = 0; i < length; i++)
             {


### PR DESCRIPTION
This is in draft mode until I get speedometer results back verifying a performance gain.

This allocation shows up as over 5% of allocations during completion in the CompletionInCohosting razor speedometer test.

The issue here is that the size of this array can exceed the the PooledArrayLengthLimitExclusive threshold specified in ArrayBuilder, thus causing items to not get placed back into the standard pool.