### PR TITLE
Report analyzer load failures as MSBuild workspace diagnostics.

### DIFF
--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -354,7 +354,7 @@ public partial class MSBuildProjectLoader
                 var analyzerConfigDocuments = CreateDocumentInfos(projectFileInfo.AnalyzerConfigDocuments, projectId, commandLineArgs.Encoding);
                 CheckForDuplicateDocuments(documents.Concat(additionalDocuments).Concat(analyzerConfigDocuments), projectPath, projectId);
 
-                var analyzerReferences = ResolveAnalyzerReferences(commandLineArgs);
+                var analyzerReferences = ResolveAnalyzerReferences(projectFileInfo.Language, commandLineArgs);
 
                 var resolvedReferences = await ResolveReferencesAsync(projectId, projectFileInfo, commandLineArgs, cancellationToken).ConfigureAwait(false);
 
@@ -397,7 +397,7 @@ public partial class MSBuildProjectLoader
             return assemblyName;
         }
 
-        private IEnumerable<AnalyzerReference> ResolveAnalyzerReferences(CommandLineArguments commandLineArgs)
+        private IEnumerable<AnalyzerReference> ResolveAnalyzerReferences(string language, CommandLineArguments commandLineArgs)
         {
             var analyzerService = GetWorkspaceService<IAnalyzerService>();
             if (analyzerService is null)
@@ -412,18 +412,66 @@ public partial class MSBuildProjectLoader
             {
                 string? fullPath;
 
-                if (PathUtilities.IsAbsolute(path))
-                {
-                    fullPath = FileUtilities.TryNormalizeAbsolutePath(path);
+                if (!PathUtilities.IsAbsolute(path))
+                    continue;
 
-                    if (fullPath != null && File.Exists(fullPath))
-                    {
-                        analyzerLoader.AddDependencyLocation(fullPath);
-                    }
-                }
+                fullPath = FileUtilities.TryNormalizeAbsolutePath(path);
+
+                if (fullPath != null && File.Exists(fullPath))
+                    analyzerLoader.AddDependencyLocation(fullPath);
             }
 
-            return commandLineArgs.ResolveAnalyzerReferences(analyzerLoader).Distinct(AnalyzerReferencePathComparer.Instance);
+            var analyzerReferences = commandLineArgs.ResolveAnalyzerReferences(analyzerLoader).Distinct(AnalyzerReferencePathComparer.Instance);
+
+            // Force loading of the analyzers so that we can record any load failures now.
+            foreach (var analyzerReference in analyzerReferences.OfType<AnalyzerFileReference>())
+            {
+                analyzerReference.AnalyzerLoadFailed += OnAnalyzerLoadFailed;
+                _ = analyzerReference.GetAnalyzers(language);
+                _ = analyzerReference.GetGenerators(language);
+                analyzerReference.AnalyzerLoadFailed -= OnAnalyzerLoadFailed;
+            }
+
+            return analyzerReferences;
+
+            void OnAnalyzerLoadFailed(object? sender, AnalyzerLoadFailureEventArgs args)
+            {
+                if (sender is not AnalyzerFileReference analyzerFileReference)
+                    return;
+
+                // Compiler error strings are not accessible here, so we will just log the information
+                // that goes into those strings (see CommandLineArguments.ResolveAnalyzersFromArguments)
+
+                StringBuilder message = new();
+
+                message.Append(args.ErrorCode);
+                message.Append(": ");
+                message.Append(analyzerFileReference.FullPath);
+                message.Append(": ");
+
+                switch (args.ErrorCode)
+                {
+                    case AnalyzerLoadFailureEventArgs.FailureErrorCode.UnableToLoadAnalyzer:
+                        message.Append(args.Exception?.Message ?? args.Message);
+                        break;
+                    case AnalyzerLoadFailureEventArgs.FailureErrorCode.UnableToCreateAnalyzer:
+                        message.Append(args.TypeName);
+                        message.Append(": ");
+                        message.Append(args.Exception?.Message ?? args.Message);
+                        break;
+                    case AnalyzerLoadFailureEventArgs.FailureErrorCode.ReferencesNewerCompiler:
+                        message.Append(args.ReferencedCompilerVersion);
+                        break;
+                    case AnalyzerLoadFailureEventArgs.FailureErrorCode.ReferencesFramework:
+                        message.Append(args.TypeName);
+                        break;
+                    case AnalyzerLoadFailureEventArgs.FailureErrorCode.NoAnalyzers:
+                    case AnalyzerLoadFailureEventArgs.FailureErrorCode.None:
+                        break;
+                }
+
+                _diagnosticReporter.Report(DiagnosticReportingMode.Log, message.ToString());
+            }
         }
 
         private ImmutableArray<DocumentInfo> CreateDocumentInfos(IReadOnlyList<DocumentFileInfo> documentFileInfos, ProjectId projectId, Encoding? encoding)

--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
@@ -125,13 +125,13 @@ public sealed class MSBuildWorkspace : Workspace
 
     /// <summary>
     /// Determines if unrecognized projects are skipped when solutions or projects are opened.
-    /// 
-    /// An project is unrecognized if it either has 
-    ///   a) an invalid file path, 
+    ///
+    /// An project is unrecognized if it either has
+    ///   a) an invalid file path,
     ///   b) a non-existent project file,
-    ///   c) has an unrecognized file extension or 
+    ///   c) has an unrecognized file extension or
     ///   d) a file extension associated with an unsupported language.
-    /// 
+    ///
     /// If unrecognized projects cannot be skipped a corresponding exception is thrown.
     /// </summary>
     public bool SkipUnrecognizedProjects

--- a/src/Workspaces/MSBuild/Test/Resources/ProjectFiles/CSharp/AnalyzerWithLaterCompilerDependency.csproj
+++ b/src/Workspaces/MSBuild/Test/Resources/ProjectFiles/CSharp/AnalyzerWithLaterCompilerDependency.csproj
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ProjectGuid>{3DA47258-9CAB-4FB9-9C04-1F367A2C2700}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CSharpProject_AnalyzerReference</RootNamespace>
+    <AssemblyName>CSharpProject_AnalyzerReference</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AdditionalFileItemNames>Content</AdditionalFileItemNames>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CSharpClass.cs" />
+    <Content Include="XamlFile.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="AnalyzerWithLaterFakeCompilerDependency.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/MSBuild/Test/Resources/ProjectFiles/VisualBasic/AnalyzerWithLaterCompilerDependency.vbproj
+++ b/src/Workspaces/MSBuild/Test/Resources/ProjectFiles/VisualBasic/AnalyzerWithLaterCompilerDependency.vbproj
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ProductVersion></ProductVersion>
+    <SchemaVersion></SchemaVersion>
+    <ProjectGuid>{AC25ECDA-DE94-4FCF-A688-EB3A2BE3670C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>VisualBasicProject_AnalyzerReference</RootNamespace>
+    <AssemblyName>VisualBasicProject_AnalyzerReference</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <MyType>Windows</MyType>
+   <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <AdditionalFileItemNames>Content</AdditionalFileItemNames>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DocumentationFile>VisualBasicProject.xml</DocumentationFile>
+    <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <RemoveIntegerChecks>true</RemoveIntegerChecks>
+    <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
+    <DefineConstants>FURBY</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <DefineDebug>false</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DocumentationFile>VisualBasicProject.xml</DocumentationFile>
+    <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionExplicit>On</OptionExplicit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionCompare>Binary</OptionCompare>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionStrict>Off</OptionStrict>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionInfer>On</OptionInfer>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Import Include="Microsoft.VisualBasic" />
+    <Import Include="System" />
+    <Import Include="System.Collections" />
+    <Import Include="System.Collections.Generic" />
+    <Import Include="System.Diagnostics" />
+    <Import Include="System.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="My Project\Application.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Application.myapp</DependentUpon>
+    </Compile>
+    <Compile Include="My Project\AssemblyInfo.vb" />
+    <Compile Include="My Project\Resources.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="My Project\Settings.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+    <Compile Include="VisualBasicClass.vb" />
+    <Content Include="XamlFile.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="My Project\Resources.resx">
+      <Generator>VbMyResourcesResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.vb</LastGenOutput>
+      <CustomToolNamespace>My.Resources</CustomToolNamespace>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="My Project\Application.myapp">
+      <Generator>MyApplicationCodeGenerator</Generator>
+      <LastGenOutput>Application.Designer.vb</LastGenOutput>
+    </None>
+    <None Include="My Project\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <CustomToolNamespace>My</CustomToolNamespace>
+      <LastGenOutput>Settings.Designer.vb</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="AnalyzerWithLaterFakeCompilerDependency.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/MSBuild/Test/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuild/Test/TestFiles/Resources.cs
@@ -111,6 +111,7 @@ public static class Resources
         public static class CSharp
         {
             public static string AnalyzerReference => GetText("ProjectFiles.CSharp.AnalyzerReference.csproj");
+            public static string AnalyzerWithLaterCompilerDependency => GetText("ProjectFiles.CSharp.AnalyzerWithLaterCompilerDependency.csproj");
             public static string AllOptions => GetText("ProjectFiles.CSharp.AllOptions.csproj");
             public static string AssemblyNameIsPath => GetText("ProjectFiles.CSharp.AssemblyNameIsPath.csproj");
             public static string AssemblyNameIsPath2 => GetText("ProjectFiles.CSharp.AssemblyNameIsPath2.csproj");
@@ -185,6 +186,7 @@ public static class Resources
         public static class VisualBasic
         {
             public static string AnalyzerReference => GetText("ProjectFiles.VisualBasic.AnalyzerReference.vbproj");
+            public static string AnalyzerWithLaterCompilerDependency => GetText("ProjectFiles.VisualBasic.AnalyzerWithLaterCompilerDependency.vbproj");
             public static string Circular_Target => GetText("ProjectFiles.VisualBasic.Circular_Target.vbproj");
             public static string Circular_Top => GetText("ProjectFiles.VisualBasic.Circular_Top.vbproj");
             public static string Embed => GetText("ProjectFiles.VisualBasic.Embed.vbproj");

--- a/src/Workspaces/MSBuild/Test/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuild/Test/VisualStudioMSBuildWorkspaceTests.cs
@@ -2320,6 +2320,41 @@ public sealed class VisualStudioMSBuildWorkspaceTests : MSBuildWorkspaceTestBase
     }
 
     [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
+    [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/918072")]
+    public async Task TestAnalyzerWithLaterCompilerDependency_HasError()
+    {
+        string[] projPaths = [@"AnalyzerSolution\CSharp_AnalyzerWithLaterCompilerDependency.csproj", @"AnalyzerSolution\VisualBasic_AnalyzerWithLaterCompilerDependency.vbproj"];
+        var files = GetAnalyzerWithLaterCompilerDependencySolutionFiles();
+
+        CreateFiles(files);
+
+        var analyzerFilePath = CreateAnalyzerWithLaterFakeCompiler("AnalyzerSolution");
+
+        using var workspace = CreateMSBuildWorkspace();
+        foreach (var projectPath in projPaths)
+        {
+            var projectFullPath = GetSolutionFileName(projectPath);
+
+            var proj = await workspace.OpenProjectAsync(projectFullPath);
+            Assert.Equal(1, proj.AnalyzerReferences.Count);
+            var analyzerReference = proj.AnalyzerReferences[0] as AnalyzerFileReference;
+            Assert.NotNull(analyzerReference);
+            Assert.True(analyzerReference.FullPath.EndsWith("AnalyzerWithLaterFakeCompilerDependency.dll", StringComparison.OrdinalIgnoreCase));
+        }
+
+        // prove that project gets opened instead.
+        Assert.Equal(2, workspace.CurrentSolution.Projects.Count());
+
+        Assert.Equal(2, workspace.Diagnostics.Count);
+
+        foreach (var diagnostic in workspace.Diagnostics)
+        {
+            Assert.Equal(WorkspaceDiagnosticKind.Failure, diagnostic.Kind);
+            Assert.Equal($"ReferencesNewerCompiler: {analyzerFilePath}: 100.0.0.0", diagnostic.Message);
+        }
+    }
+
+    [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
     public async Task TestAdditionalFilesStandalone()
     {
         var projPaths = new[] { @"AnalyzerSolution\CSharpProject_AnalyzerReference.csproj", @"AnalyzerSolution\VisualBasicProject_AnalyzerReference.vbproj" };


### PR DESCRIPTION
Force the loading of analyzers and generators when loading projects for the MSBuild Workspace. This gives us the opportunity to report failures as workspace diagnostics.

Related to #77980