### PR TITLE
Extensions: improve error recovery in older language versions

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -3241,7 +3241,9 @@ parse_member_name:;
 
         private bool IsExtensionContainerStart()
         {
-            return this.CurrentToken.ContextualKind == SyntaxKind.ExtensionKeyword && IsFeatureEnabled(MessageID.IDS_FeatureExtensions);
+            // For error recovery, we recognize `extension` followed by `<` even in older language versions
+            return this.CurrentToken.ContextualKind == SyntaxKind.ExtensionKeyword &&
+                (IsFeatureEnabled(MessageID.IDS_FeatureExtensions) || this.PeekToken(1).Kind == SyntaxKind.LessThanToken);
         }
 
         // if the modifiers do not contain async or replace and the type is the identifier "async" or "replace", then

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -47,8 +47,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (syntax.Identifier.ValueText != containingType.Name)
             {
-                // This is probably a method declaration with the type missing.
-                diagnostics.Add(ErrorCode.ERR_MemberNeedsType, location);
+                if (syntax.Identifier.Text == "extension")
+                {
+                    bool reported = !MessageID.IDS_FeatureExtensions.CheckFeatureAvailability(diagnostics, syntax);
+                    Debug.Assert(reported);
+                }
+                else
+                {
+                    // This is probably a method declaration with the type missing.
+                    diagnostics.Add(ErrorCode.ERR_MemberNeedsType, location);
+                }
             }
 
             bool hasAnyBody = syntax.HasAnyBody();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1843,6 +1843,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected void AfterMembersChecks(BindingDiagnosticBag diagnostics)
         {
             var compilation = DeclaringCompilation;
+            var location = GetFirstLocation();
+
             if (IsInterface)
             {
                 CheckInterfaceMembers(this.GetMembersAndInitializers().NonTypeMembers, diagnostics);
@@ -1850,6 +1852,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (IsExtension)
             {
                 CheckExtensionMembers(this.GetMembers(), diagnostics);
+                MessageID.IDS_FeatureExtensions.CheckFeatureAvailability(diagnostics, compilation, location);
             }
 
             CheckMemberNamesDistinctFromType(diagnostics);
@@ -1868,8 +1871,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 ReportRequiredMembers(diagnostics);
             }
-
-            var location = GetFirstLocation();
 
             if (this.IsRefLikeType)
             {


### PR DESCRIPTION
Addresses part of https://github.com/dotnet/roslyn/issues/78961 ("we should probably have better error recovery in older LangVer so that we can offer a dedicated diagnostic to trigger UpgradeProject")
Relates to test plan https://github.com/dotnet/roslyn/issues/76130