### PR TITLE
Visit deconstruction receiver in ref safety analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -1116,6 +1116,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             using var _ = new PlaceholderRegion(this, placeholders);
 
+            if (offset == 0)
+            {
+                Visit(methodInvocationInfo.Receiver);
+            }
+            else
+            {
+                Debug.Assert(offset == 1);
+                Debug.Assert(methodInvocationInfo.Receiver is null);
+                Visit(methodInvocationInfo.ArgsOpt[0]);
+            }
+
             CheckInvocationArgMixing(
                 syntax,
                 in methodInvocationInfo,


### PR DESCRIPTION
The deconstruction expression has `left` (the tuple) and `right` (the expression) sides. But it also carries an invocation info which is of the form `leftPlaceholder.Deconstruct(...)`. Except the receiver can be also wrapped in a first-class-span conversion (or whatever else can binding of the call do). The problem was that by default, our visitors only visit `left` and `right`. But `RefSafetyAnalysis` then analyzes the _invocation_ and asserts because the receiver wasn't visited.

Fixes https://github.com/dotnet/roslyn/issues/78682.