### PR TITLE
*** WIP: Reduce allocations from calling ITypeSymbol.AllInterfaces

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
         {
             get
             {
-                return UnderlyingTypeSymbol.AllInterfacesNoUseSiteDiagnostics.GetPublicSymbols();
+                return UnderlyingTypeSymbol.AllInterfacesPublicSymbolsNoUseSiteDiagnostics;
             }
         }
 


### PR DESCRIPTION
This is in draft mode until I get back speeodmeter numbers.

This method accounts for 2.0% of allocations in the Roslyn CodeAnalysis process during completion in the CompletionInCohosting Razor speedometer test.

Razor uses this method from a couple disparate locations (mostly around detecting taghelpers and components). I've verified locally that about 2/3 of these allocations can be removed by having the InterfaceInfo cache the public symbol array information too.

<img width="1544" height="558" alt="image" src="https://github.com/user-attachments/assets/782e3df6-2d66-4744-a9b8-c363b6f18f2c" />