### PR TITLE
Add tests for field keyword semantic model and IOperation

### DIFF
--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System.Collections.Immutable;
@@ -12788,6 +12789,76 @@ class C<T>
             var fieldExpression = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(node => node.ToString() == "field").Single();
             var symbolInfo = model.GetSymbolInfo(fieldExpression);
             Assert.Null(symbolInfo.Symbol);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/79201")]
+        public void PublicAPI_04()
+        {
+            var source = $$"""
+                class C
+                {
+                    public string Prop
+                    {
+                        get => field;
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+            comp.VerifyAnalyzerDiagnostics(analyzers: [new TestAnalyzer1()],
+                expected: [Diagnostic("TEST_Field", "field").WithLocation(5, 16)]);
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular13);
+            comp.VerifyEmitDiagnostics(
+                // (5,16): error CS0103: The name 'field' does not exist in the current context
+                //         get => field;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "field").WithArguments("field").WithLocation(5, 16));
+            comp.VerifyAnalyzerDiagnostics(analyzers: [new TestAnalyzer1()],
+                expected: [Diagnostic("TEST_Invalid", "field").WithLocation(5, 16)]);
+        }
+
+        private class TestAnalyzer1 : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor Descriptor_Field = new(id: "TEST_Field", title: "Test", messageFormat: "", category: "", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+            public static readonly DiagnosticDescriptor Descriptor_Invalid = new(id: "TEST_Invalid", title: "Test", messageFormat: "", category: "", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor_Field, Descriptor_Invalid];
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterOperationBlockAction(context =>
+                {
+                    foreach (var block in context.OperationBlocks)
+                    {
+                        var walker = new OperationWalker1();
+                        walker.Visit(block);
+
+                        if (walker.FieldReference is not null)
+                            context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor_Field, walker.FieldReference.Syntax.Location));
+
+                        if (walker.Invalid is not null)
+                            context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor_Invalid, walker.Invalid.Syntax.Location));
+                    }
+                });
+            }
+        }
+
+        private class OperationWalker1 : OperationWalker
+        {
+            public IOperation FieldReference = null;
+            public IOperation Invalid = null;
+
+            public override void VisitFieldReference(IFieldReferenceOperation operation)
+            {
+                FieldReference = operation;
+                base.VisitFieldReference(operation);
+            }
+
+            public override void VisitInvalid(IInvalidOperation operation)
+            {
+                Invalid = operation;
+                base.VisitInvalid(operation);
+            }
         }
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -2613,7 +2613,7 @@ class ExpressionPrinter : System.Linq.Expressions.ExpressionVisitor
         {
             var tree = compilation.SyntaxTrees[0];
             SyntaxNode? syntaxNode = GetSyntaxNodeOfTypeForBinding<TSyntaxNode>(GetSyntaxNodeList(tree));
-            Debug.Assert(syntaxNode is not null, "Did you forget to place /*<bind>*/ comments in your source?");
+            Debug.Assert(syntaxNode is not null, $"Ensure a /*<bind>*/ comment is used around syntax matching the type argument for '{nameof(TSyntaxNode)}'.");
             VerifyFlowGraph(compilation, syntaxNode, expectedFlowGraph);
         }
 


### PR DESCRIPTION
Related to #79201

Related to #57012 items

> - [ ] SemanticModel
>   - [ ] `GetSymbolInfo(fieldExpr)` returns backing field
> ...
>   - [ ] `IOperation` for expression referencing `field`

It looks like these particular APIs behave as expected and I didn't spot any existing tests for them. So seems worthwhile to go ahead and merge as a test-only change.