### PR TITLE
DefiniteAssignmentPass.MarkFieldsUsed - avoid infinite recursion due to generic substitution

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2634,6 +2634,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 #nullable enable
         private void MarkFieldsUsed(TypeSymbol type)
         {
+            type = type.OriginalDefinition;
+
             switch (type.TypeKind)
             {
                 case TypeKind.Array:


### PR DESCRIPTION
Fixes #79867.