### PR TITLE
Redo how and when we report source generator telemetry

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -216,12 +216,11 @@ internal sealed class RoslynPackage : AbstractPackage
         base.Dispose(disposing);
     }
 
-    private void ReportSessionWideTelemetry()
+    private static void ReportSessionWideTelemetry()
     {
         AsyncCompletionLogger.ReportTelemetry();
         InheritanceMarginLogger.ReportTelemetry();
         FeaturesSessionTelemetry.Report();
-        ComponentModel.GetService<VisualStudioSourceGeneratorTelemetryCollectorWorkspaceServiceFactory>().ReportOtherWorkspaceTelemetry();
     }
 
     private async Task LoadAnalyzerNodeComponentsAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioSourceGeneratorTelemetryReporterWorkspaceServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioSourceGeneratorTelemetryReporterWorkspaceServiceFactory.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.SourceGeneratorTelemetry;
+
+namespace Microsoft.VisualStudio.LanguageServices;
+
+/// <summary>
+/// Exports the reporting workspace service, which in the VS case is implemented on the same type that implements the collector factory, so we just forward it over.
+/// This is mostly a workaround for the fact we can't have a workspace factory that exports multiple different kinds of workspaces at once.
+/// </summary>
+[ExportWorkspaceServiceFactory(typeof(ISourceGeneratorTelemetryReporterWorkspaceService)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class VisualStudioSourceGeneratorTelemetryReporterWorkspaceServiceFactory(VisualStudioSourceGeneratorTelemetryCollectorWorkspaceServiceFactory implementation) : IWorkspaceServiceFactory
+{
+    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+    {
+        return implementation;
+    }
+}

--- a/src/Workspaces/Core/Portable/Log/AbstractLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/AbstractLogAggregator.cs
@@ -41,6 +41,8 @@ internal abstract class AbstractLogAggregator<TKey, TValue> : IEnumerable<KeyVal
     public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
         => _map.Select(static kvp => KeyValuePair.Create((TKey)kvp.Key, kvp.Value)).GetEnumerator();
 
+    public int Count => _map.Count;
+
     IEnumerator IEnumerable.GetEnumerator()
         => this.GetEnumerator();
 

--- a/src/Workspaces/Core/Portable/Log/StatisticResult.cs
+++ b/src/Workspaces/Core/Portable/Log/StatisticResult.cs
@@ -74,7 +74,7 @@ internal readonly struct StatisticResult(int max, int min, double mean, int rang
     /// </summary>
     /// <param name="prefix">The prefix given to any properties written. A period is used to delimit between the 
     /// prefix and the value.</param>
-    public void WriteTelemetryPropertiesTo(Dictionary<string, object?> properties, string prefix)
+    public void WriteTelemetryPropertiesTo(IDictionary<string, object?> properties, string prefix)
     {
         prefix += ".";
 

--- a/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.SourceGeneratorTelemetry;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.SourceGeneration;
@@ -64,6 +65,12 @@ internal interface IRemoteSourceGenerationService
     /// </summary>
     ValueTask<bool> HasAnalyzersOrSourceGeneratorsAsync(
         Checksum solutionChecksum, ProjectId projectId, string analyzerReferenceFullPath, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns telemetry information for source generators that were run in the remote process. This is equivalent to calling
+    /// <see cref="ISourceGeneratorTelemetryCollectorWorkspaceService.FetchKeysAndAndClear"/>
+    /// </summary>
+    ValueTask<ImmutableArray<ImmutableDictionary<string, object?>>> FetchAndClearTelemetryKeyValuePairsAsync(CancellationToken cancellationToken);
 }
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/ISourceGeneratorTelemetryCollectorWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/ISourceGeneratorTelemetryCollectorWorkspaceService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 
@@ -11,4 +12,12 @@ namespace Microsoft.CodeAnalysis.SourceGeneratorTelemetry;
 internal interface ISourceGeneratorTelemetryCollectorWorkspaceService : IWorkspaceService
 {
     void CollectRunResult(GeneratorDriverRunResult driverRunResult, GeneratorDriverTimingInfo driverTimingInfo, Func<ISourceGenerator, AnalyzerReference> getAnalyzerReference);
+
+    /// <summary>
+    /// Returns a list of telemetry keys, one set of keys for each generator that was ran.
+    /// </summary>
+    /// <remarks>
+    /// The objects in the keys are either strings or numbers like integers or floats, so they should be serializable in any reasonable format.
+    /// </remarks>
+    ImmutableArray<ImmutableDictionary<string, object?>> FetchKeysAndAndClear();
 }

--- a/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/ISourceGeneratorTelemetryReporterWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/ISourceGeneratorTelemetryReporterWorkspaceService.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.SourceGeneratorTelemetry;
+
+/// <summary>
+/// A service that lets us know when we should report telemetry for source generators. This is only created in the main process since we want to do reporting from there.
+/// </summary>
+internal interface ISourceGeneratorTelemetryReporterWorkspaceService : IWorkspaceService
+{
+    void QueueReportingOfTelemetry();
+}

--- a/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/SourceGeneratorTelemetryCollectorWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/SourceGeneratorTelemetryCollectorWorkspaceService.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -61,25 +62,36 @@ internal sealed class SourceGeneratorTelemetryCollectorWorkspaceService : ISourc
         }
     }
 
-    public void ReportStatisticsAndClear(FunctionId functionId)
+    public ImmutableArray<ImmutableDictionary<string, object?>> FetchKeysAndAndClear()
     {
+        var arrayBuilder = ImmutableArray.CreateBuilder<ImmutableDictionary<string, object?>>();
+
+        // We'll create one set of keys for each generator
         foreach (var (telemetryKey, elapsedTimeCounter) in _elapsedTimeByGenerator)
         {
-            // We'll log one event per generator
-            Logger.Log(functionId, KeyValueLogMessage.Create(map =>
-            {
-                // TODO: have a policy for when we don't have to hash them
-                map[nameof(telemetryKey.Identity.AssemblyName) + "Hashed"] = AnalyzerNameForTelemetry.ComputeSha256Hash(telemetryKey.Identity.AssemblyName);
-                map[nameof(telemetryKey.Identity.AssemblyVersion)] = telemetryKey.Identity.AssemblyVersion.ToString();
-                map[nameof(telemetryKey.Identity.TypeName) + "Hashed"] = AnalyzerNameForTelemetry.ComputeSha256Hash(telemetryKey.Identity.TypeName);
-                map[nameof(telemetryKey.FileVersion)] = telemetryKey.FileVersion;
+            var map = ImmutableDictionary.CreateBuilder<string, object?>();
 
-                var result = elapsedTimeCounter.GetStatisticResult();
-                result.WriteTelemetryPropertiesTo(map, prefix: "ElapsedTimePerRun");
+            // TODO: have a policy for when we don't have to hash them
+            map[nameof(telemetryKey.Identity.AssemblyName) + "Hashed"] = AnalyzerNameForTelemetry.ComputeSha256Hash(telemetryKey.Identity.AssemblyName);
+            map[nameof(telemetryKey.Identity.AssemblyVersion)] = telemetryKey.Identity.AssemblyVersion.ToString();
+            map[nameof(telemetryKey.Identity.TypeName) + "Hashed"] = AnalyzerNameForTelemetry.ComputeSha256Hash(telemetryKey.Identity.TypeName);
+            map[nameof(telemetryKey.FileVersion)] = telemetryKey.FileVersion;
 
-                var producedFileCount = _producedFilesByGenerator.GetStatisticResult(telemetryKey);
-                producedFileCount.WriteTelemetryPropertiesTo(map, prefix: "GeneratedFileCountPerRun");
-            }));
+            var result = elapsedTimeCounter.GetStatisticResult();
+            result.WriteTelemetryPropertiesTo(map, prefix: "ElapsedTimePerRun");
+
+            var producedFileCount = _producedFilesByGenerator.GetStatisticResult(telemetryKey);
+            producedFileCount.WriteTelemetryPropertiesTo(map, prefix: "GeneratedFileCountPerRun");
+
+            arrayBuilder.Add(map.ToImmutable());
         }
+
+        // Clear the counters so we can see performance over time and across different solutions. The StatisticLogAggregators we are using safe to use concurrently,
+        // so this clear won't break if there's a concurrent write. There's a possibility here we might be clearing a telemetry report we haven't sent, but that's
+        // fine since this is aggregate telemetry.
+        _elapsedTimeByGenerator.Clear();
+        _producedFilesByGenerator.Clear();
+
+        return arrayBuilder.ToImmutable();
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker_Generators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker_Generators.cs
@@ -105,6 +105,9 @@ internal sealed partial class SolutionCompilationState
                     solutionChecksum, projectId, withFrozenSourceGeneratedDocuments: false, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
 
+            // Since we called out to the OOP side, we'll want to later report summarized telemetry numbers.
+            solution.Services.GetService<ISourceGeneratorTelemetryReporterWorkspaceService>()?.QueueReportingOfTelemetry();
+
             if (!infosOpt.HasValue)
                 return null;
 
@@ -275,6 +278,9 @@ internal sealed partial class SolutionCompilationState
             telemetryCollector?.CollectRunResult(
                 runResult, generatorDriver.GetTimingInfo(),
                 g => GetAnalyzerReference(this.ProjectState, g));
+
+            var telemetryReporter = compilationState.SolutionState.Services.GetService<ISourceGeneratorTelemetryReporterWorkspaceService>();
+            telemetryReporter?.QueueReportingOfTelemetry();
 
             // We may be able to reuse compilationWithStaleGeneratedTrees if the generated trees are identical. We will assign null
             // to compilationWithStaleGeneratedTrees if we at any point realize it can't be used. We'll first check the count of trees

--- a/src/Workspaces/Remote/ServiceHub/Services/SourceGeneration/RemoteSourceGenerationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SourceGeneration/RemoteSourceGenerationService.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SourceGeneration;
+using Microsoft.CodeAnalysis.SourceGeneratorTelemetry;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote;
@@ -164,5 +165,11 @@ internal sealed partial class RemoteSourceGenerationService(in BrokeredServiceBa
 
             return ValueTask.FromResult(analyzerReference.HasAnalyzersOrSourceGenerators(project.Language));
         }, cancellationToken);
+    }
+
+    public ValueTask<ImmutableArray<ImmutableDictionary<string, object?>>> FetchAndClearTelemetryKeyValuePairsAsync(CancellationToken _)
+    {
+        var workspaceService = GetWorkspaceServices().GetRequiredService<ISourceGeneratorTelemetryCollectorWorkspaceService>();
+        return ValueTask.FromResult(workspaceService.FetchKeysAndAndClear());
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/SourceGeneration/RemoteWorkspaceSourceGeneratorCollectorTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SourceGeneration/RemoteWorkspaceSourceGeneratorCollectorTelemetryService.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.SourceGeneratorTelemetry;
+
+namespace Microsoft.CodeAnalysis.Remote.Services.SourceGeneration;
+
+[ExportWorkspaceServiceFactory(typeof(ISourceGeneratorTelemetryCollectorWorkspaceService), WorkspaceKind.RemoteWorkspace), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class RemoteWorkspaceSourceGeneratorCollectorTelemetryService() : IWorkspaceServiceFactory
+{
+    private readonly SourceGeneratorTelemetryCollectorWorkspaceService _service = new();
+
+    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices) => _service;
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -578,6 +578,11 @@ internal enum FunctionId
     SourceGenerator_SolutionStatistics = 620,
     SourceGenerator_OtherWorkspaceSessionStatistics = 621,
 
+    /// <summary>
+    /// Telemetry for source generators that were ran in-process; this is only expected to be fired if calling into OOP failed.
+    /// </summary>
+    SourceGenerator_SolutionInProcStatistics = 622,
+
     // 630-650 for sqlite errors.
     SQLite_SqlException = 630,
     SQLite_StorageDisabled = 631,


### PR DESCRIPTION
Previously, we were triggering a report of source generator telemetry when the user closed the solution. The intent of this was to be able to do it prior to "context" that the telemetry service has set is cleared; this means we could understand the performance for one solution versus another.

This approach however was broken once we moved the computation of source generators OOP; this meant we'd report the 'in-process' results, which are almost always empty.

This switches to reporting the results for all out-of-process and in- process runs. Unfortunately, the trick of us doing it during solution close isn't possible without blocking the UI thread synchronously on OOP which we don't want to do, so for now we'll just report telemetry every few minutes as long as there's new telemetry to report. There is work happening that would allow us to have an asynchronous handler there again which we can look at moving back to later.