### PR TITLE
Reduce allocations in InlineHintHelpers.GetDescriptionAsync

### DIFF
--- a/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
@@ -105,21 +105,18 @@ internal abstract class AbstractInlineParameterNameHintsService : IInlineParamet
 
                 if (HintMatches(kind, literalParameters, objectCreationParameters, otherParameters))
                 {
-                    var inlineHintText = GetReplacementText(parameter.Name);
                     var textSpan = new TextSpan(position, 0);
 
-                    TextChange? replacementTextChange = null;
-                    if (!parameter.IsParams)
-                    {
-                        replacementTextChange = new TextChange(textSpan, inlineHintText);
-                    }
+                    TextChange? replacementTextChange = parameter.IsParams
+                        ? null
+                        : new TextChange(textSpan, GetReplacementText(parameter.Name));
 
                     result.Add(new InlineHint(
                         textSpan,
                         [new TaggedText(TextTags.Text, parameter.Name + ": ")],
                         replacementTextChange,
                         ranking: InlineHintsConstants.ParameterRanking,
-                        InlineHintHelpers.GetDescriptionFunction(position, parameter.GetSymbolKey(cancellationToken: cancellationToken), displayOptions)));
+                        InlineHintHelpers.GetDescriptionFunction(position, parameter, displayOptions)));
                 }
             }
         }

--- a/src/Features/Core/Portable/InlineHints/AbstractInlineTypeHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineTypeHintsService.cs
@@ -95,7 +95,7 @@ internal abstract class AbstractInlineTypeHintsService : IInlineTypeHintsService
 
             result.Add(new InlineHint(
                 span, taggedText, textChange, ranking: InlineHintsConstants.TypeRanking,
-                InlineHintHelpers.GetDescriptionFunction(spanStart, type.GetSymbolKey(cancellationToken), displayOptions)));
+                InlineHintHelpers.GetDescriptionFunction(spanStart, type, displayOptions)));
         }
 
         return result.ToImmutableAndClear();

--- a/src/Features/Core/Portable/InlineHints/InlineHintHelpers.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHintHelpers.cs
@@ -16,13 +16,16 @@ namespace Microsoft.CodeAnalysis.InlineHints;
 
 internal static class InlineHintHelpers
 {
-    public static Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? GetDescriptionFunction(int position, SymbolKey symbolKey, SymbolDescriptionOptions options)
-        => (document, cancellationToken) => GetDescriptionAsync(document, position, symbolKey, options, cancellationToken);
+    public static Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? GetDescriptionFunction(int position, ISymbol symbol, SymbolDescriptionOptions options)
+    {
+        return (document, cancellationToken) => GetDescriptionAsync(document, position, symbol, options, cancellationToken);
+    }
 
-    private static async Task<ImmutableArray<TaggedText>> GetDescriptionAsync(Document document, int position, SymbolKey symbolKey, SymbolDescriptionOptions options, CancellationToken cancellationToken)
+    private static async Task<ImmutableArray<TaggedText>> GetDescriptionAsync(Document document, int position, ISymbol originalSymbol, SymbolDescriptionOptions options, CancellationToken cancellationToken)
     {
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
+        var symbolKey = originalSymbol.GetSymbolKey(cancellationToken);
         var symbol = symbolKey.Resolve(semanticModel.Compilation, cancellationToken: cancellationToken).Symbol;
         if (symbol != null)
         {


### PR DESCRIPTION
This calculation of the SymbolKey within this method shows up as about 1% of allocations during the csharp completion scenario in the CompletionInCohosting razor speedometer test. Specifically, the computation of the SymbolKey can be deferred until it's (unlikely) use when the description is actually needed.

<img width="1732" height="597" alt="image" src="https://github.com/user-attachments/assets/d5e1a02c-83cd-46e2-a94e-1b6f87d290f6" />