### PR TITLE
Update VSInternalContinueCharacter* serialization

### DIFF
--- a/src/LanguageServer/Protocol/Protocol/Internal/VSInternalContinueCharacterClass.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/VSInternalContinueCharacterClass.cs
@@ -9,14 +9,18 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// Class representing a unicode character class for completion continuation.
 /// </summary>
+[Kind(Type, "_vs_type")]
 internal sealed class VSInternalContinueCharacterClass
 {
+    public const string Type = "unicodeClass";
+
     /// <summary>
     /// Gets the type value.
     /// </summary>
     [JsonPropertyName("_vs_type")]
     [JsonRequired]
-    public const string Type = "unicodeClass";
+    [JsonInclude]
+    internal string TypeDiscriminator = Type;
 
     /// <summary>
     /// Gets or sets the unicode class.

--- a/src/LanguageServer/Protocol/Protocol/Internal/VSInternalContinueCharacterRange.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/VSInternalContinueCharacterRange.cs
@@ -9,14 +9,18 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// Class representing range of characters for completion continuation.
 /// </summary>
+[Kind(Type, "_vs_type")]
 internal sealed class VSInternalContinueCharacterRange
 {
+    public const string Type = "charRange";
+
     /// <summary>
     /// Gets the type value.
     /// </summary>
     [JsonPropertyName("_vs_type")]
     [JsonRequired]
-    public const string Type = "charRange";
+    [JsonInclude]
+    internal string TypeDiscriminator = Type;
 
     /// <summary>
     /// Gets or sets the first completion character of the range.

--- a/src/LanguageServer/Protocol/Protocol/Internal/VSInternalContinueCharacterSingle.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/VSInternalContinueCharacterSingle.cs
@@ -9,14 +9,18 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// Class representing single continue character for completion.
 /// </summary>
+[Kind(Type, "_vs_type")]
 internal sealed class VSInternalContinueCharacterSingle
 {
+    public const string Type = "singleChar";
+
     /// <summary>
     /// Gets the type value.
     /// </summary>
     [JsonPropertyName("_vs_type")]
     [JsonRequired]
-    public const string Type = "singleChar";
+    [JsonInclude]
+    internal string TypeDiscriminator = Type;
 
     /// <summary>
     /// Gets or sets the completion character.


### PR DESCRIPTION
Exception counts during the RazorEditingTEsts.CompletionInLSP test is off the chart due to JS completion utilizing VSInternalContinueCharacter classes. These classes were being improperly serialized. The vslanguageserverclient part of this change went in via https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/665374 and has made it's way to the latest Int.Main.

This PR simply does the same thing as the vslnaguageserverclient PR.

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/666067

<img width="841" height="307" alt="image" src="https://github.com/user-attachments/assets/6b2b9304-337b-4fe0-aeb1-5af62feaf32d" />