### PR TITLE
Revert commits from bad channel

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -10,7 +10,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisPackageVersion>3.11.0</MicrosoftCodeAnalysisPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>4.10.0-1.24061.4</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- dotnet/dotnet dependencies -->
-    <SystemCommandLinePackageVersion>2.0.0-rc.2.25416.109</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-rc.1.25413.101</SystemCommandLinePackageVersion>
     <!-- dotnet/runtime dependencies -->
     <MicrosoftBclAsyncInterfacesPackageVersion>9.0.0</MicrosoftBclAsyncInterfacesPackageVersion>
     <MicrosoftExtensionsConfigurationPackageVersion>9.0.0</MicrosoftExtensionsConfigurationPackageVersion>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -10,7 +10,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisPackageVersion>3.11.0</MicrosoftCodeAnalysisPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>4.10.0-1.24061.4</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- dotnet/dotnet dependencies -->
-    <SystemCommandLinePackageVersion>2.0.0-rc.2.25418.119</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-rc.2.25416.109</SystemCommandLinePackageVersion>
     <!-- dotnet/runtime dependencies -->
     <MicrosoftBclAsyncInterfacesPackageVersion>9.0.0</MicrosoftBclAsyncInterfacesPackageVersion>
     <MicrosoftExtensionsConfigurationPackageVersion>9.0.0</MicrosoftExtensionsConfigurationPackageVersion>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -10,7 +10,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisPackageVersion>3.11.0</MicrosoftCodeAnalysisPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>4.10.0-1.24061.4</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- dotnet/dotnet dependencies -->
-    <SystemCommandLinePackageVersion>2.0.0-rc.2.25420.109</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-rc.2.25418.119</SystemCommandLinePackageVersion>
     <!-- dotnet/runtime dependencies -->
     <MicrosoftBclAsyncInterfacesPackageVersion>9.0.0</MicrosoftBclAsyncInterfacesPackageVersion>
     <MicrosoftExtensionsConfigurationPackageVersion>9.0.0</MicrosoftExtensionsConfigurationPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn" Sha="619d5633513d1b31c528db4360833fce52f51829" BarId="280198" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn" Sha="ea90fea181ebdfa48b1c240085dcdc4ab5837ddb" BarId="279959" />
   <ProductDependencies>
     <!-- RoslynAnalyzers reference older builds of Roslyn and this is necessary for SourceBuild. -->
     <Dependency Name="Microsoft.CodeAnalysis" Version="3.11.0">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>ae1fff344d46976624e68ae17164e0607ab68b10</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-rc.2.25420.109">
+    <Dependency Name="System.CommandLine" Version="2.0.0-rc.2.25418.119">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>619d5633513d1b31c528db4360833fce52f51829</Sha>
+      <Sha>ea90fea181ebdfa48b1c240085dcdc4ab5837ddb</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn" Sha="ea90fea181ebdfa48b1c240085dcdc4ab5837ddb" BarId="279959" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn" Sha="7f2a07b481a3d24677ebcf6a45e7e27c8ff95a4e" BarId="279809" />
   <ProductDependencies>
     <!-- RoslynAnalyzers reference older builds of Roslyn and this is necessary for SourceBuild. -->
     <Dependency Name="Microsoft.CodeAnalysis" Version="3.11.0">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>ae1fff344d46976624e68ae17164e0607ab68b10</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-rc.2.25418.119">
+    <Dependency Name="System.CommandLine" Version="2.0.0-rc.2.25416.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ea90fea181ebdfa48b1c240085dcdc4ab5837ddb</Sha>
+      <Sha>7f2a07b481a3d24677ebcf6a45e7e27c8ff95a4e</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn" Sha="7f2a07b481a3d24677ebcf6a45e7e27c8ff95a4e" BarId="279809" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn" Sha="adfea8e331724cfd46007dfefec405b5e5faad1d" BarId="279079" />
   <ProductDependencies>
     <!-- RoslynAnalyzers reference older builds of Roslyn and this is necessary for SourceBuild. -->
     <Dependency Name="Microsoft.CodeAnalysis" Version="3.11.0">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>ae1fff344d46976624e68ae17164e0607ab68b10</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-rc.2.25416.109">
+    <Dependency Name="System.CommandLine" Version="2.0.0-rc.1.25413.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7f2a07b481a3d24677ebcf6a45e7e27c8ff95a4e</Sha>
+      <Sha>adfea8e331724cfd46007dfefec405b5e5faad1d</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0">


### PR DESCRIPTION
These builds are from the .NET 10.0.1xx channel, after main switched to .NET 11.0.1xx, so they need to be reverted