### PR TITLE
Enable the single-file analyzers

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -64,6 +64,8 @@
     <CoreCompileDependsOn>$(CoreCompileDependsOn);ResolveKeySource</CoreCompileDependsOn> 
 
     <NoWarn Condition="'$(DefineConstants.Contains(`CODE_STYLE`))' == 'false'">$(NoWarn);RS1041;RS1038</NoWarn>
+
+    <EnableSingleFileAnalyzer Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)TargetFrameworks.props" />


### PR DESCRIPTION
This can avoid recurrences of bugs like https://github.com/dotnet/roslyn/issues/77843