### PR TITLE
Add AttributeUsage to EmbeddedAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
+++ b/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override string EmbeddedAttributeDefinition => """
             namespace Microsoft.CodeAnalysis
             {
+                [global::System.AttributeUsage(global::System.AttributeTargets.All)]
                 internal sealed partial class EmbeddedAttribute : global::System.Attribute
                 {
                 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -2525,6 +2525,7 @@ class C { }
                 Assert.Equal("""
                     namespace Microsoft.CodeAnalysis
                     {
+                        [global::System.AttributeUsage(global::System.AttributeTargets.All)]
                         internal sealed partial class EmbeddedAttribute : global::System.Attribute
                         {
                         }
@@ -2568,6 +2569,7 @@ class C { }
             Assert.Equal("""
             namespace Microsoft.CodeAnalysis
             {
+                [global::System.AttributeUsage(global::System.AttributeTargets.All)]
                 internal sealed partial class EmbeddedAttribute : global::System.Attribute
                 {
                 }


### PR DESCRIPTION
prevents warning _CA1018: Specify AttributeUsage on EmbeddedAttribute_

EmbeddedAttribute was introduced in #76583