### PR TITLE
Allow AnalyzerAssemblyLoader to be collectible

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/CompilerResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CompilerResolverTests.cs
@@ -34,7 +34,7 @@ public sealed class CompilerResolverTests : IDisposable
         CompilerContext = new AssemblyLoadContext(nameof(CompilerResolverTests), isCollectible: true);
         AssemblyInCompilerContext = CompilerContext.LoadFromAssemblyPath(typeof(AnalyzerAssemblyLoader).Assembly.Location);
         ScratchContext = new AssemblyLoadContext("Scratch", isCollectible: true);
-        Loader = new AnalyzerAssemblyLoader([], [AnalyzerAssemblyLoader.DiskAnalyzerAssemblyResolver], CompilerContext);
+        Loader = new AnalyzerAssemblyLoader([], [AnalyzerAssemblyLoader.DiskAnalyzerAssemblyResolver], CompilerContext, isCollectible: false);
     }
 
     public void Dispose()

--- a/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     throw ExceptionUtilities.Unreachable();
             }
 
-            var loader = new AnalyzerAssemblyLoader(pathResolvers, assemblyResolvers, compilerLoadContext: null);
+            var loader = new AnalyzerAssemblyLoader(pathResolvers, assemblyResolvers, compilerLoadContext: null, isCollectible: false);
             var compilerContextAssemblies = loader.CompilerLoadContext.Assemblies.SelectAsArray(a => a.FullName);
             try
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -407,7 +407,8 @@ namespace Microsoft.CodeAnalysis
             string windowsShadowPath,
             ImmutableArray<IAnalyzerPathResolver> pathResolvers = default,
             ImmutableArray<IAnalyzerAssemblyResolver> assemblyResolvers = default,
-            System.Runtime.Loader.AssemblyLoadContext? compilerLoadContext = null)
+            System.Runtime.Loader.AssemblyLoadContext? compilerLoadContext = null,
+            bool isCollectible = false)
         {
             CodeAnalysisEventSource.Log.CreateNonLockingLoader(windowsShadowPath);
             pathResolvers = pathResolvers.NullToEmpty();
@@ -424,7 +425,8 @@ namespace Microsoft.CodeAnalysis
                 return new AnalyzerAssemblyLoader(
                     pathResolvers,
                     [.. assemblyResolvers, StreamResolver.Instance],
-                    compilerLoadContext);
+                    compilerLoadContext,
+                    isCollectible);
             }
 
             // The goal here is to avoid locking files on disk that are reasonably expected to be changed by 
@@ -434,7 +436,8 @@ namespace Microsoft.CodeAnalysis
             return new AnalyzerAssemblyLoader(
                 [.. pathResolvers, ProgramFilesAnalyzerPathResolver.Instance, new ShadowCopyAnalyzerPathResolver(windowsShadowPath)],
                 [.. assemblyResolvers, DiskResolver.Instance],
-                compilerLoadContext);
+                compilerLoadContext,
+                isCollectible);
         }
 
 #else

--- a/src/Features/Core/Portable/Extensions/IExtensionAssemblyLoaderProvider.cs
+++ b/src/Features/Core/Portable/Extensions/IExtensionAssemblyLoaderProvider.cs
@@ -54,7 +54,7 @@ internal sealed class DefaultExtensionAssemblyLoaderProviderFactory() : IWorkspa
             // These lines should always succeed.  If they don't, they indicate a bug in our code that we want
             // to bubble out as it must be fixed.
             var analyzerAssemblyLoaderProvider = _workspaceServices.GetRequiredService<IAnalyzerAssemblyLoaderProvider>();
-            var analyzerAssemblyLoader = analyzerAssemblyLoaderProvider.CreateNewShadowCopyLoader();
+            var analyzerAssemblyLoader = analyzerAssemblyLoaderProvider.CreateNewShadowCopyLoader(isCollectible: true);
 
             // Catch exceptions here related to working with the file system.  If we can't properly enumerate,
             // we want to report that back to the client, while not blocking the entire extension service.

--- a/src/Tools/ExternalAccess/RazorTest/RazorAnalyzerAssemblyResolverTests.cs
+++ b/src/Tools/ExternalAccess/RazorTest/RazorAnalyzerAssemblyResolverTests.cs
@@ -16,8 +16,8 @@ using System.Threading.Tasks;
 using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Roslyn.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.UnitTests;
@@ -76,7 +76,7 @@ public sealed class RazorAnalyzerAssemblyResolverTests : IDisposable
     {
         var compilerLoadContext = new AssemblyLoadContext("Compiler", isCollectible: true);
         var currentLoadContext = new AssemblyLoadContext("Current", isCollectible: true);
-        var loader = new AnalyzerAssemblyLoader([], [AnalyzerAssemblyLoader.DiskAnalyzerAssemblyResolver], compilerLoadContext);
+        var loader = new AnalyzerAssemblyLoader([], [AnalyzerAssemblyLoader.DiskAnalyzerAssemblyResolver], compilerLoadContext, isCollectible: false);
 #pragma warning disable 612 
         var resolver = CreateResolver();
 #pragma warning restore 612 

--- a/src/Workspaces/Remote/ServiceHubTest/RemoteAnalyzerAssemblyLoaderTests.cs
+++ b/src/Workspaces/Remote/ServiceHubTest/RemoteAnalyzerAssemblyLoaderTests.cs
@@ -19,7 +19,8 @@ public sealed class RemoteAnalyzerAssemblyLoaderTests
     private static AnalyzerAssemblyLoader Create(string baseDirectory) => new(
         [new RemoteAnalyzerPathResolver(baseDirectory)],
         [AnalyzerAssemblyLoader.StreamAnalyzerAssemblyResolver],
-        compilerLoadContext: null);
+        compilerLoadContext: null,
+        isCollectible: false);
 
     [Fact]
     public void NonIdeAnalyzerAssemblyShouldBeLoadedInSeparateALC()


### PR DESCRIPTION
Some scenario where AnalyzerAssemblyLoader was useds, such as Extensions, relied on the ALC to be collectible.