### PR TITLE
Don't count empty script extensions as potential script files

### DIFF
--- a/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
+++ b/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
@@ -47,14 +47,14 @@ internal static class MiscellaneousFileUtilities
 
         if (parseOptions != null &&
             compilationOptions != null &&
-            languageInformation.ScriptExtension != "" &&
+            languageInformation.ScriptExtension is not null &&
             fileExtension == languageInformation.ScriptExtension)
         {
             parseOptions = parseOptions.WithKind(SourceCodeKind.Script);
             compilationOptions = GetCompilationOptionsWithScriptReferenceResolvers(services, compilationOptions, filePath);
         }
 
-        if (parseOptions != null && languageInformation.ScriptExtension != "" && fileExtension != languageInformation.ScriptExtension)
+        if (parseOptions != null && languageInformation.ScriptExtension is not null && fileExtension != languageInformation.ScriptExtension)
         {
             // Any non-script misc file should not complain about usage of '#:' ignored directives.
             parseOptions = parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "true")]);
@@ -122,9 +122,9 @@ internal static class MiscellaneousFileUtilities
     }
 }
 
-internal sealed class LanguageInformation(string languageName, string scriptExtension)
+internal sealed class LanguageInformation(string languageName, string? scriptExtension)
 {
     public string LanguageName { get; } = languageName;
-    public string ScriptExtension { get; } = scriptExtension;
+    public string? ScriptExtension { get; } = scriptExtension;
 }
 

--- a/src/LanguageServer/Protocol/LanguageInfoProvider.cs
+++ b/src/LanguageServer/Protocol/LanguageInfoProvider.cs
@@ -18,9 +18,9 @@ internal sealed class LanguageInfoProvider : ILanguageInfoProvider
     private static readonly LanguageInformation s_csharpLanguageInformation = new(LanguageNames.CSharp, ".csx");
     private static readonly LanguageInformation s_fsharpLanguageInformation = new(LanguageNames.FSharp, ".fsx");
     private static readonly LanguageInformation s_vbLanguageInformation = new(LanguageNames.VisualBasic, ".vbx");
-    private static readonly LanguageInformation s_typeScriptLanguageInformation = new LanguageInformation(InternalLanguageNames.TypeScript, string.Empty);
-    private static readonly LanguageInformation s_razorLanguageInformation = new(RazorLanguageName, string.Empty);
-    private static readonly LanguageInformation s_xamlLanguageInformation = new("XAML", string.Empty);
+    private static readonly LanguageInformation s_typeScriptLanguageInformation = new LanguageInformation(InternalLanguageNames.TypeScript, scriptExtension: null);
+    private static readonly LanguageInformation s_razorLanguageInformation = new(RazorLanguageName, scriptExtension: null);
+    private static readonly LanguageInformation s_xamlLanguageInformation = new("XAML", scriptExtension: null);
 
     private static readonly Dictionary<string, LanguageInformation> s_extensionToLanguageInformation = new()
     {


### PR DESCRIPTION
Part of fixing https://github.com/dotnet/vscode-csharp/issues/8595 along with https://github.com/dotnet/razor/pull/12155

Razor, Xaml and TypeScript set `ScriptExtension` to an empty string, because there is no scripting support. Weird uris from the left side of a diff end up getting a file extension that is an empty string, and hence errors abound.