### PR TITLE
Disable oop processing for some diagnostics calls

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_RemoteOrLocalDispatcher.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_RemoteOrLocalDispatcher.cs
@@ -202,23 +202,28 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
         if (allAnalyzers.Length == 0)
             return [];
 
-        var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
-        if (client is not null)
+        var useOOP = false;
+
+        if (useOOP)
         {
-            var allAnalyzerIds = allAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
-            var syntaxAnalyzersIds = syntaxAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
-            var semanticSpanAnalyzersIds = semanticSpanAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
-            var semanticDocumentAnalyzersIds = semanticDocumentAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
+            var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
+            if (client is not null)
+            {
+                var allAnalyzerIds = allAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
+                var syntaxAnalyzersIds = syntaxAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
+                var semanticSpanAnalyzersIds = semanticSpanAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
+                var semanticDocumentAnalyzersIds = semanticDocumentAnalyzers.Select(a => a.GetAnalyzerId()).ToImmutableHashSet();
 
-            var result = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableArray<DiagnosticData>>(
-                document.Project,
-                (service, solution, cancellationToken) => service.ComputeDiagnosticsAsync(
-                    solution, document.Id, range,
-                    allAnalyzerIds, syntaxAnalyzersIds, semanticSpanAnalyzersIds, semanticDocumentAnalyzersIds,
-                    incrementalAnalysis, logPerformanceInfo, cancellationToken),
-                cancellationToken).ConfigureAwait(false);
+                var result = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableArray<DiagnosticData>>(
+                    document.Project,
+                    (service, solution, cancellationToken) => service.ComputeDiagnosticsAsync(
+                        solution, document.Id, range,
+                        allAnalyzerIds, syntaxAnalyzersIds, semanticSpanAnalyzersIds, semanticDocumentAnalyzersIds,
+                        incrementalAnalysis, logPerformanceInfo, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
 
-            return result.HasValue ? result.Value : [];
+                return result.HasValue ? result.Value : [];
+            }
         }
 
         return await ComputeDiagnosticsInProcessAsync(


### PR DESCRIPTION
The PR this change went in with seems to have a high regression.  This means one of two things (at least):

1. there is something that is very bad about calling into oop here that we don't understand yet.
2. the logic is just overall busted, regardless of if we are calling into oop.

This PR at least tests if '1' is the issue.  If so, we can just disable the oop call and unblock things.  If this *doesn't* address the problem, then something deeper is in effect and we'llhave to revert https://github.com/dotnet/roslyn/pull/79991 entirely.  That's going to be a painful change (due to subsequent prs going on), so it would be nice to avoid.

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12269021&view=results
PR: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/665108