### PR TITLE
Update debugger packages, move to PortableInterop IMetadataImport

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -122,9 +122,8 @@
       VS Debugger
     -->
     <PackageVersion Include="Microsoft.VisualStudio.Debugger.Contracts" Version="18.0.0-beta.25379.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Debugger.Engine-implementation" Version="17.13.1121201-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.Debugger.Metadata-implementation" Version="17.13.1121201-preview" />
-
+    <PackageVersion Include="Microsoft.VisualStudio.Debugger.Engine-implementation" Version="18.0.1082202-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Debugger.Metadata-implementation" Version="18.0.1082202-preview" />
     <!--
       VS .NET Runtime
 

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
@@ -18,8 +18,9 @@ using System.Reflection.Adds;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.MetadataReader;
+using Microsoft.MetadataReader.PortableInterop;
 using Microsoft.VisualStudio.Debugger.Symbols;
+using Token = System.Reflection.Adds.Token;
 
 namespace Microsoft.VisualStudio.Debugger.Clr
 {
@@ -76,7 +77,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                 _assembly = assembly;
             }
 
-            int IMetadataImport.GetFieldProps(int mb, out int mdTypeDef, StringBuilder szField, int cchField, out int pchField, out FieldAttributes pdwAttr, out EmbeddedBlobPointer ppvSigBlob, out int pcbSigBlob, out int pdwCPlusTypeFlab, out IntPtr ppValue, out int pcchValue)
+            int IMetadataImport.GetFieldProps(Token mb, out Token mdTypeDef, char[] szField, uint cchField, out uint pchField, out FieldAttributes pdwAttr, out EmbeddedBlobPointer ppvSigBlob, out uint pcbSigBlob, out uint pdwCPlusTypeFlab, out IntPtr ppValue, out uint pcchValue)
             {
                 mdTypeDef = default;
                 pchField = default;
@@ -96,7 +97,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                         if (field.MetadataToken == mb)
                         {
                             var fieldName = field.Name;
-                            pchField = fieldName.Length;
+                            pchField = (uint)fieldName.Length + 1; // this API returns the length including null terminator
 
                             if (szField != null && cchField != 0)
                             {
@@ -105,7 +106,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                                     return -1;
                                 }
 
-                                szField.Append(fieldName);
+                                fieldName.CopyTo(0, szField, 0, fieldName.Length);
                             }
 
                             return 0;
@@ -122,292 +123,292 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.CountEnum(HCORENUM hEnum, out int pulCount)
+            int IMetadataImport.CountEnum(HCORENUM hEnum, out uint pulCount)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.ResetEnum(HCORENUM hEnum, int ulPos)
+            int IMetadataImport.ResetEnum(HCORENUM hEnum, uint ulPos)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumTypeDefs(ref HCORENUM phEnum, out int rTypeDefs, uint cMax, out uint pcTypeDefs)
+            int IMetadataImport.EnumTypeDefs(ref HCORENUM phEnum, out Token rTypeDefs, uint cMax, out uint pcTypeDefs)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumInterfaceImpls(ref HCORENUM phEnum, int td, out int rImpls, int cMax, ref int pcImpls)
+            int IMetadataImport.EnumInterfaceImpls(ref HCORENUM phEnum, int td, out Token rImpls, uint cMax, out uint pcImpls)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumTypeRefs(ref HCORENUM phEnum, int[] td, uint cMax, uint pcTypeRefs)
+            int IMetadataImport.EnumTypeRefs(ref HCORENUM phEnum, out Token td, uint cMax, out uint pcTypeRefs)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.FindTypeDefByName(string szTypeDef, int tkEnclosingClass, out int token)
+            int IMetadataImport.FindTypeDefByName(string szTypeDef, Token tkEnclosingClass, out Token token)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetScopeProps(StringBuilder szName, int cchName, out int pchName, out Guid mvid)
+            int IMetadataImport.GetScopeProps(char[] szName, uint cchName, out uint pchName, out Guid mvid)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetModuleFromScope(out int mdModule)
+            int IMetadataImport.GetModuleFromScope(out Token mdModule)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetTypeDefProps(int td, StringBuilder szTypeDef, int cchTypeDef, out int pchTypeDef, out TypeAttributes pdwTypeDefFlags, out int ptkExtends)
+            int IMetadataImport.GetTypeDefProps(Token td, char[] szTypeDef, uint cchTypeDef, out uint pchTypeDef, out TypeAttributes pdwTypeDefFlags, out Token ptkExtends)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetInterfaceImplProps(int iiImpl, out int pClass, out int ptkIface)
+            int IMetadataImport.GetInterfaceImplProps(Token iiImpl, out Token pClass, out Token ptkIface)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetTypeRefProps(int tr, out int ptkResolutionScope, StringBuilder szName, int cchName, out int pchName)
+            int IMetadataImport.GetTypeRefProps(Token tr, out Token ptkResolutionScope, char[] szName, uint cchName, out uint pchName)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.ResolveTypeRef(int tr, ref Guid riid, out object ppIScope)
+            int IMetadataImport.ResolveTypeRef(Token tr, ref Guid riid, out object ppIScope, out Token ptd)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumMembers(ref uint phEnum, uint cl, uint[] rMembers, uint cMax, out uint pcTokens)
+            int IMetadataImport.EnumMembers(ref HCORENUM phEnum, Token cl, out Token rMembers, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumMembersWithName(ref uint phEnum, uint cl, string szName, uint[] rMembers, uint cMax, ref uint pcTokens)
+            int IMetadataImport.EnumMembersWithName(ref HCORENUM phEnum, Token cl, string szName, out Token rMembers, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumMethods(ref HCORENUM phEnum, int cl, out int mdMethodDef, int cMax, out int pcTokens)
+            int IMetadataImport.EnumMethods(ref HCORENUM phEnum, Token cl, out Token mdMethodDef, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumMethodsWithName(ref HCORENUM phEnum, int cl, string szName, out int mdMethodDef, int cMax, out int pcTokens)
+            int IMetadataImport.EnumMethodsWithName(ref HCORENUM phEnum, Token cl, string szName, out Token mdMethodDef, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumFields(ref HCORENUM phEnum, int cl, out int mdFieldDef, int cMax, out uint pcTokens)
+            int IMetadataImport.EnumFields(ref HCORENUM phEnum, Token cl, out Token mdFieldDef, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumFieldsWithName(ref uint phEnum, uint cl, string szName, uint[] rFields, uint cMax, out uint pcTokens)
+            int IMetadataImport.EnumFieldsWithName(ref HCORENUM phEnum, Token cl, string szName, out Token rFields, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumParams(ref HCORENUM phEnum, int mdMethodDef, int[] rParams, int cMax, out uint pcTokens)
+            int IMetadataImport.EnumParams(ref HCORENUM phEnum, Token mdMethodDef, out Token rParams, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumMemberRefs(ref uint phEnum, uint tkParent, uint[] rMemberRefs, uint cMax, out uint pcTokens)
+            int IMetadataImport.EnumMemberRefs(ref HCORENUM phEnum, Token tkParent, out Token rMemberRefs, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumMethodImpls(ref HCORENUM hEnum, Token typeDef, out Token methodBody, out Token methodDecl, int cMax, out int cTokens)
+            int IMetadataImport.EnumMethodImpls(ref HCORENUM hEnum, Token typeDef, out Token methodBody, out Token methodDecl, uint cMax, out uint cTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumPermissionSets(ref HCORENUM hEnum, uint tk, uint dwActions, uint[] rPermission, ref uint cMax)
+            int IMetadataImport.EnumPermissionSets(ref HCORENUM hEnum, Token tk, uint dwActions, out Token rPermission, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.FindMember(int typeDefToken, string szName, byte[] pvSigBlob, int cbSigBlob, out int memberDefToken)
+            int IMetadataImport.FindMember(Token typeDefToken, string szName, byte[] pvSigBlob, uint cbSigBlob, out Token memberDefToken)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.FindMethod(int typeDef, string szName, EmbeddedBlobPointer pvSigBlob, int cbSigBlob, out int methodDef)
+            int IMetadataImport.FindMethod(Token typeDef, string szName, EmbeddedBlobPointer pvSigBlob, uint cbSigBlob, out Token methodDef)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.FindField(int typeDef, string szName, byte[] pvSigBlob, int cbSigBlob, out int fieldDef)
+            int IMetadataImport.FindField(Token typeDef, string szName, byte[] pvSigBlob, uint cbSigBlob, out Token fieldDef)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.FindMemberRef(int typeRef, string szName, byte[] pvSigBlob, int cbSigBlob, out int result)
+            int IMetadataImport.FindMemberRef(Token typeRef, string szName, byte[] pvSigBlob, uint cbSigBlob, out Token result)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetMethodProps(uint md, out int pClass, StringBuilder szMethod, int cchMethod, out uint pchMethod, out MethodAttributes pdwAttr, out EmbeddedBlobPointer ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags)
+            int IMetadataImport.GetMethodProps(Token md, out Token pClass, char[] szMethod, uint cchMethod, out uint pchMethod, out MethodAttributes pdwAttr, out EmbeddedBlobPointer ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetMemberRefProps(Token mr, out Token ptk, StringBuilder szMember, int cchMember, out uint pchMember, out EmbeddedBlobPointer ppvSigBlob, out uint pbSig)
+            int IMetadataImport.GetMemberRefProps(Token mr, out Token ptk, char[] szMember, uint cchMember, out uint pchMember, out EmbeddedBlobPointer ppvSigBlob, out uint pbSig)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumProperties(ref HCORENUM phEnum, int td, out int mdFieldDef, int cMax, out uint pcTokens)
+            int IMetadataImport.EnumProperties(ref HCORENUM phEnum, Token td, out Token mdFieldDef, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumEvents(ref HCORENUM phEnum, int td, out int mdFieldDef, int cMax, out uint pcEvents)
+            int IMetadataImport.EnumEvents(ref HCORENUM phEnum, Token td, out Token mdFieldDef, uint cMax, out uint pcEvents)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetEventProps(int ev, out int pClass, StringBuilder szEvent, int cchEvent, out int pchEvent, out int pdwEventFlags, out int ptkEventType, out int pmdAddOn, out int pmdRemoveOn, out int pmdFire, out int rmdOtherMethod, uint cMax, out uint pcOtherMethod)
+            int IMetadataImport.GetEventProps(Token ev, out Token pClass, char[] szEvent, uint cchEvent, out uint pchEvent, out EventAttributes pdwEventFlags, out Token ptkEventType, out Token pmdAddOn, out Token pmdRemoveOn, out Token pmdFire, out Token rmdOtherMethod, uint cMax, out uint pcOtherMethod)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumMethodSemantics(ref uint phEnum, uint mb, uint[] rEventProp, uint cMax, out uint pcEventProp)
+            int IMetadataImport.EnumMethodSemantics(ref HCORENUM phEnum, Token mb, out Token rEventProp, uint cMax, out uint pcEventProp)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetMethodSemantics(uint mb, uint tkEventProp, out uint pdwSemanticsFlags)
+            int IMetadataImport.GetMethodSemantics(Token mb, Token tkEventProp, out uint pdwSemanticsFlags)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetClassLayout(int typeDef, out uint dwPackSize, COR_FIELD_OFFSET[] rFieldOffset, uint cMax, out uint cFieldOffset, out uint ulClassSize)
+            int IMetadataImport.GetClassLayout(Token typeDef, out uint dwPackSize, MetadataReader.COR_FIELD_OFFSET[] rFieldOffset, uint cMax, out uint cFieldOffset, out uint ulClassSize)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetFieldMarshal(int tk, out IntPtr ppvNativeType, out int pcbNativeType)
+            int IMetadataImport.GetFieldMarshal(Token tk, out EmbeddedBlobPointer ppvNativeType, out uint pcbNativeType)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetRVA(int token, out uint rva, out uint flags)
+            int IMetadataImport.GetRVA(Token token, out uint rva, out uint flags)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetPermissionSetProps(uint pm, out uint pdwAction, out IntPtr ppvPermission, out int pcbPermission)
+            int IMetadataImport.GetPermissionSetProps(Token pm, out uint pdwAction, out IntPtr ppvPermission, out uint pcbPermission)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetSigFromToken(int token, out EmbeddedBlobPointer pSig, out int cbSig)
+            int IMetadataImport.GetSigFromToken(Token token, out EmbeddedBlobPointer pSig, out uint cbSig)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetModuleRefProps(int mur, StringBuilder szName, int cchName, out int pchName)
+            int IMetadataImport.GetModuleRefProps(Token mur, char[] szName, uint cchName, out uint pchName)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumModuleRefs(ref HCORENUM phEnum, out int mdModuleRef, int cMax, out uint pcModuleRefs)
+            int IMetadataImport.EnumModuleRefs(ref HCORENUM phEnum, out Token mdModuleRef, uint cMax, out uint pcModuleRefs)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetTypeSpecFromToken(Token typeSpec, out EmbeddedBlobPointer pSig, out int cbSig)
+            int IMetadataImport.GetTypeSpecFromToken(Token typeSpec, out EmbeddedBlobPointer pSig, out uint cbSig)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetNameFromToken(uint tk, string pszUtf8NamePtr)
+            int IMetadataImport.GetNameFromToken(Token tk, out IntPtr pszUtf8NamePtr)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumUnresolvedMethods(ref uint phEnum, uint[] rMethods, uint cMax, out uint pcTokens)
+            int IMetadataImport.EnumUnresolvedMethods(ref HCORENUM phEnum, out Token rMethods, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetUserString(int stk, char[] szString, int cchString, out int pchString)
+            int IMetadataImport.GetUserString(Token stk, char[] szString, uint cchString, out uint pchString)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetPinvokeMap(uint tk, out uint pdwMappingFlags, StringBuilder szImportName, uint cchImportName, out uint pchImportName, out int pmrImportDLL)
+            int IMetadataImport.GetPinvokeMap(Token tk, out uint pdwMappingFlags, char[] szImportName, uint cchImportName, out uint pchImportName, out Token pmrImportDLL)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumSignatures(ref uint phEnum, uint[] rSignatures, uint cmax, out uint pcSignatures)
+            int IMetadataImport.EnumSignatures(ref HCORENUM phEnum, out Token rSignatures, uint cmax, out uint pcSignatures)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumTypeSpecs(ref uint phEnum, uint[] rTypeSpecs, uint cmax, out uint pcTypeSpecs)
+            int IMetadataImport.EnumTypeSpecs(ref HCORENUM phEnum, out Token rTypeSpecs, uint cmax, out uint pcTypeSpecs)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumUserStrings(ref uint phEnum, uint[] rStrings, uint cmax, out uint pcStrings)
+            int IMetadataImport.EnumUserStrings(ref HCORENUM phEnum, out Token rStrings, uint cmax, out uint pcStrings)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetParamForMethodIndex(uint md, uint ulParamSeq, out uint pParam, out int ppd)
+            int IMetadataImport.GetParamForMethodIndex(Token md, uint ulParamSeq, out Token ppd)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.EnumCustomAttributes(ref HCORENUM phEnum, int tk, int tkType, out Token mdCustomAttribute, uint cMax, out uint pcTokens)
+            int IMetadataImport.EnumCustomAttributes(ref HCORENUM phEnum, Token tk, Token tkType, out Token mdCustomAttribute, uint cMax, out uint pcTokens)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetCustomAttributeProps(Token cv, out Token tkObj, out Token tkType, out EmbeddedBlobPointer blob, out int cbSize)
+            int IMetadataImport.GetCustomAttributeProps(Token cv, out Token tkObj, out Token tkType, out EmbeddedBlobPointer blob, out uint cbSize)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.FindTypeRef(int tkResolutionScope, string szName, out int typeRef)
+            int IMetadataImport.FindTypeRef(Token tkResolutionScope, string szName, out Token typeRef)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetMemberProps(uint mb, out uint pClass, StringBuilder szMember, uint cchMember, out uint pchMember, out uint pdwAttr, out IntPtr ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags, out uint pdwCPlusTypeFlag, out IntPtr ppValue, out uint pcchValue)
+            int IMetadataImport.GetMemberProps(Token mb, out Token pClass, char[] szMember, uint cchMember, out uint pchMember, out uint pdwAttr, out EmbeddedBlobPointer ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags, out uint pdwCPlusTypeFlag, out IntPtr ppValue, out uint pcchValue)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetPropertyProps(Token prop, out Token pClass, StringBuilder szProperty, int cchProperty, out int pchProperty, out PropertyAttributes pdwPropFlags, out EmbeddedBlobPointer ppvSig, out int pbSig, out int pdwCPlusTypeFlag, out UnusedIntPtr ppDefaultValue, out int pcchDefaultValue, out Token pmdSetter, out Token pmdGetter, out Token rmdOtherMethod, uint cMax, out uint pcOtherMethod)
+            int IMetadataImport.GetPropertyProps(Token prop, out Token pClass, char[] szProperty, uint cchProperty, out uint pchProperty, out PropertyAttributes pdwPropFlags, out EmbeddedBlobPointer ppvSig, out uint pbSig, out uint pdwCPlusTypeFlag, out MetadataReader.UnusedIntPtr ppDefaultValue, out uint pcchDefaultValue, out Token pmdSetter, out Token pmdGetter, out Token rmdOtherMethod, uint cMax, out uint pcOtherMethod)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetParamProps(int tk, out int pmd, out uint pulSequence, StringBuilder szName, uint cchName, out uint pchName, out uint pdwAttr, out uint pdwCPlusTypeFlag, out UnusedIntPtr ppValue, out uint pcchValue)
+            int IMetadataImport.GetParamProps(Token tk, out Token pmd, out uint pulSequence, char[] szName, uint cchName, out uint pchName, out ParameterAttributes pdwAttr, out uint pdwCPlusTypeFlag, out MetadataReader.UnusedIntPtr ppValue, out uint pcchValue)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetCustomAttributeByName(int tkObj, string szName, out EmbeddedBlobPointer ppData, out uint pcbData)
+            int IMetadataImport.GetCustomAttributeByName(Token tkObj, string szName, out EmbeddedBlobPointer ppData, out uint pcbData)
             {
                 throw new NotImplementedException();
             }
 
-            bool IMetadataImport.IsValidToken(uint tk)
+            bool IMetadataImport.IsValidToken(Token tk)
             {
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.GetNestedClassProps(int tdNestedClass, out int tdEnclosingClass)
+            int IMetadataImport.GetNestedClassProps(Token tdNestedClass, out Token tdEnclosingClass)
             {
                 throw new NotImplementedException();
             }
@@ -417,7 +418,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                 throw new NotImplementedException();
             }
 
-            int IMetadataImport.IsGlobal(uint pd, out int pbGlobal)
+            int IMetadataImport.IsGlobal(Token pd, out int pbGlobal)
             {
                 throw new NotImplementedException();
             }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmMetadataImportHolder.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmMetadataImportHolder.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.MetadataReader;
+using Microsoft.MetadataReader.PortableInterop;
 
 #nullable enable
 
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
         /// <summary>
         /// The underlying IMetaDataImport interface reference
         /// </summary>
-        public IMetadataImport Value { get; }
+        public IMetadataImport PortableValue { get; }
 
         /// <summary>
         /// Creates a new instance of <see cref="DkmMetadataImportHolder"/>.
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
         /// <param name="value">[In] Implementation of IMetadataImport to wrap</param>
         public DkmMetadataImportHolder(IMetadataImport value)
         {
-            this.Value = value ?? throw new ArgumentNullException(nameof(value));
+            this.PortableValue = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         void IDisposable.Dispose()


### PR DESCRIPTION
As outlined in https://github.com/microsoft/ConcordExtensibilitySamples/issues/124, the debugger will be breaking the public definition of `IMetadataImport`. This change updates the debugger package versions to latest versions in order to pick up the new  definition under the `Microsoft.MetadataReader.PortableInterop` namespace and migrates the Roslyn usage off of the debugger definition in `Microsoft.MetadataReader.IMetadataImport`. This also updates the `DkmMetadataImportHolder` mock to expose the same property as the real class, `

Notably the new definition no longer uses `StringBuilder` marshalling, which should nominally improve performance.