### PR TITLE
Move computation of deprioritized analyzers to oop

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -25,6 +25,10 @@ internal interface IDiagnosticAnalyzerService : IWorkspaceService
     /// <inheritdoc cref="IRemoteDiagnosticAnalyzerService.ForceAnalyzeProjectAsync"/>
     Task<ImmutableArray<DiagnosticData>> ForceAnalyzeProjectAsync(Project project, CancellationToken cancellationToken);
 
+    /// <inheritdoc cref="IRemoteDiagnosticAnalyzerService.GetDeprioritizationCandidatesAsync"/>
+    Task<ImmutableArray<DiagnosticAnalyzer>> GetDeprioritizationCandidatesAsync(
+        Project project, ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken);
+
     /// <summary>
     /// Get diagnostics of the given diagnostic ids and/or analyzers from the given solution. all diagnostics returned
     /// should be up-to-date with respect to the given solution. Note that for project case, this method returns

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -377,6 +378,59 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
         }
 
         return project.Solution.SolutionState.Analyzers.GetDiagnosticDescriptorsPerReference(this._analyzerInfoCache, project);
+    }
+
+    public async Task<ImmutableArray<DiagnosticAnalyzer>> GetDeprioritizationCandidatesAsync(
+        Project project, ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken)
+    {
+        var client = await RemoteHostClient.TryGetClientAsync(project, cancellationToken).ConfigureAwait(false);
+        if (client is not null)
+        {
+            var analyzerIds = analyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
+            var result = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableHashSet<string>>(
+                project,
+                (service, solution, cancellationToken) => service.GetDeprioritizationCandidatesAsync(
+                    solution, project.Id, analyzerIds, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+            if (!result.HasValue)
+                return [];
+
+            return analyzers.FilterAnalyzers(result.Value);
+        }
+
+        using var _ = ArrayBuilder<DiagnosticAnalyzer>.GetInstance(out var builder);
+
+        var hostAnalyzerInfo = await _stateManager.GetOrCreateHostAnalyzerInfoAsync(
+            project.Solution.SolutionState, project.State, cancellationToken).ConfigureAwait(false);
+        var compilationWithAnalyzers = await GetOrCreateCompilationWithAnalyzersAsync(
+            project, analyzers, hostAnalyzerInfo, this.CrashOnAnalyzerException, cancellationToken).ConfigureAwait(false);
+
+        foreach (var analyzer in analyzers)
+        {
+            if (await IsCandidateForDeprioritizationBasedOnRegisteredActionsAsync(analyzer).ConfigureAwait(false))
+                builder.Add(analyzer);
+        }
+
+        return builder.ToImmutableAndClear();
+
+        async Task<bool> IsCandidateForDeprioritizationBasedOnRegisteredActionsAsync(DiagnosticAnalyzer analyzer)
+        {
+            // We deprioritize SymbolStart/End and SemanticModel analyzers from 'Normal' to 'Low' priority bucket,
+            // as these are computationally more expensive.
+            // Note that we never de-prioritize compiler analyzer, even though it registers a SemanticModel action.
+            if (compilationWithAnalyzers == null ||
+                analyzer.IsWorkspaceDiagnosticAnalyzer() ||
+                analyzer.IsCompilerAnalyzer())
+            {
+                return false;
+            }
+
+            var telemetryInfo = await compilationWithAnalyzers.GetAnalyzerTelemetryInfoAsync(analyzer, cancellationToken).ConfigureAwait(false);
+            if (telemetryInfo == null)
+                return false;
+
+            return telemetryInfo.SymbolStartActionsCount > 0 || telemetryInfo.SemanticModelActionsCount > 0;
+        }
     }
 
     private sealed class DiagnosticAnalyzerComparer : IEqualityComparer<DiagnosticAnalyzer>

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -18,44 +18,7 @@ internal sealed partial class DiagnosticAnalyzerService
 {
     private sealed partial class DiagnosticIncrementalAnalyzer
     {
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(
-            Project project,
-            ImmutableArray<DiagnosticAnalyzer> analyzers,
-            DocumentId? documentId,
-            ImmutableHashSet<string>? diagnosticIds,
-            bool includeLocalDocumentDiagnostics,
-            bool includeNonLocalDocumentDiagnostics,
-            CancellationToken cancellationToken)
-        {
-            return ProduceProjectDiagnosticsAsync(
-                project, analyzers, diagnosticIds,
-                // Ensure we compute and return diagnostics for both the normal docs and the additional docs in this
-                // project if no specific document id was requested.
-                documentId != null ? [documentId] : [.. project.DocumentIds, .. project.AdditionalDocumentIds],
-                includeLocalDocumentDiagnostics,
-                includeNonLocalDocumentDiagnostics,
-                // return diagnostics specific to one project or document
-                includeProjectNonLocalResult: documentId == null,
-                cancellationToken);
-        }
-
-        public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(
-            Project project,
-            ImmutableArray<DiagnosticAnalyzer> analyzers,
-            ImmutableHashSet<string>? diagnosticIds,
-            bool includeNonLocalDocumentDiagnostics,
-            CancellationToken cancellationToken)
-        {
-            return ProduceProjectDiagnosticsAsync(
-               project, analyzers, diagnosticIds,
-               documentIds: [],
-               includeLocalDocumentDiagnostics: false,
-               includeNonLocalDocumentDiagnostics: includeNonLocalDocumentDiagnostics,
-               includeProjectNonLocalResult: true,
-               cancellationToken);
-        }
-
-        private async Task<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(
+        public async Task<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(
             Project project,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             ImmutableHashSet<string>? diagnosticIds,

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -22,7 +22,7 @@ internal sealed partial class DiagnosticAnalyzerService
             Project project,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             ImmutableHashSet<string>? diagnosticIds,
-            IReadOnlyList<DocumentId> documentIds,
+            ImmutableArray<DocumentId> documentIds,
             bool includeLocalDocumentDiagnostics,
             bool includeNonLocalDocumentDiagnostics,
             bool includeProjectNonLocalResult,

--- a/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -264,7 +264,7 @@ internal sealed partial class DiagnosticAnalyzerService
 
             bool TryDeprioritizeAnalyzer(
                 DiagnosticAnalyzer analyzer, AnalysisKind kind, TextSpan? span,
-                HashSet<DiagnosticAnalyzer> deprioritizedAnalyzers)
+                HashSet<DiagnosticAnalyzer> deprioritizationCandidates)
             {
                 // PERF: In order to improve lightbulb performance, we perform de-prioritization optimization for certain analyzers
                 // that moves the analyzer to a lower priority bucket. However, to ensure that de-prioritization happens for very rare cases,
@@ -287,7 +287,7 @@ internal sealed partial class DiagnosticAnalyzerService
 
                 // Condition 3.
                 // Check if this is a candidate analyzer that can be de-prioritized into a lower priority bucket based on registered actions.
-                if (!deprioritizedAnalyzers.Contains(analyzer))
+                if (!deprioritizationCandidates.Contains(analyzer))
                     return false;
 
                 // 'LightbulbSkipExecutingDeprioritizedAnalyzers' option determines if we want to execute this analyzer

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -568,4 +568,20 @@ internal static partial class Extensions
 
         return false;
     }
+
+    public static ImmutableArray<DiagnosticAnalyzer> FilterAnalyzers(
+        this ImmutableArray<DiagnosticAnalyzer> analyzers,
+        ImmutableHashSet<string> analyzerIds)
+    {
+        using var _ = PooledDictionary<string, DiagnosticAnalyzer>.GetInstance(out var analyzerMap);
+        foreach (var analyzer in analyzers)
+        {
+            // In the case of multiple analyzers with the same ID, we keep the last one.
+            var analyzerId = analyzer.GetAnalyzerId();
+            if (analyzerIds.Contains(analyzerId))
+                analyzerMap[analyzerId] = analyzer;
+        }
+
+        return [.. analyzerMap.Values];
+    }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
@@ -16,6 +17,17 @@ internal interface IRemoteDiagnosticAnalyzerService
     /// Force analyzes the given project by running all applicable analyzers on the project.
     /// </summary>
     ValueTask<ImmutableArray<DiagnosticData>> ForceAnalyzeProjectAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the analyzers that are candidates to be de-prioritized to
+    /// <see cref="CodeActionRequestPriority.Low"/> priority for improvement in analyzer
+    /// execution performance for priority buckets above 'Low' priority.
+    /// Based on performance measurements, currently only analyzers which register SymbolStart/End actions
+    /// or SemanticModel actions are considered candidates to be de-prioritized. However, these semantics
+    /// could be changed in future based on performance measurements.
+    /// </summary>
+    ValueTask<ImmutableHashSet<string>> GetDeprioritizationCandidatesAsync(
+        Checksum solutionChecksum, ProjectId projectId, ImmutableHashSet<string> analyzerIds, CancellationToken cancellationToken);
 
     ValueTask<SerializableDiagnosticAnalysisResults> CalculateDiagnosticsAsync(Checksum solutionChecksum, DiagnosticArguments arguments, CancellationToken cancellationToken);
     ValueTask<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(

--- a/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -18,6 +18,15 @@ internal interface IRemoteDiagnosticAnalyzerService
     ValueTask<ImmutableArray<DiagnosticData>> ForceAnalyzeProjectAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
 
     ValueTask<SerializableDiagnosticAnalysisResults> CalculateDiagnosticsAsync(Checksum solutionChecksum, DiagnosticArguments arguments, CancellationToken cancellationToken);
+    ValueTask<ImmutableArray<DiagnosticData>> ProduceProjectDiagnosticsAsync(
+        Checksum solutionChecksum, ProjectId projectId,
+        ImmutableHashSet<string> analyzerIds,
+        ImmutableHashSet<string>? diagnosticIds,
+        ImmutableArray<DocumentId> documentIds,
+        bool includeLocalDocumentDiagnostics,
+        bool includeNonLocalDocumentDiagnostics,
+        bool includeProjectNonLocalResult,
+        CancellationToken cancellationToken);
 
     ValueTask<ImmutableArray<DiagnosticData>> GetSourceGeneratorDiagnosticsAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
     ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis, CancellationToken cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticAnalyzerExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticAnalyzerExtensions.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.PooledObjects;
-
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal static class CompilerDiagnosticAnalyzerNames

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticAnalyzerExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticAnalyzerExtensions.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.PooledObjects;
+
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal static class CompilerDiagnosticAnalyzerNames


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/79986.

This code needs the COmpilationWithAnalyzers value.  And we want to only make that in oop.

Due to the compelxity of this api (reordering analyzers to run) a lot of hte code still needs to live on the host side.