### PR TITLE
Allow large InlineHint ArrayBuilder pooling

### DIFF
--- a/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
@@ -59,7 +59,8 @@ internal abstract class AbstractInlineParameterNameHintsService : IInlineParamet
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
-        using var _1 = ArrayBuilder<InlineHint>.GetInstance(out var result);
+        // Allow large array instances in the pool, as these arrays often exceed the ArrayBuilder reuse size threshold
+        using var _1 = ArrayBuilder<InlineHint>.GetInstance(discardLargeInstances: false, out var result);
         using var _2 = ArrayBuilder<(int position, SyntaxNode argument, IParameterSymbol? parameter, HintKind kind)>.GetInstance(out var buffer);
 
         foreach (var node in root.DescendantNodes(textSpan, n => n.Span.IntersectsWith(textSpan)))


### PR DESCRIPTION
The razor cohosting speedometer test shows between 0.2 and 0.4% of total allocations during it's completion scenarios allocating InlineHint arrays. Manual debugging of the test scenario showed these arrays were about 260 items long, and thus weren't being placed back into the standard ArrayBuilder pool. Instead, we can use the non-bounded pool by passing in false as discardLargeInstances to the ArrayBuilder.GetInstance call.

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/662540

Speedometer results with this change cut the allocations in about half (it still does a ToArray on the pooled arraybuilder)

<img width="1535" height="540" alt="image" src="https://github.com/user-attachments/assets/2a8f730a-897d-4354-8733-b63d4ecce57a" />
