### PR TITLE
Allow Razor to hook up the source generator in misc files

### DIFF
--- a/src/Features/Core/Portable/Workspace/IMiscellaneousProjectInfoService.cs
+++ b/src/Features/Core/Portable/Workspace/IMiscellaneousProjectInfoService.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Features.Workspaces;
+
+internal interface IMiscellaneousProjectInfoService : ILanguageService
+{
+    string ProjectLanguageOverride { get; }
+    bool AddAsAdditionalDocument { get; }
+
+    IEnumerable<AnalyzerReference>? GetAnalyzerReferences(SolutionServices services);
+}

--- a/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratorLocator.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/IRazorSourceGeneratorLocator.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+
+internal interface IRazorSourceGeneratorLocator
+{
+    string GetGeneratorFilePath();
+}

--- a/src/Tools/ExternalAccess/Razor/Features/RazorMiscellaneousProjectInfoService.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorMiscellaneousProjectInfoService.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Features.Workspaces;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+
+[Shared]
+[ExportLanguageService(typeof(IMiscellaneousProjectInfoService), Constants.RazorLanguageName)]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class RazorMiscellaneousProjectInfoService([Import(AllowDefault = true)] Lazy<IRazorSourceGeneratorLocator>? razorSourceGeneratorLocator) : IMiscellaneousProjectInfoService
+{
+    public string ProjectLanguageOverride => LanguageNames.CSharp;
+
+    public bool AddAsAdditionalDocument => true;
+
+    public IEnumerable<AnalyzerReference>? GetAnalyzerReferences(Host.SolutionServices services)
+    {
+        if (razorSourceGeneratorLocator is null)
+        {
+            return null;
+        }
+
+        var filePath = razorSourceGeneratorLocator.Value.GetGeneratorFilePath();
+        var loaderProvider = services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>();
+        var reference = new AnalyzerFileReference(filePath, loaderProvider.SharedShadowCopyLoader);
+
+        return [reference];
+    }
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/vscode-csharp/issues/8512
Tracked by https://github.com/dotnet/razor/issues/9519 and https://github.com/dotnet/razor/issues/11833

This removes the `isRazor` hackiness in misc files, and allows Razor to provide a source generator reference to the project. Needs work on Razor not just to implement the service, which is trivial, but because the source generator doesn't actually support misc files at the moment :)