### PR TITLE
Disable tiered compilation in the compiler

### DIFF
--- a/src/Compilers/CSharp/csc/AnyCpu/csc.csproj
+++ b/src/Compilers/CSharp/csc/AnyCpu/csc.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   
   <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->

--- a/src/Compilers/Server/VBCSCompiler/AnyCpu/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/AnyCpu/VBCSCompiler.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   <Import Project="..\VBCSCompilerCommandLine.projitems" Label="Shared" />
 </Project>

--- a/src/Compilers/VisualBasic/vbc/AnyCpu/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/AnyCpu/vbc.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   
   <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->


### PR DESCRIPTION
VS performance data indicated that tiered compilation was negatively impacting compiler throughput. Using the
[replay tool](https://github.com/dotnet/roslyn/tree/main/src/Tools/Replay) I measured the impact of R2R, Tier and Tier PGO on a number of scenarios and got the following data:

| Scenario   | R2R | Tier | Tier PGO | Total Compilations | Iterations | Avg Time |
| ---------- | --- | ---- | -------- | ------------------ | ---------- | -------- |
| complog    | Off | Off  | Off      | 11                 | 5          | 0:04     |
| complog    | Off | On   | On       | 11                 | 5          | 0:03     |
| CSharp.Semantics  | Off | Off  | Off      | 94                 | 5          | 0:05     |
| CSharp.Semantics  | Off | On   | On       | 94                 | 5          | 0:08     |
| CSharp.Semantics  | On  | Off  | Off      | 94                 | 5          | 0:05     |
| CSharp.Semantics  | On  | On   | On       | 94                 | 5          | 0:09     |
| Compilers.slnf  | Off | Off  | Off      | 510                | 3          | 1:02     |
| Compilers.slnf  | Off | On   | On       | 510                | 3          | 1:28     |
| Compilers.slnf  | On  | Off  | Off      | 510                | 3          | 0:56     |
| Compilers.slnf  | On  | On   | Off      | 510                | 3          | 1:08     |
| Compilers.slnf  | On  | On   | On       | 510                | 3          | 1:30     |
| Roslyn.sln | Off | Off  | Off      | 1461               | 3          | 1:02     |
| Roslyn.sln | Off | On   | Off      | 1461               | 3          | 1:30     |
| Roslyn.sln | On  | Off  | Off      | 1461               | 3          | 0:58     |
| Roslyn.sln | On  | On   | On       | 1461               | 3          | 1:28     |
| Roslyn.sln | On  | On   | Off      | 1461               | 3          | 1:11     |

This strongly indicates that tiering is having a negative impact on compiler throughput. For now we're going to disable it and measure the impact in the VS perf labs.

Note:

Used the `%DOTNET_TieredCompilation%` and `%DOTNET_TieredPGO%` to control `Tier` and `TierPGO` respectively