### PR TITLE
Keep necessary parentheses around a collection expression.

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
@@ -3269,4 +3269,88 @@ compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLib
                 }
             }
             """);
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80082")]
+    [InlineData("int?")]
+    [InlineData("int*")]
+    [InlineData("int[]")]
+    [InlineData("int")]
+    [InlineData("A::B")]
+    [InlineData("List<A>")]
+    [InlineData("List<int>")]
+    [InlineData("A.List<A>")]
+    [InlineData("A.List<int>")]
+    [InlineData("global::A.List<A>")]
+    [InlineData("global::A.List<int>")]
+    [InlineData("(A, B)")]
+    public Task TestCollectionExpressionCast_NotEmpty_ShouldRemove(string type)
+        => TestInRegularAndScriptAsync($$"""
+            class C
+            {
+                public void M()
+                {
+                    var v = ({{type}})$$([a, b, c]);
+                }
+            }
+            """,
+            $$"""
+            class C
+            {
+                public void M()
+                {
+                    var v = ({{type}})[a, b, c];
+                }
+            }
+            """);
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80082")]
+    [InlineData("int?")]
+    [InlineData("int*")]
+    [InlineData("int[]")]
+    [InlineData("int")]
+    [InlineData("A::B")]
+    [InlineData("List<A>")]
+    [InlineData("List<int>")]
+    [InlineData("A.List<A>")]
+    [InlineData("A.List<int>")]
+    [InlineData("global::A.List<A>")]
+    [InlineData("global::A.List<int>")]
+    [InlineData("(A, B)")]
+    [InlineData("A")]
+    [InlineData("A.B")]
+    [InlineData("global::A.B")]
+    public Task TestCollectionExpressionCast_Empty_ShouldRemove(string type)
+        => TestInRegularAndScriptAsync($$"""
+            class C
+            {
+                public void M()
+                {
+                    var v = ({{type}})$$([]);
+                }
+            }
+            """,
+            $$"""
+            class C
+            {
+                public void M()
+                {
+                    var v = ({{type}})[];
+                }
+            }
+            """);
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80082")]
+    [InlineData("A")]
+    [InlineData("A.B")]
+    [InlineData("global::A.B")]
+    public Task TestCollectionExpressionCast_NotEmpty_ShouldNotRemove(string type)
+        => TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                public void M()
+                {
+                    var v = ({{type}})$$([a, b, c]);
+                }
+            }
+            """);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -137,17 +137,13 @@ internal static class ParenthesizedExpressionSyntaxExtensions
             //
             // Note: because `(T)[]` is never legal (an empty indexer is not legal), that form is always
             // considered a collection expression, regardless of what T is.
-            if (parentExpression is CastExpressionSyntax { Type: var castType } &&
-                collectionExpression.Elements.Count > 0)
+            if (collectionExpression.Elements.Count == 0)
+                return true;
+
+            return parentExpression is not CastExpressionSyntax
             {
-                if (castType is QualifiedNameSyntax { Right: var right })
-                    castType = right;
-
-                if (castType is IdentifierNameSyntax)
-                    return false;
-            }
-
-            return true;
+                Type: IdentifierNameSyntax or QualifiedNameSyntax { Right: IdentifierNameSyntax }
+            };
         }
 
         // int Prop => (x); -> int Prop => x;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/80081
Fixes https://github.com/dotnet/roslyn/issues/80082