### PR TITLE
Cleanup methods in DiagAnalyzerService

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.ProjectStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.ProjectStates.cs
@@ -53,16 +53,12 @@ internal sealed partial class DiagnosticAnalyzerService
     private ProjectAnalyzerInfo CreateProjectAnalyzerInfo(Project project)
     {
         if (project.AnalyzerReferences.Count == 0)
-        {
             return ProjectAnalyzerInfo.Default;
-        }
 
         var solutionAnalyzers = project.Solution.SolutionState.Analyzers;
         var analyzersPerReference = solutionAnalyzers.CreateProjectDiagnosticAnalyzersPerReference(project.State);
         if (analyzersPerReference.Count == 0)
-        {
             return ProjectAnalyzerInfo.Default;
-        }
 
         var (newHostAnalyzers, newAllAnalyzers) = PartitionAnalyzers(
             [.. analyzersPerReference.Values], hostAnalyzerCollection: [], includeWorkspacePlaceholderAnalyzers: false);

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
@@ -144,12 +144,12 @@ internal sealed partial class DiagnosticAnalyzerService
         }
     }
 
-    public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(
+    public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(
         Project project, DocumentId? documentId, ImmutableHashSet<string>? diagnosticIds, Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer, bool includeLocalDocumentDiagnostics, bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
     {
         var analyzers = GetDiagnosticAnalyzers(project, diagnosticIds, shouldIncludeAnalyzer);
 
-        return await ProduceProjectDiagnosticsAsync(
+        return ProduceProjectDiagnosticsAsync(
             project, analyzers, diagnosticIds,
             // Ensure we compute and return diagnostics for both the normal docs and the additional docs in this
             // project if no specific document id was requested.
@@ -158,23 +158,23 @@ internal sealed partial class DiagnosticAnalyzerService
             includeNonLocalDocumentDiagnostics,
             // return diagnostics specific to one project or document
             includeProjectNonLocalResult: documentId == null,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken);
     }
 
-    public async Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(
+    public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(
         Project project, ImmutableHashSet<string>? diagnosticIds,
         Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer,
         bool includeNonLocalDocumentDiagnostics, CancellationToken cancellationToken)
     {
         var analyzers = GetDiagnosticAnalyzers(project, diagnosticIds, shouldIncludeAnalyzer);
 
-        return await ProduceProjectDiagnosticsAsync(
+        return ProduceProjectDiagnosticsAsync(
             project, analyzers, diagnosticIds,
             documentIds: [],
             includeLocalDocumentDiagnostics: false,
             includeNonLocalDocumentDiagnostics: includeNonLocalDocumentDiagnostics,
             includeProjectNonLocalResult: true,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken);
     }
 
     public TestAccessor GetTestAccessor()

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
@@ -187,6 +187,6 @@ internal sealed partial class DiagnosticAnalyzerService
 
         public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeProjectInProcessAsync(
             Project project, CompilationWithAnalyzersPair compilationWithAnalyzers, bool logPerformanceInfo, bool getTelemetryInfo, CancellationToken cancellationToken)
-            => service.AnalyzeProjectInProcessAsync(project, compilationWithAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+            => service.AnalyzeInProcessAsync(documentAnalysisScope: null, project, compilationWithAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_ComputeDiagnosticAnalysisResults.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_ComputeDiagnosticAnalysisResults.cs
@@ -97,8 +97,8 @@ internal sealed partial class DiagnosticAnalyzerService
                     || compilationWithAnalyzers?.HostAnalyzers.Length > 0)
                 {
                     // calculate regular diagnostic analyzers diagnostics
-                    var resultMap = await this.AnalyzeProjectInProcessAsync(
-                        project, compilationWithAnalyzers, logPerformanceInfo: false, getTelemetryInfo: true, cancellationToken).ConfigureAwait(false);
+                    var resultMap = await this.AnalyzeInProcessAsync(
+                        documentAnalysisScope: null, project, compilationWithAnalyzers, logPerformanceInfo: false, getTelemetryInfo: true, cancellationToken).ConfigureAwait(false);
 
                     result = resultMap.AnalysisResult;
 

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CoreAnalyze.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CoreAnalyze.cs
@@ -19,14 +19,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal sealed partial class DiagnosticAnalyzerService
 {
-    private Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeProjectInProcessAsync(
-        Project project,
-        CompilationWithAnalyzersPair compilationWithAnalyzers,
-        bool logPerformanceInfo,
-        bool getTelemetryInfo,
-        CancellationToken cancellationToken)
-        => AnalyzeInProcessAsync(documentAnalysisScope: null, project, compilationWithAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
-
     private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeInProcessAsync(
         DocumentAnalysisScope? documentAnalysisScope,
         Project project,

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CoreAnalyze.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CoreAnalyze.cs
@@ -19,14 +19,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal sealed partial class DiagnosticAnalyzerService
 {
-    private Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeDocumentInProcessAsync(
-        DocumentAnalysisScope documentAnalysisScope,
-        CompilationWithAnalyzersPair compilationWithAnalyzers,
-        bool logPerformanceInfo,
-        bool getTelemetryInfo,
-        CancellationToken cancellationToken)
-        => AnalyzeInProcessAsync(documentAnalysisScope, documentAnalysisScope.TextDocument.Project, compilationWithAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
-
     private Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeProjectInProcessAsync(
         Project project,
         CompilationWithAnalyzersPair compilationWithAnalyzers,

--- a/src/Features/Core/Portable/Diagnostics/Service/DocumentAnalysisExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DocumentAnalysisExecutor.cs
@@ -70,7 +70,8 @@ internal sealed partial class DiagnosticAnalyzerService
         /// <summary>
         /// Return all local diagnostics (syntax, semantic) that belong to given document for the given analyzer by calculating them.
         /// </summary>
-        public async Task<ImmutableArray<DiagnosticData>> ComputeDiagnosticsInProcessAsync(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
+        public async Task<ImmutableArray<DiagnosticData>> ComputeDiagnosticsInProcessAsync(
+            DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(AnalysisScope.ProjectAnalyzers.Contains(analyzer) || AnalysisScope.HostAnalyzers.Contains(analyzer));
 
@@ -151,7 +152,8 @@ internal sealed partial class DiagnosticAnalyzerService
             return diagnostics;
         }
 
-        private async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> GetAnalysisResultInProcessAsync(DocumentAnalysisScope analysisScope, CancellationToken cancellationToken)
+        private async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> GetAnalysisResultInProcessAsync(
+            DocumentAnalysisScope analysisScope, CancellationToken cancellationToken)
         {
             RoslynDebug.Assert(_compilationWithAnalyzers != null);
 

--- a/src/Features/Core/Portable/Diagnostics/Service/DocumentAnalysisExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DocumentAnalysisExecutor.cs
@@ -157,8 +157,8 @@ internal sealed partial class DiagnosticAnalyzerService
 
             try
             {
-                var resultAndTelemetry = await _diagnosticAnalyzerService.AnalyzeDocumentInProcessAsync(
-                    analysisScope, _compilationWithAnalyzers, _logPerformanceInfo, getTelemetryInfo: false, cancellationToken).ConfigureAwait(false);
+                var resultAndTelemetry = await _diagnosticAnalyzerService.AnalyzeInProcessAsync(
+                    analysisScope, analysisScope.TextDocument.Project, _compilationWithAnalyzers, _logPerformanceInfo, getTelemetryInfo: false, cancellationToken).ConfigureAwait(false);
                 return resultAndTelemetry.AnalysisResult;
             }
             catch when (_onAnalysisException != null)


### PR DESCRIPTION
General idea here was to move auxiliary helpers into their singular calling methods, and inline simple forwarders.