### PR TITLE
Fix issue where analyzers are missing when computing diagnostics OOP

### DIFF
--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -2487,6 +2487,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <summary>
+        /// An analyzer that reports a diagnostic on every single named type.
+        /// </summary>
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
         public sealed class NamedTypeAnalyzerWithConfigurableEnabledByDefault : DiagnosticAnalyzer
         {

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -650,6 +651,166 @@ public sealed class DiagnosticAnalyzerServiceTests
         Assert.Empty(diagnosticMap.Syntax);
         Assert.Empty(diagnosticMap.NonLocal);
         Assert.Empty(diagnosticMap.Other);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/79706")]
+    internal async Task TestAnalysisWithAnalyzerInBothProjectAndHost_SameAnalyzerInstance(bool documentAnalysis)
+    {
+        using var workspace = TestWorkspace.CreateCSharp("class A { }");
+
+        var analyzer = new NamedTypeAnalyzerWithConfigurableEnabledByDefault(isEnabledByDefault: true, DiagnosticSeverity.Warning, throwOnAllNamedTypes: false);
+        var analyzerId = analyzer.GetAnalyzerId();
+        var analyzerReference = new AnalyzerImageReference([analyzer]);
+
+        workspace.TryApplyChanges(
+            workspace.CurrentSolution.WithAnalyzerReferences([analyzerReference])
+            .Projects.Single().AddAnalyzerReference(analyzerReference).Solution);
+
+        var project = workspace.CurrentSolution.Projects.Single();
+        var document = documentAnalysis ? project.Documents.Single() : null;
+        var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
+            document, project, Checksum.Null, span: null, projectAnalyzerIds: [analyzerId], [analyzerId],
+            AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
+            logPerformanceInfo: false, getTelemetryInfo: false,
+            cancellationToken: CancellationToken.None);
+
+        // In this case, since the analyzer identity is identical, we ran it once
+        var analyzerResults = diagnosticsMapResults.Diagnostics.Single();
+        Assert.Equal(analyzerId, analyzerResults.Item1);
+        Assert.Equal(1, analyzerResults.Item2.Semantic.Length);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/79706")]
+    internal async Task TestAnalysisWithAnalyzerInBothProjectAndHost_DifferentAnalyzerInstancesFromNonEqualReferences(bool documentAnalysis)
+    {
+        using var workspace = TestWorkspace.CreateCSharp("class A { }");
+
+        var analyzerProject = new NamedTypeAnalyzerWithConfigurableEnabledByDefault(isEnabledByDefault: true, DiagnosticSeverity.Warning, throwOnAllNamedTypes: false);
+        var analyzerProjectId = analyzerProject.GetAnalyzerId();
+        var analyzerProjectReference = new AnalyzerImageReference([analyzerProject]);
+
+        var analyzerHost = new NamedTypeAnalyzerWithConfigurableEnabledByDefault(isEnabledByDefault: true, DiagnosticSeverity.Warning, throwOnAllNamedTypes: false);
+        var analyzerHostId = analyzerHost.GetAnalyzerId();
+        var analyzerHostReference = new AnalyzerImageReference([analyzerHost]);
+
+        // AnalyzerImageReference will create a separate AnalyzerImageReference.Id for each instance created, so these will be different.
+        Assert.NotEqual(analyzerProjectReference.Id, analyzerHostReference.Id);
+        Assert.Equal(analyzerProjectId, analyzerHostId);
+
+        workspace.TryApplyChanges(
+            workspace.CurrentSolution.WithAnalyzerReferences([analyzerHostReference])
+            .Projects.Single().AddAnalyzerReference(analyzerProjectReference).Solution);
+
+        var project = workspace.CurrentSolution.Projects.Single();
+        var document = documentAnalysis ? project.Documents.Single() : null;
+        var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
+            document, project, Checksum.Null, span: null, projectAnalyzerIds: [analyzerProjectId], [analyzerHostId],
+            AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
+            logPerformanceInfo: false, getTelemetryInfo: false,
+            cancellationToken: CancellationToken.None);
+
+        // In this case, since the analyzer reference identity is identical, we ran it once
+        var analyzerResults = diagnosticsMapResults.Diagnostics.Single();
+        Assert.Equal(analyzerHostId, analyzerResults.Item1);
+        Assert.Equal(1, analyzerResults.Item2.Semantic.Length);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/79706")]
+    internal async Task TestAnalysisWithAnalyzerInBothProjectAndHost_DifferentAnalyzerInstancesFromEqualReferences(bool documentAnalysis, bool includeExtraProjectReference, bool includeExtraHostReference)
+    {
+        using var workspace = TestWorkspace.CreateCSharp("class A { }");
+
+        var analyzerProject = new NamedTypeAnalyzerWithConfigurableEnabledByDefault(isEnabledByDefault: true, DiagnosticSeverity.Warning, throwOnAllNamedTypes: false);
+        var analyzerProjectId = analyzerProject.GetAnalyzerId();
+        var analyzerProjectReference = CreateAnalyzerReferenceWithSameId(analyzerProject);
+
+        var analyzerHost = new NamedTypeAnalyzerWithConfigurableEnabledByDefault(isEnabledByDefault: true, DiagnosticSeverity.Warning, throwOnAllNamedTypes: false);
+        var analyzerHostId = analyzerHost.GetAnalyzerId();
+        var analyzerHostReference = CreateAnalyzerReferenceWithSameId(analyzerHost);
+
+        Assert.Equal(analyzerProjectReference.Id, analyzerHostReference.Id);
+        Assert.Equal(analyzerProjectId, analyzerHostId);
+
+        workspace.TryApplyChanges(
+            workspace.CurrentSolution.WithAnalyzerReferences(AddExtraReferenceIfNeeded(analyzerHostReference, includeExtraHostReference))
+            .Projects.Single().AddAnalyzerReferences(AddExtraReferenceIfNeeded(analyzerProjectReference, includeExtraProjectReference)).Solution);
+
+        var project = workspace.CurrentSolution.Projects.Single();
+        var document = documentAnalysis ? project.Documents.Single() : null;
+        var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
+            document, project, Checksum.Null, span: null, projectAnalyzerIds: [analyzerProjectId], [analyzerHostId],
+            AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
+            logPerformanceInfo: false, getTelemetryInfo: false,
+            cancellationToken: CancellationToken.None);
+
+        // In this case, the analyzers are ran twice. This appears to be a bug in SkippedHostAnalyzersInfo.Create, because it calls
+        // HostDiagnosticAnalyzers.CreateProjectDiagnosticAnalyzersPerReference which already filters out references, it doesn't return any
+        // references to skip.
+        Assert.Equal(2, diagnosticsMapResults.Diagnostics.Length);
+
+        static AnalyzerReference CreateAnalyzerReferenceWithSameId(DiagnosticAnalyzer analyzer)
+        {
+            var map = new Dictionary<string, ImmutableArray<DiagnosticAnalyzer>>()
+            {
+                { LanguageNames.CSharp, [analyzer] }
+            };
+
+            return new TestAnalyzerReferenceByLanguage(map);
+        }
+
+        static ImmutableArray<AnalyzerReference> AddExtraReferenceIfNeeded(AnalyzerReference mainReference, bool addExtraReference)
+        {
+            if (addExtraReference)
+            {
+                return [mainReference, new AnalyzerImageReference([new FieldAnalyzer("FA1234", syntaxTreeAction: false)])];
+            }
+            else
+            {
+                return [mainReference];
+            }
+        }
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/79706")]
+    internal async Task TestAnalysisWithAnalyzerInBothProjectAndHost_SameAnalyzerInstancesFromEqualReferences(bool documentAnalysis)
+    {
+        using var workspace = TestWorkspace.CreateCSharp("class A { }");
+
+        var analyzer = new NamedTypeAnalyzerWithConfigurableEnabledByDefault(isEnabledByDefault: true, DiagnosticSeverity.Warning, throwOnAllNamedTypes: false);
+        var analyzerProjectReference = CreateAnalyzerReferenceWithSameId(analyzer);
+        var analyzerHostReference = CreateAnalyzerReferenceWithSameId(analyzer);
+
+        var analyzerId = analyzer.GetAnalyzerId();
+
+        Assert.Equal(analyzerProjectReference.Id, analyzerHostReference.Id);
+
+        workspace.TryApplyChanges(
+            workspace.CurrentSolution.WithAnalyzerReferences([analyzerHostReference])
+            .Projects.Single().AddAnalyzerReference(analyzerProjectReference).Solution);
+
+        var project = workspace.CurrentSolution.Projects.Single();
+        var document = documentAnalysis ? project.Documents.Single() : null;
+        var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
+            document, project, Checksum.Null, span: null, projectAnalyzerIds: [analyzerId], [analyzerId],
+            AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
+            logPerformanceInfo: false, getTelemetryInfo: false,
+            cancellationToken: CancellationToken.None);
+
+        Assert.Equal(1, diagnosticsMapResults.Diagnostics.Length);
+
+        static AnalyzerReference CreateAnalyzerReferenceWithSameId(DiagnosticAnalyzer analyzer)
+        {
+            var map = new Dictionary<string, ImmutableArray<DiagnosticAnalyzer>>()
+            {
+                { LanguageNames.CSharp, [analyzer] }
+            };
+
+            return new TestAnalyzerReferenceByLanguage(map);
+        }
     }
 
     [Theory, WorkItem(67257, "https://github.com/dotnet/roslyn/issues/67257")]

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -130,6 +130,13 @@ internal static partial class Extensions
         var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, DiagnosticAnalysisResultBuilder>();
         foreach (var analyzer in projectAnalyzers.ConcatFast(hostAnalyzers))
         {
+            if (builder.ContainsKey(analyzer))
+            {
+                // If we already have a result for this analyzer, we had a duplicate. We already processed the results
+                // for this so no reason to process it a second time.
+                continue;
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
 
             if (skippedAnalyzersInfo.SkippedAnalyzers.Contains(analyzer))

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -127,13 +127,13 @@ internal sealed class DiagnosticComputer
         bool getTelemetryInfo,
         CancellationToken cancellationToken)
     {
-        var (compilationWithAnalyzers, analyzerToIdMap) = await GetOrCreateCompilationWithAnalyzersAsync(cancellationToken).ConfigureAwait(false);
+        var (compilationWithAnalyzers, projectAnalyzerToIdMap, hostAnalyzerToIdMap) = await GetOrCreateCompilationWithAnalyzersAsync(cancellationToken).ConfigureAwait(false);
         if (compilationWithAnalyzers == null)
         {
             return SerializableDiagnosticAnalysisResults.Empty;
         }
 
-        var (projectAnalyzers, hostAnalyzers) = GetAnalyzers(analyzerToIdMap, projectAnalyzerIds, hostAnalyzerIds);
+        var (projectAnalyzers, hostAnalyzers) = GetAnalyzers(projectAnalyzerToIdMap, hostAnalyzerToIdMap, projectAnalyzerIds, hostAnalyzerIds);
         if (projectAnalyzers.IsEmpty && hostAnalyzers.IsEmpty)
         {
             return SerializableDiagnosticAnalysisResults.Empty;
@@ -165,13 +165,14 @@ internal sealed class DiagnosticComputer
         var skippedAnalyzersInfo = _project.Solution.SolutionState.Analyzers.GetSkippedAnalyzersInfo(
             _project.State, _analyzerInfoCache);
 
-        return await AnalyzeAsync(compilationWithAnalyzers, analyzerToIdMap, projectAnalyzers, hostAnalyzers, skippedAnalyzersInfo,
+        return await AnalyzeAsync(compilationWithAnalyzers, projectAnalyzerToIdMap, hostAnalyzerToIdMap, projectAnalyzers, hostAnalyzers, skippedAnalyzersInfo,
             logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<SerializableDiagnosticAnalysisResults> AnalyzeAsync(
         CompilationWithAnalyzersPair compilationWithAnalyzers,
-        BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap,
+        BidirectionalMap<string, DiagnosticAnalyzer> projectAnalyzerToIdMap,
+        BidirectionalMap<string, DiagnosticAnalyzer> hostAnalyzerToIdMap,
         ImmutableArray<DiagnosticAnalyzer> projectAnalyzers,
         ImmutableArray<DiagnosticAnalyzer> hostAnalyzers,
         SkippedHostAnalyzersInfo skippedAnalyzersInfo,
@@ -212,21 +213,22 @@ internal sealed class DiagnosticComputer
         }
 
         var telemetry = getTelemetryInfo
-            ? GetTelemetryInfo(analysisResult, projectAnalyzers, hostAnalyzers, analyzerToIdMap)
+            ? GetTelemetryInfo(analysisResult, projectAnalyzers, hostAnalyzers, projectAnalyzerToIdMap, hostAnalyzerToIdMap)
             : [];
 
-        return new SerializableDiagnosticAnalysisResults(Dehydrate(builderMap, analyzerToIdMap), telemetry);
+        return new SerializableDiagnosticAnalysisResults(Dehydrate(builderMap, projectAnalyzerToIdMap, hostAnalyzerToIdMap), telemetry);
     }
 
     private static ImmutableArray<(string analyzerId, SerializableDiagnosticMap diagnosticMap)> Dehydrate(
         ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResultBuilder> builderMap,
-        BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)
+        BidirectionalMap<string, DiagnosticAnalyzer> projectAnalyzerToIdMap,
+        BidirectionalMap<string, DiagnosticAnalyzer> hostAnalyzerToIdMap)
     {
         var diagnostics = new FixedSizeArrayBuilder<(string analyzerId, SerializableDiagnosticMap diagnosticMap)>(builderMap.Count);
 
         foreach (var (analyzer, analyzerResults) in builderMap)
         {
-            var analyzerId = GetAnalyzerId(analyzerToIdMap, analyzer);
+            var analyzerId = GetAnalyzerId(projectAnalyzerToIdMap, hostAnalyzerToIdMap, analyzer);
 
             diagnostics.Add((analyzerId,
                 new SerializableDiagnosticMap(
@@ -243,7 +245,8 @@ internal sealed class DiagnosticComputer
         AnalysisResultPair? analysisResult,
         ImmutableArray<DiagnosticAnalyzer> projectAnalyzers,
         ImmutableArray<DiagnosticAnalyzer> hostAnalyzers,
-        BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)
+        BidirectionalMap<string, DiagnosticAnalyzer> projectAnalyzerToIdMap,
+        BidirectionalMap<string, DiagnosticAnalyzer> hostAnalyzerToIdMap)
     {
         Func<DiagnosticAnalyzer, bool> shouldInclude;
         if (projectAnalyzers.Length < (analysisResult?.ProjectAnalysisResult?.AnalyzerTelemetryInfo.Count ?? 0)
@@ -268,7 +271,7 @@ internal sealed class DiagnosticComputer
             {
                 if (shouldInclude(analyzer))
                 {
-                    var analyzerId = GetAnalyzerId(analyzerToIdMap, analyzer);
+                    var analyzerId = GetAnalyzerId(projectAnalyzerToIdMap, hostAnalyzerToIdMap, analyzer);
                     telemetryBuilder.Add((analyzerId, analyzerTelemetry));
                 }
             }
@@ -277,15 +280,15 @@ internal sealed class DiagnosticComputer
         return telemetryBuilder.ToImmutableAndClear();
     }
 
-    private static string GetAnalyzerId(BidirectionalMap<string, DiagnosticAnalyzer> analyzerMap, DiagnosticAnalyzer analyzer)
+    private static string GetAnalyzerId(BidirectionalMap<string, DiagnosticAnalyzer> analyzerMap1, BidirectionalMap<string, DiagnosticAnalyzer> analyzerMap2, DiagnosticAnalyzer analyzer)
     {
-        var analyzerId = analyzerMap.GetKeyOrDefault(analyzer);
+        var analyzerId = analyzerMap1.GetKeyOrDefault(analyzer) ?? analyzerMap2.GetKeyOrDefault(analyzer);
         Contract.ThrowIfNull(analyzerId);
 
         return analyzerId;
     }
 
-    private static (ImmutableArray<DiagnosticAnalyzer> projectAnalyzers, ImmutableArray<DiagnosticAnalyzer> hostAnalyzers) GetAnalyzers(BidirectionalMap<string, DiagnosticAnalyzer> analyzerMap, ImmutableArray<string> projectAnalyzerIds, ImmutableArray<string> hostAnalyzerIds)
+    private static (ImmutableArray<DiagnosticAnalyzer> projectAnalyzers, ImmutableArray<DiagnosticAnalyzer> hostAnalyzers) GetAnalyzers(BidirectionalMap<string, DiagnosticAnalyzer> projectAnalyzerMap, BidirectionalMap<string, DiagnosticAnalyzer> hostAnalyzerMap, ImmutableArray<string> projectAnalyzerIds, ImmutableArray<string> hostAnalyzerIds)
     {
         // TODO: this probably need to be cached as well in analyzer service?
         var projectBuilder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
@@ -293,7 +296,7 @@ internal sealed class DiagnosticComputer
 
         foreach (var analyzerId in projectAnalyzerIds)
         {
-            if (analyzerMap.TryGetValue(analyzerId, out var analyzer))
+            if (projectAnalyzerMap.TryGetValue(analyzerId, out var analyzer))
             {
                 projectBuilder.Add(analyzer);
             }
@@ -301,7 +304,7 @@ internal sealed class DiagnosticComputer
 
         foreach (var analyzerId in hostAnalyzerIds)
         {
-            if (analyzerMap.TryGetValue(analyzerId, out var analyzer))
+            if (hostAnalyzerMap.TryGetValue(analyzerId, out var analyzer))
             {
                 hostBuilder.Add(analyzer);
             }
@@ -322,10 +325,10 @@ internal sealed class DiagnosticComputer
         return (projectAnalyzers, hostBuilder.ToImmutableAndClear());
     }
 
-    private async Task<(CompilationWithAnalyzersPair? compilationWithAnalyzers, BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)> GetOrCreateCompilationWithAnalyzersAsync(CancellationToken cancellationToken)
+    private async Task<(CompilationWithAnalyzersPair? compilationWithAnalyzers, BidirectionalMap<string, DiagnosticAnalyzer> projectAnalyzerToIdMap, BidirectionalMap<string, DiagnosticAnalyzer> hostAnalyzerToIdMap)> GetOrCreateCompilationWithAnalyzersAsync(CancellationToken cancellationToken)
     {
         var cacheEntry = await GetOrCreateCacheEntryAsync().ConfigureAwait(false);
-        return (cacheEntry.CompilationWithAnalyzers, cacheEntry.AnalyzerToIdMap);
+        return (cacheEntry.CompilationWithAnalyzers, cacheEntry.ProjectAnalyzerToIdMap, cacheEntry.HostAnalyzerToIdMap);
 
         async Task<CompilationWithAnalyzersCacheEntry> GetOrCreateCacheEntryAsync()
         {
@@ -359,9 +362,11 @@ internal sealed class DiagnosticComputer
     {
         // We could consider creating a service so that we don't do this repeatedly if this shows up as perf cost
         using var pooledObject = SharedPools.Default<HashSet<object>>().GetPooledObject();
-        using var pooledMap = SharedPools.Default<Dictionary<string, DiagnosticAnalyzer>>().GetPooledObject();
+        using var pooledMapProjectAnalyzerMap = SharedPools.Default<Dictionary<string, DiagnosticAnalyzer>>().GetPooledObject();
+        using var pooledMapHostAnalyzerMap = SharedPools.Default<Dictionary<string, DiagnosticAnalyzer>>().GetPooledObject();
         var referenceSet = pooledObject.Object;
-        var analyzerMapBuilder = pooledMap.Object;
+        var projectAnalyzerMapBuilder = pooledMapProjectAnalyzerMap.Object;
+        var hostAnalyzerMapBuilder = pooledMapHostAnalyzerMap.Object;
 
         // This follows what we do in DiagnosticAnalyzerInfoCache.CheckAnalyzerReferenceIdentity
         using var _1 = ArrayBuilder<DiagnosticAnalyzer>.GetInstance(out var projectAnalyzerBuilder);
@@ -381,17 +386,18 @@ internal sealed class DiagnosticComputer
             if (ShouldRedirectAnalyzers(_project, reference))
             {
                 projectAnalyzerBuilder.AddRange(analyzers);
+                projectAnalyzerMapBuilder.AppendAnalyzerMap(analyzers);
             }
             else
             {
                 hostAnalyzerBuilder.AddRange(analyzers);
+                hostAnalyzerMapBuilder.AppendAnalyzerMap(analyzers);
             }
-
-            analyzerMapBuilder.AppendAnalyzerMap(analyzers);
         }
 
-        // Evaluate project analyzers after host analyzers to ensure duplicates in analyzerMapBuilder are
-        // overwritten with project analyzers if/when applicable.
+        // Clear the set -- we want these two loops to be independent
+        referenceSet.Clear();
+
         foreach (var reference in _project.AnalyzerReferences)
         {
             if (!referenceSet.Add(reference.Id))
@@ -408,15 +414,16 @@ internal sealed class DiagnosticComputer
             hostAnalyzerBuilder.RemoveRange(projectSuppressors);
             hostAnalyzerBuilder.AddRange(projectSuppressors);
 
-            analyzerMapBuilder.AppendAnalyzerMap(analyzers);
+            projectAnalyzerMapBuilder.AppendAnalyzerMap(analyzers);
         }
 
         var compilationWithAnalyzers = projectAnalyzerBuilder.Count > 0 || hostAnalyzerBuilder.Count > 0
             ? await CreateCompilationWithAnalyzerAsync(projectAnalyzerBuilder.ToImmutable(), hostAnalyzerBuilder.ToImmutable(), cancellationToken).ConfigureAwait(false)
             : null;
-        var analyzerToIdMap = new BidirectionalMap<string, DiagnosticAnalyzer>(analyzerMapBuilder);
+        var projectAnalyzerToIdMap = new BidirectionalMap<string, DiagnosticAnalyzer>(projectAnalyzerMapBuilder);
+        var hostAnalyzerToIdMap = new BidirectionalMap<string, DiagnosticAnalyzer>(hostAnalyzerMapBuilder);
 
-        return new CompilationWithAnalyzersCacheEntry(_solutionChecksum, _project, compilationWithAnalyzers, analyzerToIdMap);
+        return new CompilationWithAnalyzersCacheEntry(_solutionChecksum, _project, compilationWithAnalyzers, projectAnalyzerToIdMap, hostAnalyzerToIdMap);
 
         static bool ShouldRedirectAnalyzers(Project project, AnalyzerReference reference)
         {
@@ -470,14 +477,21 @@ internal sealed class DiagnosticComputer
         public Checksum SolutionChecksum { get; }
         public Project Project { get; }
         public CompilationWithAnalyzersPair? CompilationWithAnalyzers { get; }
-        public BidirectionalMap<string, DiagnosticAnalyzer> AnalyzerToIdMap { get; }
+        public BidirectionalMap<string, DiagnosticAnalyzer> ProjectAnalyzerToIdMap { get; }
+        public BidirectionalMap<string, DiagnosticAnalyzer> HostAnalyzerToIdMap { get; }
 
-        public CompilationWithAnalyzersCacheEntry(Checksum solutionChecksum, Project project, CompilationWithAnalyzersPair? compilationWithAnalyzers, BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)
+        public CompilationWithAnalyzersCacheEntry(
+            Checksum solutionChecksum,
+            Project project,
+            CompilationWithAnalyzersPair? compilationWithAnalyzers,
+            BidirectionalMap<string, DiagnosticAnalyzer> projectAnalyzerToIdMap,
+            BidirectionalMap<string, DiagnosticAnalyzer> hostAnalyzerToIdMap)
         {
             SolutionChecksum = solutionChecksum;
             Project = project;
             CompilationWithAnalyzers = compilationWithAnalyzers;
-            AnalyzerToIdMap = analyzerToIdMap;
+            ProjectAnalyzerToIdMap = projectAnalyzerToIdMap;
+            HostAnalyzerToIdMap = hostAnalyzerToIdMap;
         }
     }
 }


### PR DESCRIPTION
If you were to have the same analyzer added as both a host analyzer and a project analyzer, we might end up removing it from the "project analyzer" set when we create the project CompilationWithAnalyzers. This confuses later code since it expects the analyzers to be present.

This was regressed in c860af4093a89d0d09bc6a11baca592a013abb3c, where a mechanical refactoring took us from having a single CompilationWithAnalyzers to two, one for project analyzers and one for host analyzers. The loop in the method was copied into two, but the set wasn't cleared between the two loops. I believe the intent was to clear out the set (rather than the set persist to deal with duplicates between the host and project sets), given the comment implies we do want duplicates to overwrite in the analyzerMap that we're also producing.

I also split the two analyzer maps, one for project analyzers and one for host analyzers. If you don't do this, it means that a conflict where the same analyzer existing in both sets will overwrite each other, later code will then return a project analyzer which might be a different instance than the host analyzer equivalent.

Fixes https://github.com/dotnet/roslyn/issues/79706
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2325694