### PR TITLE
Restore SemanticModel behavior for invocations of not invocable targets

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -268,14 +268,18 @@ class K
 ";
             var semanticInfo = GetSemanticInfoForTest(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("System.Int32", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal(TypeKind.Struct, semanticInfo.Type.TypeKind);
+            Assert.Equal("System.Int32", semanticInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal(TypeKind.Struct, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
-            Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
-            // Tracked by https://github.com/dotnet/roslyn/issues/78957 : public API, see if we can restore a behavior closer to previous (ie. returning the field as candidate symbol)
-            Assert.Empty(semanticInfo.CandidateSymbols);
+            Assert.Equal(CandidateReason.NotInvocable, semanticInfo.CandidateReason);
+            Assert.Equal(1, semanticInfo.CandidateSymbols.Length);
+            var sortedCandidates = semanticInfo.CandidateSymbols.OrderBy(s => s.ToTestDisplayString(), StringComparer.Ordinal).ToArray();
+            Assert.Equal("System.Int32 K.f", sortedCandidates[0].ToTestDisplayString());
+            Assert.Equal(SymbolKind.Field, sortedCandidates[0].Kind);
 
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
             Assert.False(semanticInfo.IsCompileTimeConstant);


### PR DESCRIPTION
Fixes #79930