### PR TITLE
Add another UI context to control Razor cohost pre-init

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Constants.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Constants.cs
@@ -11,6 +11,8 @@ internal static class Constants
 {
     public const string RazorLanguageName = LanguageInfoProvider.RazorLanguageName;
 
-    // The UI context is provided by Razor, so this guid must match the one in https://github.com/dotnet/razor/blob/main/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorConstants.cs
+    // These UI contexts are provided by Razor, so must match https://github.com/dotnet/razor/blob/main/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorConstants.cs
     public static readonly Guid RazorCohostingUIContext = new Guid("6d5b86dc-6b8a-483b-ae30-098a3c7d6774");
+
+    public static readonly Guid RazorCapabilityPresentUIContext = new Guid("2077a158-ee71-484c-be76-350a1d49eaea");
 }


### PR DESCRIPTION
~Putting this up as draft for now, gonna see if I can do a dual test insertion to confirm this makes RPS happy. The UI context is defined in https://github.com/dotnet/razor/pull/12079 so its a little bit painful to validate everything together :)~

This PR does two things:
1. Makes the lifetime service Lazy, which it should have always been but I forgot. Not being lazy means Razor can't move to it, as just MEF construction causes RPS regressions. Oops!
2. Adds a ui context to control pre-initialization. This allows Razor to control whether that occurs, when, and whether it actually does anything.

Until Razor is in this won't do anything, but runs in the dual test insertion (https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/664449) look good so far.