### PR TITLE
Pass global properties and the binary log path via RPC

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -18,17 +19,23 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 internal sealed class BuildHost : IBuildHost
 {
     private readonly BuildHostLogger _logger;
-    private readonly ImmutableDictionary<string, string> _globalMSBuildProperties;
-    private readonly string? _binaryLogPath;
     private readonly RpcServer _server;
     private readonly object _gate = new object();
     private ProjectBuildManager? _buildManager;
 
-    public BuildHost(BuildHostLogger logger, ImmutableDictionary<string, string> globalMSBuildProperties, string? binaryLogPath, RpcServer server)
+    /// <summary>
+    /// The global properties to use for all builds; should not be changed once the <see cref="_buildManager"/> is initialized.
+    /// </summary>
+    private ImmutableDictionary<string, string>? _globalMSBuildProperties;
+
+    /// <summary>
+    /// The binary log path to use for all builds; should not be changed once the <see cref="_buildManager"/> is initialized.
+    /// </summary>
+    private string? _binaryLogPath;
+
+    public BuildHost(BuildHostLogger logger, RpcServer server)
     {
         _logger = logger;
-        _globalMSBuildProperties = globalMSBuildProperties;
-        _binaryLogPath = binaryLogPath;
         _server = server;
     }
 
@@ -122,6 +129,9 @@ internal sealed class BuildHost : IBuildHost
             if (_buildManager != null)
                 return;
 
+            if (_globalMSBuildProperties is null)
+                throw new InvalidOperationException($"{nameof(ConfigureGlobalState)} should have been called first to set up global state.");
+
             BinaryLogger? logger = null;
 
             if (_binaryLogPath != null)
@@ -148,6 +158,18 @@ internal sealed class BuildHost : IBuildHost
     private void EnsureMSBuildLoaded(string projectFilePath)
     {
         Contract.ThrowIfFalse(TryEnsureMSBuildLoaded(projectFilePath), $"We don't have an MSBuild to use; {nameof(HasUsableMSBuild)} should have been called first to check.");
+    }
+
+    public void ConfigureGlobalState(ImmutableDictionary<string, string> globalProperties, string? binlogPath)
+    {
+        lock (_gate)
+        {
+            if (_buildManager != null)
+                throw new InvalidOperationException($"{nameof(_buildManager)} has already been initialized and cannot be changed");
+
+            _globalMSBuildProperties = globalProperties;
+            _binaryLogPath = binlogPath;
+        }
     }
 
     /// <summary>

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/Contracts/IBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/Contracts/IBuildHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,6 +28,12 @@ internal interface IBuildHost
     /// This may return true even if the project or solution require a newer version of MSBuild.
     /// </remarks>
     bool HasUsableMSBuild(string projectOrSolutionFilePath);
+
+    /// <summary>
+    /// Called once on a new process to configure some global state. This is used for these rather than passing through command line strings, since these contain data that might
+    /// contain paths (which can have escaping issues) or could be quite large (which could run into length limits).
+    /// </summary>
+    void ConfigureGlobalState(ImmutableDictionary<string, string> globalProperties, string? binlogPath);
 
     Task<int> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken);
 

--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
@@ -238,7 +238,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
 
         AddArgument(processStartInfo, netCoreBuildHostPath);
 
-        AppendBuildHostCommandLineArgumentsConfigureProcess(processStartInfo, pipeName);
+        AppendBuildHostCommandLineArgumentsAndConfigureProcess(processStartInfo, pipeName);
 
         return processStartInfo;
     }
@@ -256,7 +256,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
             FileName = netFrameworkBuildHost,
         };
 
-        AppendBuildHostCommandLineArgumentsConfigureProcess(processStartInfo, pipeName);
+        AppendBuildHostCommandLineArgumentsAndConfigureProcess(processStartInfo, pipeName);
 
         return processStartInfo;
     }
@@ -270,7 +270,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
 
         AddArgument(processStartInfo, GetDotNetFrameworkBuildHostPath());
 
-        AppendBuildHostCommandLineArgumentsConfigureProcess(processStartInfo, pipeName);
+        AppendBuildHostCommandLineArgumentsAndConfigureProcess(processStartInfo, pipeName);
 
         return processStartInfo;
     }
@@ -307,7 +307,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         return buildHostPath;
     }
 
-    private void AppendBuildHostCommandLineArgumentsConfigureProcess(ProcessStartInfo processStartInfo, string pipeName)
+    private static void AppendBuildHostCommandLineArgumentsAndConfigureProcess(ProcessStartInfo processStartInfo, string pipeName)
     {
         AddArgument(processStartInfo, "--pipe");
         AddArgument(processStartInfo, pipeName);

--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
@@ -120,6 +120,8 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
                 throw new Exception($"BuildHost process exited immediately with {process.ExitCode}");
             }
 
+            await buildHostProcess.BuildHost.ConfigureGlobalStateAsync(_globalMSBuildProperties, _binaryLogPathProvider.GetNewLogPath(), cancellationToken).ConfigureAwait(false);
+
             if (buildHostKind != BuildHostProcessKind.NetCore
                 || projectOrSolutionFilePath is null
                 || dotnetPath is not null)
@@ -309,18 +311,6 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
     {
         AddArgument(processStartInfo, "--pipe");
         AddArgument(processStartInfo, pipeName);
-
-        foreach (var globalMSBuildProperty in _globalMSBuildProperties)
-        {
-            AddArgument(processStartInfo, "--property");
-            AddArgument(processStartInfo, globalMSBuildProperty.Key + '=' + globalMSBuildProperty.Value);
-        }
-
-        if (_binaryLogPathProvider?.GetNewLogPath() is string binaryLogPath)
-        {
-            AddArgument(processStartInfo, "--binlog");
-            AddArgument(processStartInfo, binaryLogPath);
-        }
 
         AddArgument(processStartInfo, "--locale");
         AddArgument(processStartInfo, System.Globalization.CultureInfo.CurrentUICulture.Name);

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,6 +39,10 @@ internal sealed class RemoteBuildHost
     public Task<bool> HasUsableMSBuildAsync(string projectOrSolutionFilePath, CancellationToken cancellationToken)
         => _client.InvokeAsync<bool>(BuildHostTargetObject, nameof(IBuildHost.HasUsableMSBuild), parameters: [projectOrSolutionFilePath], cancellationToken);
 
+    /// <inheritdoc cref="IBuildHost.ConfigureGlobalState(ImmutableDictionary{string, string}, string?)"/>
+    public Task ConfigureGlobalStateAsync(ImmutableDictionary<string, string> globalProperties, string? binlogPath, CancellationToken cancellationToken)
+        => _client.InvokeAsync(BuildHostTargetObject, nameof(IBuildHost.ConfigureGlobalState), parameters: [globalProperties, binlogPath], cancellationToken);
+
     public async Task<RemoteProjectFile> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken)
     {
         var remoteProjectFileTargetObject = await _client.InvokeAsync<int>(BuildHostTargetObject, nameof(IBuildHost.LoadProjectFileAsync), parameters: [projectFilePath, languageName], cancellationToken).ConfigureAwait(false);
@@ -61,5 +67,4 @@ internal sealed class RemoteBuildHost
 
     public Task ShutdownAsync(CancellationToken cancellationToken)
         => _client.InvokeAsync(BuildHostTargetObject, nameof(IBuildHost.ShutdownAsync), parameters: [], cancellationToken);
-
 }


### PR DESCRIPTION
This avoids all the complexities of having to deal with escaping for the global properties or binary log, which can contain hard-to-escape file paths, or might just be really long.

Fixes https://github.com/dotnet/roslyn/issues/78889
Closes https://github.com/dotnet/roslyn/issues/71021