### PR TITLE
Targeting IFormattable builds a FormattableString too

### DIFF
--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
@@ -40,12 +40,13 @@ internal abstract class AbstractSimplifyInterpolationDiagnosticAnalyzer<
                 var readOnlySpanOfCharType = compilation.ReadOnlySpanOfTType()?.Construct(compilation.GetSpecialType(SpecialType.System_Char));
                 var handlersAvailable = compilation.InterpolatedStringHandlerAttributeType() != null;
 
-                context.RegisterOperationAction(context => AnalyzeInterpolation(context, compilation.FormattableStringType(), readOnlySpanOfCharType, knownToStringFormats, handlersAvailable), OperationKind.Interpolation);
+                context.RegisterOperationAction(context => AnalyzeInterpolation(context, compilation.FormattableStringType(), compilation.IFormattableType(), readOnlySpanOfCharType, knownToStringFormats, handlersAvailable), OperationKind.Interpolation);
             });
 
     private void AnalyzeInterpolation(
         OperationAnalysisContext context,
         INamedTypeSymbol? formattableStringType,
+        INamedTypeSymbol? iFormattableType,
         INamedTypeSymbol? readOnlySpanOfCharType,
         ImmutableDictionary<IMethodSymbol, string> knownToStringFormats,
         bool handlersAvailable)
@@ -61,7 +62,7 @@ internal abstract class AbstractSimplifyInterpolationDiagnosticAnalyzer<
         // Formattable strings can observe the inner types of the arguments passed to them.  So we can't safely change
         // to drop ToString in that.
         if (interpolation.Parent is IInterpolatedStringOperation { Parent: IConversionOperation { Type: { } convertedType } conversion } &&
-            convertedType.Equals(formattableStringType))
+            (convertedType.Equals(formattableStringType) || convertedType.Equals(iFormattableType)))
         {
             // One exception to this is calling directly into FormattableString.Invariant.  That method has known good
             // behavior that is fine to continue calling into.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Compilation/CompilationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Compilation/CompilationExtensions.cs
@@ -123,6 +123,9 @@ internal static class CompilationExtensions
     public static INamedTypeSymbol? FormattableStringType(this Compilation compilation)
         => compilation.GetTypeByMetadataName(typeof(FormattableString).FullName!);
 
+    public static INamedTypeSymbol? IFormattableType(this Compilation compilation)
+        => compilation.GetTypeByMetadataName(typeof(IFormattable).FullName!);
+
     public static INamedTypeSymbol? EventArgsType(this Compilation compilation)
         => compilation.GetTypeByMetadataName(typeof(EventArgs).FullName!);
 


### PR DESCRIPTION
Fixes #47956 when creating a FormattableString typed as System.IFormattable.

(C# spec: <https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1025-implicit-interpolated-string-conversions>)