### PR TITLE
Fix issue reporting diagnostic in additional file when diagnostic produced by a source generator

### DIFF
--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
@@ -41,9 +41,6 @@ internal struct DiagnosticAnalysisResultBuilder(Project project)
         if (diagnostics.Length == 0)
             return;
 
-        // this is for diagnostic producer that doesnt use compiler based DiagnosticAnalyzer such as TypeScript.
-        Contract.ThrowIfTrue(Project.SupportsCompilation);
-
         AddExternalDiagnostics(ref _lazySemanticLocals, documentId, diagnostics);
     }
 


### PR DESCRIPTION
Resolves https://github.com/microsoft/vscode-dotnettools/issues/2173

IDE diagnostic analyzers specifically go through a special path when reporting semantic diagnostics (different to other analyzers).  This path had an old, bogus assert to verify that if the semantic diagnostic was in a file with no syntax tree (e.g. additional file), that also the project the file was in had no compilation (assuming it was a typescript project which has neither).

However this assert now gets hit because
1.  Source generator diagnostics are reported as semantic diagnostics via an IDE diagnostic analyzer ([link](https://github.com/dotnet/roslyn/blob/main/src/Workspaces/Core/Portable/Diagnostics/GeneratorDiagnosticsPlaceholderAnalyzer.cs)).
2.  The Razor source generator reports diagnostics in additional files (the .razor file)

This change removes the assert as it doesn't appear to be necessary or valid.