### PR TITLE
Store client's version for open docs in LSP

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -290,7 +290,7 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
             var message = $"Error occurred processing queue: {ex.Message}.";
             if (lspServices is not null)
             {
-                await _languageServer.ShutdownAsync("Error processing queue, shutting down").ConfigureAwait(false);
+                await _languageServer.ShutdownAsync(message).ConfigureAwait(false);
                 await _languageServer.ExitAsync().ConfigureAwait(false);
             }
 

--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -359,9 +359,39 @@ public abstract partial class AbstractLanguageServerProtocolTests
         return await TestLspServer.CreateAsync(workspace, lspOptions, TestOutputLspLogger);
     }
 
+    private void CheckForCompositionErrors(TestComposition composition)
+    {
+        // The test compositions tend to have a bunch of errors.
+        // We only want to fail the test if we're seeing errors in relevant parts to the language server.
+        // This isn't foolproof, but helps catch issues early.
+
+        var config = composition.GetCompositionConfiguration();
+        var hasLanguageServerErrors = config.CompositionErrors.Flatten().Any(error => error.Parts.Any(IsRelevantPartError));
+
+        if (hasLanguageServerErrors)
+        {
+            try
+            {
+                config.ThrowOnErrors();
+            }
+            catch (CompositionFailedException ex)
+            {
+                // The ToString for the composition failed exception doesn't output a nice set of errors by default, so log it separately
+                this.TestOutputLspLogger.LogError($"Encountered errors in the MEF composition: {ex.Message}{Environment.NewLine}{ex.ErrorsAsString}");
+                throw;
+            }
+        }
+
+        bool IsRelevantPartError(ComposedPart part)
+        {
+            return part.Definition.Type.FullName?.Contains("Microsoft.CodeAnalysis.LanguageServer") == true;
+        }
+    }
+
     internal async Task<LspTestWorkspace> CreateWorkspaceAsync(
         InitializationOptions? options, string? workspaceKind, bool mutatingLspWorkspace, TestComposition? composition = null)
     {
+        CheckForCompositionErrors(composition ?? Composition);
         var workspace = new LspTestWorkspace(
             composition?.ExportProviderFactory.CreateExportProvider() ?? await CreateExportProviderAsync(),
             workspaceKind,
@@ -494,7 +524,8 @@ public abstract partial class AbstractLanguageServerProtocolTests
 
     private static LSP.DidChangeTextDocumentParams CreateDidChangeTextDocumentParams(
         DocumentUri documentUri,
-        ImmutableArray<(LSP.Range Range, string Text)> changes)
+        ImmutableArray<(LSP.Range Range, string Text)> changes,
+        int version = 0)
     {
         var changeEvents = changes.Select(change => new LSP.TextDocumentContentChangeEvent
         {
@@ -506,20 +537,22 @@ public abstract partial class AbstractLanguageServerProtocolTests
         {
             TextDocument = new LSP.VersionedTextDocumentIdentifier
             {
-                DocumentUri = documentUri
+                DocumentUri = documentUri,
+                Version = version
             },
             ContentChanges = changeEvents
         };
     }
 
-    private static LSP.DidOpenTextDocumentParams CreateDidOpenTextDocumentParams(DocumentUri uri, string source, string languageId = "")
+    private static LSP.DidOpenTextDocumentParams CreateDidOpenTextDocumentParams(DocumentUri uri, string source, string languageId = "", int version = 0)
         => new LSP.DidOpenTextDocumentParams
         {
             TextDocument = new LSP.TextDocumentItem
             {
                 Text = source,
                 DocumentUri = uri,
-                LanguageId = languageId
+                LanguageId = languageId,
+                Version = version
             }
         };
 
@@ -704,7 +737,7 @@ public abstract partial class AbstractLanguageServerProtocolTests
             return _clientRpc.InvokeWithParameterObjectAsync(methodName, serializedRequest);
         }
 
-        public async Task OpenDocumentAsync(DocumentUri documentUri, string? text = null, string languageId = "")
+        public async Task OpenDocumentAsync(DocumentUri documentUri, string? text = null, string languageId = "", int version = 0)
         {
             if (text == null)
             {
@@ -714,13 +747,13 @@ public abstract partial class AbstractLanguageServerProtocolTests
                 text = sourceText.ToString();
             }
 
-            var didOpenParams = CreateDidOpenTextDocumentParams(documentUri, text.ToString(), languageId);
+            var didOpenParams = CreateDidOpenTextDocumentParams(documentUri, text.ToString(), languageId, version);
             await ExecuteRequestAsync<LSP.DidOpenTextDocumentParams, object>(LSP.Methods.TextDocumentDidOpenName, didOpenParams, CancellationToken.None);
         }
 
         /// <summary>
         /// Opens a document in the workspace only, and waits for workspace operations.
-        /// Use <see cref="OpenDocumentAsync(DocumentUri, string, string)"/> if the document should be opened in LSP"/>
+        /// Use <see cref="OpenDocumentAsync(DocumentUri, string, string, int)"/> if the document should be opened in LSP"/>
         /// </summary>
         public async Task OpenDocumentInWorkspaceAsync(DocumentId documentId, bool openAllLinkedDocuments, SourceText? text = null)
         {
@@ -745,21 +778,32 @@ public abstract partial class AbstractLanguageServerProtocolTests
             await WaitForWorkspaceOperationsAsync(TestWorkspace);
         }
 
-        public Task ReplaceTextAsync(DocumentUri documentUri, params (LSP.Range Range, string Text)[] changes)
+        public Task ReplaceTextAsync(DocumentUri documentUri, int version, params (LSP.Range Range, string Text)[] changes)
         {
             var didChangeParams = CreateDidChangeTextDocumentParams(
                 documentUri,
-                [.. changes]);
+                [.. changes],
+                version);
             return ExecuteRequestAsync<LSP.DidChangeTextDocumentParams, object>(LSP.Methods.TextDocumentDidChangeName, didChangeParams, CancellationToken.None);
         }
 
-        public Task InsertTextAsync(DocumentUri documentUri, params (int Line, int Column, string Text)[] changes)
+        public Task ReplaceTextAsync(DocumentUri documentUri, params (LSP.Range Range, string Text)[] changes)
         {
-            return ReplaceTextAsync(documentUri, [.. changes.Select(change => (new LSP.Range
+            return ReplaceTextAsync(documentUri, version: 0, changes);
+        }
+
+        public Task InsertTextAsync(DocumentUri documentUri, int version, params (int Line, int Column, string Text)[] changes)
+        {
+            return ReplaceTextAsync(documentUri, version, [.. changes.Select(change => (new LSP.Range
             {
                 Start = new LSP.Position { Line = change.Line, Character = change.Column },
                 End = new LSP.Position { Line = change.Line, Character = change.Column }
             }, change.Text))]);
+        }
+
+        public Task InsertTextAsync(DocumentUri documentUri, params (int Line, int Column, string Text)[] changes)
+        {
+            return InsertTextAsync(documentUri, version: 0, changes);
         }
 
         public Task DeleteTextAsync(DocumentUri documentUri, params (int StartLine, int StartColumn, int EndLine, int EndColumn)[] changes)

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
@@ -28,11 +28,11 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
 
     public Task<object?> HandleRequestAsync(DidChangeTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
     {
-        var text = context.GetTrackedDocumentSourceText(request.TextDocument.DocumentUri);
+        var text = context.GetTrackedDocumentInfo(request.TextDocument.DocumentUri).SourceText;
 
         text = GetUpdatedSourceText(request.ContentChanges, text);
 
-        context.UpdateTrackedDocument(request.TextDocument.DocumentUri, text);
+        context.UpdateTrackedDocument(request.TextDocument.DocumentUri, text, request.TextDocument.Version);
 
         return SpecializedTasks.Default<object>();
     }

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -35,6 +35,6 @@ internal class DidOpenHandler() : ILspServiceNotificationHandler<LSP.DidOpenText
         // Create SourceText from binary representation of the document, retrieve encoding from the request and checksum algorithm from the project.
         var sourceText = SourceText.From(request.TextDocument.Text, System.Text.Encoding.UTF8, SourceHashAlgorithms.OpenDocumentChecksumAlgorithm);
 
-        await context.StartTrackingAsync(request.TextDocument.DocumentUri, sourceText, request.TextDocument.LanguageId, cancellationToken).ConfigureAwait(false);
+        await context.StartTrackingAsync(request.TextDocument.DocumentUri, sourceText, request.TextDocument.LanguageId, request.TextDocument.Version, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
+++ b/src/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
@@ -17,14 +17,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 /// </summary>
 internal interface IDocumentChangeTracker
 {
-    ValueTask StartTrackingAsync(DocumentUri documentUri, SourceText initialText, string languageId, CancellationToken cancellationToken);
-    void UpdateTrackedDocument(DocumentUri documentUri, SourceText text);
+    ValueTask StartTrackingAsync(DocumentUri documentUri, SourceText initialText, string languageId, int lspVersion, CancellationToken cancellationToken);
+    void UpdateTrackedDocument(DocumentUri documentUri, SourceText text, int lspVersion);
     ValueTask StopTrackingAsync(DocumentUri documentUri, CancellationToken cancellationToken);
 }
 
 internal sealed class NonMutatingDocumentChangeTracker : IDocumentChangeTracker
 {
-    public ValueTask StartTrackingAsync(DocumentUri documentUri, SourceText initialText, string languageId, CancellationToken cancellationToken)
+    public ValueTask StartTrackingAsync(DocumentUri documentUri, SourceText initialText, string languageId, int lspVersion, CancellationToken cancellationToken)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }
@@ -34,7 +34,7 @@ internal sealed class NonMutatingDocumentChangeTracker : IDocumentChangeTracker
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }
 
-    public void UpdateTrackedDocument(DocumentUri documentUri, SourceText text)
+    public void UpdateTrackedDocument(DocumentUri documentUri, SourceText text, int lspVersion)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }

--- a/src/LanguageServer/Protocol/Workspaces/TrackedDocumentInfo.cs
+++ b/src/LanguageServer/Protocol/Workspaces/TrackedDocumentInfo.cs
@@ -3,7 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer;
 
+/// <summary>
+/// Holds state information from the client about a tracked LSP document.  See <see cref="LspWorkspaceManager"/> 
+/// </summary>
+/// <param name="SourceText">A snapshot of the text as seen by LSP.</param>
+/// <param name="LanguageId">The language id for the text, from <see cref="TextDocumentItem.LanguageId"/> </param>
+/// <param name="LspVersion">The client version associated with the text, from <see cref="VersionedTextDocumentIdentifier.Version"/></param>
 internal record struct TrackedDocumentInfo(SourceText SourceText, string LanguageId, int LspVersion);

--- a/src/LanguageServer/Protocol/Workspaces/TrackedDocumentInfo.cs
+++ b/src/LanguageServer/Protocol/Workspaces/TrackedDocumentInfo.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.LanguageServer;
+
+internal record struct TrackedDocumentInfo(SourceText SourceText, string LanguageId, int LspVersion);

--- a/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
@@ -2,9 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -13,11 +20,9 @@ using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.DocumentChanges;
 
-public sealed partial class DocumentChangesTests : AbstractLanguageServerProtocolTests
+public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHelper) : AbstractLanguageServerProtocolTests(testOutputHelper)
 {
-    public DocumentChangesTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
-    {
-    }
+    protected override TestComposition Composition => base.Composition.AddParts(typeof(TestVersionHandler));
 
     [Theory, CombinatorialData]
     public async Task DocumentChanges_EndToEnd(bool mutatingLspWorkspace)
@@ -425,6 +430,33 @@ public sealed partial class DocumentChangesTests : AbstractLanguageServerProtoco
         }
     }
 
+    [Theory, CombinatorialData]
+    public async Task DocumentChanges_WithVersion(bool mutatingLspWorkspace)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync("Hello{|type:|}", mutatingLspWorkspace, CapabilitiesWithVSExtensions);
+        Assert.Empty(testLspServer.GetTrackedTexts());
+
+        var locationTyped = testLspServer.GetLocations("type").Single();
+
+        await DidOpen(testLspServer, locationTyped.DocumentUri, version: 0);
+        var version = await GetVersionAsync(locationTyped.DocumentUri);
+        Assert.Equal(0, version);
+
+        await DidChange(testLspServer, locationTyped.DocumentUri, version: 1, (0, 5, ", World"));
+        Assert.Equal(1, await GetVersionAsync(locationTyped.DocumentUri));
+
+        var document = testLspServer.GetTrackedTexts().FirstOrDefault();
+        Assert.Equal("Hello, World", document!.ToString());
+
+        async Task<int> GetVersionAsync(DocumentUri documentUri)
+        {
+            var textDocumentIdentifier = new LSP.TextDocumentIdentifier() { DocumentUri = documentUri };
+            var response = await testLspServer.ExecuteRequestAsync<TextDocumentIdentifier, TestVersionResponse>(TestVersionHandler.MethodName, textDocumentIdentifier, CancellationToken.None);
+            Assert.NotNull(response);
+            return response.Version;
+        }
+    }
+
     private async Task<(TestLspServer, LSP.Location, string)> GetTestLspServerAndLocationAsync(string source, bool mutatingLspWorkspace)
     {
         var testLspServer = await CreateTestLspServerAsync(source, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
@@ -434,10 +466,39 @@ public sealed partial class DocumentChangesTests : AbstractLanguageServerProtoco
         return (testLspServer, locationTyped, documentText.ToString());
     }
 
-    private static Task DidOpen(TestLspServer testLspServer, DocumentUri uri) => testLspServer.OpenDocumentAsync(uri);
+    private static Task DidOpen(TestLspServer testLspServer, DocumentUri uri, int version = 0) => testLspServer.OpenDocumentAsync(uri, version: version);
 
-    private static async Task DidChange(TestLspServer testLspServer, DocumentUri uri, params (int line, int column, string text)[] changes)
-        => await testLspServer.InsertTextAsync(uri, changes);
+    private static async Task DidChange(TestLspServer testLspServer, DocumentUri uri, int version, params (int line, int column, string text)[] changes)
+        => await testLspServer.InsertTextAsync(uri, version, changes);
+
+    private static Task DidChange(TestLspServer testLspServer, DocumentUri uri, params (int line, int column, string text)[] changes)
+        => DidChange(testLspServer, uri, version: 0, changes);
 
     private static async Task DidClose(TestLspServer testLspServer, DocumentUri uri) => await testLspServer.CloseDocumentAsync(uri);
+
+    internal record TestVersionResponse(int Version);
+
+    [ExportCSharpVisualBasicStatelessLspService(typeof(TestVersionHandler)), PartNotDiscoverable, Shared]
+    [Method(MethodName)]
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class TestVersionHandler() : ILspServiceDocumentRequestHandler<TextDocumentIdentifier, TestVersionResponse>
+    {
+        public const string MethodName = nameof(TestVersionHandler);
+
+        public bool MutatesSolutionState => false;
+        public bool RequiresLSPSolution => true;
+
+        public TextDocumentIdentifier GetTextDocumentIdentifier(TextDocumentIdentifier request)
+        {
+            return request;
+        }
+
+        public Task<TestVersionResponse> HandleRequestAsync(TextDocumentIdentifier request, RequestContext context, CancellationToken cancellationToken)
+        {
+            var trackedDocumentInfo = context.GetTrackedDocumentInfo(request.DocumentUri);
+
+            return Task.FromResult(new TestVersionResponse(trackedDocumentInfo.LspVersion));
+        }
+    }
 }


### PR DESCRIPTION
The client tells us the version of the text associated with each didOpen and didChange request.  This PR updates our open document tracker to remember that version and allow subsequent requests to access the current snapshot's LSP version(s).

I'm planning on using this version in a followup on to improve scenarios where we send the client edits to apply (e.g. complex completion edits) to better track why edits may not be applying correctly.