### PR TITLE
Use apphost for core compiler

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,6 +125,10 @@ parameters:
     default:
       name: $(PoolName)
       demands: ImageOverride -equals $(WindowsQueueName)
+  - name: macOSPool
+    type: object
+    default:
+      vmImage: macOS-15
   - name: vs2022PreviewPool
     type: object
     default:
@@ -169,6 +173,16 @@ stages:
       jobName: Build_Unix_Debug
       testArtifactName: Transport_Artifacts_Unix_Debug
       poolParameters: ${{ parameters.ubuntuPool }}
+
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - stage: MacOS_Build
+    dependsOn: []
+    jobs:
+    - template: eng/pipelines/build-unix-job.yml
+      parameters:
+        jobName: Build_macOS_Debug
+        testArtifactName: Transport_Artifacts_macOS_Debug
+        poolParameters: ${{ parameters.macOSPool }}
 
 - stage: Source_Build
   dependsOn: []
@@ -370,14 +384,19 @@ stages:
         testArguments: --testCoreClr
         poolParameters: ${{ parameters.ubuntuPool }}
 
-  # https://github.com/dotnet/runtime/issues/97186
-  # Disabled until runtime can track down the crash
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - stage: MacOS_Debug_CoreClr
+    dependsOn: MacOS_Build
+    variables:
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - group: DotNet-HelixApi-Access
+    jobs:
+    # https://github.com/dotnet/runtime/issues/97186
     - template: eng/pipelines/test-unix-job.yml
       parameters:
         testRunName: 'Test macOS Debug'
         jobName: Test_macOS_Debug
-        testArtifactName: Transport_Artifacts_Unix_Debug
+        testArtifactName: Transport_Artifacts_macOS_Debug
         configuration: Debug
         testArguments: --testCoreClr 
         helixQueueName: $(HelixMacOsQueueName)

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -341,6 +341,7 @@ function GetCompilerTestAssembliesIncludePaths {
   assemblies+=" --include '^Microsoft\.CodeAnalysis\.VisualBasic\.Emit\.UnitTests$'"
   assemblies+=" --include '^Roslyn\.Compilers\.VisualBasic\.IOperation\.UnitTests$'"
   assemblies+=" --include '^Microsoft\.CodeAnalysis\.VisualBasic\.CommandLine\.UnitTests$'"
+  assemblies+=" --include '^Microsoft\.Build\.Tasks\.CodeAnalysis\.UnitTests$'"
   echo "$assemblies"
 }
 

--- a/src/Compilers/CSharp/csc/AnyCpu/csc.csproj
+++ b/src/Compilers/CSharp/csc/AnyCpu/csc.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
-    <UseAppHost>false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>
   

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -16,8 +16,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     public abstract class InteractiveCompiler : ManagedToolTask
     {
-        internal readonly PropertyDictionary _store = new PropertyDictionary();
-
         public InteractiveCompiler()
             : base(ErrorString.ResourceManager)
         {

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -182,14 +182,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #region Tool Members
 
-        protected sealed override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands, object? logger)
+        protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
             if (ProvideCommandLineArgs)
             {
                 CommandLineArgs = GenerateCommandLineArgsTaskItems(responseFileCommands);
             }
 
-            return (SkipInteractiveExecution) ? 0 : base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+            return (SkipInteractiveExecution) ? 0 : base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
         }
 
         #endregion

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -182,14 +182,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #region Tool Members
 
-        protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
+        protected sealed override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands, object? logger)
         {
             if (ProvideCommandLineArgs)
             {
                 CommandLineArgs = GenerateCommandLineArgsTaskItems(responseFileCommands);
             }
 
-            return (SkipInteractiveExecution) ? 0 : base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+            return (SkipInteractiveExecution) ? 0 : base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
         }
 
         #endregion

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -51,7 +51,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         private CancellationTokenSource? _sharedCompileCts;
-        internal readonly PropertyDictionary _store = new PropertyDictionary();
 
         internal abstract RequestLanguage Language { get; }
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -503,16 +503,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return GenerateFullPathToTool();
         }
 
-        protected override object? CreateServerLogger()
+        protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
             using var innerLogger = new CompilerServerLogger($"MSBuild {Process.GetCurrentProcess().Id}");
-            return new TaskCompilerServerLogger(Log, innerLogger);
-        }
-
-        protected sealed override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands, object? logger)
-        {
-            Debug.Assert(logger is ICompilerServerLogger);
-            return ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, (ICompilerServerLogger)logger);
+            var logger = new TaskCompilerServerLogger(Log, innerLogger);
+            return ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
         }
 
         internal int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands, ICompilerServerLogger logger)
@@ -539,7 +534,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     !BuildServerConnection.IsCompilerServerSupported)
                 {
                     LogCompilationMessage(logger, requestId, CompilationKind.Tool, $"using command line tool by design '{pathToTool}'");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 
                 _sharedCompileCts = new CancellationTokenSource();
@@ -550,7 +545,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 if (clientDirectory is null || tempDirectory is null)
                 {
                     LogCompilationMessage(logger, requestId, CompilationKind.Tool, $"using command line tool because we could not find client or temp directory '{PathToBuiltInTool}'");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 
                 // Note: using ToolArguments here (the property) since
@@ -687,7 +682,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             if (response is null)
             {
                 LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, "could not launch server");
-                return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
             }
 
             switch (response.Type)
@@ -700,30 +695,30 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                 case BuildResponse.ResponseType.MismatchedVersion:
                     LogCompilationMessage(logger, requestId, CompilationKind.FatalError, "server reports different protocol version than build task");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.IncorrectHash:
                     LogCompilationMessage(logger, requestId, CompilationKind.FatalError, "server reports different hash version than build task");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.CannotConnect:
                     LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"cannot connect to the server");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.Rejected:
                     var rejectedResponse = (RejectedBuildResponse)response;
                     LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"server rejected the request '{rejectedResponse.Reason}'");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.AnalyzerInconsistency:
                     var analyzerResponse = (AnalyzerInconsistencyBuildResponse)response;
                     var combinedMessage = string.Join(", ", analyzerResponse.ErrorMessages.ToArray());
                     LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"server rejected the request due to analyzer / generator issues '{combinedMessage}'");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 default:
                     LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"server gave an unrecognized response");
-                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
             }
         }
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected sealed override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands, object? logger)
         {
-            Debug.Assert(logger != null);
+            Debug.Assert(logger is ICompilerServerLogger);
             return ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, (ICompilerServerLogger)logger);
         }
 

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// It returns the name of the managed assembly, which might not be the path returned by
         /// GenerateFullPathToTool, which can return the path to e.g. the dotnet executable.
         /// </remarks>
-        protected sealed override string ToolName => $"{ToolNameWithoutExtension}{PlatformInformation.Exe}";
+        protected sealed override string ToolName => $"{ToolNameWithoutExtension}{PlatformInformation.ExeExtension}";
 
         /// <summary>
         /// This generates the command line arguments passed to the tool.
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             var logger = CreateServerLogger();
 
-            // Set DOTNET_ROOT.
+            // Set DOTNET_ROOT so that the apphost executables launch properly.
             if (RuntimeHostInfo.GetToolDotNetRoot() is { } dotNetRoot)
             {
                 (logger as ICompilerServerLogger)?.Log("Setting {0} to '{1}'", RuntimeHostInfo.DotNetRootEnvironmentName, dotNetRoot);

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -197,28 +197,16 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return buildTaskDirectory;
         }
 
-        protected sealed override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
+        protected override bool ValidateParameters()
         {
-            var logger = CreateServerLogger();
-
             // Set DOTNET_ROOT so that the apphost executables launch properly.
             if (RuntimeHostInfo.GetToolDotNetRoot() is { } dotNetRoot)
             {
-                (logger as ICompilerServerLogger)?.Log("Setting {0} to '{1}'", RuntimeHostInfo.DotNetRootEnvironmentName, dotNetRoot);
+                Log.LogMessage("Setting {0} to '{1}'", RuntimeHostInfo.DotNetRootEnvironmentName, dotNetRoot);
                 EnvironmentVariables = [.. EnvironmentVariables ?? [], $"{RuntimeHostInfo.DotNetRootEnvironmentName}={dotNetRoot}"];
             }
 
-            return ExecuteTool(pathToTool, responseFileCommands, commandLineCommands, logger);
-        }
-
-        protected virtual object? CreateServerLogger()
-        {
-            return null;
-        }
-
-        protected virtual int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands, object? logger)
-        {
-            return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+            return base.ValidateParameters();
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -484,14 +485,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc.ToolExe = "";
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
             Assert.Equal("", csc.GenerateCommandLineContents());
-            // StartsWith because it can be csc.exe or csc.dll
-            Assert.StartsWith(Path.Combine("path", "to", "custom_csc", "csc."), csc.GeneratePathToTool());
+            AssertEx.Equal(Path.Combine("path", "to", "custom_csc", $"csc{PlatformInformation.Exe}"), csc.GeneratePathToTool());
 
             csc = new Csc();
             csc.ToolPath = Path.Combine("path", "to", "custom_csc");
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
             Assert.Equal("", csc.GenerateCommandLineContents());
-            Assert.StartsWith(Path.Combine("path", "to", "custom_csc", "csc."), csc.GeneratePathToTool());
+            AssertEx.Equal(Path.Combine("path", "to", "custom_csc", $"csc{PlatformInformation.Exe}"), csc.GeneratePathToTool());
         }
 
         [Fact]
@@ -565,7 +565,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.cs"),
-                UseDotNetHost = true,
             };
 
             TaskTestUtil.AssertCommandLine(csc, engine, "/out:test.exe", "test.cs");
@@ -579,8 +578,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.cs", "blah.cs"),
-                TargetType = "library",
-                UseDotNetHost = true,
+                TargetType = "library"
             };
 
             TaskTestUtil.AssertCommandLine(csc, engine, "/out:test.dll", "/target:library", "test.cs", "blah.cs");
@@ -622,7 +620,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                     Sources = MSBuildUtil.CreateTaskItems("test.cs"),
                     TargetType = "library",
                     References = [SimpleTaskItem.CreateReference(refText, alias: alias, embedInteropTypes)],
-                    UseDotNetHost = true,
                 };
 
                 TaskTestUtil.AssertCommandLine(csc, engine, [.. expectedArgs, "/out:test.dll", "/target:library", "test.cs"]);

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -485,13 +485,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc.ToolExe = "";
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
             Assert.Equal("", csc.GenerateCommandLineContents());
-            AssertEx.Equal(Path.Combine("path", "to", "custom_csc", $"csc{PlatformInformation.Exe}"), csc.GeneratePathToTool());
+            AssertEx.Equal(Path.Combine("path", "to", "custom_csc", $"csc{PlatformInformation.ExeExtension}"), csc.GeneratePathToTool());
 
             csc = new Csc();
             csc.ToolPath = Path.Combine("path", "to", "custom_csc");
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
             Assert.Equal("", csc.GenerateCommandLineContents());
-            AssertEx.Equal(Path.Combine("path", "to", "custom_csc", $"csc{PlatformInformation.Exe}"), csc.GeneratePathToTool());
+            AssertEx.Equal(Path.Combine("path", "to", "custom_csc", $"csc{PlatformInformation.ExeExtension}"), csc.GeneratePathToTool());
         }
 
         [Fact]

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -565,6 +565,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.cs"),
+                UseDotNetHost = true,
             };
 
             TaskTestUtil.AssertCommandLine(csc, engine, "/out:test.exe", "test.cs");
@@ -578,7 +579,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.cs", "blah.cs"),
-                TargetType = "library"
+                TargetType = "library",
+                UseDotNetHost = true,
             };
 
             TaskTestUtil.AssertCommandLine(csc, engine, "/out:test.dll", "/target:library", "test.cs", "blah.cs");
@@ -620,6 +622,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                     Sources = MSBuildUtil.CreateTaskItems("test.cs"),
                     TargetType = "library",
                     References = [SimpleTaskItem.CreateReference(refText, alias: alias, embedInteropTypes)],
+                    UseDotNetHost = true,
                 };
 
                 TaskTestUtil.AssertCommandLine(csc, engine, [.. expectedArgs, "/out:test.dll", "/target:library", "test.cs"]);

--- a/src/Compilers/Core/MSBuildTaskTests/IntegrationTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/IntegrationTests.cs
@@ -23,24 +23,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             return ProcessUtilities.Run(file.Path, "", Path.GetDirectoryName(file.Path));
         }
 
-        private static void VerifyResult(ProcessResult result)
-        {
-            Assert.Equal("", result.Output);
-            Assert.Equal("", result.Errors);
-            Assert.Equal(0, result.ExitCode);
-        }
-
-        private void VerifyResultAndOutput(ProcessResult result, TempDirectory path, string expectedOutput)
-        {
-            using (var resultFile = GetResultFile(path, "hello.exe"))
-            {
-                VerifyResult(result);
-
-                var runningResult = RunCompilerOutput(resultFile);
-                Assert.Equal(expectedOutput, runningResult.Output);
-            }
-        }
-
         // A dictionary with name and contents of all the files we want to create for the SimpleMSBuild test.
         private Dictionary<string, string> SimpleMsBuildFiles => new Dictionary<string, string> {
 { "HelloSolution.sln",

--- a/src/Compilers/Core/MSBuildTaskTests/IntegrationTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/IntegrationTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NET472
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -536,7 +535,7 @@ End Class
             string arguments = string.Format(@"/m /nr:false /t:Rebuild /p:UseSharedCompilation=false /p:UseRoslyn=1 HelloSolution.sln");
             var result = RunCommandLineCompiler(_msbuildExecutable, arguments, _tempDirectory, ReportAnalyzerMsBuildFiles,
                 new Dictionary<string, string>
-                { { "MyMSBuildToolsPath", Path.GetDirectoryName(typeof(IntegrationTests).Assembly.Location) } });
+                { { "MyMSBuildToolsPath", Path.GetDirectoryName(typeof(IntegrationTests).Assembly.Location)! } });
 
             Assert.True(result.ExitCode != 0);
             Assert.Contains("/reportanalyzer", result.Output);
@@ -717,4 +716,3 @@ namespace Class____goo____Library1
         }
     }
 }
-#endif

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
@@ -2,23 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
-using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests;
 
 public sealed class MSBuildManagedToolTests
 {
-    [Theory, CombinatorialData]
-    public void PathToBuiltinTool(bool useDotNetHost)
+    [Fact]
+    public void PathToBuiltinTool()
     {
         var taskPath = Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!;
         var relativePath = RuntimeHostInfo.IsCoreClrRuntime
-            ? Path.Combine("bincore", $"csc.{(useDotNetHost ? "dll" : "exe")}")
+            ? Path.Combine("bincore", $"csc{PlatformInformation.Exe}")
             : "csc.exe";
-        var task = new Csc { UseDotNetHost = useDotNetHost };
+        var task = new Csc();
         Assert.Equal(Path.Combine(taskPath, relativePath), task.PathToBuiltInTool);
     }
 

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
@@ -11,14 +11,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests;
 
 public sealed class MSBuildManagedToolTests
 {
-    [Fact]
-    public void PathToBuiltinTool()
+    [Theory, CombinatorialData]
+    public void PathToBuiltinTool(bool useDotNetHost)
     {
         var taskPath = Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!;
         var relativePath = RuntimeHostInfo.IsCoreClrRuntime
-            ? Path.Combine("bincore", "csc.dll")
+            ? Path.Combine("bincore", $"csc.{(useDotNetHost ? "dll" : "exe")}")
             : "csc.exe";
-        var task = new Csc();
+        var task = new Csc { UseDotNetHost = useDotNetHost };
         Assert.Equal(Path.Combine(taskPath, relativePath), task.PathToBuiltInTool);
     }
 

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
@@ -15,7 +15,7 @@ public sealed class MSBuildManagedToolTests
     {
         var taskPath = Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!;
         var relativePath = RuntimeHostInfo.IsCoreClrRuntime
-            ? Path.Combine("bincore", $"csc{PlatformInformation.Exe}")
+            ? Path.Combine("bincore", $"csc{PlatformInformation.ExeExtension}")
             : "csc.exe";
         var task = new Csc();
         Assert.Equal(Path.Combine(taskPath, relativePath), task.PathToBuiltInTool);

--- a/src/Compilers/Core/MSBuildTaskTests/Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj
+++ b/src/Compilers/Core/MSBuildTaskTests/Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj
@@ -69,6 +69,7 @@
   <Target Name="CopyAssetsForIntegrationTests" Condition="'@(CommandLineCompilerReference)' != ''" AfterTargets="ResolveProjectReferences" BeforeTargets="AssignTargetPaths">
     <PropertyGroup>
       <_CommandLineCompilerReferenceOutputPath>@(CommandLineCompilerReference->'%(RootDir)%(Directory)*.*')</_CommandLineCompilerReferenceOutputPath>
+      <_LinkPrefix Condition="'$(TargetFramework)' != 'net472'">bincore\</_LinkPrefix>
     </PropertyGroup>
     <ItemGroup>
       <_CommandLineCompilerReferenceContent Include="$(_CommandLineCompilerReferenceOutputPath)" />
@@ -78,7 +79,7 @@
       <Output TaskParameter="Filtered" ItemName="_CommandLineCompilerReferenceDeduplicated" />
     </RemoveDuplicates>
     <ItemGroup>
-      <Content Include="%(_CommandLineCompilerReferenceDeduplicated.Original)" CopyToOutputDirectory="PreserveNewest" />
+      <Content Include="%(_CommandLineCompilerReferenceDeduplicated.Original)" Link="$(_LinkPrefix)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/IntegrationTestBase.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/IntegrationTestBase.cs
@@ -88,7 +88,7 @@ public abstract class IntegrationTestBase : TestBase
             additionalEnvironmentVars: AddForLoggingEnvironmentVars(additionalEnvironmentVars));
     }
 
-    protected ProcessResult RunMsbuild(
+    protected ProcessResult? RunMsbuild(
         string arguments,
         TempDirectory currentDirectory,
         IEnumerable<KeyValuePair<string, string>> filesInDirectory,
@@ -102,6 +102,13 @@ public abstract class IntegrationTestBase : TestBase
                 currentDirectory,
                 filesInDirectory,
                 additionalEnvironmentVars);
+        }
+
+        if (ExecutionConditionUtil.IsDesktop)
+        {
+            _output.WriteLine("Skipping because Framework MSBuild is missing, this is a desktop test, " +
+                "and we cannot use the desktop Csc/Vbc task from 'dotnet msbuild', i.e., Core MSBuild.");
+            return null;
         }
 
         return RunCommandLineCompiler(
@@ -133,6 +140,9 @@ public abstract class IntegrationTestBase : TestBase
                     </Project>
                     """ },
             });
+
+        if (result == null) return;
+
         _output.WriteLine(result.Output);
 
         Assert.Equal(0, result.ExitCode);
@@ -166,6 +176,9 @@ public abstract class IntegrationTestBase : TestBase
                     </Project>
                     """ },
             });
+
+        if (result == null) return;
+
         _output.WriteLine(result.Output);
 
         Assert.Equal(0, result.ExitCode);

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/IntegrationTestBase.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/IntegrationTestBase.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NET472
-
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -19,10 +16,12 @@ public abstract class IntegrationTestBase : TestBase
 {
     protected static readonly string? s_msbuildDirectory;
 
+#if NET472
     static IntegrationTestBase()
     {
         s_msbuildDirectory = DesktopTestHelpers.GetMSBuildDirectory();
     }
+#endif
 
     protected readonly ITestOutputHelper _output;
     protected readonly string? _msbuildExecutable;
@@ -87,6 +86,92 @@ public abstract class IntegrationTestBase : TestBase
             arguments,
             currentDirectory.Path,
             additionalEnvironmentVars: AddForLoggingEnvironmentVars(additionalEnvironmentVars));
+    }
+
+    protected ProcessResult RunMsbuild(
+        string arguments,
+        TempDirectory currentDirectory,
+        IEnumerable<KeyValuePair<string, string>> filesInDirectory,
+        IEnumerable<KeyValuePair<string, string>>? additionalEnvironmentVars = null)
+    {
+        if (_msbuildExecutable != null)
+        {
+            return RunCommandLineCompiler(
+                _msbuildExecutable,
+                arguments,
+                currentDirectory,
+                filesInDirectory,
+                additionalEnvironmentVars);
+        }
+
+        return RunCommandLineCompiler(
+            "dotnet",
+            $"msbuild {arguments}",
+            currentDirectory,
+            filesInDirectory,
+            additionalEnvironmentVars);
+    }
+
+    [Theory, CombinatorialData]
+    public void SdkBuild_Csc(bool useSharedCompilation)
+    {
+        var result = RunMsbuild(
+            "/v:n /m /nr:false /t:Build /restore Test.csproj",
+            _tempDirectory,
+            new Dictionary<string, string>
+            {
+                { "File.cs", """
+                    class Program { static void Main() { System.Console.WriteLine("Hello from file"); } }
+                    """ },
+                { "Test.csproj", $"""
+                    <Project Sdk="Microsoft.NET.Sdk">
+                        <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc" AssemblyFile="{_buildTaskDll}" />
+                        <PropertyGroup>
+                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <UseSharedCompilation>{useSharedCompilation}</UseSharedCompilation>
+                        </PropertyGroup>
+                    </Project>
+                    """ },
+            });
+        _output.WriteLine(result.Output);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(useSharedCompilation ? "server processed compilation" : "using command line tool by design", result.Output);
+        Assert.DoesNotContain("csc.dll", result.Output);
+        Assert.Contains(ExecutionConditionUtil.IsWindows ? "csc.exe" : "csc", result.Output);
+    }
+
+    [Theory, CombinatorialData]
+    public void SdkBuild_Vbc(bool useSharedCompilation)
+    {
+        var result = RunMsbuild(
+            "/v:n /m /nr:false /t:Build /restore Test.vbproj",
+            _tempDirectory,
+            new Dictionary<string, string>
+            {
+                { "File.cs", """
+                    Public Module Program
+                        Public Sub Main()
+                            System.Console.WriteLine("Hello from file")
+                        End Sub
+                    End Module
+                    """ },
+                { "Test.vbproj", $"""
+                    <Project Sdk="Microsoft.NET.Sdk">
+                        <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc" AssemblyFile="{_buildTaskDll}" />
+                        <PropertyGroup>
+                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <UseSharedCompilation>{useSharedCompilation}</UseSharedCompilation>
+                        </PropertyGroup>
+                    </Project>
+                    """ },
+            });
+        _output.WriteLine(result.Output);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(useSharedCompilation ? "server processed compilation" : "using command line tool by design", result.Output);
+        Assert.DoesNotContain("vbc.dll", result.Output);
+        Assert.Contains(ExecutionConditionUtil.IsWindows ? "vbc.exe" : "vbc", result.Output);
     }
 
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/79907")]
@@ -170,5 +255,3 @@ public abstract class IntegrationTestBase : TestBase
         }
     }
 }
-
-#endif

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/IntegrationTestBase.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/IntegrationTestBase.cs
@@ -159,7 +159,7 @@ public abstract class IntegrationTestBase : TestBase
             _tempDirectory,
             new Dictionary<string, string>
             {
-                { "File.cs", """
+                { "File.vb", """
                     Public Module Program
                         Public Sub Main()
                             System.Console.WriteLine("Hello from file")

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
@@ -26,7 +26,7 @@ internal static class TaskTestUtil
         Assert.Equal(expected, task.GenerateCommandLineArgsTaskItems(rsp).Select(x => x.ItemSpec));
 
 #if NET
-        Assert.Equal($"exec \"{task.PathToBuiltInTool}\"", task.GenerateCommandLineContents().Trim());
+        Assert.Empty(task.GenerateCommandLineContents().Trim());
 
         // Can only run the Execute path on .NET Core presently. The internal workings of ToolTask 
         // will fail if it can't find the tool exe and we don't have csc.exe, vbc.exe, etc ... 
@@ -40,7 +40,7 @@ internal static class TaskTestUtil
 
             var message = engine.BuildMessages.OfType<TaskCommandLineEventArgs>().Single();
             var commandLine = message.CommandLine.Replace("  ", " ").Trim();
-            Assert.Equal($@"{RuntimeHostInfo.GetDotNetPathOrDefault()} exec ""{task.PathToBuiltInTool}"" {line}", commandLine);
+            AssertEx.Equal($@"{task.PathToBuiltInTool} {line}", commandLine);
 
             compilerTask.NoConfig = true;
             Assert.Equal("/noconfig", compilerTask.GenerateToolArguments());

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -536,7 +536,6 @@ C:\Test Path (123)\hellovb.vb(7) : error BC30451: 'asdf' is not declared. It may
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.vb"),
-                UseDotNetHost = true,
             };
 
             TaskTestUtil.AssertCommandLine(vbc, engine, "/optionstrict:custom", "/out:test.exe", "test.vb");
@@ -550,8 +549,7 @@ C:\Test Path (123)\hellovb.vb(7) : error BC30451: 'asdf' is not declared. It may
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.vb", "blah.vb"),
-                TargetType = "library",
-                UseDotNetHost = true,
+                TargetType = "library"
             };
 
             TaskTestUtil.AssertCommandLine(vbc, engine, "/optionstrict:custom", "/out:test.dll", "/target:library", "test.vb", "blah.vb");

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -536,6 +536,7 @@ C:\Test Path (123)\hellovb.vb(7) : error BC30451: 'asdf' is not declared. It may
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.vb"),
+                UseDotNetHost = true,
             };
 
             TaskTestUtil.AssertCommandLine(vbc, engine, "/optionstrict:custom", "/out:test.exe", "test.vb");
@@ -549,7 +550,8 @@ C:\Test Path (123)\hellovb.vb(7) : error BC30451: 'asdf' is not declared. It may
             {
                 BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.vb", "blah.vb"),
-                TargetType = "library"
+                TargetType = "library",
+                UseDotNetHost = true,
             };
 
             TaskTestUtil.AssertCommandLine(vbc, engine, "/optionstrict:custom", "/out:test.dll", "/target:library", "test.vb", "blah.vb");

--- a/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
@@ -57,5 +57,7 @@ namespace Roslyn.Utilities
                 }
             }
         }
+
+        public static string Exe => IsWindows ? ".exe" : string.Empty;
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
@@ -58,6 +58,6 @@ namespace Roslyn.Utilities
             }
         }
 
-        public static string Exe => IsWindows ? ".exe" : string.Empty;
+        public static string ExeExtension => IsWindows ? ".exe" : string.Empty;
     }
 }

--- a/src/Compilers/Core/SdkTaskTests/Microsoft.Build.Tasks.CodeAnalysis.Sdk.UnitTests.csproj
+++ b/src/Compilers/Core/SdkTaskTests/Microsoft.Build.Tasks.CodeAnalysis.Sdk.UnitTests.csproj
@@ -58,5 +58,6 @@
     <ItemGroup>
       <Content Include="%(_CommandLineCompilerReferenceDeduplicated.Original)" Link="bincore\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
+    <RemoveDir Directories="$(OutDir)..\bincore" Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingProject)' == 'true'" />
   </Target>
 </Project>

--- a/src/Compilers/Core/SdkTaskTests/SdkManagedToolTests.cs
+++ b/src/Compilers/Core/SdkTaskTests/SdkManagedToolTests.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
-using Roslyn.Test.Utilities;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Xunit.Abstractions;
+using Roslyn.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.Sdk.UnitTests;
 
@@ -20,13 +18,12 @@ public sealed class SdkManagedToolTests
         TestOutputHelper = testOutputHelper;
     }
 
-    [Theory, CombinatorialData]
-    public void PathToBuiltinTool(bool useDotNetHost)
+    [Fact]
+    public void PathToBuiltinTool()
     {
         var taskPath = Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!;
-        var task = new Csc { UseDotNetHost = useDotNetHost };
-        var ext = useDotNetHost ? "dll" : "exe";
-        Assert.Equal(Path.Combine(taskPath, "..", "bincore", $"csc.{ext}"), task.PathToBuiltInTool);
+        var task = new Csc();
+        Assert.Equal(Path.Combine(taskPath, "..", "bincore", $"csc{PlatformInformation.Exe}"), task.PathToBuiltInTool);
     }
 
     [Fact]

--- a/src/Compilers/Core/SdkTaskTests/SdkManagedToolTests.cs
+++ b/src/Compilers/Core/SdkTaskTests/SdkManagedToolTests.cs
@@ -23,7 +23,7 @@ public sealed class SdkManagedToolTests
     {
         var taskPath = Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!;
         var task = new Csc();
-        Assert.Equal(Path.Combine(taskPath, "..", "bincore", $"csc{PlatformInformation.Exe}"), task.PathToBuiltInTool);
+        Assert.Equal(Path.Combine(taskPath, "..", "bincore", $"csc{PlatformInformation.ExeExtension}"), task.PathToBuiltInTool);
     }
 
     [Fact]

--- a/src/Compilers/Core/SdkTaskTests/SdkManagedToolTests.cs
+++ b/src/Compilers/Core/SdkTaskTests/SdkManagedToolTests.cs
@@ -20,12 +20,13 @@ public sealed class SdkManagedToolTests
         TestOutputHelper = testOutputHelper;
     }
 
-    [Fact]
-    public void PathToBuiltinTool()
+    [Theory, CombinatorialData]
+    public void PathToBuiltinTool(bool useDotNetHost)
     {
         var taskPath = Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!;
-        var task = new Csc();
-        Assert.Equal(Path.Combine(taskPath, "..", "bincore", "csc.dll"), task.PathToBuiltInTool);
+        var task = new Csc { UseDotNetHost = useDotNetHost };
+        var ext = useDotNetHost ? "dll" : "exe";
+        Assert.Equal(Path.Combine(taskPath, "..", "bincore", $"csc.{ext}"), task.PathToBuiltInTool);
     }
 
     [Fact]

--- a/src/Compilers/Server/VBCSCompiler/AnyCpu/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/AnyCpu/VBCSCompiler.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
-    <UseAppHost>false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>
   <Import Project="..\VBCSCompilerCommandLine.projitems" Label="Shared" />

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         [Fact]
         public async Task IncorrectServerHashReturnsIncorrectHashResponse()
         {
-            using var serverData = await ServerUtil.CreateServer(logger: Logger);
+            using var serverData = await ServerUtil.CreateServer(Logger);
             var buildResponse = await serverData.SendAsync(new BuildRequest(RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
             Assert.Equal(BuildResponse.ResponseType.IncorrectHash, buildResponse.Type);
         }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         [Fact]
         public async Task IncorrectServerHashReturnsIncorrectHashResponse()
         {
-            using var serverData = await ServerUtil.CreateServer(Logger);
+            using var serverData = await ServerUtil.CreateServer(logger: Logger);
             var buildResponse = await serverData.SendAsync(new BuildRequest(RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
             Assert.Equal(BuildResponse.ResponseType.IncorrectHash, buildResponse.Type);
         }
@@ -130,9 +130,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public void QuotePipeName_Desktop()
         {
             var serverInfo = BuildServerConnection.GetServerProcessInfo(@"q:\tools", "name with space");
-            // Because q:\tools\VBCSCompiler.exe does not exist, the fallback 'dotnet exec VBCSCompiler.dll' is returned.
-            Assert.EndsWith(@"\dotnet.exe", serverInfo.processFilePath);
-            Assert.Equal(@"exec ""q:\tools\VBCSCompiler.dll"" ""-pipename:name with space""", serverInfo.commandLineArguments);
+            AssertEx.Equal(@"q:\tools\VBCSCompiler.exe", serverInfo.processFilePath);
+            AssertEx.Equal(@"""-pipename:name with space""", serverInfo.commandLineArguments);
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]
@@ -144,7 +143,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 : "/tools";
             var serverInfo = BuildServerConnection.GetServerProcessInfo(toolDir, "name with space");
             var vbcsFilePath = Path.Combine(toolDir, "VBCSCompiler.dll");
-            Assert.Equal($@"exec ""{vbcsFilePath}"" ""-pipename:name with space""", serverInfo.commandLineArguments);
+            AssertEx.Equal($@"""-pipename:name with space""", serverInfo.commandLineArguments);
         }
 
         [Theory]

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -432,7 +432,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static (string processFilePath, string commandLineArguments) GetServerProcessInfo(string clientDir, string pipeName)
         {
-            var processFilePath = Path.Combine(clientDir, $"VBCSCompiler{PlatformInformation.Exe}");
+            var processFilePath = Path.Combine(clientDir, $"VBCSCompiler{PlatformInformation.ExeExtension}");
             var commandLineArgs = $@"""-pipename:{pipeName}""";
             return (processFilePath, commandLineArgs);
         }

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -432,15 +432,8 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static (string processFilePath, string commandLineArguments) GetServerProcessInfo(string clientDir, string pipeName)
         {
-            var processFilePath = Path.Combine(clientDir, "VBCSCompiler.exe");
+            var processFilePath = Path.Combine(clientDir, $"VBCSCompiler{PlatformInformation.Exe}");
             var commandLineArgs = $@"""-pipename:{pipeName}""";
-            if (!File.Exists(processFilePath))
-            {
-                // This is a .NET Core deployment
-                commandLineArgs = RuntimeHostInfo.GetDotNetExecCommandLine(Path.ChangeExtension(processFilePath, ".dll"), commandLineArgs);
-                processFilePath = RuntimeHostInfo.GetDotNetPathOrDefault();
-            }
-
             return (processFilePath, commandLineArgs);
         }
 
@@ -463,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             logger.Log("Attempting to create process '{0}' {1}", serverInfo.processFilePath, serverInfo.commandLineArguments);
 
             string? previousDotNetRoot = Environment.GetEnvironmentVariable(RuntimeHostInfo.DotNetRootEnvironmentName);
-            if (string.IsNullOrEmpty(previousDotNetRoot) && RuntimeHostInfo.GetDotNetRoot() is { } dotNetRoot)
+            if (RuntimeHostInfo.GetToolDotNetRoot() is { } dotNetRoot)
             {
                 logger.Log("Setting {0} to '{1}'", RuntimeHostInfo.DotNetRootEnvironmentName, dotNetRoot);
                 Environment.SetEnvironmentVariable(RuntimeHostInfo.DotNetRootEnvironmentName, dotNetRoot);

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -462,80 +462,94 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
             logger.Log("Attempting to create process '{0}' {1}", serverInfo.processFilePath, serverInfo.commandLineArguments);
 
-            if (PlatformInformation.IsWindows)
+            string? previousDotNetRoot = Environment.GetEnvironmentVariable(RuntimeHostInfo.DotNetRootEnvironmentName);
+            if (string.IsNullOrEmpty(previousDotNetRoot) && RuntimeHostInfo.GetDotNetRoot() is { } dotNetRoot)
             {
-                // As far as I can tell, there isn't a way to use the Process class to
-                // create a process with no stdin/stdout/stderr, so we use P/Invoke.
-                // This code was taken from MSBuild task starting code.
+                logger.Log("Setting {0} to '{1}'", RuntimeHostInfo.DotNetRootEnvironmentName, dotNetRoot);
+                Environment.SetEnvironmentVariable(RuntimeHostInfo.DotNetRootEnvironmentName, dotNetRoot);
+            }
 
-                STARTUPINFO startInfo = new STARTUPINFO();
-                startInfo.cb = Marshal.SizeOf(startInfo);
-                startInfo.hStdError = InvalidIntPtr;
-                startInfo.hStdInput = InvalidIntPtr;
-                startInfo.hStdOutput = InvalidIntPtr;
-                startInfo.dwFlags = STARTF_USESTDHANDLES;
-                uint dwCreationFlags = NORMAL_PRIORITY_CLASS | CREATE_NO_WINDOW;
-
-                PROCESS_INFORMATION processInfo;
-
-                var builder = new StringBuilder($@"""{serverInfo.processFilePath}"" {serverInfo.commandLineArguments}");
-
-                bool success = CreateProcess(
-                    lpApplicationName: null,
-                    lpCommandLine: builder,
-                    lpProcessAttributes: NullPtr,
-                    lpThreadAttributes: NullPtr,
-                    bInheritHandles: false,
-                    dwCreationFlags: dwCreationFlags,
-                    lpEnvironment: NullPtr, // Inherit environment
-                    lpCurrentDirectory: clientDirectory,
-                    lpStartupInfo: ref startInfo,
-                    lpProcessInformation: out processInfo);
-
-                if (success)
+            try
+            {
+                if (PlatformInformation.IsWindows)
                 {
-                    logger.Log("Successfully created process with process id {0}", processInfo.dwProcessId);
-                    CloseHandle(processInfo.hProcess);
-                    CloseHandle(processInfo.hThread);
-                    processId = processInfo.dwProcessId;
+                    // As far as I can tell, there isn't a way to use the Process class to
+                    // create a process with no stdin/stdout/stderr, so we use P/Invoke.
+                    // This code was taken from MSBuild task starting code.
+
+                    STARTUPINFO startInfo = new STARTUPINFO();
+                    startInfo.cb = Marshal.SizeOf(startInfo);
+                    startInfo.hStdError = InvalidIntPtr;
+                    startInfo.hStdInput = InvalidIntPtr;
+                    startInfo.hStdOutput = InvalidIntPtr;
+                    startInfo.dwFlags = STARTF_USESTDHANDLES;
+                    uint dwCreationFlags = NORMAL_PRIORITY_CLASS | CREATE_NO_WINDOW;
+
+                    PROCESS_INFORMATION processInfo;
+
+                    var builder = new StringBuilder($@"""{serverInfo.processFilePath}"" {serverInfo.commandLineArguments}");
+
+                    bool success = CreateProcess(
+                        lpApplicationName: null,
+                        lpCommandLine: builder,
+                        lpProcessAttributes: NullPtr,
+                        lpThreadAttributes: NullPtr,
+                        bInheritHandles: false,
+                        dwCreationFlags: dwCreationFlags,
+                        lpEnvironment: NullPtr, // Inherit environment
+                        lpCurrentDirectory: clientDirectory,
+                        lpStartupInfo: ref startInfo,
+                        lpProcessInformation: out processInfo);
+
+                    if (success)
+                    {
+                        logger.Log("Successfully created process with process id {0}", processInfo.dwProcessId);
+                        CloseHandle(processInfo.hProcess);
+                        CloseHandle(processInfo.hThread);
+                        processId = processInfo.dwProcessId;
+                    }
+                    else
+                    {
+                        logger.LogError("Failed to create process. GetLastError={0}", Marshal.GetLastWin32Error());
+                    }
+                    return success;
                 }
                 else
                 {
-                    logger.LogError("Failed to create process. GetLastError={0}", Marshal.GetLastWin32Error());
-                }
-                return success;
-            }
-            else
-            {
-                try
-                {
-                    var startInfo = new ProcessStartInfo()
+                    try
                     {
-                        FileName = serverInfo.processFilePath,
-                        Arguments = serverInfo.commandLineArguments,
-                        UseShellExecute = false,
-                        WorkingDirectory = clientDirectory,
-                        RedirectStandardInput = true,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        CreateNoWindow = true
-                    };
+                        var startInfo = new ProcessStartInfo()
+                        {
+                            FileName = serverInfo.processFilePath,
+                            Arguments = serverInfo.commandLineArguments,
+                            UseShellExecute = false,
+                            WorkingDirectory = clientDirectory,
+                            RedirectStandardInput = true,
+                            RedirectStandardOutput = true,
+                            RedirectStandardError = true,
+                            CreateNoWindow = true
+                        };
 
-                    if (Process.Start(startInfo) is { } process)
-                    {
-                        processId = process.Id;
-                        logger.Log("Successfully created process with process id {0}", processId);
-                        return true;
+                        if (Process.Start(startInfo) is { } process)
+                        {
+                            processId = process.Id;
+                            logger.Log("Successfully created process with process id {0}", processId);
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
                     }
-                    else
+                    catch
                     {
                         return false;
                     }
                 }
-                catch
-                {
-                    return false;
-                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(RuntimeHostInfo.DotNetRootEnvironmentName, previousDotNetRoot);
             }
         }
 

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -31,15 +31,26 @@ namespace Microsoft.CodeAnalysis
             false;
 #endif
 
+        internal const string DotNetRootEnvironmentName = "DOTNET_ROOT";
         private const string DotNetHostPathEnvironmentName = "DOTNET_HOST_PATH";
         private const string DotNetExperimentalHostPathEnvironmentName = "DOTNET_EXPERIMENTAL_HOST_PATH";
 
-        /// <summary>
-        /// Get the path to the dotnet executable. In the case the .NET SDK did not provide this information
-        /// in the environment this tries to find "dotnet" on the PATH. In the case it is not found,
-        /// this will return simply "dotnet".
-        /// </summary>
-        internal static string GetDotNetPathOrDefault()
+        internal static string? GetDotNetRoot()
+        {
+            if (Environment.GetEnvironmentVariable(DotNetRootEnvironmentName) is { Length: > 0 } dotNetRoot)
+            {
+                return dotNetRoot;
+            }
+
+            if (GetDotNetHostPath() is { } dotNetHostPath)
+            {
+                return Path.GetDirectoryName(dotNetHostPath);
+            }
+
+            return null;
+        }
+
+        internal static string? GetDotNetHostPath()
         {
             if (Environment.GetEnvironmentVariable(DotNetHostPathEnvironmentName) is { Length: > 0 } pathToDotNet)
             {
@@ -49,6 +60,21 @@ namespace Microsoft.CodeAnalysis
             if (Environment.GetEnvironmentVariable(DotNetExperimentalHostPathEnvironmentName) is { Length: > 0 } pathToDotNetExperimental)
             {
                 return pathToDotNetExperimental;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get the path to the dotnet executable. In the case the .NET SDK did not provide this information
+        /// in the environment this tries to find "dotnet" on the PATH. In the case it is not found,
+        /// this will return simply "dotnet".
+        /// </summary>
+        internal static string GetDotNetPathOrDefault()
+        {
+            if (GetDotNetHostPath() is { } pathToDotNet)
+            {
+                return pathToDotNet;
             }
 
             var (fileName, sep) = PlatformInformation.IsWindows

--- a/src/Compilers/VisualBasic/vbc/AnyCpu/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/AnyCpu/vbc.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
-    <UseAppHost>false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>
   

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
@@ -19,14 +19,17 @@
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.exe" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.runtimeconfig.json" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.exe" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.runtimeconfig.json" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.exe" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.runtimeconfig.json" />
 
       <!-- References that are either not in the target framework or are a higher version -->

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
@@ -19,17 +19,17 @@
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.exe" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.exe" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.runtimeconfig.json" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.exe" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.exe" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.runtimeconfig.json" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.exe" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.exe" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.runtimeconfig.json" />
 
       <!-- References that are either not in the target framework or are a higher version -->

--- a/src/Tools/PrepareTests/MinimizeUtil.cs
+++ b/src/Tools/PrepareTests/MinimizeUtil.cs
@@ -98,7 +98,7 @@ internal static class MinimizeUtil
                     var destFilePath = Path.Combine(currentOutputDirectory, fileName);
                     CreateHardLink(destFilePath, sourceFilePath);
 
-                    if (isUnix && OperatingSystem.IsLinux() && File.GetUnixFileMode(sourceFilePath).HasFlag(UnixFileMode.UserExecute))
+                    if (isUnix && !OperatingSystem.IsWindows() && File.GetUnixFileMode(sourceFilePath).HasFlag(UnixFileMode.UserExecute))
                     {
                         yield return (s_executablesGroup, new FilePathInfo(
                             RelativeDirectory: currentRelativeDirectory,

--- a/src/Tools/PrepareTests/MinimizeUtil.cs
+++ b/src/Tools/PrepareTests/MinimizeUtil.cs
@@ -16,6 +16,9 @@ internal static class MinimizeUtil
 {
     internal record FilePathInfo(string RelativeDirectory, string Directory, string RelativePath, string FullPath);
 
+    /// <summary>
+    /// Special group for collecting files which need <c>chmod +x</c>.
+    /// </summary>
     private static readonly Guid s_executablesGroup = new Guid("2665eb42-0a7d-4ea2-bb92-e4251d48df44");
 
     internal static void Run(string sourceDirectory, string destinationDirectory, bool isUnix)

--- a/src/Tools/PrepareTests/MinimizeUtil.cs
+++ b/src/Tools/PrepareTests/MinimizeUtil.cs
@@ -16,6 +16,8 @@ internal static class MinimizeUtil
 {
     internal record FilePathInfo(string RelativeDirectory, string Directory, string RelativePath, string FullPath);
 
+    private static readonly Guid s_executablesGroup = new Guid("2665eb42-0a7d-4ea2-bb92-e4251d48df44");
+
     internal static void Run(string sourceDirectory, string destinationDirectory, bool isUnix)
     {
         const string duplicateDirectoryName = ".duplicate";
@@ -35,13 +37,13 @@ internal static class MinimizeUtil
             CreateHardLink(outputPath, Path.Combine(sourceDirectory, individualFile));
         }
 
-        // Map of all PE files MVID to the path information
+        // Map of all PE files MVID (or s_executablesGroup) to the path information
         var idToFilePathMap = initialWalk();
         resolveDuplicates();
         writeHydrateFile();
 
         // The goal of initial walk is to
-        //  1. Record any PE files as they are eligable for de-dup
+        //  1. Record any PE files as they are eligible for de-dup
         //  2. Hard link all other files into destination directory
         Dictionary<Guid, List<FilePathInfo>> initialWalk()
         {
@@ -66,7 +68,7 @@ internal static class MinimizeUtil
             return idToFilePathMap;
         }
 
-        static IEnumerable<(Guid mvid, FilePathInfo pathInfo)> walkDirectory(string unitDirPath, string sourceDirectory, string destinationDirectory)
+        IEnumerable<(Guid mvid, FilePathInfo pathInfo)> walkDirectory(string unitDirPath, string sourceDirectory, string destinationDirectory)
         {
             Console.WriteLine($"Walking {unitDirPath}");
             string? lastOutputDirectory = null;
@@ -95,6 +97,15 @@ internal static class MinimizeUtil
                 {
                     var destFilePath = Path.Combine(currentOutputDirectory, fileName);
                     CreateHardLink(destFilePath, sourceFilePath);
+
+                    if (isUnix && OperatingSystem.IsLinux() && File.GetUnixFileMode(sourceFilePath).HasFlag(UnixFileMode.UserExecute))
+                    {
+                        yield return (s_executablesGroup, new FilePathInfo(
+                            RelativeDirectory: currentRelativeDirectory,
+                            Directory: currentDirName,
+                            RelativePath: Path.Combine(currentRelativeDirectory, fileName),
+                            FullPath: sourceFilePath));
+                    }
                 }
             }
         }
@@ -104,6 +115,11 @@ internal static class MinimizeUtil
         {
             foreach (var pair in idToFilePathMap)
             {
+                if (pair.Key == s_executablesGroup)
+                {
+                    continue;
+                }
+
                 if (pair.Value.Count > 1)
                 {
                     CreateHardLink(getPeFilePath(pair.Key), pair.Value[0].FullPath);
@@ -185,6 +201,11 @@ internal static class MinimizeUtil
                 var count = 0;
                 foreach (var tuple in group)
                 {
+                    if (tuple.Id == s_executablesGroup)
+                    {
+                        continue;
+                    }
+
                     var source = getPeFileName(tuple.Id);
                     var destFileName = Path.GetRelativePath(group.Key, tuple.FilePath.RelativePath);
                     if (Path.GetDirectoryName(destFileName) is { Length: not 0 } directory)
@@ -231,8 +252,24 @@ scriptroot=""$( cd -P ""$( dirname ""$source"" )"" && pwd )""
                 var count = 0;
                 foreach (var tuple in group)
                 {
-                    var source = getPeFileName(tuple.Id);
+                    if (string.IsNullOrEmpty(group.Key) && tuple.Id == s_executablesGroup)
+                    {
+                        Console.WriteLine($"Skipping executable: {tuple.FilePath.FullPath}");
+                        continue;
+                    }
+
                     var destFilePath = Path.GetRelativePath(group.Key, tuple.FilePath.RelativePath);
+
+                    // Working around an AzDo file permissions bug. The uploaded and re-downloaded artifacts don't preserve execute file mode.
+                    if (tuple.Id == s_executablesGroup)
+                    {
+                        builder.AppendLine($"""
+                            chmod 755 "$scriptroot/{destFilePath}"
+                            """);
+                        continue;
+                    }
+
+                    var source = getPeFileName(tuple.Id);
                     if (Path.GetDirectoryName(destFilePath) is { Length: not 0 } directory)
                     {
                         builder.AppendLine($@"mkdir -p ""$scriptroot/{directory}""");
@@ -246,10 +283,7 @@ scriptroot=""$( cd -P ""$( dirname ""$source"" )"" && pwd )""
                     }
                 }
 
-                // Working around an AzDo file permissions bug.
-                // We want this to happen at the end so we can be agnostic about whether ilasm was already in the directory, or was linked in from the .duplicate directory.
                 builder.AppendLine();
-                builder.AppendLine(@"find $scriptroot -name ilasm -exec chmod 755 {} +");
             }
 
             static string getGroupDirectory(string relativePath)


### PR DESCRIPTION
The trick is to set DOTNET_ROOT based on the DOTNET_HOST_PATH which we already have available. Then `csc.exe`/`vbc.exe`/`VBCSCompiler.exe` should behave just like the `dotnet exec *.dll` equivalent behaved previously. Plus there are benefits - quoting @jaredpar: with this we get named processes back and all the benefits that come with it: better perf bucketing, Watson, kill VBCSCompiler.exe keeps working, etc.

Part of https://github.com/dotnet/msbuild/issues/11142.