### PR TITLE
♻️ MSBuildWorkspaceDirectory - Fallback to AppContext.BaseDirectory when Assembly Location is empty

### DIFF
--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
@@ -30,7 +30,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
     private readonly SemaphoreSlim _gate = new(initialCount: 1);
     private readonly Dictionary<BuildHostProcessKind, BuildHostProcess> _processes = [];
 
-    private static string MSBuildWorkspaceDirectory => Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location)!;
+    private static string MSBuildWorkspaceDirectory => Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location) is { Length: > 0 } dir ? dir : AppContext.BaseDirectory;
     private static bool IsLoadedFromNuGetPackage => File.Exists(Path.Combine(MSBuildWorkspaceDirectory, "..", "..", "microsoft.codeanalysis.workspaces.msbuild.nuspec"));
 
     private static readonly string DotnetExecutable = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";


### PR DESCRIPTION
When assemblies are loaded via a stream, the Assembly.Location property returns an empty string, causing the BuildHost to fail to start.

Fallback to `AppContext.BaseDirectory` when Assembly Location is empty. Potentially `AppContext.BaseDirectory` should just be used instead?