### PR TITLE
WIP (not for review): Create BoundBadExpression instead of BoundCall for erroneous invocations

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1652,6 +1652,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(call.Method.Name == "Add");
                         return call.Arguments[call.InvokedAsExtensionMethod ? 1 : 0];
                     case BoundBadExpression badExpression:
+                        if (badExpression.ChildBoundNodes is [BoundObjectOrCollectionValuePlaceholder, var child])
+                        {
+                            return child;
+                        }
+
                         Debug.Assert(false); // Add test if we hit this assert.
                         return badExpression;
                     default:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -679,6 +679,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return MissingDeconstruct(receiver, rightSyntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                 }
 
+                if (result.Kind == BoundKind.BadExpression)
+                {
+                    outPlaceholders = default;
+                    return result;
+                }
+
                 // Verify all the parameters (except "this" for extension methods) are out parameters.
                 // This prevents, for example, an unused params parameter after the out parameters.
                 var deconstructMethod = ((BoundCall)result).Method;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6852,7 +6852,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return creation;
         }
 
-        private BoundExpression CreateBadClassCreationExpression(
+        private BoundBadExpression CreateBadClassCreationExpression(
             SyntaxNode node,
             SyntaxNode typeNode,
             NamedTypeSymbol type,
@@ -10263,7 +10263,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert(lengthOrCountAccess is BoundPropertyAccess);
-            Debug.Assert(indexerOrSliceAccess is BoundIndexerAccess or BoundCall);
+            Debug.Assert(indexerOrSliceAccess is BoundIndexerAccess or BoundCall or BoundBadExpression);
             Debug.Assert(indexerOrSliceAccess.Type is not null);
 
             implicitIndexerAccess = new BoundImplicitIndexerAccess(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1746,7 +1746,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // this[int]
                 BoundImplicitIndexerAccess { IndexerOrSliceAccess: BoundIndexerAccess indexerAccess } => indexerAccess.Indexer,
                 // array[Index]
-                BoundImplicitIndexerAccess { IndexerOrSliceAccess: BoundArrayAccess } => null,
+                BoundImplicitIndexerAccess { IndexerOrSliceAccess: BoundArrayAccess or BoundBadExpression } => null,
                 // array[int or Range]
                 BoundArrayAccess => null,
                 BoundDynamicIndexerAccess => null,
@@ -4182,6 +4182,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (patternMethodCall.Kind != BoundKind.Call)
                 {
+                    if (patternMethodCall is BoundBadExpression { ResultKind: not LookupResultKind.Empty })
+                    {
+                        diagnostics.AddRange(bindingDiagnostics);
+                        return PatternLookupResult.ResultHasErrors;
+                    }
+
                     return PatternLookupResult.NotCallable;
                 }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundImplicitIndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundImplicitIndexerAccess.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private partial void Validate()
         {
             Debug.Assert(LengthOrCountAccess is BoundPropertyAccess or BoundArrayLength or BoundLocal or BoundBadExpression);
-            Debug.Assert(IndexerOrSliceAccess is BoundIndexerAccess or BoundCall or BoundArrayAccess);
+            Debug.Assert(IndexerOrSliceAccess is BoundIndexerAccess or BoundCall or BoundArrayAccess or BoundBadExpression);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -219,6 +219,8 @@
 
     <!-- Any child bound nodes that we need to preserve are put here. -->
     <Field Name="ChildBoundNodes" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+
+    <Field Name="ArgumentRefKindsOpt" Type="ImmutableArray&lt;RefKind&gt;" Null="allow"/>
   </Node>
 
   <!-- This node is used when we can't create a real statement because things are too broken. -->

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 LookupResultKind resultKind,
                                 TypeSymbol type)
             => Update(receiverOpt, initialBindingReceiverIsSubjectToCloning, method, arguments, argumentNamesOpt, argumentRefKindsOpt, isDelegateCall, expanded, invokedAsExtensionMethod, argsToParamsOpt, defaultArguments, resultKind, this.OriginalMethodsOpt, type);
-
+/*
         public static BoundCall ErrorCall(
             SyntaxNode node,
             BoundExpression receiverOpt,
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 type: method.ReturnType,
                 hasErrors: true);
         }
-
+*/
         public BoundCall Update(ImmutableArray<BoundExpression> arguments)
         {
             return this.Update(ReceiverOpt, InitialBindingReceiverIsSubjectToCloning, Method, arguments, ArgumentNamesOpt, ArgumentRefKindsOpt, IsDelegateCall, Expanded, InvokedAsExtensionMethod, ArgsToParamsOpt, DefaultArguments, ResultKind, OriginalMethodsOpt, Type);
@@ -529,6 +529,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             : this(syntax, resultKind, symbols, childBoundNodes, type, true)
         {
             Debug.Assert((object)type != null);
+        }
+
+        public BoundBadExpression(SyntaxNode syntax, LookupResultKind resultKind, ImmutableArray<Symbol?> symbols, ImmutableArray<BoundExpression> childBoundNodes, TypeSymbol? type, bool hasErrors = false)
+            : this(syntax, resultKind, symbols, childBoundNodes, argumentRefKindsOpt: default, type, hasErrors)
+        {
+        }
+
+        public BoundBadExpression Update(LookupResultKind resultKind, ImmutableArray<Symbol?> symbols, ImmutableArray<BoundExpression> childBoundNodes, TypeSymbol? type)
+        {
+            return Update(resultKind, symbols, childBoundNodes, ArgumentRefKindsOpt, type);
         }
     }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4344,6 +4344,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ImmutableArray<Symbol> myMethodGroup = memberGroup;
 
                         symbols = OneOrMany.Create(((BoundBadExpression)boundNodeForSyntacticParent).Symbols.WhereAsArray((sym, myMethodGroup) => myMethodGroup.Contains(sym), myMethodGroup));
+                        if (!symbols.Any())
+                        {
+                            symbols = OneOrMany.Create(myMethodGroup.WhereAsArray(static (g, symbols) => symbols.Any(static (sym, g) => sym.Equals((g as MethodSymbol)?.ReducedFrom), g), ((BoundBadExpression)boundNodeForSyntacticParent).Symbols));
+                        }
+
                         if (symbols.Any())
                         {
                             resultKind = ((BoundBadExpression)boundNodeForSyntacticParent).ResultKind;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
@@ -70,7 +70,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method)
+#nullable enable
+        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol? method)
         {
             // ref parameter does not "always" assign.
             if (refKind == RefKind.Out)
@@ -78,6 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Assign(arg, value: null);
             }
         }
+#nullable disable
 
         protected override void ResolveBranch(PendingBranch pending, LabelSymbol label, BoundStatement target, ref bool labelStateChanged)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2424,6 +2424,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitMethodGroup(node);
         }
 
+        public override BoundNode VisitBadExpression(BoundBadExpression node)
+        {
+            foreach (var symbol in node.Symbols)
+            {
+                if (symbol is LocalFunctionSymbol localFunction)
+                {
+                    _usedLocalFunctions.Add(localFunction);
+                }
+            }
+
+            return base.VisitBadExpression(node);
+        }
+
         public override BoundNode VisitLambda(BoundLambda node)
         {
             var oldSymbol = this.CurrentSymbol;
@@ -2569,7 +2582,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method)
+        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol? method)
         {
             if (refKind == RefKind.Ref)
             {
@@ -2585,7 +2598,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we assume that external method may write and/or read all of its fields (recursively).
             // Strangely, the native compiler requires the "ref", even for reference types, to exhibit
             // this behavior.
-            if (refKind != RefKind.None && ((object)method == null || method.IsExtern) && arg.Type is TypeSymbol type)
+            if (refKind != RefKind.None && ((object?)method == null || method.IsExtern) && arg.Type is TypeSymbol type)
             {
                 MarkFieldsUsed(type);
             }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1271,7 +1271,7 @@ namespace Microsoft.CodeAnalysis.Operations
             SyntaxNode syntax = element.Syntax;
             bool isImplicit = element.WasCompilerGenerated;
             var elementType = element.EnumeratorInfoOpt?.ElementType.GetPublicSymbol();
-            var elementConversion = BoundNode.GetConversion(iteratorItem, element.ElementPlaceholder);
+            var elementConversion = iteratorItem is BoundBadExpression ? Conversion.Identity : BoundNode.GetConversion(iteratorItem, element.ElementPlaceholder);
             return new SpreadOperation(
                 collection,
                 elementType: elementType,

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -2286,5 +2286,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return false;
         }
+
+        /// <summary>
+        /// Certain (struct) types are known by the compiler to be immutable.  In these cases calling a method on
+        /// the type is known (by flow analysis) not to write the receiver.
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        internal static bool TypeIsImmutable(this TypeSymbol t)
+        {
+            switch (t.SpecialType)
+            {
+                case SpecialType.System_Boolean:
+                case SpecialType.System_Char:
+                case SpecialType.System_SByte:
+                case SpecialType.System_Byte:
+                case SpecialType.System_Int16:
+                case SpecialType.System_UInt16:
+                case SpecialType.System_Int32:
+                case SpecialType.System_UInt32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_UInt64:
+                case SpecialType.System_Decimal:
+                case SpecialType.System_Single:
+                case SpecialType.System_Double:
+                case SpecialType.System_DateTime:
+                    return true;
+                default:
+                    return t.IsNullableType();
+            }
+        }
     }
 }


### PR DESCRIPTION
There are 52 known test failures in C# compiler tests:
```
Test
Class: OutVarTests Failed Stale (3)
Project: Microsoft.CodeAnalysis.CSharp.Emit3.UnitTests (net9.0) Failed Stale (10)
Namespace: Microsoft.CodeAnalysis.CSharp.UnitTests Failed Stale (5)
Class: DiagnosticAnalyzerTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.DiagnosticAnalyzerTests.TestOperationConstructorBlockCallbackOnInvalidBaseCall Failed Stale
Class: FlowDiagnosticTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.FlowDiagnosticTests.RegressionTest949324 Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.OutVarTests.DiagnosticsDifferenceBetweenLanguageVersions_01 Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.OutVarTests.OutVarDiscardInCtor_02 Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.OutVarTests.VarIsNotVar_02 Failed Stale
Namespace: Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics Failed Stale (5)
Class: ExtensionTests Failed Stale (4)
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.ExtensionTests.ExtensionMemberLookup_InterpolationHandler_AppendFormattedExtensionMethod Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.ExtensionTests.ExtensionMemberLookup_InterpolationHandler_AppendFormattedExtensionTypeMethod Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.ExtensionTests.ExtensionMemberLookup_InterpolationHandler_AppendLiteralExtensionDeclarationMethod Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.ExtensionTests.ExtensionMemberLookup_InterpolationHandler_AppendLiteralExtensionMethod Failed Stale
Class: RefReadonlyParameterTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.RefReadonlyParameterTests.RefReadonlyParameter_Ctor_OutArgument Failed Stale
Project: Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests (net9.0) Failed Stale (21)
Namespace: Microsoft.CodeAnalysis.CSharp.UnitTests Failed Stale (21)
Class: IOperationTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests.NullInPlaceOfParamArray Failed Stale
Class: IOperationTests_IArgument Failed Stale (3)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IArgument.ExtraArgument Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IArgument.TestOmittedArgument Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IArgument.WrongArgumentType Failed Stale
Class: IOperationTests_IConstructorBodyOperation Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IConstructorBodyOperation.ConstructorBody_19 Failed Stale
Class: IOperationTests_IDeclarationExpression Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IDeclarationExpression.DeclarationFlow_01 Failed Stale
Class: IOperationTests_IDefaultValueOperation Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IDefaultValueOperation.DefaultValueFlow_03 Failed Stale
Class: IOperationTests_IInterpolatedStringExpression Failed Stale (4)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IInterpolatedStringExpression.InterpolatedStringExpression_EmptyInterpolationPart(hasDefaultHandler: True) Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IInterpolatedStringExpression.InterpolatedStringExpression_InvalidExpressionInInterpolation(hasDefaultHandler: True) Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IInterpolatedStringExpression.InterpolatedStringHandlerConversion_05 Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IInterpolatedStringExpression.InterpolatedStringHandlerConversion_07 Failed Stale
Class: IOperationTests_InvalidExpression Failed Stale (4)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_InvalidExpression.BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder_Methods Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_InvalidExpression.BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder_Methods Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_InvalidExpression.InvalidInvocationExpression_OverloadResolutionFailureBadArgument Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_InvalidExpression.InvalidInvocationExpression_OverloadResolutionFailureExtraArgument Failed Stale
Class: IOperationTests_IObjectCreationExpression Failed Stale (4)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IObjectCreationExpression.ImplicitObjectCreationCollectionInitializerStaticAddMethod Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IObjectCreationExpression.ImplicitObjectCreationCollectionInitializerWithRefAddMethod Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IObjectCreationExpression.ObjectCreationCollectionInitializerStaticAddMethod Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IObjectCreationExpression.ObjectCreationCollectionInitializerWithRefAddMethod Failed Stale
Class: IOperationTests_IThrowOperation Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_IThrowOperation.ThrowFlow_13 Failed Stale
Class: IOperationTests_StackAllocArrayCreationAndInitializer Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.IOperationTests_StackAllocArrayCreationAndInitializer.StackAllocArrayCreationErrorCase_InvocationExpressionAsDimension Failed Stale
Project: Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests (net472) Failed Stale (12)
Namespace: Microsoft.CodeAnalysis.CSharp.UnitTests Failed Stale (5)
Class: DelegateTypeTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.DelegateTypeTests.TypeInference_03 Failed Stale
Class: FunctionPointerTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.FunctionPointerTests.FunctionPointerInferenceInReturn Failed Stale
Class: LocalFunctionTests Failed Stale (2)
Microsoft.CodeAnalysis.CSharp.UnitTests.LocalFunctionTests.ConstraintBinding2 Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.LocalFunctionTests.ParameterScope_NotInTypeConstraint Failed Stale
Class: UnsafeTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.UnsafeTests.FixingVariables_TypeParameters2 Failed Stale
Namespace: Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics Failed Stale (7)
Class: BindingTests Failed Stale (2)
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.BindingTests.NonMethodsWithArgs Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.BindingTests.NonViableDelegates Failed Stale
Class: InterpolationTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.InterpolationTests.MissingAppendMethods Failed Stale
Class: NullableReferenceTypesTests Failed Stale (4)
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NullableReferenceTypesTests.Lambda_21 Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NullableReferenceTypesTests.MemberNotNull_NonStaticLocalFunction_MissingArgument Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NullableReferenceTypesTests.NullableBaseMembers Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NullableReferenceTypesTests.TypeInference_LowerBounds_NestedNullability_Pointers Failed Stale
Project: Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests (net472) Failed Stale (9)
Namespace: Microsoft.CodeAnalysis.CSharp.UnitTests Failed Stale (3)
Class: NullablePublicAPITests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.NullablePublicAPITests.LambdaInBadExpression Failed Stale
Class: SemanticModelGetSemanticInfoTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.SemanticModelGetSemanticInfoTests.GenericExtensionMethodCall Failed Stale
Class: SemanticTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.SemanticTests.UnmanagedConstraintOnExtensionMethod Failed Stale
Namespace: Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols Failed Stale (6)
Class: ExtensionMethodTests Failed Stale (1)
Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.ExtensionMethodTests.InaccessibleInstanceMember Failed Stale
Class: RequiredMembersTests Failed Stale (5)
Test Group: Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.RequiredMembersTests.ForbidRequiredAsNew_Inheritance Failed Stale (2)
Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.RequiredMembersTests.ForbidRequiredAsNew_Inheritance(useMetadataReference: False) Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.RequiredMembersTests.ForbidRequiredAsNew_Inheritance(useMetadataReference: True) Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.RequiredMembersTests.ForbidRequiredAsNew_MalformedMembersList Failed Stale
Test Group: Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.RequiredMembersTests.ForbidRequiredAsNew_NoInheritance Failed Stale (2)
Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.RequiredMembersTests.ForbidRequiredAsNew_NoInheritance(typeKind: "class") Failed Stale
Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.RequiredMembersTests.ForbidRequiredAsNew_NoInheritance(typeKind: "struct") Failed Stale
```