### PR TITLE
EnC: Fix symbol mapping of delegates with indexed name

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3598,8 +3598,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        private protected override EmitBaseline MapToCompilation(CommonPEModuleBuilder moduleBeingBuilt)
-            => EmitHelpers.MapToCompilation(this, (PEDeltaAssemblyBuilder)moduleBeingBuilt);
+        private protected override SymbolMatcher CreatePreviousToCurrentSourceAssemblyMatcher(
+            EmitBaseline previousGeneration,
+            SynthesizedTypeMaps otherSynthesizedTypes,
+            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherSynthesizedMembers,
+            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherDeletedMembers)
+        {
+            return new CSharpSymbolMatcher(
+                sourceAssembly: ((CSharpCompilation)previousGeneration.Compilation).SourceAssembly,
+                SourceAssembly,
+                otherSynthesizedTypes,
+                otherSynthesizedMembers,
+                otherDeletedMembers);
+        }
 
         private class DuplicateFilePathsVisitor : CSharpSymbolVisitor
         {

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -7,13 +7,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis.Emit.EditAndContinue;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
@@ -27,25 +26,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         public CSharpSymbolMatcher(
             SourceAssemblySymbol sourceAssembly,
             SourceAssemblySymbol otherAssembly,
-            SynthesizedTypeMaps synthesizedTypes,
-            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherSynthesizedMembers,
-            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherDeletedMembers)
-        {
-            _visitor = new Visitor(sourceAssembly, otherAssembly, synthesizedTypes, otherSynthesizedMembers, otherDeletedMembers, new DeepTranslator(otherAssembly.GetSpecialType(SpecialType.System_Object)));
-        }
-
-        public CSharpSymbolMatcher(
-            SynthesizedTypeMaps synthesizedTypes,
-            SourceAssemblySymbol sourceAssembly,
-            PEAssemblySymbol otherAssembly)
+            SynthesizedTypeMaps otherSynthesizedTypes,
+            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherSynthesizedMembers,
+            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherDeletedMembers)
         {
             _visitor = new Visitor(
                 sourceAssembly,
                 otherAssembly,
-                synthesizedTypes,
-                otherSynthesizedMembers: null,
-                deepTranslator: null,
-                otherDeletedMembers: null);
+                otherSynthesizedTypes,
+                otherSynthesizedMembers,
+                otherDeletedMembers,
+                new DeepTranslator(otherAssembly.GetSpecialType(SpecialType.System_Object)));
+        }
+
+        public CSharpSymbolMatcher(
+            SourceAssemblySymbol sourceAssembly,
+            PEAssemblySymbol otherAssembly,
+            SynthesizedTypeMaps otherSynthesizedTypes)
+        {
+            _visitor = new Visitor(
+                sourceAssembly,
+                otherAssembly,
+                otherSynthesizedTypes,
+                otherSynthesizedMembers: SpecializedCollections.EmptyReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>(),
+                otherDeletedMembers: SpecializedCollections.EmptyReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>(),
+                deepTranslator: null);
         }
 
         public override Cci.IDefinition? MapDefinition(Cci.IDefinition definition)
@@ -93,9 +98,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal bool TryGetAnonymousTypeValue(AnonymousTypeManager.AnonymousTypeOrDelegateTemplateSymbol template, out AnonymousTypeValue typeValue)
             => _visitor.TryGetAnonymousTypeValue(template, out typeValue);
 
+        protected override bool TryGetMatchingDelegateWithIndexedName(INamedTypeSymbolInternal delegateTemplate, ImmutableArray<AnonymousTypeValue> values, out AnonymousTypeValue match)
+            => _visitor.TryGetMatchingDelegateWithIndexedName((AnonymousTypeManager.AnonymousDelegateTemplateSymbol)delegateTemplate, values, out match);
+
         private sealed class Visitor : CSharpSymbolVisitor<Symbol?>
         {
-            private readonly SynthesizedTypeMaps _synthesizedTypes;
+            private readonly SynthesizedTypeMaps _otherSynthesizedTypes;
             private readonly SourceAssemblySymbol _sourceAssembly;
 
             // metadata or source assembly:
@@ -105,9 +113,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             /// Members that are not listed directly on their containing type or namespace symbol as they were synthesized in a lowering phase,
             /// after the symbol has been created.
             /// </summary>
-            private readonly IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? _otherSynthesizedMembers;
+            private readonly IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> _otherSynthesizedMembers;
 
-            private readonly IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? _otherDeletedMembers;
+            private readonly IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> _otherDeletedMembers;
 
             private readonly SymbolComparer _comparer;
             private readonly ConcurrentDictionary<Symbol, Symbol?> _matches = new(ReferenceEqualityComparer.Instance);
@@ -123,12 +131,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public Visitor(
                 SourceAssemblySymbol sourceAssembly,
                 AssemblySymbol otherAssembly,
-                SynthesizedTypeMaps synthesizedTypes,
-                IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherSynthesizedMembers,
-                IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherDeletedMembers,
+                SynthesizedTypeMaps otherSynthesizedTypes,
+                IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherSynthesizedMembers,
+                IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherDeletedMembers,
                 DeepTranslator? deepTranslator)
             {
-                _synthesizedTypes = synthesizedTypes;
+                _otherSynthesizedTypes = otherSynthesizedTypes;
                 _sourceAssembly = sourceAssembly;
                 _otherAssembly = otherAssembly;
                 _otherSynthesizedMembers = otherSynthesizedMembers;
@@ -470,45 +478,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     CSharpCustomModifier.CreateRequired(type);
             }
 
-            internal bool TryGetAnonymousDelegateValue(AnonymousTypeManager.AnonymousDelegateTemplateSymbol delegateSymbol, out SynthesizedDelegateValue otherDelegateSymbol)
+            private bool TryGetAnonymousDelegateValue(AnonymousTypeManager.AnonymousDelegateTemplateSymbol delegateSymbol, out SynthesizedDelegateValue otherDelegateSymbol)
             {
-                Debug.Assert((object)delegateSymbol.ContainingSymbol == (object)_sourceAssembly.GlobalNamespace);
-
                 var key = new SynthesizedDelegateKey(delegateSymbol.MetadataName);
-                return _synthesizedTypes.AnonymousDelegates.TryGetValue(key, out otherDelegateSymbol);
+                return _otherSynthesizedTypes.AnonymousDelegates.TryGetValue(key, out otherDelegateSymbol);
             }
 
             internal bool TryGetAnonymousTypeValue(AnonymousTypeManager.AnonymousTypeOrDelegateTemplateSymbol template, out AnonymousTypeValue otherType)
             {
-                Debug.Assert((object)template.ContainingSymbol == (object)_sourceAssembly.GlobalNamespace);
-
                 if (template is AnonymousTypeManager.AnonymousTypeTemplateSymbol typeTemplate)
                 {
-                    return _synthesizedTypes.AnonymousTypes.TryGetValue(typeTemplate.GetAnonymousTypeKey(), out otherType);
+                    return _otherSynthesizedTypes.AnonymousTypes.TryGetValue(typeTemplate.GetAnonymousTypeKey(), out otherType);
                 }
 
                 var delegateTemplate = (AnonymousTypeManager.AnonymousDelegateTemplateSymbol)template;
                 Debug.Assert(delegateTemplate.DelegateInvokeMethod != null);
 
+                otherType = default;
+
                 var key = new AnonymousDelegateWithIndexedNamePartialKey(delegateTemplate.Arity, delegateTemplate.DelegateInvokeMethod.ParameterCount);
-                if (_synthesizedTypes.AnonymousDelegatesWithIndexedNames.TryGetValue(key, out var otherTypeCandidates))
+                return _otherSynthesizedTypes.AnonymousDelegatesWithIndexedNames.TryGetValue(key, out var otherTypeCandidates) &&
+                       TryGetMatchingDelegateWithIndexedName(delegateTemplate, otherTypeCandidates, out otherType);
+            }
+
+            internal bool TryGetMatchingDelegateWithIndexedName(AnonymousTypeManager.AnonymousDelegateTemplateSymbol delegateTemplate, ImmutableArray<AnonymousTypeValue> values, out AnonymousTypeValue match)
+            {
+                foreach (var otherTypeCandidate in values)
                 {
-                    // The key is partial (not unique). Find a matching Invoke method signature.
+                    var otherDelegateType = (NamedTypeSymbol?)otherTypeCandidate.Type.GetInternalSymbol();
+                    Debug.Assert(otherDelegateType is not null);
 
-                    foreach (var otherTypeCandidate in otherTypeCandidates)
+                    if (isCorrespondingAnonymousDelegate(delegateTemplate, otherDelegateType))
                     {
-                        var otherDelegateType = (NamedTypeSymbol?)otherTypeCandidate.Type.GetInternalSymbol();
-                        Debug.Assert(otherDelegateType is not null);
-
-                        if (isCorrespondingAnonymousDelegate(delegateTemplate, otherDelegateType))
-                        {
-                            otherType = otherTypeCandidate;
-                            return true;
-                        }
+                        match = otherTypeCandidate;
+                        return true;
                     }
                 }
 
-                otherType = default;
+                match = default;
                 return false;
 
                 bool isCorrespondingAnonymousDelegate(NamedTypeSymbol type, NamedTypeSymbol otherType)
@@ -526,12 +533,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                 x.IsParamsArray == y.IsParamsArray &&
                                 x.IsParamsCollection == y.IsParamsCollection) &&
                         isCorrespondingType(invokeMethod.ReturnTypeWithAnnotations, otherInvokeMethod.ReturnTypeWithAnnotations);
-                }
 
-                bool isCorrespondingType(TypeWithAnnotations type, TypeWithAnnotations expectedType)
-                {
-                    var otherType = type.WithTypeAndModifiers((TypeSymbol?)this.Visit(type.Type), this.VisitCustomModifiers(type.CustomModifiers));
-                    return otherType.Equals(expectedType, TypeCompareKind.CLRSignatureCompareOptions);
+                    bool isCorrespondingType(TypeWithAnnotations type, TypeWithAnnotations expectedType)
+                    {
+                        var otherType = type.WithTypeAndModifiers((TypeSymbol?)this.Visit(type.Type), this.VisitCustomModifiers(type.CustomModifiers));
+                        return otherType.Equals(expectedType, TypeCompareKind.CLRSignatureCompareOptions);
+                    }
                 }
             }
 
@@ -799,12 +806,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     members.AddRange(((NamespaceSymbol)symbol).GetMembers());
                 }
 
-                if (_otherSynthesizedMembers != null && _otherSynthesizedMembers.TryGetValue(symbol, out var synthesizedMembers))
+                if (_otherSynthesizedMembers.TryGetValue(symbol, out var synthesizedMembers))
                 {
                     members.AddRange(synthesizedMembers);
                 }
 
-                if (_otherDeletedMembers?.TryGetValue(symbol, out var deletedMembers) == true)
+                if (_otherDeletedMembers.TryGetValue(symbol, out var deletedMembers))
                 {
                     members.AddRange(deletedMembers);
                 }

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata;
@@ -15,7 +14,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Emit
 {
@@ -177,70 +175,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 string.Format(CodeAnalysisResources.Type0DoesNotHaveExpectedConstructor, type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)));
 
             return false;
-        }
-
-        /// <summary>
-        /// Return a version of the baseline with all definitions mapped to this compilation.
-        /// Definitions from the initial generation, from metadata, are not mapped since
-        /// the initial generation is always included as metadata. That is, the symbols from
-        /// types, methods, ... in the TypesAdded, MethodsAdded, ... collections are replaced
-        /// by the corresponding symbols from the current compilation.
-        /// </summary>
-        internal static EmitBaseline MapToCompilation(
-            CSharpCompilation compilation,
-            PEDeltaAssemblyBuilder moduleBeingBuilt)
-        {
-            var previousGeneration = moduleBeingBuilt.PreviousGeneration;
-            RoslynDebug.Assert(previousGeneration.Compilation != compilation);
-
-            if (previousGeneration.Ordinal == 0)
-            {
-                // Initial generation, nothing to map. (Since the initial generation
-                // is always loaded from metadata in the context of the current
-                // compilation, there's no separate mapping step.)
-                return previousGeneration;
-            }
-
-            RoslynDebug.AssertNotNull(previousGeneration.Compilation);
-            RoslynDebug.AssertNotNull(previousGeneration.PEModuleBuilder);
-            RoslynDebug.AssertNotNull(moduleBeingBuilt.EncSymbolChanges);
-
-            var currentSynthesizedTypes = moduleBeingBuilt.GetAllSynthesizedTypes();
-            var currentSynthesizedMembers = moduleBeingBuilt.GetAllSynthesizedMembers();
-            var currentDeletedMembers = moduleBeingBuilt.EncSymbolChanges.DeletedMembers;
-
-            // Mapping from previous compilation to the current.
-            var previousSourceAssembly = ((CSharpCompilation)previousGeneration.Compilation).SourceAssembly;
-
-            var matcher = new CSharpSymbolMatcher(
-                sourceAssembly: previousSourceAssembly,
-                otherAssembly: compilation.SourceAssembly,
-                otherSynthesizedTypes: currentSynthesizedTypes,
-                otherSynthesizedMembers: currentSynthesizedMembers,
-                otherDeletedMembers: currentDeletedMembers);
-
-            var mappedSynthesizedTypes = matcher.MapSynthesizedTypes(previousGeneration.SynthesizedTypes, currentSynthesizedTypes);
-
-            var mappedSynthesizedMembers = matcher.MapSynthesizedOrDeletedMembers(previousGeneration.SynthesizedMembers, currentSynthesizedMembers, isDeletedMemberMapping: false);
-
-            // Deleted members are mapped the same way as synthesized members, so we can just call the same method.
-            var mappedDeletedMembers = matcher.MapSynthesizedOrDeletedMembers(previousGeneration.DeletedMembers, currentDeletedMembers, isDeletedMemberMapping: true);
-
-            // TODO: can we reuse some data from the previous matcher?
-            var matcherWithAllSynthesizedTypesAndMembers = new CSharpSymbolMatcher(
-                sourceAssembly: previousSourceAssembly,
-                otherAssembly: compilation.SourceAssembly,
-                otherSynthesizedTypes: mappedSynthesizedTypes,
-                otherSynthesizedMembers: mappedSynthesizedMembers,
-                otherDeletedMembers: mappedDeletedMembers);
-
-            return matcherWithAllSynthesizedTypesAndMembers.MapBaselineToCompilation(
-                previousGeneration,
-                compilation,
-                moduleBeingBuilt,
-                mappedSynthesizedTypes,
-                mappedSynthesizedMembers,
-                mappedDeletedMembers);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -224,19 +224,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal CSharpDefinitionMap PreviousDefinitions
             => (CSharpDefinitionMap)_changes.DefinitionMap;
 
-        public SynthesizedTypeMaps GetSynthesizedTypes()
-        {
-            var result = new SynthesizedTypeMaps(
-                Compilation.AnonymousTypeManager.GetAnonymousTypeMap(),
-                Compilation.AnonymousTypeManager.GetAnonymousDelegates(),
-                Compilation.AnonymousTypeManager.GetAnonymousDelegatesWithIndexedNames());
-
-            // Should contain all entries in previous generation.
-            Debug.Assert(PreviousGeneration.SynthesizedTypes.IsSubsetOf(result));
-
-            return result;
-        }
-
         public override IEnumerable<Cci.INamespaceTypeDefinition> GetTopLevelTypeDefinitions(EmitContext context)
             => GetTopLevelTypeDefinitionsExcludingNoPiaAndRootModule(context, includePrivateImplementationDetails: true);
 
@@ -256,16 +243,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             Debug.Assert(EmitOptions.InstrumentationKinds.IsEmpty);
 
             return _changes.DefinitionMap.GetMethodBodyInstrumentations(method);
-        }
-
-        internal override ImmutableArray<AnonymousTypeKey> GetPreviousAnonymousTypes()
-        {
-            return ImmutableArray.CreateRange(PreviousGeneration.SynthesizedTypes.AnonymousTypes.Keys);
-        }
-
-        internal override ImmutableArray<SynthesizedDelegateKey> GetPreviousAnonymousDelegates()
-        {
-            return ImmutableArray.CreateRange(PreviousGeneration.SynthesizedTypes.AnonymousDelegates.Keys);
         }
 
         internal override int GetNextAnonymousTypeIndex()

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -505,16 +505,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal virtual MethodInstrumentation GetMethodBodyInstrumentations(MethodSymbol method)
             => new MethodInstrumentation { Kinds = EmitOptions.InstrumentationKinds };
 
-        internal virtual ImmutableArray<AnonymousTypeKey> GetPreviousAnonymousTypes()
-        {
-            return ImmutableArray<AnonymousTypeKey>.Empty;
-        }
-
-        internal virtual ImmutableArray<SynthesizedDelegateKey> GetPreviousAnonymousDelegates()
-        {
-            return ImmutableArray<SynthesizedDelegateKey>.Empty;
-        }
-
         internal virtual int GetNextAnonymousTypeIndex()
         {
             return 0;

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -29,17 +27,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Cache of created anonymous type templates used as an implementation of anonymous 
         /// types in emit phase.
         /// </summary>
-        private ConcurrentDictionary<string, AnonymousTypeTemplateSymbol> _lazyAnonymousTypeTemplates;
+        private ConcurrentDictionary<string, AnonymousTypeTemplateSymbol>? _lazyAnonymousTypeTemplates;
 
         /// <summary>
         /// Maps delegate signature shape (number of parameters and their ref-ness) to a synthesized generic delegate symbol.
         /// Currently used for dynamic call-sites and inferred delegate types whose signature doesn't match any of the well-known Func or Action types.
         /// </summary>
-        private ConcurrentDictionary<SynthesizedDelegateKey, AnonymousDelegateTemplateSymbol> _lazyAnonymousDelegates;
+        private ConcurrentDictionary<SynthesizedDelegateKey, AnonymousDelegateTemplateSymbol>? _lazyAnonymousDelegates;
 
         private readonly struct SynthesizedDelegateKey : IEquatable<SynthesizedDelegateKey>
         {
-            internal readonly string Name;
+            internal readonly string? Name;
             internal readonly int ParameterCount;
             internal readonly AnonymousTypeDescriptor TypeDescriptor;
 
@@ -57,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 TypeDescriptor = typeDescr;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is SynthesizedDelegateKey && Equals((SynthesizedDelegateKey)obj);
             }
@@ -111,6 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #endif
         }
 
+#nullable enable
         private ConcurrentDictionary<string, AnonymousTypeTemplateSymbol> AnonymousTypeTemplates
         {
             get
@@ -118,10 +117,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Lazily create a template types cache
                 if (_lazyAnonymousTypeTemplates == null)
                 {
-                    CSharpCompilation previousSubmission = this.Compilation.PreviousSubmission;
-
                     // TODO (tomat): avoid recursion
-                    var previousCache = (previousSubmission == null) ? null : previousSubmission.AnonymousTypeManager.AnonymousTypeTemplates;
+                    var previousCache = Compilation.PreviousSubmission?.AnonymousTypeManager.AnonymousTypeTemplates;
 
                     Interlocked.CompareExchange(ref _lazyAnonymousTypeTemplates,
                                                 previousCache == null
@@ -140,10 +137,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (_lazyAnonymousDelegates == null)
                 {
-                    CSharpCompilation previousSubmission = this.Compilation.PreviousSubmission;
-
                     // TODO (tomat): avoid recursion
-                    var previousCache = (previousSubmission == null) ? null : previousSubmission.AnonymousTypeManager._lazyAnonymousDelegates;
+                    var previousCache = Compilation.PreviousSubmission?.AnonymousTypeManager._lazyAnonymousDelegates;
 
                     Interlocked.CompareExchange(ref _lazyAnonymousDelegates,
                                                 previousCache == null
@@ -156,13 +151,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-#nullable enable
         internal AnonymousDelegateTemplateSymbol SynthesizeDelegate(int parameterCount, RefKindVector refKinds, bool returnsVoid, int generation)
         {
             // parameterCount doesn't include return type
             Debug.Assert(refKinds.IsNull || parameterCount == refKinds.Capacity - (returnsVoid ? 0 : 1));
 
             var key = new SynthesizedDelegateKey(parameterCount, refKinds, returnsVoid, generation);
+            Debug.Assert(key.Name != null);
 
             AnonymousDelegateTemplateSymbol? synthesizedDelegate;
             if (this.AnonymousDelegates.TryGetValue(key, out synthesizedDelegate))
@@ -456,26 +451,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeArguments = typeDescr.Fields.SelectAsArray(f => f.Type);
             return template.Construct(typeArguments);
         }
-#nullable disable
-
-        private AnonymousTypeTemplateSymbol CreatePlaceholderTemplate(Microsoft.CodeAnalysis.Emit.AnonymousTypeKey key)
-        {
-            var fields = key.Fields.SelectAsArray(f => new AnonymousTypeField(f.Name, Location.None, typeWithAnnotations: default, refKind: RefKind.None, ScopedKind.None));
-            var typeDescr = new AnonymousTypeDescriptor(fields, Location.None);
-            return new AnonymousTypeTemplateSymbol(this, typeDescr);
-        }
-
-        private AnonymousDelegateTemplateSymbol CreatePlaceholderSynthesizedDelegateValue(string name, RefKindVector refKinds, bool returnsVoid, int parameterCount)
-        {
-            return new AnonymousDelegateTemplateSymbol(
-                this,
-               MetadataHelpers.InferTypeArityAndUnmangleMetadataName(name, out _),
-               this.System_Object,
-               Compilation.GetSpecialType(SpecialType.System_IntPtr),
-               returnsVoid ? Compilation.GetSpecialType(SpecialType.System_Void) : null,
-               parameterCount,
-               refKinds);
-        }
 
         /// <summary>
         /// Resets numbering in anonymous type names and compiles the
@@ -483,53 +458,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public void AssignTemplatesNamesAndCompile(MethodCompiler compiler, PEModuleBuilder moduleBeingBuilt, BindingDiagnosticBag diagnostics)
         {
-            // Ensure all previous anonymous type templates are included so the
-            // types are available for subsequent edit and continue generations.
-            foreach (var key in moduleBeingBuilt.GetPreviousAnonymousTypes())
-            {
-                Debug.Assert(!key.IsDelegate);
-                var templateKey = AnonymousTypeDescriptor.ComputeKey(key.Fields, f => f.Name);
-                this.AnonymousTypeTemplates.GetOrAdd(templateKey, k => this.CreatePlaceholderTemplate(key));
-            }
-
             // Get all anonymous types owned by this manager
             var anonymousTypes = ArrayBuilder<AnonymousTypeTemplateSymbol>.GetInstance();
+            var anonymousDelegates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             var anonymousDelegatesWithIndexedNames = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
+
             GetCreatedAnonymousTypeTemplates(anonymousTypes);
+            GetCreatedAnonymousDelegates(anonymousDelegates);
             GetCreatedAnonymousDelegatesWithIndexedNames(anonymousDelegatesWithIndexedNames);
 
             // If the collection is not sealed yet we should assign 
             // new indexes to the created anonymous type templates
-            if (!this.AreTemplatesSealed)
+            if (!AreTemplatesSealed)
             {
-                // If we are emitting .NET module, include module's name into type's name to ensure
-                // uniqueness across added modules.
-                string moduleId;
+                string moduleId = getModuleId();
+                int submissionSlotIndex = Compilation.GetSubmissionSlotIndex();
 
-                if (moduleBeingBuilt.OutputKind == OutputKind.NetModule)
-                {
-                    moduleId = moduleBeingBuilt.Name;
+                assignIndexedNames(anonymousTypes, moduleBeingBuilt.GetNextAnonymousTypeIndex(), isDelegate: false);
+                assignIndexedNames(anonymousDelegatesWithIndexedNames, moduleBeingBuilt.GetNextAnonymousDelegateIndex(), isDelegate: true);
 
-                    string extension = OutputKind.NetModule.GetDefaultExtension();
-
-                    if (moduleId.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
-                    {
-                        moduleId = moduleId.Substring(0, moduleId.Length - extension.Length);
-                    }
-
-                    moduleId = MetadataHelpers.MangleForTypeNameIfNeeded(moduleId);
-                }
-                else
-                {
-                    moduleId = string.Empty;
-                }
-
-                int submissionSlotIndex = this.Compilation.GetSubmissionSlotIndex();
-
-                assignNames(anonymousTypes, moduleBeingBuilt.GetNextAnonymousTypeIndex(), isDelegate: false);
-                assignNames(anonymousDelegatesWithIndexedNames, moduleBeingBuilt.GetNextAnonymousDelegateIndex(), isDelegate: true);
-
-                void assignNames(IReadOnlyList<AnonymousTypeOrDelegateTemplateSymbol> templates, int nextIndex, bool isDelegate)
+                void assignIndexedNames(IReadOnlyList<AnonymousTypeOrDelegateTemplateSymbol> templates, int nextIndex, bool isDelegate)
                 {
                     foreach (var template in templates)
                     {
@@ -550,7 +498,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                 }
 
-                this.SealTemplates();
+                SealTemplates();
             }
 
             if (anonymousTypes.Count > 0 && !ReportMissingOrErroneousSymbols(diagnostics))
@@ -566,21 +514,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            anonymousTypes.Free();
-
-            // Ensure all previous synthesized delegates are included so the
-            // types are available for subsequent edit and continue generations.
-            foreach (var key in moduleBeingBuilt.GetPreviousAnonymousDelegates())
-            {
-                if (GeneratedNames.TryParseSynthesizedDelegateName(key.Name, out var refKinds, out var returnsVoid, out var generation, out var parameterCount))
-                {
-                    var delegateKey = new SynthesizedDelegateKey(parameterCount, refKinds, returnsVoid, generation);
-                    this.AnonymousDelegates.GetOrAdd(delegateKey, (k, args) => CreatePlaceholderSynthesizedDelegateValue(key.Name, args.refKinds, args.returnsVoid, args.parameterCount), (refKinds, returnsVoid, parameterCount));
-                }
-            }
-
-            var anonymousDelegates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
-            GetCreatedAnonymousDelegates(anonymousDelegates);
             if (anonymousDelegatesWithIndexedNames.Count > 0 || anonymousDelegates.Count > 0)
             {
                 ReportMissingOrErroneousSymbolsForDelegates(diagnostics);
@@ -593,9 +526,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     compiler.Visit(anonymousDelegate, null);
                 }
             }
-            anonymousDelegates.Free();
 
+            anonymousTypes.Free();
+            anonymousDelegates.Free();
             anonymousDelegatesWithIndexedNames.Free();
+
+            string getModuleId()
+            {
+                // If we are emitting .NET module, include module's name into type's name to ensure
+                // uniqueness across added modules.
+
+                if (moduleBeingBuilt.OutputKind == OutputKind.NetModule)
+                {
+                    string extension = OutputKind.NetModule.GetDefaultExtension();
+
+                    var moduleId = moduleBeingBuilt.Name;
+                    if (moduleId.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+                    {
+                        moduleId = moduleId[..^extension.Length];
+                    }
+
+                    return MetadataHelpers.MangleForTypeNameIfNeeded(moduleId);
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
         }
 
         /// <summary>
@@ -658,7 +615,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 builder.Sort(SynthesizedDelegateSymbolComparer.Instance);
             }
         }
-
+#nullable disable
         private class SynthesizedDelegateSymbolComparer : IComparer<AnonymousDelegateTemplateSymbol>
         {
             public static readonly SynthesizedDelegateSymbolComparer Instance = new SynthesizedDelegateSymbolComparer();
@@ -740,6 +697,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return builder.ToImmutableAndFree();
         }
+
+        internal override SynthesizedTypeMaps GetSynthesizedTypeMaps()
+            => new SynthesizedTypeMaps(
+                    GetAnonymousTypeMap(),
+                    GetAnonymousDelegates(),
+                    GetAnonymousDelegatesWithIndexedNames());
 
         /// <summary>
         /// Returns true if the named type is an implementation template for an anonymous type

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -109,7 +109,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #endif
         }
 
-#nullable enable
         private ConcurrentDictionary<string, AnonymousTypeTemplateSymbol> AnonymousTypeTemplates
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols

--- a/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -10071,6 +10071,7 @@ class C
                     })
 
                 .AddGeneration(
+                    // 1
                     source: """
                     using System;
                     class C
@@ -10138,6 +10139,65 @@ class C
                           .maxstack  8
                           IL_0000:  ldc.r8     1
                           IL_0009:  ret
+                        }
+                        """);
+                    })
+                .AddGeneration(
+                    // 2
+                    source: """
+                    using System;
+                    class C
+                    {
+                        public void F()
+                        <N:0>{
+                            _ = new Func<byte>(<N:1>() => (byte)1</N:1>);
+                        }</N:0>
+                    }
+                    """,
+                    edits:
+                    [
+                        Edit(SemanticEditKind.Update, c => c.GetMember("C.F"), preserveLocalVariables: true, rudeEdits: _ => new RuntimeRudeEdit("Return type changed", 0x123)),
+                    ],
+                    validator: g =>
+                    {
+                        g.VerifySynthesizedMembers(
+                            "System.Runtime.CompilerServices.HotReloadException",
+                            "C: {<>c}",
+                            "C.<>c: {<>9__0_0#2, <F>b__0_0#2, <>9__0_0#1, <F>b__0_0#1}");
+
+                        g.VerifyMethodDefNames(
+                            "F", "<F>b__0_0#1", "<F>b__0_0#2");
+
+                        g.VerifyIL(
+                        """
+                        F
+                        {
+                          // Code size       30 (0x1e)
+                          .maxstack  8
+                          IL_0000:  nop
+                          IL_0001:  ldsfld     0x04000005
+                          IL_0006:  brtrue.s   IL_001d
+                          IL_0008:  ldsfld     0x04000001
+                          IL_000d:  ldftn      0x06000008
+                          IL_0013:  newobj     0x0A00000B
+                          IL_0018:  stsfld     0x04000005
+                          IL_001d:  ret
+                        }
+                        <F>b__0_0#1
+                        {
+                          // Code size       16 (0x10)
+                          .maxstack  8
+                          IL_0000:  ldstr      0x7000010D
+                          IL_0005:  ldc.i4     0x123
+                          IL_000a:  newobj     0x06000006
+                          IL_000f:  throw
+                        }
+                        <F>b__0_0#2
+                        {
+                          // Code size        2 (0x2)
+                          .maxstack  8
+                          IL_0000:  ldc.i4.1
+                          IL_0001:  ret
                         }
                         """);
                     })

--- a/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -37,14 +38,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                 fromCompilation.SourceAssembly,
                 toCompilation.SourceAssembly,
                 SynthesizedTypeMaps.Empty,
-                otherSynthesizedMembers: null,
-                otherDeletedMembers: null);
+                otherSynthesizedMembers: SpecializedCollections.EmptyReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>(),
+                otherDeletedMembers: SpecializedCollections.EmptyReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>());
 
         private static CSharpSymbolMatcher CreateMatcher(CSharpCompilation fromCompilation, PEAssemblySymbol peAssemblySymbol)
             => new CSharpSymbolMatcher(
-                SynthesizedTypeMaps.Empty,
                 fromCompilation.SourceAssembly,
-                peAssemblySymbol);
+                peAssemblySymbol,
+                SynthesizedTypeMaps.Empty);
 
         private static IEnumerable<string> Inspect(ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> anonymousDelegatesWithIndexedNames)
             => from entry in anonymousDelegatesWithIndexedNames
@@ -505,7 +506,7 @@ class C
             Assert.Equal("x1", x1.Name);
             Assert.Equal("x2", x2.Name);
 
-            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(compilation1.SourceAssembly, peAssemblySymbol0, synthesizedTypes0);
 
             var mappedX1 = (Cci.IFieldDefinition)matcher.MapDefinition(x1);
             var mappedX2 = (Cci.IFieldDefinition)matcher.MapDefinition(x2);
@@ -575,7 +576,7 @@ class C
             var x1 = fields.Where(f => f.Name == "x1").Single();
             var x2 = fields.Where(f => f.Name == "x2").Single();
 
-            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(compilation1.SourceAssembly, peAssemblySymbol0, synthesizedTypes0);
 
             var mappedX1 = (Cci.IFieldDefinition)matcher.MapDefinition(x1);
             var mappedX2 = (Cci.IFieldDefinition)matcher.MapDefinition(x2);
@@ -1129,7 +1130,7 @@ class C
             var y1 = fields.Where(f => f.Name == "y1").Single();
             var y2 = fields.Where(f => f.Name == "y2").Single();
 
-            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(compilation1.SourceAssembly, peAssemblySymbol0, synthesizedTypes0);
 
             var mappedY1 = (Cci.IFieldDefinition)matcher.MapDefinition(y1);
             var mappedY2 = (Cci.IFieldDefinition)matcher.MapDefinition(y2);
@@ -1486,7 +1487,7 @@ class C
             Assert.Equal("<>9__0_1", field2.Name);
             Assert.Equal("<>9__0_2", field3.Name);
 
-            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(compilation1.SourceAssembly, peAssemblySymbol0, synthesizedTypes0);
 
             var mappedField1 = (Cci.IFieldDefinition)matcher.MapDefinition(field1);
             var mappedField2 = (Cci.IFieldDefinition)matcher.MapDefinition(field2);
@@ -1544,7 +1545,7 @@ class C
             var field0 = displayClass.GetFields(emitContext).Single(f => f.Name == "<>9__0_0");
             Assert.Equal("<>f__AnonymousDelegate0", field0.GetType(emitContext).ToString());
 
-            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(compilation1.SourceAssembly, peAssemblySymbol0, synthesizedTypes0);
             var field1 = (Cci.IFieldDefinition)matcher.MapDefinition(field0);
             Assert.Equal("<>9__0_0", field1.Name);
         }
@@ -1614,7 +1615,7 @@ class C
             Assert.Equal("<>9__0_1", field2.Name);
             Assert.Equal("<>9__0_2", field3.Name);
 
-            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(compilation1.SourceAssembly, peAssemblySymbol0, synthesizedTypes0);
 
             Assert.Null(matcher.MapDefinition(field1));
             Assert.Null(matcher.MapDefinition(field2));
@@ -1684,7 +1685,7 @@ class C
             Assert.Equal("<>9__0_1", field2.Name);
             Assert.Equal("<>9__0_2", field3.Name);
 
-            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(compilation1.SourceAssembly, peAssemblySymbol0, synthesizedTypes0);
 
             var mappedField1 = (Cci.IFieldDefinition)matcher.MapDefinition(field1);
             var mappedField2 = (Cci.IFieldDefinition)matcher.MapDefinition(field2);

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -3435,7 +3435,70 @@ namespace Microsoft.CodeAnalysis
             return true;
         }
 
-        private protected abstract EmitBaseline MapToCompilation(CommonPEModuleBuilder moduleBeingBuilt);
+        /// <summary>
+        /// Return a version of the baseline with all definitions mapped to this compilation.
+        /// Definitions from the initial generation, from metadata, are not mapped since
+        /// the initial generation is always included as metadata. That is, the symbols from
+        /// types, methods, ... in the TypesAdded, MethodsAdded, ... collections are replaced
+        /// by the corresponding symbols from the current compilation.
+        /// </summary>
+        internal EmitBaseline MapToCompilation(CommonPEModuleBuilder moduleBeingBuilt)
+        {
+            var previousGeneration = moduleBeingBuilt.PreviousGeneration;
+            Debug.Assert(previousGeneration != null);
+            Debug.Assert(previousGeneration.Compilation != this);
+
+            if (previousGeneration.Ordinal == 0)
+            {
+                // Initial generation, nothing to map. (Since the initial generation
+                // is always loaded from metadata in the context of the current
+                // compilation, there's no separate mapping step.)
+                return previousGeneration;
+            }
+
+            Debug.Assert(previousGeneration.Compilation != null);
+            Debug.Assert(previousGeneration.PEModuleBuilder != null);
+            Debug.Assert(moduleBeingBuilt.EncSymbolChanges != null);
+
+            var currentSynthesizedTypes = moduleBeingBuilt.GetAllSynthesizedTypes();
+            var currentSynthesizedMembers = moduleBeingBuilt.GetAllSynthesizedMembers();
+            var currentDeletedMembers = moduleBeingBuilt.EncSymbolChanges.DeletedMembers;
+
+            // Mapping from previous compilation to the current.
+            var matcher = CreatePreviousToCurrentSourceAssemblyMatcher(
+                previousGeneration,
+                currentSynthesizedTypes,
+                currentSynthesizedMembers,
+                currentDeletedMembers);
+
+            var mappedSynthesizedTypes = matcher.MapSynthesizedTypes(previousGeneration.SynthesizedTypes, currentSynthesizedTypes);
+
+            var mappedSynthesizedMembers = matcher.MapSynthesizedOrDeletedMembers(previousGeneration.SynthesizedMembers, currentSynthesizedMembers, isDeletedMemberMapping: false);
+
+            // Deleted members are mapped the same way as synthesized members, so we can just call the same method.
+            var mappedDeletedMembers = matcher.MapSynthesizedOrDeletedMembers(previousGeneration.DeletedMembers, currentDeletedMembers, isDeletedMemberMapping: true);
+
+            // TODO: can we reuse some data from the previous matcher?
+            var matcherWithAllSynthesizedTypesAndMembers = CreatePreviousToCurrentSourceAssemblyMatcher(
+                previousGeneration,
+                mappedSynthesizedTypes,
+                mappedSynthesizedMembers,
+                mappedDeletedMembers);
+
+            return matcherWithAllSynthesizedTypesAndMembers.MapBaselineToCompilation(
+                previousGeneration,
+                this,
+                moduleBeingBuilt,
+                mappedSynthesizedTypes,
+                mappedSynthesizedMembers,
+                mappedDeletedMembers);
+        }
+
+        private protected abstract SymbolMatcher CreatePreviousToCurrentSourceAssemblyMatcher(
+            EmitBaseline previousGeneration,
+            SynthesizedTypeMaps otherSynthesizedTypes,
+            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherSynthesizedMembers,
+            IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> otherDeletedMembers);
 
         internal EmitBaseline? SerializeToDeltaStreams(
             CommonPEModuleBuilder moduleBeingBuilt,

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -159,7 +159,17 @@ namespace Microsoft.CodeAnalysis.Emit
         internal abstract IAssemblySymbolInternal CommonCorLibrary { get; }
         internal abstract CommonModuleCompilationState CommonModuleCompilationState { get; }
         internal abstract void CompilationFinished();
+
+        /// <summary>
+        /// Returns all type members synthesized when compiling method bodies for this module.
+        /// </summary>
         internal abstract ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> GetAllSynthesizedMembers();
+
+        /// <summary>
+        /// Returns all delegates and anonymous templates synthesized when compiling method bodies for this module.
+        /// </summary>
+        internal abstract SynthesizedTypeMaps GetAllSynthesizedTypes();
+
         internal abstract CommonEmbeddedTypesManager CommonEmbeddedTypesManagerOpt { get; }
         internal abstract Cci.ITypeReference EncTranslateType(ITypeSymbolInternal type, DiagnosticBag diagnostics);
         public abstract IEnumerable<Cci.ICustomAttribute> GetSourceAssemblyAttributes(bool isRefAssembly);
@@ -1076,6 +1086,9 @@ namespace Microsoft.CodeAnalysis.Emit
 
             return builder.ToImmutable();
         }
+
+        internal override SynthesizedTypeMaps GetAllSynthesizedTypes()
+            => Compilation.CommonAnonymousTypeManager.GetSynthesizedTypeMaps();
 
         #endregion
 

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -1087,7 +1087,7 @@ namespace Microsoft.CodeAnalysis.Emit
             return builder.ToImmutable();
         }
 
-        internal override SynthesizedTypeMaps GetAllSynthesizedTypes()
+        internal sealed override SynthesizedTypeMaps GetAllSynthesizedTypes()
             => Compilation.CommonAnonymousTypeManager.GetSynthesizedTypeMaps();
 
         #endregion

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -194,9 +194,10 @@ namespace Microsoft.CodeAnalysis.Emit
                 tableSizes[i] = previousTableSizes[i] + deltaTableSizes[i];
             }
 
-            // If the previous generation is 0 (metadata) get the synthesized members from the current compilation's builder,
+            // If the previous generation is 0 (metadata) get the synthesized members and types from the current compilation's builder,
             // otherwise members from the current compilation have already been merged into the baseline.
             var synthesizedMembers = (_previousGeneration.Ordinal == 0) ? module.GetAllSynthesizedMembers() : _previousGeneration.SynthesizedMembers;
+            var synthesizedTypes = (_previousGeneration.Ordinal == 0) ? module.GetAllSynthesizedTypes() : _previousGeneration.SynthesizedTypes;
 
             Debug.Assert(module.EncSymbolChanges is not null);
             var deletedMembers = (_previousGeneration.Ordinal == 0) ? module.EncSymbolChanges.DeletedMembers : _previousGeneration.DeletedMembers;
@@ -238,7 +239,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 userStringStreamLengthAdded: metadataSizes.GetAlignedHeapSize(HeapIndex.UserString) + _previousGeneration.UserStringStreamLengthAdded,
                 // Guid stream accumulates on the GUID heap unlike other heaps, so the previous generations are already included.
                 guidStreamLengthAdded: metadataSizes.HeapSizes[(int)HeapIndex.Guid],
-                synthesizedTypes: ((IPEDeltaAssemblyBuilder)module).GetSynthesizedTypes(),
+                synthesizedTypes: synthesizedTypes,
                 synthesizedMembers: synthesizedMembers,
                 deletedMembers: deletedMembers,
                 addedOrChangedMethods: AddRange(_previousGeneration.AddedOrChangedMethods, addedOrChangedMethodsByIndex),

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/IPEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/IPEDeltaAssemblyBuilder.cs
@@ -7,5 +7,4 @@ namespace Microsoft.CodeAnalysis.Emit;
 internal interface IPEDeltaAssemblyBuilder
 {
     void OnCreatedIndices(DiagnosticBag diagnostics);
-    SynthesizedTypeMaps GetSynthesizedTypes();
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
@@ -17,6 +16,7 @@ namespace Microsoft.CodeAnalysis.Emit
         public abstract Cci.ITypeReference? MapReference(Cci.ITypeReference reference);
         public abstract Cci.IDefinition? MapDefinition(Cci.IDefinition definition);
         public abstract Cci.INamespace? MapNamespace(Cci.INamespace @namespace);
+        protected abstract bool TryGetMatchingDelegateWithIndexedName(INamedTypeSymbolInternal delegateTemplate, ImmutableArray<AnonymousTypeValue> values, out AnonymousTypeValue match);
 
         public ISymbolInternal? MapDefinitionOrNamespace(ISymbolInternal symbol)
         {
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Emit
             EmitBaseline baseline,
             Compilation targetCompilation,
             CommonPEModuleBuilder targetModuleBuilder,
+            SynthesizedTypeMaps mappedSynthesizedTypes,
             IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> mappedSynthesizedMembers,
             IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> mappedDeletedMembers)
         {
@@ -62,10 +63,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 stringStreamLengthAdded: baseline.StringStreamLengthAdded,
                 userStringStreamLengthAdded: baseline.UserStringStreamLengthAdded,
                 guidStreamLengthAdded: baseline.GuidStreamLengthAdded,
-                synthesizedTypes: new SynthesizedTypeMaps(
-                    MapAnonymousTypes(baseline.SynthesizedTypes.AnonymousTypes),
-                    MapAnonymousDelegates(baseline.SynthesizedTypes.AnonymousDelegates),
-                    MapAnonymousDelegatesWithIndexedNames(baseline.SynthesizedTypes.AnonymousDelegatesWithIndexedNames)),
+                synthesizedTypes: mappedSynthesizedTypes,
                 synthesizedMembers: mappedSynthesizedMembers,
                 deletedMembers: mappedDeletedMembers,
                 addedOrChangedMethods: MapAddedOrChangedMethods(baseline.AddedOrChangedMethods),
@@ -105,47 +103,107 @@ namespace Microsoft.CodeAnalysis.Emit
             return result;
         }
 
-        private ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> MapAnonymousTypes(IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap)
+        private static ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> MapAnonymousTypes(
+            ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> previousTypes,
+            ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> newTypes)
         {
-            var builder = ImmutableSegmentedDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
-
-            foreach (var (key, value) in anonymousTypeMap)
+            if (previousTypes.Count == 0)
             {
-                var type = (Cci.ITypeDefinition?)MapDefinition(value.Type);
-                Debug.Assert(type != null);
-                builder.Add(key, new AnonymousTypeValue(value.Name, value.UniqueIndex, type));
+                return newTypes;
+            }
+
+            var builder = ImmutableSegmentedDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
+            builder.AddRange(newTypes);
+
+            foreach (var (key, previousValue) in previousTypes)
+            {
+                if (newTypes.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                builder.Add(key, previousValue);
             }
 
             return builder.ToImmutable();
         }
 
-        private ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> MapAnonymousDelegates(IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates)
+        private static ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> MapAnonymousDelegates(
+            ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> previousDelegates,
+            ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> newDelegates)
         {
-            var builder = ImmutableSegmentedDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
-
-            foreach (var (key, value) in anonymousDelegates)
+            if (previousDelegates.Count == 0)
             {
-                var delegateTypeDef = (Cci.ITypeDefinition?)MapDefinition(value.Delegate);
-                Debug.Assert(delegateTypeDef != null);
-                builder.Add(key, new SynthesizedDelegateValue(delegateTypeDef));
+                return newDelegates;
+            }
+
+            var builder = ImmutableSegmentedDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
+            builder.AddRange(newDelegates);
+
+            foreach (var (key, previousValue) in previousDelegates)
+            {
+                if (newDelegates.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                builder.Add(key, previousValue);
             }
 
             return builder.ToImmutable();
         }
 
         private ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> MapAnonymousDelegatesWithIndexedNames(
-            IReadOnlyDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> anonymousDelegates)
+            ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> previousDelegates,
+            ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> newDelegates)
         {
-            var builder = ImmutableSegmentedDictionary.CreateBuilder<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>>();
-
-            foreach (var (key, values) in anonymousDelegates)
+            if (previousDelegates.Count == 0)
             {
-                builder.Add(key, values.SelectAsArray(value => new AnonymousTypeValue(
-                    value.Name, value.UniqueIndex, (Cci.ITypeDefinition?)MapDefinition(value.Type) ?? throw ExceptionUtilities.UnexpectedValue(value.Type))));
+                return newDelegates;
+            }
+
+            var builder = ImmutableSegmentedDictionary.CreateBuilder<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>>();
+            builder.AddRange(newDelegates);
+
+            foreach (var (key, previousValues) in previousDelegates)
+            {
+                if (!newDelegates.TryGetValue(key, out var newValues))
+                {
+                    builder.Add(key, previousValues);
+                    continue;
+                }
+
+                ArrayBuilder<AnonymousTypeValue>? mergedValuesBuilder = null;
+
+                foreach (var previousValue in previousValues)
+                {
+                    var template = (INamedTypeSymbolInternal?)previousValue.Type.GetInternalSymbol();
+                    Debug.Assert(template is not null);
+
+                    if (TryGetMatchingDelegateWithIndexedName(template, newValues, out _))
+                    {
+                        continue;
+                    }
+
+                    mergedValuesBuilder ??= ArrayBuilder<AnonymousTypeValue>.GetInstance();
+                    mergedValuesBuilder.Add(previousValue);
+                }
+
+                if (mergedValuesBuilder != null)
+                {
+                    mergedValuesBuilder.AddRange(newValues);
+                    builder[key] = mergedValuesBuilder.ToImmutableAndFree();
+                }
             }
 
             return builder.ToImmutable();
         }
+
+        internal SynthesizedTypeMaps MapSynthesizedTypes(SynthesizedTypeMaps previousTypes, SynthesizedTypeMaps newTypes)
+            => new SynthesizedTypeMaps(
+                MapAnonymousTypes(previousTypes.AnonymousTypes, newTypes.AnonymousTypes),
+                MapAnonymousDelegates(previousTypes.AnonymousDelegates, newTypes.AnonymousDelegates),
+                MapAnonymousDelegatesWithIndexedNames(previousTypes.AnonymousDelegatesWithIndexedNames, newTypes.AnonymousDelegatesWithIndexedNames));
 
         /// <summary>
         /// Merges synthesized or deleted members generated during lowering, or emit, of the current compilation with aggregate

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
@@ -31,14 +31,10 @@ internal readonly struct SynthesizedTypeMaps(
         = anonymousDelegates ?? ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>.Empty;
 
     /// <summary>
-    /// A map of the assembly identities of the baseline compilation to the identities of the original metadata AssemblyRefs.
-    /// Only includes identities that differ between these two.
+    /// In C#, the set of anonymous delegates with name that is not determined by parameter types only 
+    /// and need to suffixed by an index (e.g. delegates may have same parameter types but differ in default parameter values);
+    /// in VB, this set is unused and empty.
     /// </summary>
     public ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> AnonymousDelegatesWithIndexedNames { get; }
         = anonymousDelegatesWithIndexedNames ?? ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>>.Empty;
-
-    public bool IsSubsetOf(SynthesizedTypeMaps other)
-        => AnonymousTypes.Keys.All(static (key, other) => other.AnonymousTypes.ContainsKey(key), other) &&
-           AnonymousDelegates.Keys.All(static (key, other) => other.AnonymousDelegates.ContainsKey(key), other) &&
-           AnonymousDelegatesWithIndexedNames.Keys.All(static (key, other) => other.AnonymousDelegatesWithIndexedNames.ContainsKey(key), other);
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
@@ -32,7 +32,7 @@ internal readonly struct SynthesizedTypeMaps(
 
     /// <summary>
     /// In C#, the set of anonymous delegates with name that is not determined by parameter types only 
-    /// and need to suffixed by an index (e.g. delegates may have same parameter types but differ in default parameter values);
+    /// and need to be suffixed by an index (e.g. delegates may have same parameter types but differ in default parameter values);
     /// in VB, this set is unused and empty.
     /// </summary>
     public ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> AnonymousDelegatesWithIndexedNames { get; }

--- a/src/Compilers/Core/Portable/Symbols/AnonymousTypes/CommonAnonymousTypeManager.cs
+++ b/src/Compilers/Core/Portable/Symbols/AnonymousTypes/CommonAnonymousTypeManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.Emit;
+
 namespace Microsoft.CodeAnalysis.Symbols
 {
     internal abstract class CommonAnonymousTypeManager
@@ -24,5 +26,7 @@ namespace Microsoft.CodeAnalysis.Symbols
         {
             _templatesSealed = ThreeState.True;
         }
+
+        internal abstract SynthesizedTypeMaps GetSynthesizedTypeMaps();
     }
 }

--- a/src/Compilers/Test/Core/Compilation/CompilationDifference.cs
+++ b/src/Compilers/Test/Core/Compilation/CompilationDifference.cs
@@ -165,6 +165,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             AssertEx.SetEqual(expected, actual, itemSeparator: ",\r\n", itemInspector: s => $"\"{s}\"");
         }
 
+        internal static void VerifySynthesizedSymbols(IEnumerable<ISymbolInternal> actualSymbols, params string[] expected)
+        {
+            AssertEx.SetEqual(expected, actualSymbols.Select(v => v.GetISymbol().ToDisplayString(SymbolDisplayFormat.TestFormat)), itemSeparator: ",\r\n", itemInspector: s => $"\"{s}\"");
+        }
+
         public void VerifySynthesizedFields(string typeName, params string[] expectedSynthesizedTypesAndMemberCounts)
         {
             var actual = EmitResult.Baseline.SynthesizedMembers.Single(e => e.Key.ToString() == typeName).Value.Where(s => s.Kind == SymbolKind.Field).Select(s => (IFieldSymbol)s.GetISymbol()).Select(f => f.Name + ": " + f.Type);

--- a/src/Compilers/Test/Core/Metadata/ILValidation.cs
+++ b/src/Compilers/Test/Core/Metadata/ILValidation.cs
@@ -271,6 +271,8 @@ namespace Roslyn.Test.Utilities
 
             var rvasAndNames = from handle in reader.MethodDefinitions
                                let method = reader.GetMethodDefinition(handle)
+                               // filter out runtime-implemented methods that do not have IL:
+                               where (method.ImplAttributes & MethodImplAttributes.CodeTypeMask) == MethodImplAttributes.IL
                                orderby method.RelativeVirtualAddress
                                group method.Name by method.RelativeVirtualAddress into g
                                // Legacy test support: name can only be resolved when readers for all generations are given.

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2534,8 +2534,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return True
         End Function
 
-        Private Protected Overrides Function MapToCompilation(moduleBeingBuilt As CommonPEModuleBuilder) As EmitBaseline
-            Return EmitHelpers.MapToCompilation(Me, DirectCast(moduleBeingBuilt, PEDeltaAssemblyBuilder))
+        Private Protected Overrides Function CreatePreviousToCurrentSourceAssemblyMatcher(
+            previousGeneration As EmitBaseline,
+            otherSynthesizedTypes As SynthesizedTypeMaps,
+            otherSynthesizedMembers As IReadOnlyDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)),
+            otherDeletedMembers As IReadOnlyDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal))) As SymbolMatcher
+
+            Return New VisualBasicSymbolMatcher(
+                sourceAssembly:=DirectCast(previousGeneration.Compilation, VisualBasicCompilation).SourceAssembly,
+                otherAssembly:=SourceAssembly,
+                otherSynthesizedTypes,
+                otherSynthesizedMembers,
+                otherDeletedMembers)
         End Function
 
         Friend Overrides Function GenerateResources(

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -225,29 +225,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Get
         End Property
 
-        Friend Overloads Function GetSynthesizedTypes() As SynthesizedTypeMaps Implements IPEDeltaAssemblyBuilder.GetSynthesizedTypes
-            ' VB anonymous delegates are handled as anonymous types
-            Dim result = New SynthesizedTypeMaps(
-                Compilation.AnonymousTypeManager.GetAnonymousTypeMap(),
-                anonymousDelegates:=Nothing,
-                anonymousDelegatesWithIndexedNames:=Nothing)
-
-            ' Should contain all entries in previous generation.
-            Debug.Assert(PreviousGeneration.SynthesizedTypes.IsSubsetOf(result))
-
-            Return result
-        End Function
-
         Friend Overrides Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol, diagnostics As DiagnosticBag) As VariableSlotAllocator
             Return _changes.DefinitionMap.TryCreateVariableSlotAllocator(Compilation, method, topLevelMethod, diagnostics)
         End Function
 
         Friend Overrides Function GetMethodBodyInstrumentations(method As MethodSymbol) As MethodInstrumentation
             Return _changes.DefinitionMap.GetMethodBodyInstrumentations(method)
-        End Function
-
-        Friend Overrides Function GetPreviousAnonymousTypes() As ImmutableArray(Of AnonymousTypeKey)
-            Return ImmutableArray.CreateRange(PreviousGeneration.SynthesizedTypes.AnonymousTypes.Keys)
         End Function
 
         Friend Overrides Function GetNextAnonymousTypeIndex(fromDelegates As Boolean) As Integer

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -325,10 +325,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return New MethodInstrumentation() With {.Kinds = EmitOptions.InstrumentationKinds}
         End Function
 
-        Friend Overridable Function GetPreviousAnonymousTypes() As ImmutableArray(Of AnonymousTypeKey)
-            Return ImmutableArray(Of AnonymousTypeKey).Empty
-        End Function
-
         Friend Overridable Function GetNextAnonymousTypeIndex(fromDelegates As Boolean) As Integer
             Return 0
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
@@ -3,13 +3,12 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Concurrent
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Diagnostics
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
@@ -172,18 +171,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' anonymous type methods. Also seals the collection of templates.
         ''' </summary>
         Public Sub AssignTemplatesNamesAndCompile(compiler As MethodCompiler, moduleBeingBuilt As Emit.PEModuleBuilder, diagnostics As BindingDiagnosticBag)
-
-            ' Ensure all previous anonymous type templates are included so the
-            ' types are available for subsequent edit and continue generations.
-            For Each key In moduleBeingBuilt.GetPreviousAnonymousTypes()
-                Dim templateKey = AnonymousTypeDescriptor.ComputeKey(key.Fields, Function(f) f.Name, Function(f) f.IsKey)
-                If key.IsDelegate Then
-                    AnonymousDelegateTemplates.GetOrAdd(templateKey, Function(k) AnonymousDelegateTemplateSymbol.Create(Me, CreatePlaceholderTypeDescriptor(key)))
-                Else
-                    AnonymousTypeTemplates.GetOrAdd(templateKey, Function(k) New AnonymousTypeTemplateSymbol(Me, CreatePlaceholderTypeDescriptor(key)))
-                End If
-            Next
-
             ' Get all anonymous types owned by this manager
             Dim builder = ArrayBuilder(Of AnonymousTypeOrDelegateTemplateSymbol).GetInstance()
             GetAllCreatedTemplates(builder)
@@ -192,23 +179,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' to the created anonymous type and delegate templates
             If Not Me.AreTemplatesSealed Then
 
-                ' If we are emitting .NET module, include module's name into type's name to ensure
-                ' uniqueness across added modules.
-                Dim moduleId As String
-
-                If moduleBeingBuilt.OutputKind = OutputKind.NetModule Then
-                    moduleId = moduleBeingBuilt.Name
-                    Dim extension As String = OutputKind.NetModule.GetDefaultExtension()
-
-                    If moduleId.EndsWith(extension, StringComparison.OrdinalIgnoreCase) Then
-                        moduleId = moduleId.Substring(0, moduleId.Length - extension.Length)
-                    End If
-
-                    moduleId = "<" & MetadataHelpers.MangleForTypeNameIfNeeded(moduleId) & ">"
-                Else
-                    moduleId = String.Empty
-                End If
-
+                Dim moduleId = GetModuleId(moduleBeingBuilt)
                 Dim typeIndex = moduleBeingBuilt.GetNextAnonymousTypeIndex(fromDelegates:=False)
                 Dim delegateIndex = moduleBeingBuilt.GetNextAnonymousTypeIndex(fromDelegates:=True)
                 For Each template In builder
@@ -247,6 +218,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             builder.Free()
         End Sub
+
+        Function GetModuleId(moduleBeingBuilt As Emit.PEModuleBuilder) As String
+            ' If we are emitting .NET module, include module's name into type's name to ensure
+            ' uniqueness across added modules.
+
+            If moduleBeingBuilt.OutputKind = OutputKind.NetModule Then
+                Dim moduleId = moduleBeingBuilt.Name
+                Dim extension As String = OutputKind.NetModule.GetDefaultExtension()
+
+                If moduleId.EndsWith(extension, StringComparison.OrdinalIgnoreCase) Then
+                    moduleId = moduleId.Substring(0, moduleId.Length - extension.Length)
+                End If
+
+                Return "<" & MetadataHelpers.MangleForTypeNameIfNeeded(moduleId) & ">"
+            Else
+                Return String.Empty
+            End If
+        End Function
 
         Friend Function GetAnonymousTypeMap() As ImmutableSegmentedDictionary(Of Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue)
             Dim templates = ArrayBuilder(Of AnonymousTypeOrDelegateTemplateSymbol).GetInstance()
@@ -303,6 +292,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 builder.Sort(New AnonymousTypeComparer(Me.Compilation))
             End If
         End Sub
+
+        Friend Overrides Function GetSynthesizedTypeMaps() As SynthesizedTypeMaps
+            ' VB anonymous delegates are handled as anonymous types
+            Return New SynthesizedTypeMaps(
+                GetAnonymousTypeMap(),
+                anonymousDelegates:=Nothing,
+                anonymousDelegatesWithIndexedNames:=Nothing)
+        End Function
 
         Private NotInheritable Class AnonymousTypeComparer
             Implements IComparer(Of AnonymousTypeOrDelegateTemplateSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
@@ -161,11 +161,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Sub
 
-        Private Shared Function CreatePlaceholderTypeDescriptor(key As Microsoft.CodeAnalysis.Emit.AnonymousTypeKey) As AnonymousTypeDescriptor
-            Dim names = key.Fields.SelectAsArray(Function(f) New AnonymousTypeField(f.Name, Location.None, f.IsKey))
-            Return New AnonymousTypeDescriptor(names, Location.None, True)
-        End Function
-
         ''' <summary>
         ''' Resets numbering in anonymous type names and compiles the
         ''' anonymous type methods. Also seals the collection of templates.

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
@@ -8,9 +8,11 @@ Imports System.Reflection.Metadata
 Imports System.Reflection.Metadata.Ecma335
 Imports System.Runtime.CompilerServices
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -307,11 +309,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         Friend Shared Function CreateMatcher(fromCompilation As VisualBasicCompilation, toCompilation As VisualBasicCompilation) As VisualBasicSymbolMatcher
             Return New VisualBasicSymbolMatcher(
-                fromCompilation.SourceAssembly,
-                toCompilation.SourceAssembly,
-                synthesizedTypes:=SynthesizedTypeMaps.Empty,
-                otherSynthesizedMembersOpt:=Nothing,
-                otherDeletedMembersOpt:=Nothing)
+                sourceAssembly:=fromCompilation.SourceAssembly,
+                otherAssembly:=toCompilation.SourceAssembly,
+                otherSynthesizedTypes:=SynthesizedTypeMaps.Empty,
+                otherSynthesizedMembers:=SpecializedCollections.EmptyReadOnlyDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)),
+                otherDeletedMembers:=SpecializedCollections.EmptyReadOnlyDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)))
         End Function
     End Class
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -4943,91 +4943,121 @@ End Class
 
         <Fact>
         Public Sub AnonymousTypes()
-            Dim sources0 = <compilation>
-                               <file name="a.vb"><![CDATA[
-Namespace N
-    Class A
-        Shared F As Object = New With {.A = 1, .B = 2}
-    End Class
-End Namespace
-Namespace M
-    Class B
-        Shared Sub M()
-            Dim x As New With {.B = 3, .A = 4}
-            Dim y = x.A
-            Dim z As New With {.C = 5}
-        End Sub
-    End Class
-End Namespace
-]]></file>
-                           </compilation>
-            Dim sources1 = <compilation>
-                               <file name="a.vb"><![CDATA[
-Namespace N
-    Class A
-        Shared F As Object = New With {.A = 1, .B = 2}
-    End Class
-End Namespace
-Namespace M
-    Class B
-        Shared Sub M()
-            Dim x As New With {.B = 3, .A = 4}
-            Dim y As New With {.A = x.A}
-            Dim z As New With {.C = 5}
-        End Sub
-    End Class
-End Namespace
-]]></file>
-                           </compilation>
-            Dim compilation0 = CreateCompilationWithMscorlib40(sources0, options:=TestOptions.DebugDll)
-            Dim compilation1 = compilation0.WithSource(sources1)
+            Using test = New EditAndContinueTest()
+                test.AddBaseline(
+                    source:="Module C
+    Sub F()
+        Dim f = New With { .a = 1, .b = 2 }
+    End Sub
+End Module",
+                    validator:=
+                    Sub(g)
+                        g.VerifySynthesizedMembers({})
 
-            Dim testData0 = New CompilationTestData()
-            Dim bytes0 = compilation0.EmitToArray(testData:=testData0)
-            Using md0 = ModuleMetadata.CreateFromImage(bytes0)
-                Dim generation0 = CreateInitialBaseline(compilation0, ModuleMetadata.CreateFromImage(bytes0),
-                                                                     testData0.GetMethodData("M.B.M").EncDebugInfoProvider)
-                Dim method0 = compilation0.GetMember(Of MethodSymbol)("M.B.M")
-                Dim reader0 = md0.MetadataReader
-                CheckNames(reader0, reader0.GetTypeDefNames(),
-                           "<Module>",
-                           "VB$AnonymousType_0`2",
-                           "VB$AnonymousType_1`2",
-                           "VB$AnonymousType_2`1",
-                           "A",
-                           "B")
-                Dim method1 = compilation1.GetMember(Of MethodSymbol)("M.B.M")
-                Dim diff1 = compilation1.EmitDifference(
-                    generation0,
-                    ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, method0, method1, GetEquivalentNodesMap(method1, method0))))
+                        g.VerifySynthesizedTypes(
+                            "VB$AnonymousType_0(Of T0, T1)")
 
-                Using md1 = diff1.GetMetadata()
-                    Dim reader1 = md1.Reader
-                    CheckNames({reader0, reader1}, reader1.GetTypeDefNames(), "VB$AnonymousType_3`1")
-                    diff1.VerifyIL("M.B.M", "
+                        g.VerifyIL("C.F", "
 {
-  // Code size       29 (0x1d)
+  // Code size       10 (0xa)
   .maxstack  2
-  .locals init (VB$AnonymousType_1(Of Integer, Integer) V_0, //x
-  [int] V_1,
-  VB$AnonymousType_2(Of Integer) V_2, //z
-  VB$AnonymousType_3(Of Integer) V_3) //y
+  .locals init (VB$AnonymousType_0(Of Integer, Integer) V_0) //f
   IL_0000:  nop
-  IL_0001:  ldc.i4.3
-  IL_0002:  ldc.i4.4
-  IL_0003:  newobj     ""Sub VB$AnonymousType_1(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0001:  ldc.i4.1
+  IL_0002:  ldc.i4.2
+  IL_0003:  newobj     ""Sub VB$AnonymousType_0(Of Integer, Integer)..ctor(Integer, Integer)""
   IL_0008:  stloc.0
-  IL_0009:  ldloc.0
-  IL_000a:  callvirt   ""Function VB$AnonymousType_1(Of Integer, Integer).get_A() As Integer""
-  IL_000f:  newobj     ""Sub VB$AnonymousType_3(Of Integer)..ctor(Integer)""
-  IL_0014:  stloc.3
-  IL_0015:  ldc.i4.5
-  IL_0016:  newobj     ""Sub VB$AnonymousType_2(Of Integer)..ctor(Integer)""
-  IL_001b:  stloc.2
-  IL_001c:  ret
-}
-")
-                End Using
+  IL_0009:  ret
+}")
+                    End Sub).
+                AddGeneration(' 1
+                    source:="Module C
+    Sub F()
+        Dim g = New With { .x = 1 }
+        Dim f = New With { .a = 1, .b = 2 }
+    End Sub
+End Module",
+                    edits:=
+                    {
+                        Edit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"), preserveLocalVariables:=True)
+                    },
+                    validator:=
+                    Sub(g)
+                        g.VerifySynthesizedMembers({})
+
+                        g.VerifySynthesizedTypes(
+                            "VB$AnonymousType_0(Of T0, T1)",
+                            "VB$AnonymousType_1(Of T0)")
+
+                        g.VerifyTypeDefNames("VB$AnonymousType_1`1")
+                        g.VerifyMethodDefNames("F", "get_x", "set_x", ".ctor", "ToString")
+
+                        g.VerifyIL("C.F", "
+{
+  // Code size       17 (0x11)
+  .maxstack  2
+  .locals init (VB$AnonymousType_0(Of Integer, Integer) V_0, //f
+                VB$AnonymousType_1(Of Integer) V_1) //g
+  IL_0000:  nop
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""Sub VB$AnonymousType_1(Of Integer)..ctor(Integer)""
+  IL_0007:  stloc.1
+  IL_0008:  ldc.i4.1
+  IL_0009:  ldc.i4.2
+  IL_000a:  newobj     ""Sub VB$AnonymousType_0(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_000f:  stloc.0
+  IL_0010:  ret
+}")
+                    End Sub).
+                    AddGeneration(' 2
+                        source:="
+Module C
+    Sub F()
+        Dim f = New With { .a = 1, .b = 2, .c = 3 }
+    End Sub
+End Module",
+                        edits:=
+                        {
+                            Edit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"), preserveLocalVariables:=True)
+                        },
+                        validator:=
+                        Sub(g)
+                            g.VerifySynthesizedMembers({})
+
+                            g.VerifySynthesizedTypes(
+                                "VB$AnonymousType_0(Of T0, T1)",
+                                "VB$AnonymousType_1(Of T0)",
+                                "VB$AnonymousType_2(Of T0, T1, T2)")
+
+                            g.VerifyTypeDefNames("VB$AnonymousType_2`3")
+                            g.VerifyMethodDefNames("F", "get_a", "set_a", "get_b", "set_b", "get_c", "set_c", ".ctor", "ToString")
+                        End Sub).
+                    AddGeneration(' 3
+                    source:="
+        Module C
+            Sub F()
+                Dim f = New With { .a = 1, .b = 2, .c = 3 }
+                Dim g = New With { .x = 1, .y = 2 }
+            End Sub
+        End Module",
+                    edits:=
+                    {
+                        Edit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"), preserveLocalVariables:=True)
+                    },
+                    validator:=
+                    Sub(g)
+                        g.VerifySynthesizedMembers({})
+
+                        g.VerifySynthesizedTypes(
+                            "VB$AnonymousType_0(Of T0, T1)",
+                            "VB$AnonymousType_1(Of T0)",
+                            "VB$AnonymousType_2(Of T0, T1, T2)",
+                            "VB$AnonymousType_3(Of T0, T1)")
+
+                        g.VerifyTypeDefNames("VB$AnonymousType_3`2")
+                        g.VerifyMethodDefNames("F", "get_x", "set_x", "get_y", "set_y", ".ctor", "ToString")
+                    End Sub).
+                Verify()
             End Using
         End Sub
 
@@ -5736,6 +5766,115 @@ End Class
   IL_002d:  ret
 }
 ")
+        End Sub
+
+        <Fact>
+        Public Sub Lambda_SynthesizedDelegate()
+            Using test = New EditAndContinueTest()
+                test.AddBaseline(
+                    source:="
+Class C
+    Sub F()
+        Dim f = <N:1>Function(ByRef a As Integer) a</N:1>
+    End Sub
+End Class",
+                    validator:=
+                    Sub(g)
+                        g.VerifySynthesizedMembers(
+                        {
+                            "C: {_Closure$__}",
+                            "C._Closure$__: {$I1-0, _Lambda$__1-0}"
+                        })
+
+                        g.VerifySynthesizedTypes(
+                            "VB$AnonymousDelegate_0(Of TArg0, TResult)")
+                    End Sub).
+                AddGeneration(' 1
+                    source:="
+Class C
+    Sub F()
+        Dim g = <N:2>Function(ByRef a As Byte, b As Integer) a</N:2>
+        Dim f = <N:1>Function(ByRef a As Integer) a</N:1>
+    End Sub
+End Class",
+                    edits:=
+                    {
+                        Edit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"), preserveLocalVariables:=True)
+                    },
+                    validator:=
+                    Sub(g)
+                        g.VerifySynthesizedMembers(
+                        {
+                            "C: {_Closure$__}",
+                            "C._Closure$__: {$I1-0#1, $I1-0, _Lambda$__1-0#1, _Lambda$__1-0}"
+                        })
+
+                        g.VerifySynthesizedTypes(
+                            "VB$AnonymousDelegate_0(Of TArg0, TResult)",
+                            "VB$AnonymousDelegate_1(Of TArg0, TArg1, TResult)")
+
+                        g.VerifyMethodDefNames("F", "_Lambda$__1-0", ".ctor", "BeginInvoke", "EndInvoke", "Invoke", "_Lambda$__1-0#1")
+                    End Sub).
+                AddGeneration(' 2
+                    source:="
+Class C
+    Sub F()
+        Dim f = <N:1>Function(ByRef a As Boolean, ByRef b As Boolean) a</N:1>
+    End Sub
+End Class",
+                    edits:=
+                    {
+                        Edit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"), preserveLocalVariables:=True, rudeEdits:=Function(node) New RuntimeRudeEdit("Parameter changed", &H123))
+                    },
+                    validator:=
+                    Sub(g)
+                        g.VerifySynthesizedMembers(
+                        {
+                            "System.Runtime.CompilerServices.HotReloadException",
+                            "C: {_Closure$__}",
+                            "C._Closure$__: {$I1-0#2, _Lambda$__1-0#2, $I1-0#1, $I1-0, _Lambda$__1-0#1, _Lambda$__1-0}"
+                        })
+
+                        g.VerifySynthesizedTypes(
+                            "VB$AnonymousDelegate_0(Of TArg0, TResult)",
+                            "VB$AnonymousDelegate_1(Of TArg0, TArg1, TResult)",
+                            "VB$AnonymousDelegate_2(Of TArg0, TArg1, TResult)")
+
+                        g.VerifyTypeDefNames("VB$AnonymousDelegate_2`3", "HotReloadException")
+                        g.VerifyMethodDefNames("F", "_Lambda$__1-0", "_Lambda$__1-0#1", ".ctor", "BeginInvoke", "EndInvoke", "Invoke", ".ctor", "_Lambda$__1-0#2")
+                    End Sub).
+                AddGeneration(' 3
+                    source:="
+Class C
+    Sub F()
+        Dim f = Function(ByRef a As Boolean, ByRef b As Boolean) a
+        Dim g = Function(ByRef a As Boolean, ByRef b As Boolean, c As Boolean) a
+    End Sub
+End Class",
+                    edits:=
+                    {
+                        Edit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"), preserveLocalVariables:=True)
+                    },
+                    validator:=
+                    Sub(g)
+                        g.VerifySynthesizedMembers(
+                        {
+                            "System.Runtime.CompilerServices.HotReloadException",
+                            "C._Closure$__: {$I1-0#3, $I1-1#3, _Lambda$__1-0#3, _Lambda$__1-1#3, $I1-0#2, _Lambda$__1-0#2, $I1-0#1, $I1-0, _Lambda$__1-0#1, _Lambda$__1-0}",
+                            "C: {_Closure$__}"
+                        })
+
+                        g.VerifySynthesizedTypes(
+                            "VB$AnonymousDelegate_0(Of TArg0, TResult)",
+                            "VB$AnonymousDelegate_1(Of TArg0, TArg1, TResult)",
+                            "VB$AnonymousDelegate_2(Of TArg0, TArg1, TResult)",
+                            "VB$AnonymousDelegate_3(Of TArg0, TArg1, TArg2, TResult)")
+
+                        g.VerifyTypeDefNames("VB$AnonymousDelegate_3`4")
+                        g.VerifyMethodDefNames("F", "_Lambda$__1-0#2", ".ctor", "BeginInvoke", "EndInvoke", "Invoke", "_Lambda$__1-0#3", "_Lambda$__1-1#3")
+                    End Sub).
+                Verify()
+            End Using
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
@@ -355,9 +355,9 @@ End Class
             Assert.Equal("$VB$Local_x2", x2.Name)
 
             Dim matcher = New VisualBasicSymbolMatcher(
-                synthesizedTypes0,
                 compilation1.SourceAssembly,
-                peAssemblySymbol0)
+                peAssemblySymbol0,
+                synthesizedTypes0)
 
             Dim mappedX1 = DirectCast(matcher.MapDefinition(x1), Cci.IFieldDefinition)
             Dim mappedX2 = DirectCast(matcher.MapDefinition(x2), Cci.IFieldDefinition)
@@ -426,9 +426,9 @@ End Class
             Assert.Equal("$VB$Local_x2", x2.Name)
 
             Dim matcher = New VisualBasicSymbolMatcher(
-                synthesizedTypes0,
                 compilation1.SourceAssembly,
-                peAssemblySymbol0)
+                peAssemblySymbol0,
+                synthesizedTypes0)
 
             Dim mappedX1 = DirectCast(matcher.MapDefinition(x1), Cci.IFieldDefinition)
             Dim mappedX2 = DirectCast(matcher.MapDefinition(x2), Cci.IFieldDefinition)
@@ -503,9 +503,9 @@ End Class
             Assert.Equal("$VB$Local_x2", x2.Name)
 
             Dim matcher = New VisualBasicSymbolMatcher(
-                synthesizedTypes0,
                 compilation1.SourceAssembly,
-                peAssemblySymbol0)
+                peAssemblySymbol0,
+                synthesizedTypes0)
 
             Dim mappedX1 = DirectCast(matcher.MapDefinition(x1), Cci.IFieldDefinition)
             Dim mappedX2 = DirectCast(matcher.MapDefinition(x2), Cci.IFieldDefinition)

--- a/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -3755,10 +3755,46 @@ public sealed class StatementEditingTests : EditingTestBase
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/79783")]
+    public void Lambdas_Update_Signature_ParameterDefaultValue()
+    {
+        var src1 = """
+            using System;
+
+            class C
+            {
+                void F()
+                {
+                    var f = <N:0>(int a = 1) => 1</N:0>;
+                }
+            }
+            """;
+        var src2 = """
+            using System;
+            
+            class C
+            {
+                void F()
+                {
+                    var f = <N:0>(int a = 2) => 1</N:0>;
+                }
+            }
+            """;
+
+        var edits = GetTopEdits(src1, src2);
+        var syntaxMap = edits.GetSyntaxMap();
+
+        edits.VerifySemantics(
+            SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"), syntaxMap, rudeEdits:
+            [
+                RuntimeRudeEdit(0, RudeEditKind.ChangingLambdaParameters, syntaxMap.NodePosition(0), arguments: [GetResource("lambda")])
+            ]));
+    }
+
+    [Fact]
     public void Lambdas_Update_Signature_ParameterRefness1()
     {
         var src1 = """
-
             using System;
 
             delegate int D1(ref int a);
@@ -3774,10 +3810,8 @@ public sealed class StatementEditingTests : EditingTestBase
                     G1(<N:0>(ref int a) => 1</N:0>);
                 }
             }
-
             """;
         var src2 = """
-
             using System;
 
             delegate int D1(ref int a);
@@ -3793,8 +3827,8 @@ public sealed class StatementEditingTests : EditingTestBase
                     G2(<N:0>(int a) => 2</N:0>);
                 }
             }
-
             """;
+
         var edits = GetTopEdits(src1, src2);
         var syntaxMap = edits.GetSyntaxMap();
 

--- a/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -3792,6 +3792,42 @@ public sealed class StatementEditingTests : EditingTestBase
     }
 
     [Fact]
+    public void Lambdas_Update_Signature_ParamsArray()
+    {
+        var src1 = """
+            using System;
+
+            class C
+            {
+                void F()
+                {
+                    var f = <N:0>(int[] a) => 1</N:0>;
+                }
+            }
+            """;
+        var src2 = """
+            using System;
+            
+            class C
+            {
+                void F()
+                {
+                    var f = <N:0>(params int[] a) => 1</N:0>;
+                }
+            }
+            """;
+
+        var edits = GetTopEdits(src1, src2);
+        var syntaxMap = edits.GetSyntaxMap();
+
+        edits.VerifySemantics(
+            SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"), syntaxMap, rudeEdits:
+            [
+                RuntimeRudeEdit(0, RudeEditKind.ChangingLambdaParameters, syntaxMap.NodePosition(0), arguments: [GetResource("lambda")])
+            ]));
+    }
+
+    [Fact]
     public void Lambdas_Update_Signature_ParameterRefness1()
     {
         var src1 = """

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2544,6 +2544,9 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
     protected static bool ParameterTypesEquivalent(ImmutableArray<IParameterSymbol> oldParameters, ImmutableArray<IParameterSymbol> newParameters, bool exact)
         => oldParameters.SequenceEqual(newParameters, exact, ParameterTypesEquivalent);
 
+    protected static bool ParameterDefaultValuesEquivalent(ImmutableArray<IParameterSymbol> oldParameters, ImmutableArray<IParameterSymbol> newParameters)
+        => oldParameters.SequenceEqual(newParameters, ParameterDefaultValuesEquivalent);
+
     protected static bool CustomModifiersEquivalent(CustomModifier oldModifier, CustomModifier newModifier, bool exact)
         => oldModifier.IsOptional == newModifier.IsOptional &&
            TypesEquivalent(oldModifier.Modifier, newModifier.Modifier, exact);
@@ -2581,6 +2584,10 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
 
     protected static bool ParameterTypesEquivalent(IParameterSymbol oldParameter, IParameterSymbol newParameter, bool exact)
         => (exact ? s_exactSymbolEqualityComparer : s_runtimeSymbolEqualityComparer).ParameterEquivalenceComparer.Equals(oldParameter, newParameter);
+
+    protected static bool ParameterDefaultValuesEquivalent(IParameterSymbol oldParameter, IParameterSymbol newParameter)
+        => oldParameter.HasExplicitDefaultValue == newParameter.HasExplicitDefaultValue &&
+           (!oldParameter.HasExplicitDefaultValue || Equals(oldParameter.ExplicitDefaultValue, newParameter.ExplicitDefaultValue));
 
     protected static bool TypeParameterConstraintsEquivalent(ITypeParameterSymbol oldParameter, ITypeParameterSymbol newParameter, bool exact)
         => TypesEquivalent(oldParameter.ConstraintTypes, newParameter.ConstraintTypes, exact) &&
@@ -4490,8 +4497,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
                     hasGeneratedAttributeChange = true;
                 }
 
-                if (oldParameter.HasExplicitDefaultValue != newParameter.HasExplicitDefaultValue ||
-                    oldParameter.HasExplicitDefaultValue && !Equals(oldParameter.ExplicitDefaultValue, newParameter.ExplicitDefaultValue))
+                if (!ParameterDefaultValuesEquivalent(oldParameter, newParameter))
                 {
                     rudeEdit = RudeEditKind.InitializerUpdate;
                 }
@@ -6572,8 +6578,13 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         var newLambdaSymbol = (IMethodSymbol)diagnosticContext.RequiredNewSymbol;
 
         // signature validation:
-        if (!ParameterTypesEquivalent(oldLambdaSymbol.Parameters, newLambdaSymbol.Parameters, exact: false))
+        if (!ParameterTypesEquivalent(oldLambdaSymbol.Parameters, newLambdaSymbol.Parameters, exact: false) ||
+            !ParameterDefaultValuesEquivalent(oldLambdaSymbol.Parameters, newLambdaSymbol.Parameters))
         {
+            // If a delegate type for the lambda is synthesized (anonymous) changing default parameter value changes the synthesized delegate type.
+            // If the delegate type is not synthesized the default value is ignored and warning is reported by the compiler.
+            // Technically, the runtime rude edit does not need to be reported in the latter case but we report it anyway for simplicity.
+
             runtimeRudeEditsBuilder[newLambda] = diagnosticContext.CreateRudeEdit(RudeEditKind.ChangingLambdaParameters, cancellationToken);
             return;
         }
@@ -6585,7 +6596,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
         }
 
         if (!TypeParametersEquivalent(oldLambdaSymbol.TypeParameters, newLambdaSymbol.TypeParameters, exact: false) ||
-                 !oldLambdaSymbol.TypeParameters.SequenceEqual(newLambdaSymbol.TypeParameters, static (p, q) => p.Name == q.Name))
+            !oldLambdaSymbol.TypeParameters.SequenceEqual(newLambdaSymbol.TypeParameters, static (p, q) => p.Name == q.Name))
         {
             runtimeRudeEditsBuilder[newLambda] = diagnosticContext.CreateRudeEdit(RudeEditKind.ChangingTypeParameters, cancellationToken);
             return;

--- a/src/Test/PdbUtilities/EditAndContinue/EditAndContinueTest.GenerationVerifier.cs
+++ b/src/Test/PdbUtilities/EditAndContinue/EditAndContinueTest.GenerationVerifier.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;


### PR DESCRIPTION
Handle synthesized anonymous types and delegates in the same way we handle other synthesized members.
The previous implementation (creating placeholder templates by parsing the metadata names of previously generated templates) doesn't work for anonymous delegates with indexed names that do not have unique keys and their Invoke method needs to be matched.

Move implementation of Compilation.MapToCompilation to common code that is shared between C# and VB.

Fixes https://github.com/dotnet/roslyn/issues/79783