### PR TITLE
Disable incremental binary analysis to workaround duplicate VSSetup artifacts

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -111,6 +111,7 @@ extends:
   parameters:
     featureFlags:
       autoBaseline: true
+      incrementalSDLBinaryAnalysis: false
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Svc-Internal


### PR DESCRIPTION
Previously I made https://github.com/dotnet/roslyn-tools/pull/1494 to workaround an issue with guardian duplicating a bunch of folders in our VSSetup pipeline artifacts.

However, the artifacts they generate have changed their name, so using the workaround they suggested instead.  This fixes the VS insertion PR merge diff again.

Validation running here - https://dnceng.visualstudio.com/internal/_build/results?buildId=2767413&view=results

Prior run with the broken artifacts:
<img width="638" height="568" alt="image" src="https://github.com/user-attachments/assets/d0f4f3b2-07d9-4477-93ab-9c0a4cec4e95" />
