### PR TITLE
msbuild dogfood

### DIFF
--- a/eng/pipelines/variables-build.yml
+++ b/eng/pipelines/variables-build.yml
@@ -13,3 +13,7 @@ variables:
   value: 1
 - name: MSBUILDDEBUGPATH
   value: '$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configuration }}/MSBuild.comm.log'
+- name: DOTNET_CLI_USE_MSBUILD_SERVER
+  value: 1
+- name: MSBUILDUSESERVER
+  value: 1


### PR DESCRIPTION
## [msbuild - 12119](https://github.com/dotnet/msbuild/issues/12119)

We're moving forward with our MSBuild server rollout effort and for that we would like to first dogfood it in our partner repositories.
Please help me with dogfooding server in roslyn pipelines.
Currently we've verified that local developer loop is without issue, aspnetcore is dogfooding it for a while now and I've recently managed to get a passing run in sdk so we're relatively confident it is reasonably safe.

I've looked through the pipeline files and these locations look reasonable. If the variables should be set somewhere else, please let me know so that I can adjust the PR.

For the first attempt, I'm setting both 
MSBUILDUSESERVER
and
DOTNET_CLI_USE_MSBUILD_SERVER
because there were some issues with sdk cli overwriting the MSBUILDUSESERVER in some cases.