### PR TITLE
Don't try to load file based projects unless we get a .cs file

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -117,6 +117,13 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
     protected override async Task<RemoteProjectLoadResult?> TryLoadProjectInMSBuildHostAsync(
         BuildHostProcessManager buildHostProcessManager, string documentPath, CancellationToken cancellationToken)
     {
+        if (Path.GetExtension(documentPath) != ".cs")
+        {
+            // We only support loading C# file-based programs.
+            _logger.LogInformation($"Skipping loading of non-C# file-based program: {documentPath}");
+            return null;
+        }
+
         var content = await _projectXmlProvider.GetVirtualProjectContentAsync(documentPath, _logger, cancellationToken);
         if (content is not var (virtualProjectContent, diagnostics))
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/8480

I've run out of time today to get a failing test, but will keep working on it :)