### PR TITLE
Upgrade servicehub.client to fix test source discovery

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -60,7 +60,7 @@
     -->
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="18.0.2101-preview.1" />
     <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="18.0.1211-preview.1" />
-    <PackageVersion Include="Microsoft.ServiceHub.Client" Version="4.2.1017" />
+    <PackageVersion Include="Microsoft.ServiceHub.Client" Version="4.6.3200" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="18.0.52-preview1" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility" Version="18.0.52-preview1" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.JsonGenerators.Sdk" Version="18.0.52-preview1" />


### PR DESCRIPTION
Unit testing has an issue with source based discovery, fix was made in servicehubclient which we need to consume

internal link - https://devdiv.visualstudio.com/DevDiv/_git/DevCore/pullrequest/656354