### PR TITLE
Move logic up into DiagService

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -22,9 +22,7 @@ internal interface IDiagnosticAnalyzerService : IWorkspaceService
     /// </remarks>
     void RequestDiagnosticRefresh();
 
-    /// <summary>
-    /// Force analyzes the given project by running all applicable analyzers on the project.
-    /// </summary>
+    /// <inheritdoc cref="IRemoteDiagnosticAnalyzerService.ForceAnalyzeProjectAsync"/>
     Task<ImmutableArray<DiagnosticData>> ForceAnalyzeProjectAsync(Project project, CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
@@ -58,6 +58,7 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
     private readonly IDiagnosticsRefresher _diagnosticsRefresher;
     private readonly DiagnosticIncrementalAnalyzer _incrementalAnalyzer;
     private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
+    private readonly StateManager _stateManager;
 
     public DiagnosticAnalyzerService(
         IGlobalOptionService globalOptions,
@@ -71,6 +72,7 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
         GlobalOptions = globalOptions;
         _diagnosticsRefresher = diagnosticsRefresher;
         _incrementalAnalyzer = new DiagnosticIncrementalAnalyzer(this, _analyzerInfoCache, this.GlobalOptions);
+        _stateManager = new StateManager(_analyzerInfoCache);
 
         globalOptions.AddOptionChangedHandler(this, (_, _, e) =>
         {

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.HostAnalyzerInfo.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.HostAnalyzerInfo.cs
@@ -2,95 +2,90 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal sealed partial class DiagnosticAnalyzerService
 {
-    private sealed partial class DiagnosticIncrementalAnalyzer
+    private sealed partial class StateManager
     {
-        private sealed partial class StateManager
+        private HostAnalyzerInfo GetOrCreateHostAnalyzerInfo(
+            SolutionState solution, ProjectState project, ProjectAnalyzerInfo projectAnalyzerInfo)
         {
-            private HostAnalyzerInfo GetOrCreateHostAnalyzerInfo(
-                SolutionState solution, ProjectState project, ProjectAnalyzerInfo projectAnalyzerInfo)
+            var key = new HostAnalyzerInfoKey(project.Language, project.HasSdkCodeStyleAnalyzers, solution.Analyzers.HostAnalyzerReferences);
+            // Some Host Analyzers may need to be treated as Project Analyzers so that they do not have access to the
+            // Host fallback options. These ids will be used when building up the Host and Project analyzer collections.
+            var referenceIdsToRedirect = GetReferenceIdsToRedirectAsProjectAnalyzers(solution, project);
+            var hostAnalyzerInfo = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, key, CreateLanguageSpecificAnalyzerMap, (solution.Analyzers, referenceIdsToRedirect));
+            return hostAnalyzerInfo.WithExcludedAnalyzers(projectAnalyzerInfo.SkippedAnalyzersInfo.SkippedAnalyzers);
+
+            static HostAnalyzerInfo CreateLanguageSpecificAnalyzerMap(HostAnalyzerInfoKey arg, (HostDiagnosticAnalyzers HostAnalyzers, ImmutableHashSet<object> ReferenceIdsToRedirect) state)
             {
-                var key = new HostAnalyzerInfoKey(project.Language, project.HasSdkCodeStyleAnalyzers, solution.Analyzers.HostAnalyzerReferences);
-                // Some Host Analyzers may need to be treated as Project Analyzers so that they do not have access to the
-                // Host fallback options. These ids will be used when building up the Host and Project analyzer collections.
-                var referenceIdsToRedirect = GetReferenceIdsToRedirectAsProjectAnalyzers(solution, project);
-                var hostAnalyzerInfo = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, key, CreateLanguageSpecificAnalyzerMap, (solution.Analyzers, referenceIdsToRedirect));
-                return hostAnalyzerInfo.WithExcludedAnalyzers(projectAnalyzerInfo.SkippedAnalyzersInfo.SkippedAnalyzers);
+                var language = arg.Language;
+                var analyzersPerReference = state.HostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
 
-                static HostAnalyzerInfo CreateLanguageSpecificAnalyzerMap(HostAnalyzerInfoKey arg, (HostDiagnosticAnalyzers HostAnalyzers, ImmutableHashSet<object> ReferenceIdsToRedirect) state)
-                {
-                    var language = arg.Language;
-                    var analyzersPerReference = state.HostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
+                var (hostAnalyzerCollection, projectAnalyzerCollection) = GetAnalyzerCollections(analyzersPerReference, state.ReferenceIdsToRedirect);
+                var (hostAnalyzers, allAnalyzers) = PartitionAnalyzers(projectAnalyzerCollection, hostAnalyzerCollection, includeWorkspacePlaceholderAnalyzers: true);
 
-                    var (hostAnalyzerCollection, projectAnalyzerCollection) = GetAnalyzerCollections(analyzersPerReference, state.ReferenceIdsToRedirect);
-                    var (hostAnalyzers, allAnalyzers) = PartitionAnalyzers(projectAnalyzerCollection, hostAnalyzerCollection, includeWorkspacePlaceholderAnalyzers: true);
-
-                    return new HostAnalyzerInfo(hostAnalyzers, allAnalyzers);
-                }
-
-                static (IEnumerable<ImmutableArray<DiagnosticAnalyzer>> HostAnalyzerCollection, IEnumerable<ImmutableArray<DiagnosticAnalyzer>> ProjectAnalyzerCollection) GetAnalyzerCollections(
-                    ImmutableDictionary<object, ImmutableArray<DiagnosticAnalyzer>> analyzersPerReference,
-                    ImmutableHashSet<object> referenceIdsToRedirectAsProjectAnalyzers)
-                {
-                    if (referenceIdsToRedirectAsProjectAnalyzers.IsEmpty)
-                    {
-                        return (analyzersPerReference.Values, []);
-                    }
-
-                    var hostAnalyzerCollection = ArrayBuilder<ImmutableArray<DiagnosticAnalyzer>>.GetInstance();
-                    var projectAnalyzerCollection = ArrayBuilder<ImmutableArray<DiagnosticAnalyzer>>.GetInstance();
-
-                    foreach (var (referenceId, analyzers) in analyzersPerReference)
-                    {
-                        if (referenceIdsToRedirectAsProjectAnalyzers.Contains(referenceId))
-                        {
-                            projectAnalyzerCollection.Add(analyzers);
-                        }
-                        else
-                        {
-                            hostAnalyzerCollection.Add(analyzers);
-                        }
-                    }
-
-                    return (hostAnalyzerCollection.ToImmutableAndFree(), projectAnalyzerCollection.ToImmutableAndFree());
-                }
+                return new HostAnalyzerInfo(hostAnalyzers, allAnalyzers);
             }
 
-            private static ImmutableHashSet<object> GetReferenceIdsToRedirectAsProjectAnalyzers(
-                SolutionState solution, ProjectState project)
+            static (IEnumerable<ImmutableArray<DiagnosticAnalyzer>> HostAnalyzerCollection, IEnumerable<ImmutableArray<DiagnosticAnalyzer>> ProjectAnalyzerCollection) GetAnalyzerCollections(
+                ImmutableDictionary<object, ImmutableArray<DiagnosticAnalyzer>> analyzersPerReference,
+                ImmutableHashSet<object> referenceIdsToRedirectAsProjectAnalyzers)
             {
-                if (project.HasSdkCodeStyleAnalyzers)
+                if (referenceIdsToRedirectAsProjectAnalyzers.IsEmpty)
                 {
-                    // When a project uses CodeStyle analyzers added by the SDK, we remove them in favor of the
-                    // Features analyzers. We need to then treat the Features analyzers as Project analyzers so
-                    // they do not get access to the Host fallback options.
-                    return GetFeaturesAnalyzerReferenceIds(solution.Analyzers);
+                    return (analyzersPerReference.Values, []);
                 }
 
-                return [];
+                var hostAnalyzerCollection = ArrayBuilder<ImmutableArray<DiagnosticAnalyzer>>.GetInstance();
+                var projectAnalyzerCollection = ArrayBuilder<ImmutableArray<DiagnosticAnalyzer>>.GetInstance();
 
-                static ImmutableHashSet<object> GetFeaturesAnalyzerReferenceIds(HostDiagnosticAnalyzers hostAnalyzers)
+                foreach (var (referenceId, analyzers) in analyzersPerReference)
                 {
-                    var builder = ImmutableHashSet.CreateBuilder<object>();
-
-                    foreach (var analyzerReference in hostAnalyzers.HostAnalyzerReferences)
+                    if (referenceIdsToRedirectAsProjectAnalyzers.Contains(referenceId))
                     {
-                        if (analyzerReference.IsFeaturesAnalyzer())
-                            builder.Add(analyzerReference.Id);
+                        projectAnalyzerCollection.Add(analyzers);
                     }
-
-                    return builder.ToImmutable();
+                    else
+                    {
+                        hostAnalyzerCollection.Add(analyzers);
+                    }
                 }
+
+                return (hostAnalyzerCollection.ToImmutableAndFree(), projectAnalyzerCollection.ToImmutableAndFree());
+            }
+        }
+
+        private static ImmutableHashSet<object> GetReferenceIdsToRedirectAsProjectAnalyzers(
+            SolutionState solution, ProjectState project)
+        {
+            if (project.HasSdkCodeStyleAnalyzers)
+            {
+                // When a project uses CodeStyle analyzers added by the SDK, we remove them in favor of the
+                // Features analyzers. We need to then treat the Features analyzers as Project analyzers so
+                // they do not get access to the Host fallback options.
+                return GetFeaturesAnalyzerReferenceIds(solution.Analyzers);
+            }
+
+            return [];
+
+            static ImmutableHashSet<object> GetFeaturesAnalyzerReferenceIds(HostDiagnosticAnalyzers hostAnalyzers)
+            {
+                var builder = ImmutableHashSet.CreateBuilder<object>();
+
+                foreach (var analyzerReference in hostAnalyzers.HostAnalyzerReferences)
+                {
+                    if (analyzerReference.IsFeaturesAnalyzer())
+                        builder.Add(analyzerReference.Id);
+                }
+
+                return builder.ToImmutable();
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -13,91 +13,88 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal sealed partial class DiagnosticAnalyzerService
 {
-    private sealed partial class DiagnosticIncrementalAnalyzer
+    /// <summary>
+    /// This is in charge of anything related to <see cref="DiagnosticAnalyzer"/>
+    /// </summary>
+    private sealed partial class StateManager(DiagnosticAnalyzerInfoCache analyzerInfoCache)
     {
+        private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache = analyzerInfoCache;
+
         /// <summary>
-        /// This is in charge of anything related to <see cref="DiagnosticAnalyzer"/>
+        /// Analyzers supplied by the host (IDE). These are built-in to the IDE, the compiler, or from an installed IDE extension (VSIX). 
+        /// Maps language name to the analyzers and their state.
         /// </summary>
-        private sealed partial class StateManager(DiagnosticAnalyzerInfoCache analyzerInfoCache)
+        private ImmutableDictionary<HostAnalyzerInfoKey, HostAnalyzerInfo> _hostAnalyzerStateMap = ImmutableDictionary<HostAnalyzerInfoKey, HostAnalyzerInfo>.Empty;
+
+        /// <summary>
+        /// Analyzers referenced by the project via a PackageReference. Updates are protected by _projectAnalyzerStateMapGuard.
+        /// ImmutableDictionary used to present a safe, non-immutable view to users.
+        /// </summary>
+        private ImmutableDictionary<ProjectId, ProjectAnalyzerInfo> _projectAnalyzerStateMap = ImmutableDictionary<ProjectId, ProjectAnalyzerInfo>.Empty;
+
+        /// <summary>
+        /// Guard around updating _projectAnalyzerStateMap. This is used in UpdateProjectStateSets to avoid
+        /// duplicated calculations for a project during contentious calls.
+        /// </summary>
+        private readonly SemaphoreSlim _projectAnalyzerStateMapGuard = new(initialCount: 1);
+
+        /// <summary>
+        /// Return <see cref="DiagnosticAnalyzer"/>s for the given <see cref="Project"/>. 
+        /// </summary>
+        public async Task<ImmutableArray<DiagnosticAnalyzer>> GetOrCreateAnalyzersAsync(
+            SolutionState solution, ProjectState project, CancellationToken cancellationToken)
         {
-            private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache = analyzerInfoCache;
-
-            /// <summary>
-            /// Analyzers supplied by the host (IDE). These are built-in to the IDE, the compiler, or from an installed IDE extension (VSIX). 
-            /// Maps language name to the analyzers and their state.
-            /// </summary>
-            private ImmutableDictionary<HostAnalyzerInfoKey, HostAnalyzerInfo> _hostAnalyzerStateMap = ImmutableDictionary<HostAnalyzerInfoKey, HostAnalyzerInfo>.Empty;
-
-            /// <summary>
-            /// Analyzers referenced by the project via a PackageReference. Updates are protected by _projectAnalyzerStateMapGuard.
-            /// ImmutableDictionary used to present a safe, non-immutable view to users.
-            /// </summary>
-            private ImmutableDictionary<ProjectId, ProjectAnalyzerInfo> _projectAnalyzerStateMap = ImmutableDictionary<ProjectId, ProjectAnalyzerInfo>.Empty;
-
-            /// <summary>
-            /// Guard around updating _projectAnalyzerStateMap. This is used in UpdateProjectStateSets to avoid
-            /// duplicated calculations for a project during contentious calls.
-            /// </summary>
-            private readonly SemaphoreSlim _projectAnalyzerStateMapGuard = new(initialCount: 1);
-
-            /// <summary>
-            /// Return <see cref="DiagnosticAnalyzer"/>s for the given <see cref="Project"/>. 
-            /// </summary>
-            public async Task<ImmutableArray<DiagnosticAnalyzer>> GetOrCreateAnalyzersAsync(
-                SolutionState solution, ProjectState project, CancellationToken cancellationToken)
-            {
-                var hostAnalyzerInfo = await GetOrCreateHostAnalyzerInfoAsync(solution, project, cancellationToken).ConfigureAwait(false);
-                var projectAnalyzerInfo = await GetOrCreateProjectAnalyzerInfoAsync(solution, project, cancellationToken).ConfigureAwait(false);
-                return hostAnalyzerInfo.OrderedAllAnalyzers.AddRange(projectAnalyzerInfo.Analyzers);
-            }
-
-            public async Task<HostAnalyzerInfo> GetOrCreateHostAnalyzerInfoAsync(
-                SolutionState solution, ProjectState project, CancellationToken cancellationToken)
-            {
-                var projectAnalyzerInfo = await GetOrCreateProjectAnalyzerInfoAsync(solution, project, cancellationToken).ConfigureAwait(false);
-                return GetOrCreateHostAnalyzerInfo(solution, project, projectAnalyzerInfo);
-            }
-
-            private static (ImmutableHashSet<DiagnosticAnalyzer> hostAnalyzers, ImmutableHashSet<DiagnosticAnalyzer> allAnalyzers) PartitionAnalyzers(
-                IEnumerable<ImmutableArray<DiagnosticAnalyzer>> projectAnalyzerCollection,
-                IEnumerable<ImmutableArray<DiagnosticAnalyzer>> hostAnalyzerCollection,
-                bool includeWorkspacePlaceholderAnalyzers)
-            {
-                using var _1 = PooledHashSet<DiagnosticAnalyzer>.GetInstance(out var hostAnalyzers);
-                using var _2 = PooledHashSet<DiagnosticAnalyzer>.GetInstance(out var allAnalyzers);
-
-                if (includeWorkspacePlaceholderAnalyzers)
-                {
-                    hostAnalyzers.Add(FileContentLoadAnalyzer.Instance);
-                    hostAnalyzers.Add(GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
-                    allAnalyzers.Add(FileContentLoadAnalyzer.Instance);
-                    allAnalyzers.Add(GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
-                }
-
-                foreach (var analyzers in projectAnalyzerCollection)
-                {
-                    foreach (var analyzer in analyzers)
-                    {
-                        Debug.Assert(analyzer != FileContentLoadAnalyzer.Instance && analyzer != GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
-                        allAnalyzers.Add(analyzer);
-                    }
-                }
-
-                foreach (var analyzers in hostAnalyzerCollection)
-                {
-                    foreach (var analyzer in analyzers)
-                    {
-                        Debug.Assert(analyzer != FileContentLoadAnalyzer.Instance && analyzer != GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
-                        allAnalyzers.Add(analyzer);
-                        hostAnalyzers.Add(analyzer);
-                    }
-                }
-
-                return (hostAnalyzers.ToImmutableHashSet(), allAnalyzers.ToImmutableHashSet());
-            }
-
-            private readonly record struct HostAnalyzerInfoKey(
-                string Language, bool HasSdkCodeStyleAnalyzers, IReadOnlyList<AnalyzerReference> AnalyzerReferences);
+            var hostAnalyzerInfo = await GetOrCreateHostAnalyzerInfoAsync(solution, project, cancellationToken).ConfigureAwait(false);
+            var projectAnalyzerInfo = await GetOrCreateProjectAnalyzerInfoAsync(solution, project, cancellationToken).ConfigureAwait(false);
+            return hostAnalyzerInfo.OrderedAllAnalyzers.AddRange(projectAnalyzerInfo.Analyzers);
         }
+
+        public async Task<HostAnalyzerInfo> GetOrCreateHostAnalyzerInfoAsync(
+            SolutionState solution, ProjectState project, CancellationToken cancellationToken)
+        {
+            var projectAnalyzerInfo = await GetOrCreateProjectAnalyzerInfoAsync(solution, project, cancellationToken).ConfigureAwait(false);
+            return GetOrCreateHostAnalyzerInfo(solution, project, projectAnalyzerInfo);
+        }
+
+        private static (ImmutableHashSet<DiagnosticAnalyzer> hostAnalyzers, ImmutableHashSet<DiagnosticAnalyzer> allAnalyzers) PartitionAnalyzers(
+            IEnumerable<ImmutableArray<DiagnosticAnalyzer>> projectAnalyzerCollection,
+            IEnumerable<ImmutableArray<DiagnosticAnalyzer>> hostAnalyzerCollection,
+            bool includeWorkspacePlaceholderAnalyzers)
+        {
+            using var _1 = PooledHashSet<DiagnosticAnalyzer>.GetInstance(out var hostAnalyzers);
+            using var _2 = PooledHashSet<DiagnosticAnalyzer>.GetInstance(out var allAnalyzers);
+
+            if (includeWorkspacePlaceholderAnalyzers)
+            {
+                hostAnalyzers.Add(FileContentLoadAnalyzer.Instance);
+                hostAnalyzers.Add(GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
+                allAnalyzers.Add(FileContentLoadAnalyzer.Instance);
+                allAnalyzers.Add(GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
+            }
+
+            foreach (var analyzers in projectAnalyzerCollection)
+            {
+                foreach (var analyzer in analyzers)
+                {
+                    Debug.Assert(analyzer != FileContentLoadAnalyzer.Instance && analyzer != GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
+                    allAnalyzers.Add(analyzer);
+                }
+            }
+
+            foreach (var analyzers in hostAnalyzerCollection)
+            {
+                foreach (var analyzer in analyzers)
+                {
+                    Debug.Assert(analyzer != FileContentLoadAnalyzer.Instance && analyzer != GeneratorDiagnosticsPlaceholderAnalyzer.Instance);
+                    allAnalyzers.Add(analyzer);
+                    hostAnalyzers.Add(analyzer);
+                }
+            }
+
+            return (hostAnalyzers.ToImmutableHashSet(), allAnalyzers.ToImmutableHashSet());
+        }
+
+        private readonly record struct HostAnalyzerInfoKey(
+            string Language, bool HasSdkCodeStyleAnalyzers, IReadOnlyList<AnalyzerReference> AnalyzerReferences);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -21,7 +21,6 @@ internal sealed partial class DiagnosticAnalyzerService
     private sealed partial class DiagnosticIncrementalAnalyzer
     {
         private readonly DiagnosticAnalyzerTelemetry _telemetry = new();
-        private readonly StateManager _stateManager;
         private readonly InProcOrRemoteHostAnalyzerRunner _diagnosticAnalyzerRunner;
         private readonly IncrementalMemberEditAnalyzer _incrementalMemberEditAnalyzer = new();
 
@@ -37,16 +36,16 @@ internal sealed partial class DiagnosticAnalyzerService
             AnalyzerService = analyzerService;
             GlobalOptions = globalOptionService;
 
-            _stateManager = new StateManager(analyzerInfoCache);
-
             _diagnosticAnalyzerRunner = new InProcOrRemoteHostAnalyzerRunner(analyzerInfoCache, analyzerService.Listener);
         }
+
+        private StateManager StateManager => this.AnalyzerService._stateManager;
 
         internal IGlobalOptionService GlobalOptions { get; }
         internal DiagnosticAnalyzerInfoCache DiagnosticAnalyzerInfoCache => _diagnosticAnalyzerRunner.AnalyzerInfoCache;
 
         public Task<ImmutableArray<DiagnosticAnalyzer>> GetAnalyzersForTestingPurposesOnlyAsync(Project project, CancellationToken cancellationToken)
-            => _stateManager.GetOrCreateAnalyzersAsync(project.Solution.SolutionState, project.State, cancellationToken);
+            => StateManager.GetOrCreateAnalyzersAsync(project.Solution.SolutionState, project.State, cancellationToken);
 
         private static string GetProjectLogMessage(Project project, ImmutableArray<DocumentDiagnosticAnalyzer> analyzers)
             => $"project: ({project.Id}), ({string.Join(Environment.NewLine, analyzers.Select(a => a.ToString()))})";

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -61,9 +61,9 @@ internal sealed partial class DiagnosticAnalyzerService
             using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var builder);
 
             var solution = project.Solution;
-            var analyzersForProject = await _stateManager.GetOrCreateAnalyzersAsync(
+            var analyzersForProject = await StateManager.GetOrCreateAnalyzersAsync(
                 solution.SolutionState, project.State, cancellationToken).ConfigureAwait(false);
-            var hostAnalyzerInfo = await _stateManager.GetOrCreateHostAnalyzerInfoAsync(
+            var hostAnalyzerInfo = await StateManager.GetOrCreateHostAnalyzerInfoAsync(
                 solution.SolutionState, project.State, cancellationToken).ConfigureAwait(false);
             var analyzers = analyzersForProject.WhereAsArray(a => ShouldIncludeAnalyzer(project, a));
 

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -18,44 +18,7 @@ internal sealed partial class DiagnosticAnalyzerService
 {
     private sealed partial class DiagnosticIncrementalAnalyzer
     {
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(
-            Project project,
-            ImmutableArray<DiagnosticAnalyzer> analyzers,
-            DocumentId? documentId,
-            ImmutableHashSet<string>? diagnosticIds,
-            bool includeLocalDocumentDiagnostics,
-            bool includeNonLocalDocumentDiagnostics,
-            CancellationToken cancellationToken)
-        {
-            return ProduceProjectDiagnosticsAsync(
-                project, analyzers, diagnosticIds,
-                // Ensure we compute and return diagnostics for both the normal docs and the additional docs in this
-                // project if no specific document id was requested.
-                documentId != null ? [documentId] : [.. project.DocumentIds, .. project.AdditionalDocumentIds],
-                includeLocalDocumentDiagnostics,
-                includeNonLocalDocumentDiagnostics,
-                // return diagnostics specific to one project or document
-                includeProjectNonLocalResult: documentId == null,
-                cancellationToken);
-        }
-
-        public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(
-            Project project,
-            ImmutableArray<DiagnosticAnalyzer> analyzers,
-            ImmutableHashSet<string>? diagnosticIds,
-            bool includeNonLocalDocumentDiagnostics,
-            CancellationToken cancellationToken)
-        {
-            return ProduceProjectDiagnosticsAsync(
-               project, analyzers, diagnosticIds,
-               documentIds: [],
-               includeLocalDocumentDiagnostics: false,
-               includeNonLocalDocumentDiagnostics: includeNonLocalDocumentDiagnostics,
-               includeProjectNonLocalResult: true,
-               cancellationToken);
-        }
-
-        private async Task<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(
+        public async Task<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(
             Project project,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             ImmutableHashSet<string>? diagnosticIds,

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -60,12 +60,12 @@ internal sealed partial class DiagnosticAnalyzerService
 
             var project = document.Project;
             var solutionState = project.Solution.SolutionState;
-            var unfilteredAnalyzers = await _stateManager
+            var unfilteredAnalyzers = await StateManager
                 .GetOrCreateAnalyzersAsync(solutionState, project.State, cancellationToken)
                 .ConfigureAwait(false);
             var analyzers = unfilteredAnalyzers
                 .WhereAsArray(a => DocumentAnalysisExecutor.IsAnalyzerEnabledForProject(a, document.Project, GlobalOptions));
-            var hostAnalyzerInfo = await _stateManager.GetOrCreateHostAnalyzerInfoAsync(solutionState, project.State, cancellationToken).ConfigureAwait(false);
+            var hostAnalyzerInfo = await StateManager.GetOrCreateHostAnalyzerInfoAsync(solutionState, project.State, cancellationToken).ConfigureAwait(false);
 
             // Note that some callers, such as diagnostic tagger, might pass in a range equal to the entire document span.
             // We clear out range for such cases as we are computing full document diagnostics.
@@ -224,7 +224,7 @@ internal sealed partial class DiagnosticAnalyzerService
 
                 analyzers = filteredAnalyzers.ToImmutable();
 
-                var hostAnalyzerInfo = await _stateManager.GetOrCreateHostAnalyzerInfoAsync(solutionState, project.State, cancellationToken).ConfigureAwait(false);
+                var hostAnalyzerInfo = await StateManager.GetOrCreateHostAnalyzerInfoAsync(solutionState, project.State, cancellationToken).ConfigureAwait(false);
 
                 var projectAnalyzers = analyzers.WhereAsArray(static (a, info) => !info.IsHostAnalyzer(a), hostAnalyzerInfo);
                 var hostAnalyzers = analyzers.WhereAsArray(static (a, info) => info.IsHostAnalyzer(a), hostAnalyzerInfo);

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -76,8 +76,8 @@ internal sealed partial class DiagnosticAnalyzerService
             async Task<(Checksum checksum, ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> diagnosticAnalysisResults)> ComputeForceAnalyzeProjectAsync()
             {
                 var solutionState = project.Solution.SolutionState;
-                var allAnalyzers = await _stateManager.GetOrCreateAnalyzersAsync(solutionState, projectState, cancellationToken).ConfigureAwait(false);
-                var hostAnalyzerInfo = await _stateManager.GetOrCreateHostAnalyzerInfoAsync(solutionState, projectState, cancellationToken).ConfigureAwait(false);
+                var allAnalyzers = await StateManager.GetOrCreateAnalyzersAsync(solutionState, projectState, cancellationToken).ConfigureAwait(false);
+                var hostAnalyzerInfo = await StateManager.GetOrCreateHostAnalyzerInfoAsync(solutionState, projectState, cancellationToken).ConfigureAwait(false);
 
                 var fullSolutionAnalysisAnalyzers = allAnalyzers.WhereAsArray(
                     static (analyzer, arg) => IsCandidateForFullSolutionAnalysis(

--- a/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -12,7 +12,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal interface IRemoteDiagnosticAnalyzerService
 {
+    /// <summary>
+    /// Force analyzes the given project by running all applicable analyzers on the project.
+    /// </summary>
+    ValueTask<ImmutableArray<DiagnosticData>> ForceAnalyzeProjectAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
+
     ValueTask<SerializableDiagnosticAnalysisResults> CalculateDiagnosticsAsync(Checksum solutionChecksum, DiagnosticArguments arguments, CancellationToken cancellationToken);
+
     ValueTask<ImmutableArray<DiagnosticData>> GetSourceGeneratorDiagnosticsAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
     ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -75,6 +75,22 @@ internal sealed class RemoteDiagnosticAnalyzerService(in BrokeredServiceBase.Ser
         }
     }
 
+    public ValueTask<ImmutableArray<DiagnosticData>> ForceAnalyzeProjectAsync(
+        Checksum solutionChecksum,
+        ProjectId projectId,
+        CancellationToken cancellationToken)
+    {
+        return RunWithSolutionAsync(
+            solutionChecksum,
+            async solution =>
+            {
+                var project = solution.GetRequiredProject(projectId);
+                var service = solution.Services.GetRequiredService<IDiagnosticAnalyzerService>();
+                return await service.ForceAnalyzeProjectAsync(project, cancellationToken).ConfigureAwait(false);
+            },
+            cancellationToken);
+    }
+
     public ValueTask<ImmutableArray<DiagnosticData>> GetSourceGeneratorDiagnosticsAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken)
     {
         return RunWithSolutionAsync(


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/79984

The goal here is to allow the DIagService to do all up front work on the host, then as soon as possible make the call over to OOP to do all the actual work.  This ensures that we avoid undesirable work (like making Compilations or CompilationWithAnals) on the host side, and do all compilation/semantic work on the OOP side.