### PR TITLE
Move the initialization of the global notification service

### DIFF
--- a/src/VisualStudio/Core/Def/ExternalAccess/UnitTesting/SolutionEventMonitor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/UnitTesting/SolutionEventMonitor.cs
@@ -26,7 +26,6 @@ internal sealed class SolutionEventMonitor : IDisposable
 
     public SolutionEventMonitor(IGlobalOperationNotificationService notificationService)
     {
-        Contract.ThrowIfNull(notificationService);
         _notificationService = notificationService;
 
         RegisterEventHandler(KnownUIContexts.SolutionBuildingContext, SolutionBuildingContextChanged);

--- a/src/VisualStudio/Core/Def/ExternalAccess/UnitTesting/VisualStudioGlobalOperationNotificationService.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/UnitTesting/VisualStudioGlobalOperationNotificationService.cs
@@ -3,18 +3,77 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Notification;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.UnitTesting;
 
 [Export(typeof(IGlobalOperationNotificationService)), Shared]
-[method: ImportingConstructor]
-[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed partial class VisualStudioGlobalOperationNotificationService(
+internal sealed partial class VisualStudioGlobalOperationNotificationService : AbstractGlobalOperationNotificationService, IDisposable
+{
+    private readonly SolutionEventMonitor _solutionEventMonitor;
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public VisualStudioGlobalOperationNotificationService(
     IThreadingContext threadingContext,
-    IAsynchronousOperationListenerProvider listenerProvider)
-    : AbstractGlobalOperationNotificationService(listenerProvider, threadingContext.DisposalToken);
+    IAsynchronousOperationListenerProvider listenerProvider) : base(listenerProvider, threadingContext.DisposalToken)
+    {
+        _solutionEventMonitor = new SolutionEventMonitor(this);
+
+        // we will pause whatever ambient work loads we have that are tied to IGlobalOperationNotificationService
+        // such as solution crawler, preemptive remote host synchronization and etc. any background work users
+        // didn't explicitly asked for.
+        //
+        // this should give all resources to BulkFileOperation. we do same for things like build, debugging, wait
+        // dialog and etc. BulkFileOperation is used for things like git branch switching and etc.
+
+        // BulkFileOperation can't have nested events. there will be ever only 1 events (Begin/End)
+        // so we only need simple tracking.
+        var gate = new object();
+        IDisposable? localRegistration = null;
+
+        BulkFileOperation.Begin += (s, a) => StartBulkFileOperationNotification();
+        BulkFileOperation.End += (s, a) => StopBulkFileOperationNotification();
+
+        return;
+
+        void StartBulkFileOperationNotification()
+        {
+            lock (gate)
+            {
+                // this shouldn't happen, but we are using external component
+                // so guarding us from them
+                if (localRegistration != null)
+                {
+                    FatalError.ReportAndCatch(new InvalidOperationException("BulkFileOperation already exist"), ErrorSeverity.General);
+                    return;
+                }
+
+                localRegistration = Start("BulkFileOperation");
+            }
+        }
+
+        void StopBulkFileOperationNotification()
+        {
+            lock (gate)
+            {
+                // localRegistration may be null if BulkFileOperation was already in the middle of running.  So we
+                // explicitly do not assert that is is non-null here.
+                localRegistration?.Dispose();
+                localRegistration = null;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _solutionEventMonitor.Dispose();
+    }
+}

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -7,14 +7,12 @@ using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ColorSchemes;
 using Microsoft.CodeAnalysis.Common;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Notification;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings;
@@ -33,9 +31,7 @@ using Microsoft.VisualStudio.LanguageServices.StackTraceExplorer;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
-using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
-using Roslyn.Utilities;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.Setup;
@@ -108,12 +104,6 @@ internal sealed class RoslynPackage : AbstractPackage
 
             var colorSchemeApplier = ComponentModel.GetService<ColorSchemeApplier>();
             colorSchemeApplier.RegisterInitializationWork(afterPackageLoadedTasks);
-
-            // We are at the VS layer, so we know we must be able to get the IGlobalOperationNotificationService here.
-            var globalNotificationService = this.ComponentModel.GetService<IGlobalOperationNotificationService>();
-
-            _solutionEventMonitor = new SolutionEventMonitor(globalNotificationService);
-            TrackBulkFileOperations(globalNotificationService);
 
             return Task.CompletedTask;
         }
@@ -241,54 +231,6 @@ internal sealed class RoslynPackage : AbstractPackage
         {
             _ruleSetEventHandler.Unregister();
             _ruleSetEventHandler = null;
-        }
-    }
-
-    private static void TrackBulkFileOperations(IGlobalOperationNotificationService globalNotificationService)
-    {
-        // we will pause whatever ambient work loads we have that are tied to IGlobalOperationNotificationService
-        // such as solution crawler, preemptive remote host synchronization and etc. any background work users
-        // didn't explicitly asked for.
-        //
-        // this should give all resources to BulkFileOperation. we do same for things like build, debugging, wait
-        // dialog and etc. BulkFileOperation is used for things like git branch switching and etc.
-        Contract.ThrowIfNull(globalNotificationService);
-
-        // BulkFileOperation can't have nested events. there will be ever only 1 events (Begin/End)
-        // so we only need simple tracking.
-        var gate = new object();
-        IDisposable? localRegistration = null;
-
-        BulkFileOperation.Begin += (s, a) => StartBulkFileOperationNotification();
-        BulkFileOperation.End += (s, a) => StopBulkFileOperationNotification();
-
-        return;
-
-        void StartBulkFileOperationNotification()
-        {
-            lock (gate)
-            {
-                // this shouldn't happen, but we are using external component
-                // so guarding us from them
-                if (localRegistration != null)
-                {
-                    FatalError.ReportAndCatch(new InvalidOperationException("BulkFileOperation already exist"), ErrorSeverity.General);
-                    return;
-                }
-
-                localRegistration = globalNotificationService.Start("BulkFileOperation");
-            }
-        }
-
-        void StopBulkFileOperationNotification()
-        {
-            lock (gate)
-            {
-                // localRegistration may be null if BulkFileOperation was already in the middle of running.  So we
-                // explicitly do not assert that is is non-null here.
-                localRegistration?.Dispose();
-                localRegistration = null;
-            }
         }
     }
 }


### PR DESCRIPTION
We were initializing this in package load, because at one point the APIs to do so had to be on the UI thread. At this point the only remaining use of this service is for the legacy solution crawler, so there's no point in initializing it until the service is actually constructed. And since everything is now free threaded, it's easy to move.