### PR TITLE
IDE0071 should suggest removing ToString on {ReadOnly}Span<char> for .NET 6+

### DIFF
--- a/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -1056,13 +1056,49 @@ public sealed class SimplifyInterpolationTests(ITestOutputHelper logger)
             }
             """);
 
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42936")]
-    public Task ToStringSimplificationIsNotOfferedOnRefStruct()
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsNotOfferedOnRefStructIfInterpolatedStringHandlersUnavailavable()
         => TestMissingInRegularAndScriptAsync(
             """
             class C
             {
                 string M(RefStruct someValue) => $"Test: {someValue[||].ToString()}";
+            }
+
+            ref struct RefStruct
+            {
+                public override string ToString() => "A";
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsOfferedOnRefStructIfInterpolatedStringHandlersAvailavable()
+        => TestInRegularAndScriptAsync(
+            """
+            namespace System.Runtime.CompilerServices
+            {
+                public ref struct DefaultInterpolatedStringHandler { }
+            }
+
+            class C
+            {
+                string M(RefStruct someValue) => $"Test: {someValue[||].ToString()}";
+            }
+
+            ref struct RefStruct
+            {
+                public override string ToString() => "A";
+            }
+            """,
+            """
+            namespace System.Runtime.CompilerServices
+            {
+                public ref struct DefaultInterpolatedStringHandler { }
+            }
+            
+            class C
+            {
+                string M(RefStruct someValue) => $"Test: {someValue}";
             }
 
             ref struct RefStruct

--- a/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -1253,6 +1253,51 @@ public sealed class SimplifyInterpolationTests(ITestOutputHelper logger)
             }
             """);
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsNotOfferedOnReadOnlySpanIfTargetsFormattableStringAndInterpolatedStringHandlersAvailable()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+
+            namespace System
+            {
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            namespace System.Runtime.CompilerServices
+            {
+                public class InterpolatedStringHandlerAttribute { }
+            }
+
+            class C
+            {
+                FormattableString M(ReadOnlySpan<char> span) => $"Test: {span[||].ToString()}";
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsNotOfferedOnSpanIfTargetsFormattableStringAndInterpolatedStringHandlersAvailable()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+
+            namespace System
+            {
+                public ref struct Span<T> { }
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            namespace System.Runtime.CompilerServices
+            {
+                public class InterpolatedStringHandlerAttribute { }
+            }
+
+            class C
+            {
+                FormattableString M(Span<char> span) => $"Test: {span[||].ToString()}";
+            }
+            """);
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42936")]
     public Task PadLeftSimplificationIsStillOfferedOnRefStruct()
         => TestInRegularAndScriptAsync(

--- a/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -1057,7 +1057,7 @@ public sealed class SimplifyInterpolationTests(ITestOutputHelper logger)
             """);
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
-    public Task ToStringSimplificationIsNotOfferedOnRefStructIfInterpolatedStringHandlersUnavailavable()
+    public Task ToStringSimplificationIsNotOfferedOnRefStructIfInterpolatedStringHandlersUnavailable()
         => TestMissingInRegularAndScriptAsync(
             """
             class C
@@ -1072,12 +1072,47 @@ public sealed class SimplifyInterpolationTests(ITestOutputHelper logger)
             """);
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
-    public Task ToStringSimplificationIsOfferedOnRefStructIfInterpolatedStringHandlersAvailavable()
-        => TestInRegularAndScriptAsync(
+    public Task ToStringSimplificationIsNotOfferedOnReadOnlySpanIfInterpolatedStringHandlersUnavailable()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+            
+            namespace System
+            {
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            class C
+            {
+                string M(ReadOnlySpan<char> span) => $"Test: {span[||].ToString()}";
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsNotOfferedOnSpanIfInterpolatedStringHandlersUnavailable()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+            
+            namespace System
+            {
+                public ref struct Span<T> { }
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            class C
+            {
+                string M(Span<char> span) => $"Test: {span[||].ToString()}";
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsNotOfferedOnRefStructIfInterpolatedStringHandlersAvailable()
+        => TestMissingInRegularAndScriptAsync(
             """
             namespace System.Runtime.CompilerServices
             {
-                public ref struct DefaultInterpolatedStringHandler { }
+                public class InterpolatedStringHandlerAttribute { }
             }
 
             class C
@@ -1089,21 +1124,132 @@ public sealed class SimplifyInterpolationTests(ITestOutputHelper logger)
             {
                 public override string ToString() => "A";
             }
-            """,
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsOfferedOnReadOnlySpanOfCharIfInterpolatedStringHandlersAvailable()
+        => TestInRegularAndScriptAsync(
             """
+            using System;
+
+            namespace System
+            {
+                public ref struct ReadOnlySpan<T> { }
+            }
+
             namespace System.Runtime.CompilerServices
             {
-                public ref struct DefaultInterpolatedStringHandler { }
+                public class InterpolatedStringHandlerAttribute { }
+            }
+
+            class C
+            {
+                string M(ReadOnlySpan<char> span) => $"Test: {span[||].ToString()}";
+            }
+            """,
+            """
+            using System;
+
+            namespace System
+            {
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            namespace System.Runtime.CompilerServices
+            {
+                public class InterpolatedStringHandlerAttribute { }
             }
             
             class C
             {
-                string M(RefStruct someValue) => $"Test: {someValue}";
+                string M(ReadOnlySpan<char> span) => $"Test: {span}";
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsOfferedOnSpanOfCharIfInterpolatedStringHandlersAvailable()
+        => TestInRegularAndScriptAsync(
+            """
+            using System;
+
+            namespace System
+            {
+                public ref struct Span<T> { }
+                public ref struct ReadOnlySpan<T> { }
             }
 
-            ref struct RefStruct
+            namespace System.Runtime.CompilerServices
             {
-                public override string ToString() => "A";
+                public class InterpolatedStringHandlerAttribute { }
+            }
+
+            class C
+            {
+                string M(Span<char> span) => $"Test: {span[||].ToString()}";
+            }
+            """,
+            """
+            using System;
+            
+            namespace System
+            {
+                public ref struct Span<T> { }
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            namespace System.Runtime.CompilerServices
+            {
+                public class InterpolatedStringHandlerAttribute { }
+            }
+            
+            class C
+            {
+                string M(Span<char> span) => $"Test: {span}";
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsNotOfferedOnReadOnlySpanOfIntIfInterpolatedStringHandlersAvailable()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+
+            namespace System
+            {
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            namespace System.Runtime.CompilerServices
+            {
+                public class InterpolatedStringHandlerAttribute { }
+            }
+
+            class C
+            {
+                string M(ReadOnlySpan<int> span) => $"Test: {span[||].ToString()}";
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80132")]
+    public Task ToStringSimplificationIsNotOfferedOnSpanOfIntIfInterpolatedStringHandlersAvailable()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+
+            namespace System
+            {
+                public ref struct Span<T> { }
+                public ref struct ReadOnlySpan<T> { }
+            }
+            
+            namespace System.Runtime.CompilerServices
+            {
+                public class InterpolatedStringHandlerAttribute { }
+            }
+
+            class C
+            {
+                string M(Span<int> span) => $"Test: {span[||].ToString()}";
             }
             """);
 

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationHelpers.cs
@@ -142,7 +142,7 @@ internal abstract class AbstractSimplifyInterpolationHelpers<
                     {
                         if (invocation.Arguments[0].Value is ILiteralOperation { ConstantValue: { HasValue: true, Value: string value } } literal &&
                             FindType<IFormattable>(expression.SemanticModel) is { } systemIFormattable &&
-                            instance.Type.Implements(systemIFormattable) == true)
+                            instance.Type.Implements(systemIFormattable))
                         {
                             unwrapped = instance;
                             formatString = value;

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationHelpers.cs
@@ -135,14 +135,14 @@ internal abstract class AbstractSimplifyInterpolationHelpers<
             if (targetMethod.Name == nameof(ToString))
             {
                 // If type of instance is not ref-like type or is {ReadOnly}Span<char> that is allowed in interpolated strings in .NET 6+
-                if (instance.Type?.IsRefLikeType == false || IsRefLikeTypeAllowed(instance.Type))
+                if (instance.Type is { IsRefLikeType: false } || IsRefLikeTypeAllowed(instance.Type))
                 {
                     if (invocation.Arguments.Length == 1
                         || (invocation.Arguments.Length == 2 && UsesInvariantCultureReferenceInsideFormattableStringInvariant(invocation, formatProviderArgumentIndex: 1)))
                     {
                         if (invocation.Arguments[0].Value is ILiteralOperation { ConstantValue: { HasValue: true, Value: string value } } literal &&
                             FindType<IFormattable>(expression.SemanticModel) is { } systemIFormattable &&
-                            instance.Type?.Implements(systemIFormattable) == true)
+                            instance.Type.Implements(systemIFormattable) == true)
                         {
                             unwrapped = instance;
                             formatString = value;
@@ -184,7 +184,7 @@ internal abstract class AbstractSimplifyInterpolationHelpers<
         unwrapped = expression;
         formatString = null;
 
-        bool IsRefLikeTypeAllowed(ITypeSymbol? type)
+        bool IsRefLikeTypeAllowed([NotNullWhen(true)] ITypeSymbol? type)
         {
             var compilation = expression.SemanticModel.Compilation;
             // {ReadOnly}Span<char> is allowed if interpolated string handlers are available in the compilation (.NET 6+)

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationHelpers.cs
@@ -136,14 +136,14 @@ internal abstract class AbstractSimplifyInterpolationHelpers<
             {
                 var compilation = expression.SemanticModel.Compilation;
 
-                if (instance.Type?.IsRefLikeType == false || (handlersAvailable && compilation.HasImplicitConversion(instance?.Type, readOnlySpanOfCharType)))
+                if (instance.Type?.IsRefLikeType == false || (handlersAvailable && compilation.HasImplicitConversion(instance.Type, readOnlySpanOfCharType)))
                 {
                     if (invocation.Arguments.Length == 1
                         || (invocation.Arguments.Length == 2 && UsesInvariantCultureReferenceInsideFormattableStringInvariant(invocation, formatProviderArgumentIndex: 1)))
                     {
                         if (invocation.Arguments[0].Value is ILiteralOperation { ConstantValue: { HasValue: true, Value: string value } } literal &&
                             FindType<IFormattable>(expression.SemanticModel) is { } systemIFormattable &&
-                            instance.Type.Implements(systemIFormattable))
+                            instance.Type?.Implements(systemIFormattable) == true)
                         {
                             unwrapped = instance;
                             formatString = value;

--- a/src/Analyzers/Core/CodeFixes/SimplifyInterpolation/AbstractSimplifyInterpolationCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/SimplifyInterpolation/AbstractSimplifyInterpolationCodeFixProvider.cs
@@ -53,6 +53,7 @@ internal abstract class AbstractSimplifyInterpolationCodeFixProvider<
         var helpers = this.Helpers;
 
         var knownToStringFormats = helpers.BuildKnownToStringFormatsLookupTable(semanticModel.Compilation);
+        var handlersAvailable = semanticModel.Compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler") != null;
 
         foreach (var diagnostic in diagnostics)
         {
@@ -64,7 +65,7 @@ internal abstract class AbstractSimplifyInterpolationCodeFixProvider<
                 helpers.UnwrapInterpolation(
                     document.GetRequiredLanguageService<IVirtualCharLanguageService>(),
                     document.GetRequiredLanguageService<ISyntaxFactsService>(),
-                    interpolation, knownToStringFormats, out var unwrapped, out var alignment, out var negate, out var formatString, out _);
+                    interpolation, knownToStringFormats, handlersAvailable, out var unwrapped, out var alignment, out var negate, out var formatString, out _);
 
                 if (unwrapped == null)
                     continue;

--- a/src/Analyzers/Core/CodeFixes/SimplifyInterpolation/AbstractSimplifyInterpolationCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/SimplifyInterpolation/AbstractSimplifyInterpolationCodeFixProvider.cs
@@ -48,12 +48,15 @@ internal abstract class AbstractSimplifyInterpolationCodeFixProvider<
         SyntaxEditor editor, CancellationToken cancellationToken)
     {
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var compilation = semanticModel.Compilation;
         var generator = editor.Generator;
         var generatorInternal = document.GetRequiredLanguageService<SyntaxGeneratorInternal>();
         var helpers = this.Helpers;
 
         var knownToStringFormats = helpers.BuildKnownToStringFormatsLookupTable(semanticModel.Compilation);
-        var handlersAvailable = semanticModel.Compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler") != null;
+
+        var readOnlySpanOfCharType = compilation.ReadOnlySpanOfTType()?.Construct(compilation.GetSpecialType(SpecialType.System_Char));
+        var handlersAvailable = compilation.InterpolatedStringHandlerAttributeType() != null;
 
         foreach (var diagnostic in diagnostics)
         {
@@ -65,7 +68,7 @@ internal abstract class AbstractSimplifyInterpolationCodeFixProvider<
                 helpers.UnwrapInterpolation(
                     document.GetRequiredLanguageService<IVirtualCharLanguageService>(),
                     document.GetRequiredLanguageService<ISyntaxFactsService>(),
-                    interpolation, knownToStringFormats, handlersAvailable, out var unwrapped, out var alignment, out var negate, out var formatString, out _);
+                    interpolation, knownToStringFormats, readOnlySpanOfCharType, handlersAvailable, out var unwrapped, out var alignment, out var negate, out var formatString, out _);
 
                 if (unwrapped == null)
                     continue;


### PR DESCRIPTION
This PR should fix #80132

With the introduction of interpolated string handlers in .NET 6 `Span<char>` and `ReadOnlySpan<char>` can be used in interpolated strings without `ToString` call. The analyzer can determine if these types can be used in interpolation expressions by checking if `System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute` type is available in the compilation.

**Changes**

- Updated the analyzer so that it reports IDE0071 for interpolation expressions if `ToString` is called on `Span<char>` or `ReadOnlySpan<char>` if `InterpolatedStringHandlerAttribute` is available (.NET 6+):

  ```cs
  var span = "abc".AsSpan();
  var s = $"{span.ToString()}"; // Should trigger IDE0071
  ```

- Fixed a small issue when the analyzer may check if the method name in invocation expression match one of the special `ToString`-like methods (e.g. `DateTime.ToLongDateString`) even if the method name is `ToString`.

  > There's another [small issue](https://github.com/dotnet/roslyn/pull/80137#discussion_r2322380653) that the analyzer makes additional checks for an invocation expression before checking the method name to make sure it's actually a `ToString` call (or one of the special methods call). I believe it would be more efficient to check the name first so that it doesn't do unnecessary work for all unrelated method invocations.

- Added unit tests.