### PR TITLE
Fix issue where PopulateSwitch would suggest populating already exhaustive switch expressions

### DIFF
--- a/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchExpressionTests.cs
@@ -14,13 +14,9 @@ using Xunit.Abstractions;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwitch;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
-public sealed partial class PopulateSwitchExpressionTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor
+public sealed partial class PopulateSwitchExpressionTests(ITestOutputHelper logger)
+    : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor(logger)
 {
-    public PopulateSwitchExpressionTests(ITestOutputHelper logger)
-       : base(logger)
-    {
-    }
-
     internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
         => (new CSharpPopulateSwitchExpressionDiagnosticAnalyzer(), new CSharpPopulateSwitchExpressionCodeFixProvider());
 
@@ -1745,6 +1741,158 @@ public sealed partial class PopulateSwitchExpressionTests : AbstractCSharpDiagno
                         {{underlyingTypePattern}} => 1,
                     };
                 }
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74977")]
+    public Task TestMissingWithExhaustiveSwitchExpression1()
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                void M(bool showDiagnosticMessages, string assemblyDisplayName, bool noColor)
+                {
+                    var prefix = (showDiagnosticMessages, assemblyDisplayName, noColor) [||]switch
+                    {
+                        (false, _, _) => null,
+                        (true, null, false) => "",
+                        (true, null, true) => "[D]",
+                        (true, _, false) => "No color output",
+                        (true, _, true) => "Color output enabled",
+                    };
+                }
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74977")]
+    public Task TestMissingWithExhaustiveSwitchExpression2()
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                uint[] GetUnlockableRows(uint row1, uint row2)
+                {
+                    return (row1, row2) [||]switch
+                    {
+                        (0, _) => [],
+                        (uint i, 0) => [i],
+                        (uint i, uint j) => [i, j],
+                    };
+                }
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/60784")]
+    public Task TestMissingWithExhaustiveSwitchExpression3()
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                void GetUnlockableRows(bool FirstBoolean, bool SecondBoolean)
+                {
+                    var v = (FirstBoolean, SecondBoolean) [||]switch
+                    {
+                        (true, true) => 1,
+                        (true, false) => 2,
+                        (false, true) => 3,
+                        (false, false) => 4
+                    };
+                }
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66433")]
+    public Task TestMissingWithExhaustiveSwitchExpression4()
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                static string TestSwitch(int goo)
+                    => goo [||]switch
+                    {
+                        0 => "zero",
+                        < 0 => "negative",
+                        > 0 => "positive",
+                    };
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76080")]
+    public Task TestMissingWithExhaustiveSwitchExpression5()
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                static void M()
+                {
+                    char c = 'x';
+                    bool i = false;
+
+                    var x = (c, i) [||]switch
+                    {
+                        ('L', _) => '#',
+                        ('#', true) => 'L',
+                        ('#', false) => 'M',
+                        (var z, _) => z,
+                    };
+                }
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76080")]
+    public Task TestMissingWithExhaustiveSwitchExpression6()
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                static void M()
+                {
+                    char c = 'x';
+                    bool i = false;
+
+                    var y = (c, i) [||]switch
+                    {
+                        ('L', _) => '#',
+                        ('#', true) => 'L',
+                        ('#', false) => 'M',
+                        (var z, _) => z,
+                        _ => ' ',
+                    };
+                }
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/57523")]
+    public Task TestMissingWithExhaustiveSwitchExpression7()
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                public static string ToApiString(this bool? value)
+                    => value [||]switch
+                    {
+            	        { } val => val.ToApiString(),
+            	        null => "Unknown",
+                    };
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/57523")]
+    public Task TestMissingWithExhaustiveSwitchExpression8()
+        => TestMissingInRegularAndScriptAsync($$"""
+            public class Program
+            {
+                public static int Main() => GetCuts(Shape.Circle) is null ? -1 : 0;
+
+                static int? GetCuts(Shape? shape)
+                    => shape [||]switch
+                    {
+                        Shape.Triangle => 3,
+                        Shape.Square or Shape.Rectangle => 4,
+                        Shape.Circle => 0,
+                        _ => throw new System.NotSupportedException(),
+                    };
+            }
+
+            public enum Shape
+            {
+                Circle,
+                Square,
+                Rectangle,
+                Triangle,
             }
             """);
 }

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
@@ -10,26 +10,25 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.PopulateSwitch;
 
-internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperation, TSwitchSyntax> :
-    AbstractBuiltInCodeStyleDiagnosticAnalyzer
+internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperation, TSwitchSyntax>(
+    string diagnosticId,
+    EnforceOnBuild enforceOnBuild)
+    : AbstractBuiltInCodeStyleDiagnosticAnalyzer(diagnosticId,
+        enforceOnBuild,
+        option: null,
+        s_localizableTitle, s_localizableMessage)
     where TSwitchOperation : IOperation
     where TSwitchSyntax : SyntaxNode
 {
     private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(AnalyzersResources.Add_missing_cases), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
     private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(AnalyzersResources.Populate_switch), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
 
-    protected AbstractPopulateSwitchDiagnosticAnalyzer(string diagnosticId, EnforceOnBuild enforceOnBuild)
-        : base(diagnosticId,
-               enforceOnBuild,
-               option: null,
-               s_localizableTitle, s_localizableMessage)
-    {
-    }
-
     protected abstract OperationKind OperationKind { get; }
 
     protected abstract bool IsSwitchTypeUnknown(TSwitchOperation operation);
     protected abstract IOperation GetValueOfSwitchOperation(TSwitchOperation operation);
+
+    protected abstract bool IsKnownToBeExhaustive(TSwitchOperation switchOperation);
 
     protected abstract bool HasConstantCase(TSwitchOperation operation, object? value);
     protected abstract ICollection<ISymbol> GetMissingEnumMembers(TSwitchOperation operation);
@@ -37,7 +36,8 @@ internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperatio
     protected abstract bool HasExhaustiveNullAndTypeCheckCases(TSwitchOperation operation);
     protected abstract Location GetDiagnosticLocation(TSwitchSyntax switchBlock);
 
-    public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+    public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory()
+        => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
     protected sealed override void InitializeWorker(AnalysisContext context)
         => context.RegisterOperationAction(AnalyzeOperation, OperationKind);
@@ -81,18 +81,23 @@ internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperatio
     {
         var typeWithoutNullable = type.RemoveNullableIfPresent();
 
-        if (typeWithoutNullable.SpecialType == SpecialType.System_Boolean)
-        {
-            return AnalyzeBooleanSwitch(switchOperation, type);
-        }
-        else if (typeWithoutNullable.TypeKind == TypeKind.Enum)
-        {
+        // We treat enum switches specially.  Specifically, even if exhaustive (because of a 'default' case),
+        // we still want to let users use the feature to fill in missing enum members.  That way if they add
+        // new enum members, they can quickly find and fix the switches that aren't explicitly handling those cases.
+        //
+        // Note: this should likely be a refactoring instead of an analyzer.  However, for historical reasons,
+        // we shipped in this fashion.
+        if (typeWithoutNullable.TypeKind == TypeKind.Enum)
             return AnalyzeEnumSwitch(switchOperation, type);
-        }
-        else
-        {
-            return (missingCases: false, missingDefaultCase: !HasDefaultCase(switchOperation));
-        }
+
+        // For all other types, we don't want to offer the user anything if the switch is already exhaustive.
+        if (this.IsKnownToBeExhaustive(switchOperation))
+            return default;
+
+        if (typeWithoutNullable.SpecialType == SpecialType.System_Boolean)
+            return AnalyzeBooleanSwitch(switchOperation, type);
+
+        return (missingCases: false, missingDefaultCase: !HasDefaultCase(switchOperation));
     }
 
     private (bool missingCases, bool missingDefaultCase) AnalyzeBooleanSwitch(TSwitchOperation operation, ITypeSymbol type)

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchExpressionDiagnosticAnalyzer.cs
@@ -8,17 +8,16 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.PopulateSwitch;
 
-internal abstract class AbstractPopulateSwitchExpressionDiagnosticAnalyzer<TSwitchSyntax> :
-    AbstractPopulateSwitchDiagnosticAnalyzer<ISwitchExpressionOperation, TSwitchSyntax>
+internal abstract class AbstractPopulateSwitchExpressionDiagnosticAnalyzer<TSwitchSyntax>()
+    : AbstractPopulateSwitchDiagnosticAnalyzer<ISwitchExpressionOperation, TSwitchSyntax>(
+        IDEDiagnosticIds.PopulateSwitchExpressionDiagnosticId,
+        EnforceOnBuildValues.PopulateSwitchExpression)
     where TSwitchSyntax : SyntaxNode
 {
-    protected AbstractPopulateSwitchExpressionDiagnosticAnalyzer()
-        : base(IDEDiagnosticIds.PopulateSwitchExpressionDiagnosticId,
-               EnforceOnBuildValues.PopulateSwitchExpression)
-    {
-    }
-
     protected sealed override OperationKind OperationKind => OperationKind.SwitchExpression;
+
+    protected override bool IsKnownToBeExhaustive(ISwitchExpressionOperation switchOperation)
+        => switchOperation.IsExhaustive;
 
     protected override IOperation GetValueOfSwitchOperation(ISwitchExpressionOperation operation)
         => operation.Value;

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchStatementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchStatementDiagnosticAnalyzer.cs
@@ -8,17 +8,16 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.PopulateSwitch;
 
-internal abstract class AbstractPopulateSwitchStatementDiagnosticAnalyzer<TSwitchSyntax> :
-    AbstractPopulateSwitchDiagnosticAnalyzer<ISwitchOperation, TSwitchSyntax>
+internal abstract class AbstractPopulateSwitchStatementDiagnosticAnalyzer<TSwitchSyntax>()
+    : AbstractPopulateSwitchDiagnosticAnalyzer<ISwitchOperation, TSwitchSyntax>(
+        IDEDiagnosticIds.PopulateSwitchStatementDiagnosticId,
+        EnforceOnBuildValues.PopulateSwitchStatement)
     where TSwitchSyntax : SyntaxNode
 {
-    protected AbstractPopulateSwitchStatementDiagnosticAnalyzer()
-        : base(IDEDiagnosticIds.PopulateSwitchStatementDiagnosticId,
-               EnforceOnBuildValues.PopulateSwitchStatement)
-    {
-    }
-
     protected sealed override OperationKind OperationKind => OperationKind.Switch;
+
+    protected override bool IsKnownToBeExhaustive(ISwitchOperation switchOperation)
+        => false;
 
     protected override IOperation GetValueOfSwitchOperation(ISwitchOperation operation)
         => operation.Value;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74977
Fixes https://github.com/dotnet/roslyn/issues/60784
Fixes https://github.com/dotnet/roslyn/issues/66433
Fixes https://github.com/dotnet/roslyn/issues/76080
Fixes https://github.com/dotnet/roslyn/issues/57523