### PR TITLE
Fix invalid link to Analyzer Configuration.md

### DIFF
--- a/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
@@ -13,7 +13,7 @@ To get started with the Public API Analyzer:
 dotnet_public_api_analyzer.require_api_files = true
 ```
 
-See [Analyzer Configuration.md](https://github.com/dotnet/roslyn-analyzers/blob/main/docs/Analyzer%20Configuration.md) for more details on how to setup editorconfig based configuration.
+See [Configuration options for code analysis](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-options) for more details on how to setup editorconfig based configuration.
 
 ## Package version earlier than 3.3.x
 

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
@@ -13,7 +13,7 @@ To get started with the Public API Analyzer:
 dotnet_public_api_analyzer.require_api_files = true
 ```
 
-See [Analyzer Configuration.md](../../docs/Analyzer%20Configuration.md) for more details on how to setup editorconfig based configuration.
+See [Analyzer Configuration.md](https://github.com/dotnet/roslyn-analyzers/blob/main/docs/Analyzer%20Configuration.md) for more details on how to setup editorconfig based configuration.
 
 ## Package version earlier than 3.3.x
 


### PR DESCRIPTION
This PR fixes a broken link to a file in the dotnet/roslyn-analyzers repo, relative links are broken since the code was moved into this repository.