### PR TITLE
Emit telemetry 'durations' with known radix point '.'

### DIFF
--- a/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
+++ b/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,7 +42,7 @@ internal sealed class RoslynProposalAdjusterProvider() : ProposalAdjusterProvide
         // Common properties that all adjustments will log.
         map["ProviderName"] = providerName;
         map["AdjustProposalBeforeDisplay"] = before;
-        map["ComputationTime"] = elapsedTime.TotalMilliseconds.ToString("G17");
+        map["ComputationTime"] = elapsedTime.TotalMilliseconds.ToString("G17", CultureInfo.InvariantCulture);
     }
 
     private async Task<ProposalBase> AdjustProposalAsync(

--- a/src/Features/Core/Portable/Copilot/CopilotChangeAnalysisUtilities.cs
+++ b/src/Features/Core/Portable/Copilot/CopilotChangeAnalysisUtilities.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -116,7 +117,7 @@ internal static class CopilotChangeAnalysisUtilities
             return string.Join(":", strings.OrderBy(v => v));
 
         if (value is TimeSpan timeSpan)
-            return timeSpan.TotalMilliseconds.ToString("G17");
+            return timeSpan.TotalMilliseconds.ToString("G17", CultureInfo.InvariantCulture);
 
         return value.ToString() ?? "";
     }


### PR DESCRIPTION
Emit telemetry 'durations' with known radix point '.'

ISSUE:
Some telemetry "computationtime" values contain a ',' where a '.' is expected.  The resulting conversions to double assume that all of the text digits are part of a very large integer rather than a relatively small double.

Example:
5/4, in some locales, is 1,25; when parsed as an double it becomes 125.  The expectation is 1 1/4 or 5/4 or 1.25.

FIX:
Pass the InvariantCulture where the ToString on the double occurs.