### PR TITLE
Do not create MEF services eagerly if they're not likely to be used right away

### DIFF
--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
@@ -61,7 +61,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
             return null;
         }
 
-        return this.Workspace.GetProjectWithHierarchyAndName(hierarchy, projectName);
+        return this.Workspace.Value.GetProjectWithHierarchyAndName(hierarchy, projectName);
     }
 
     public int GetLanguage(IVsHierarchy hierarchy, uint itemid, IVsTextBufferCoordinator bufferCoordinator, out IVsContainedLanguage language)

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -50,8 +51,10 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         {
             if (!this.filters.TryGetValue(textView, out var filter))
             {
+                var editorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+
                 filter = new DebuggerIntelliSenseFilter(
-                    this.EditorAdaptersFactoryService.GetWpfTextView(textView),
+                    editorAdaptersFactoryService.GetWpfTextView(textView),
                     this.Package.ComponentModel,
                     this.Package.ComponentModel.GetService<IFeatureServiceFactory>());
                 this.filters[textView] = filter;
@@ -83,13 +86,14 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         // commit, so we need to drag the IVsTextLines around, too.
         Marshal.ThrowExceptionForHR(textView.GetBuffer(out var debuggerBuffer));
 
-        var view = EditorAdaptersFactoryService.GetWpfTextView(textView);
+        var editorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+        var view = editorAdaptersFactoryService.GetWpfTextView(textView);
 
         // Sometimes, they give us a null context buffer. In that case, there's probably not any
         // work to do.
         if (buffer != null)
         {
-            var contextBuffer = EditorAdaptersFactoryService.GetDataBuffer(buffer);
+            var contextBuffer = editorAdaptersFactoryService.GetDataBuffer(buffer);
 
             if (!contextBuffer.ContentType.IsOfType(this.ContentTypeName))
             {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageBlock.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageBlock.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
@@ -29,7 +30,9 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         out string pbstrDescription,
         out int pfBlockAvailable)
     {
-        var snapshot = this.EditorAdaptersFactoryService.GetDataBuffer(pTextLines).CurrentSnapshot;
+        var editorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+
+        var snapshot = editorAdaptersFactoryService.GetDataBuffer(pTextLines).CurrentSnapshot;
         var position = snapshot?.TryGetPosition(iCurrentLine, iCurrentChar);
         if (position == null)
         {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageContextProvider.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageContextProvider.cs
@@ -5,6 +5,7 @@
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.F1Help;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -17,7 +18,8 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
     {
         return this.ThreadingContext.JoinableTaskFactory.Run(async () =>
         {
-            var textBuffer = EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
+            var editorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+            var textBuffer = editorAdaptersFactoryService.GetDataBuffer(pBuffer);
             var context = (IVsUserContext)pUC;
 
             if (textBuffer == null || context == null)

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
@@ -20,7 +20,7 @@ internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVs
     {
         try
         {
-            return _languageDebugInfo.GetLanguageID(pBuffer, iLine, iCol, out pguidLanguageID);
+            return _languageDebugInfo.Value.GetLanguageID(pBuffer, iLine, iCol, out pguidLanguageID);
         }
         catch (Exception e) when (FatalError.ReportAndPropagate(e))
         {
@@ -32,7 +32,7 @@ internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVs
     {
         try
         {
-            return _languageDebugInfo.GetLocationOfName(pszName, out pbstrMkDoc, out pspanLocation);
+            return _languageDebugInfo.Value.GetLocationOfName(pszName, out pbstrMkDoc, out pspanLocation);
         }
         catch (Exception e) when (FatalError.ReportAndPropagate(e))
         {
@@ -44,7 +44,7 @@ internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVs
     {
         try
         {
-            return _languageDebugInfo.GetNameOfLocation(pBuffer, iLine, iCol, out pbstrName, out piLineOffset);
+            return _languageDebugInfo.Value.GetNameOfLocation(pBuffer, iLine, iCol, out pbstrName, out piLineOffset);
         }
         catch (Exception e) when (FatalError.ReportAndPropagate(e))
         {
@@ -56,7 +56,7 @@ internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVs
     {
         try
         {
-            return _languageDebugInfo.GetProximityExpressions(pBuffer, iLine, iCol, cLines, out ppEnum);
+            return _languageDebugInfo.Value.GetProximityExpressions(pBuffer, iLine, iCol, cLines, out ppEnum);
         }
         catch (Exception e) when (FatalError.ReportAndPropagate(e))
         {
@@ -68,7 +68,7 @@ internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVs
     {
         try
         {
-            return _languageDebugInfo.IsMappedLocation(pBuffer, iLine, iCol);
+            return _languageDebugInfo.Value.IsMappedLocation(pBuffer, iLine, iCol);
         }
         catch (Exception e) when (FatalError.ReportAndPropagate(e))
         {
@@ -80,7 +80,7 @@ internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVs
     {
         try
         {
-            return _languageDebugInfo.ResolveName(pszName, dwFlags, out ppNames);
+            return _languageDebugInfo.Value.ResolveName(pszName, dwFlags, out ppNames);
         }
         catch (Exception e) when (FatalError.ReportAndPropagate(e))
         {
@@ -92,7 +92,7 @@ internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVs
     {
         try
         {
-            return _languageDebugInfo.ValidateBreakpointLocation(pBuffer, iLine, iCol, pCodeSpan);
+            return _languageDebugInfo.Value.ValidateBreakpointLocation(pBuffer, iLine, iCol, pCodeSpan);
         }
         catch (Exception e) when (FatalError.ReportAndPropagate(e))
         {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
@@ -56,7 +57,8 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         var documentSyntax = ParsedDocument.CreateSynchronously(document, cancellationToken);
         var text = documentSyntax.Text;
         var root = documentSyntax.Root;
-        var formattingOptions = textBuffer.GetSyntaxFormattingOptions(EditorOptionsService, document.Project.GetFallbackAnalyzerOptions(), document.Project.Services, explicitFormat: true);
+        var editorOptionsService = this.Package.ComponentModel.GetService<EditorOptionsService>();
+        var formattingOptions = textBuffer.GetSyntaxFormattingOptions(editorOptionsService, document.Project.GetFallbackAnalyzerOptions(), document.Project.Services, explicitFormat: true);
 
         var ts = selections.Single();
         var start = text.Lines[ts.iStartLine].Start + ts.iStartIndex;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -67,7 +67,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
 
         // Since we know we are on the UI thread, lets get the base indentation now, so that there is less
         // cleanup work to do later in Venus.
-        var ruleFactory = Workspace.Services.GetService<IHostDependentFormattingRuleFactoryService>();
+        var ruleFactory = Workspace.Value.Services.GetService<IHostDependentFormattingRuleFactoryService>();
 
         // use formatting that return text changes rather than tree rewrite which is more expensive
         var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -8,12 +8,12 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
@@ -42,7 +42,8 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
 
     private int FormatWorker(IVsTextLayer textLayer, TextSpan[] selections, CancellationToken cancellationToken)
     {
-        var textBuffer = this.EditorAdaptersFactoryService.GetDataBuffer((IVsTextBuffer)textLayer);
+        var editorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+        var textBuffer = editorAdaptersFactoryService.GetDataBuffer((IVsTextBuffer)textLayer);
         if (textBuffer == null)
         {
             return VSConstants.E_UNEXPECTED;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -77,7 +77,8 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
                 return;
             }
 
-            var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(buffer);
+            var editorAdaptersFactoryService = _languageService.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+            var textBuffer = editorAdaptersFactoryService.GetDataBuffer(buffer);
             var document = textBuffer?.AsTextContainer()?.GetRelatedDocuments().FirstOrDefault();
             // TODO - Remove the TS check once they move the liveshare navbar to LSP.  Then we can also switch to LSP
             // for the local navbar implementation.
@@ -156,7 +157,8 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
             }
 
             var navigationBarClient = new NavigationBarClient(dropdownManager, _codeWindow, _languageService.SystemServiceProvider, _languageService.Workspace.Value);
-            var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(buffer);
+            var editorAdaptersFactoryService = _languageService.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+            var textBuffer = editorAdaptersFactoryService.GetDataBuffer(buffer);
             var controllerFactoryService = _languageService.Package.ComponentModel.GetService<INavigationBarControllerFactoryService>();
             var newController = controllerFactoryService.CreateController(navigationBarClient, textBuffer!);
             var hr = dropdownManager.AddDropdownBar(cCombos: 3, pClient: navigationBarClient);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -155,7 +155,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
                 return;
             }
 
-            var navigationBarClient = new NavigationBarClient(dropdownManager, _codeWindow, _languageService.SystemServiceProvider, _languageService.Workspace);
+            var navigationBarClient = new NavigationBarClient(dropdownManager, _codeWindow, _languageService.SystemServiceProvider, _languageService.Workspace.Value);
             var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(buffer);
             var controllerFactoryService = _languageService.Package.ComponentModel.GetService<INavigationBarControllerFactoryService>();
             var newController = controllerFactoryService.CreateController(navigationBarClient, textBuffer!);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -195,7 +195,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
                     var cancellationToken = waitContext.UserCancellationToken;
                     if (dwFlags == (uint)RESOLVENAMEFLAGS.RNF_BREAKPOINT)
                     {
-                        var solution = _languageService.Workspace.CurrentSolution;
+                        var solution = _languageService.Workspace.Value.CurrentSolution;
 
                         if (_breakpointService != null)
                         {
@@ -220,7 +220,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
                 // and using the blocked thread whenever possible.
 
                 var document = breakpoint.Document;
-                var filePath = _languageService.Workspace.GetFilePath(document.Id);
+                var filePath = _languageService.Workspace.Value.GetFilePath(document.Id);
 
                 // We're (unfortunately) blocking the UI thread here.  So avoid async io as we actually
                 // awant the IO to complete as quickly as possible, on this thread if necessary.

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Utilities;
@@ -92,7 +93,9 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
                             showProgress: false);
 
                         var cancellationToken = waitContext.UserCancellationToken;
-                        var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
+                        var editorAdaptersFactoryService = _languageService.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+
+                        var textBuffer = editorAdaptersFactoryService.GetDataBuffer(pBuffer);
                         if (textBuffer == null)
                             return default;
 
@@ -135,7 +138,9 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
                     if (_proximityExpressionsService == null)
                         return null;
 
-                    var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
+                    var editorAdaptersFactoryService = _languageService.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+
+                    var textBuffer = editorAdaptersFactoryService.GetDataBuffer(pBuffer);
                     if (textBuffer == null)
                         return null;
 
@@ -264,7 +269,8 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
             if (_breakpointService == null)
                 return VSConstants.E_FAIL;
 
-            var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
+            var editorAdaptersFactoryService = _languageService.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+            var textBuffer = editorAdaptersFactoryService.GetDataBuffer(pBuffer);
             if (textBuffer != null)
             {
                 var snapshot = textBuffer.CurrentSnapshot;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
@@ -53,7 +53,6 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
     // exception assistant.
     internal object? ComAggregate { get; private set; }
 
-    internal readonly EditorOptionsService EditorOptionsService;
     internal readonly VisualStudioWorkspaceImpl Workspace;
     internal readonly IVsEditorAdaptersFactoryService EditorAdaptersFactoryService;
 
@@ -68,7 +67,6 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
 
         Debug.Assert(!this.Package.JoinableTaskFactory.Context.IsOnMainThread, "Language service should be instantiated on background thread");
 
-        this.EditorOptionsService = this.Package.ComponentModel.GetService<EditorOptionsService>();
         this.Workspace = this.Package.ComponentModel.GetService<VisualStudioWorkspaceImpl>();
         this.EditorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
         this._languageDebugInfo = CreateLanguageDebugInfo();

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
@@ -36,7 +36,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
 {
     internal TPackage Package { get; }
 
-    private readonly VsLanguageDebugInfo _languageDebugInfo;
+    private readonly Lazy<VsLanguageDebugInfo> _languageDebugInfo;
 
     // DevDiv 753309:
     // We've redefined some VS interfaces that had incorrect PIAs. When 
@@ -68,7 +68,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
 
         this.Workspace = this.Package.ComponentModel.DefaultExportProvider.GetExport<VisualStudioWorkspaceImpl>();
 
-        this._languageDebugInfo = CreateLanguageDebugInfo();
+        this._languageDebugInfo = new Lazy<VsLanguageDebugInfo>(CreateLanguageDebugInfo);
     }
 
     private IThreadingContext ThreadingContext => this.Package.ComponentModel.GetService<IThreadingContext>();

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
@@ -103,8 +103,6 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
 
         Debug.Assert(!wpfTextView.Properties.ContainsProperty(typeof(AbstractVsTextViewFilter)));
 
-        var workspace = Package.ComponentModel.GetService<VisualStudioWorkspace>();
-
         // The lifetime of CommandFilter is married to the view
         wpfTextView.GetOrCreateAutoClosingProperty(v =>
             new StandaloneCommandFilter(

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
@@ -54,7 +54,6 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
     internal object? ComAggregate { get; private set; }
 
     internal readonly Lazy<VisualStudioWorkspaceImpl> Workspace;
-    internal readonly IVsEditorAdaptersFactoryService EditorAdaptersFactoryService;
 
     protected abstract string ContentTypeName { get; }
     protected abstract string LanguageName { get; }
@@ -68,7 +67,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         Debug.Assert(!this.Package.JoinableTaskFactory.Context.IsOnMainThread, "Language service should be instantiated on background thread");
 
         this.Workspace = this.Package.ComponentModel.DefaultExportProvider.GetExport<VisualStudioWorkspaceImpl>();
-        this.EditorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+
         this._languageDebugInfo = CreateLanguageDebugInfo();
     }
 
@@ -96,7 +95,8 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
     {
         Contract.ThrowIfNull(textView);
 
-        var wpfTextView = EditorAdaptersFactoryService.GetWpfTextView(textView);
+        var editorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+        var wpfTextView = editorAdaptersFactoryService.GetWpfTextView(textView);
         Contract.ThrowIfNull(wpfTextView, "Could not get IWpfTextView for IVsTextView");
 
         Debug.Assert(!wpfTextView.Properties.ContainsProperty(typeof(AbstractVsTextViewFilter)));

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -33,9 +33,7 @@ using Microsoft.VisualStudio.LanguageServices.StackTraceExplorer;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
-using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
-using Roslyn.Utilities;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.Setup;


### PR DESCRIPTION
The setup of our language service had a bunch of fetches of MEF components for things that would get used 'later'. This was either for 'convenience', or dated back to the time when we were focused on the performance of opening a source file after solution load and as such it was preferred to preload things when you could. At this point however, the stuff using these are only in certain entrypoints that are unlikely to be used, so there's no reason to be creating some MEF components eagerly for those cases. This also simplifies the creation of our language service object to be nearly a no-op which is just easier to reason about.