### PR TITLE
Only cache compilation if we have the same set of analyzers

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -49,9 +48,12 @@ internal sealed partial class DiagnosticAnalyzerService
     /// we've created for it.  Note: the CompilationWithAnalyzersPair instance is dependent on the set of <see
     /// cref="DiagnosticAnalyzer"/>s passed along with the project.
     /// <para/>
-    /// The value of the table is a <see cref="Dictionary{TKey, TValue}"/> that maps from the 
+    /// The value of the table is a SmallDictionary that maps from the 
     /// <see cref="Project"/> checksum the set of <see cref="DiagnosticAnalyzer"/>s being requested.
-    /// Note: this dictionary must be locked with <see cref="s_gate"/> before accessing it.
+    /// Note: this dictionary must be locked with <see cref="s_gate"/> before accessing it.  A 
+    /// small dictionary is chosen as this will normally only have one item in it (the current project
+    /// and all its analyzers).  Occasionally it will have more, if (for example) a request to run
+    /// a single analyzer is performed.
     /// </summary>
     private static readonly ConditionalWeakTable<
         ProjectState,

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -89,12 +89,11 @@ internal sealed partial class DiagnosticAnalyzerService
             var checksumAndAnalyzers = (checksum, analyzers);
             if (!map.TryGetValue(checksumAndAnalyzers, out lazy))
             {
-                lazy = AsyncLazy.Create(static async (tuple, cancellationToken) =>
+                lazy = AsyncLazy.Create(static (tuple, cancellationToken) =>
                 {
                     var (project, analyzers, hostAnalyzerInfo, crashOnAnalyzerException) = tuple;
-                    var compilationWithAnalyzersPair = await CreateCompilationWithAnalyzersAsync(
-                        project, analyzers, hostAnalyzerInfo, crashOnAnalyzerException, cancellationToken).ConfigureAwait(false);
-                    return compilationWithAnalyzersPair;
+                    return CreateCompilationWithAnalyzersAsync(
+                        project, analyzers, hostAnalyzerInfo, crashOnAnalyzerException, cancellationToken);
                 }, (project, analyzers, hostAnalyzerInfo, crashOnAnalyzerException));
                 map.Add(checksumAndAnalyzers, lazy);
             }

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -38,11 +38,11 @@ internal sealed partial class DiagnosticAnalyzerService
         var projectState = project.State;
         var checksum = await project.GetDiagnosticChecksumAsync(cancellationToken).ConfigureAwait(false);
 
-        // Make sure the cached pair was computed with at least the same state sets we're asking about.  if not,
+        // Make sure the cached pair was computed with the same state sets we're asking about.  if not,
         // recompute and cache with the new state sets.
         if (!s_projectToCompilationWithAnalyzers.TryGetValue(projectState, out var tupleBox) ||
             tupleBox.Value.checksum != checksum ||
-            !analyzers.IsSubsetOf(tupleBox.Value.analyzers))
+            !analyzers.SetEquals(tupleBox.Value.analyzers))
         {
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
             var compilationWithAnalyzersPair = CreateCompilationWithAnalyzers(projectState, compilation);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SharedStopwatch.cs" Link="InternalUtilities\SharedStopwatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Syntax\SyntaxTreeExtensions.cs" Link="Syntax\SyntaxTreeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Collections\BitVector.cs" Link="Collections\BitVector.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Collections\SmallDictionary.cs" Link="Collections\SmallDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Collections\IOrderedReadOnlySet.cs" Link="Collections\IOrderedReadOnlySet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\SourceGeneration\GeneratedCodeUtilities.cs" Link="SourceGeneration\GeneratedCodeUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\SourceCodeKindExtensions.cs" Link="Utilities\Compiler\SourceCodeKindExtensions.cs" />


### PR DESCRIPTION
The core issue hee is that we were caching the CompilationWithAnalyzers for a compilation with *all* analyzers.  Then, when being asked to compute again with, say, a single analyzer, we'd reuse the CompialtionWithAnalyzers.

This would then take ages to run *all* analyzers, even when running a fix-all for a single analyzer.