### PR TITLE
Fall back to `dotnet exec` if apphost does not exist

### DIFF
--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -434,6 +434,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
         {
             var processFilePath = Path.Combine(clientDir, $"VBCSCompiler{PlatformInformation.ExeExtension}");
             var commandLineArgs = $@"""-pipename:{pipeName}""";
+
+            if (!File.Exists(processFilePath))
+            {
+                // Fallback to not use the apphost if it is not present (can happen in compiler toolset scenarios for example).
+                commandLineArgs = RuntimeHostInfo.GetDotNetExecCommandLine(Path.ChangeExtension(processFilePath, ".dll"), commandLineArgs);
+                processFilePath = RuntimeHostInfo.GetDotNetPathOrDefault();
+            }
+
             return (processFilePath, commandLineArgs);
         }
 

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
@@ -19,17 +19,14 @@
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.exe" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(TargetFramework)\publish\csc.runtimeconfig.json" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.exe" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(TargetFramework)\publish\vbc.runtimeconfig.json" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.exe" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(TargetFramework)\publish\VBCSCompiler.runtimeconfig.json" />
 
       <!-- References that are either not in the target framework or are a higher version -->


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn/issues/80151.