### PR TITLE
Fix our registration for our TempPE compilers

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -75,7 +75,7 @@ internal sealed class CSharpPackage : AbstractPackage<CSharpPackage, CSharpLangu
             {
                 var workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
                 return new TempPECompilerService(workspace.Services.GetService<IMetadataService>());
-            });
+            }, promote: true);
         }
         catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, ErrorSeverity.General))
         {

--- a/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
@@ -34,6 +34,13 @@
 "Name"="C# Language Service"
 "IsAsyncQueryable"=dword:00000001
 
+[$RootKey$\Services\{dba64c84-56df-4e20-8aa6-02332a97f474}]
+@="{13c3bbb4-f18f-4111-9f54-a0fb010d9194}"
+"Name"="C# TempPE Compiler Service"
+"IsAsyncQueryable"=dword:00000000
+"IsCacheable"=dword:00000001
+"IsFreeThreaded"=dword:00000001
+
 [$RootKey$\AutomationProperties\TextEditor\CSharp-Specific]
 @="#104"
 "Description"="#105"

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpTempPE.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpTempPE.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop;
+using Microsoft.VisualStudio.Shell;
+using Roslyn.VisualStudio.IntegrationTests;
+using Xunit;
+
+namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp;
+
+public sealed class CSharpTempPE : AbstractIntegrationTest
+{
+    [IdeFact]
+    public async Task TempPEServiceWorks()
+    {
+        using TempRoot root = new();
+        var outputPath = root.CreateFile().Path;
+
+        var service = await AsyncServiceProvider.GlobalProvider.GetServiceAsync<ICSharpTempPECompilerService, ICSharpTempPECompilerService>();
+        var result = service.CompileTempPE(outputPath, 1, ["Test.cs"], ["class Program { static void Main() { } }"], 0, [], []);
+        Assert.Equal(VSConstants.S_OK, result);
+
+        Assert.True(File.Exists(outputPath));
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicTempPE.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicTempPE.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop;
+using Microsoft.VisualStudio.Shell;
+using Roslyn.VisualStudio.IntegrationTests;
+using Xunit;
+
+namespace Roslyn.VisualStudio.NewIntegrationTests.VisualBasic;
+
+public sealed class BasicTempPE : AbstractIntegrationTest
+{
+    [IdeFact]
+    public async Task TempPEServiceWorks()
+    {
+        using TempRoot root = new();
+        var outputPath = root.CreateFile().Path;
+
+        var factory = await AsyncServiceProvider.GlobalProvider.GetServiceAsync<IVbTempPECompilerFactory, IVbTempPECompilerFactory>();
+        var compiler = factory.CreateCompiler();
+
+        Assert.NotNull(compiler);
+
+        // Create a temporary project to test compilation
+        var project = compiler.CreateProject("TestProject", null, null, new VbCompilerHost());
+        Assert.NotNull(project);
+
+        var sourceFile = root.CreateFile("Test.vb").WriteAllText("Module Program\r\n    Sub Main()\r\n    End Sub\r\nEnd Module").Path;
+        project.AddFile(sourceFile, (uint)VSConstants.VSITEMID.Nil, fAddDuringOpen: false);
+
+        project.SetCompilerOptions(new VBCompilerOptions() { wszOutputPath = Path.GetDirectoryName(outputPath), wszExeName = Path.GetFileName(outputPath) });
+
+        // Compile the project
+        var result = compiler.Compile(IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+        Assert.Equal(VSConstants.S_OK, result);
+
+        Assert.True(File.Exists(outputPath));
+    }
+
+    private class VbCompilerHost : IVbCompilerHost
+    {
+        public void OutputString(string @string)
+        {
+        }
+
+        public int GetSdkPath(out string sdkPath)
+        {
+            sdkPath = "";
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public VBTargetLibraryType GetTargetLibraryType()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -77,7 +77,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
                               DirectCast(Me, IServiceContainer).AddService(
                                   GetType(IVbTempPECompilerFactory),
-                                  Function(_1, _2) New TempPECompilerFactory(Me.ComponentModel.GetService(Of VisualStudioWorkspace)()))
+                                  Function(_1, _2) New TempPECompilerFactory(Me.ComponentModel.GetService(Of VisualStudioWorkspace)()),
+                                  promote:=True)
                           Catch ex As Exception When FatalError.ReportAndPropagateUnlessCanceled(ex)
                               Throw ExceptionUtilities.Unreachable
                           End Try

--- a/src/VisualStudio/VisualBasic/Impl/Microsoft.VisualStudio.LanguageServices.VisualBasic.vbproj
+++ b/src/VisualStudio/VisualBasic/Impl/Microsoft.VisualStudio.LanguageServices.VisualBasic.vbproj
@@ -47,6 +47,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures2.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Test.Utilities2" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.New.IntegrationTests" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Next.UnitTests" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
@@ -32,6 +32,13 @@
 "Name"="Visual Basic Project System Shim"
 "IsAsyncQueryable"=dword:00000001
 
+[$RootKey$\Services\{8df9750d-069b-4b81-973a-152e97420c5c}]
+@="{574fc912-f74f-4b4e-92c3-f695c208a2bb}"
+"Name"="Visual Basic TempPE Compiler Factory Service"
+"IsAsyncQueryable"=dword:00000000
+"IsCacheable"=dword:00000001
+"IsFreeThreaded"=dword:00000001
+
 [$RootKey$\AutomationProperties\TextEditor\Basic-Specific]
 @="#104"
 "Description"="#106"


### PR DESCRIPTION
Commit 1b4f5d798e0c9b9df3e305c0310590224a8f323d removed the service registration from our pkgefs, but this was incorrect. We don't run the CreatePkgDef tool, so the attributes defined on the package don't actually register the service into the system. The refactoring in 391e50f027c238a619a4a6ec3fdf04b1eed8bce4 also lost the promote: true arguments, so the service registration didn't work either.

Since we didn't have any tests on this, this adds some tests directly testing the TempPE services so we don't break this again.