### PR TITLE
Handled negative span start in SyntaxTreeDiagnosticEnumerator.

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // don't produce locations outside of tree span
                     Debug.Assert(_syntaxTree is object);
                     var length = _syntaxTree.GetRoot().FullSpan.Length;
-                    var spanStart = Math.Min(_position - leadingWidthAlreadyCounted + sdi.Offset, length);
+                    var spanStart = Math.Max(Math.Min(_position - leadingWidthAlreadyCounted + sdi.Offset, length), 0);
                     var spanWidth = Math.Min(spanStart + sdi.Width, length) - spanStart;
 
                     _current = new CSDiagnostic(sdi, new SourceLocation(_syntaxTree, new TextSpan(spanStart, spanWidth)));

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2441,6 +2441,21 @@ public class Test
             Assert.Equal(1, compilation.GetDiagnostics().Length);
         }
 
+        [Fact, WorkItem(79935, "https://github.com/dotnet/roslyn/issues/79935")]
+        public void NegativeSpanStart()
+        {
+            var text =
+                """
+                i,(#
+
+                interface
+                """;
+
+            var compilation = CreateCompilation(text);
+            var diagnostics = compilation.GetDiagnostics();
+            Assert.InRange(diagnostics.Count(), 1, int.MaxValue);
+        }
+
         [WorkItem(39992, "https://github.com/dotnet/roslyn/issues/39992")]
         [Fact]
         public void GetDiagnosticsCalledTwice_GetEmitDiagnostics()


### PR DESCRIPTION
This PR updates `SyntaxTreeDiagnosticEnumerator` to properly handle negative span starts, as described in #79935.