### PR TITLE
Avoid loading MEF caches that are clearly bad

### DIFF
--- a/src/Workspaces/Remote/Core/ExportProviderBuilder.cs
+++ b/src/Workspaces/Remote/Core/ExportProviderBuilder.cs
@@ -55,7 +55,11 @@ internal abstract class ExportProviderBuilder(
         // Try to load a cached composition.
         try
         {
-            if (File.Exists(compositionCacheFile))
+            var compositionCacheFileInfo = new FileInfo(compositionCacheFile);
+
+            // We're seeing issues in the wild right now where the cache file is invalid and doesn't contain the parts we expect; those files tend to be around 5 KB in size.
+            // The valid caches are usually a few hundred kilobytes, so toss out the clearly bad ones.
+            if (compositionCacheFileInfo.Exists && compositionCacheFileInfo.Length >= 10 * 1024)
             {
                 LogTrace($"Loading cached MEF catalog: {compositionCacheFile}");
 


### PR DESCRIPTION
Right now we're seeing an issue where sometimes we have invalid cache files written that don't contain the parts we expect them to have. This causes us to be unable to create our ServiceHub's services. As a tactical workaround, the files that are bad tend to be just a few kilobytes in size, but the ones that are valid are much bigger. This allows us to easily filter out bad ones.