### PR TITLE
Fix the fast-up-to-date check for pkgdef files

### DIFF
--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -86,8 +86,17 @@
       </_FileContentEntries>
 
       <PkgDefFileContent Include="@(_FileContentEntries->'%(FullFilePath)')" />
+
+      <!-- Ensure we add these to the fast-up-to-date-check collections -->
+      <UpToDateCheckInput Include="@(PkgDefFileContent)" Set="PkgdefFiles" />
+      <UpToDateCheckOutput Include="$(_GeneratePkgDefOutputFile)" Set="PkgdefFiles" />
     </ItemGroup>
   </Target>
+
+  <PropertyGroup>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);_SetGeneratePkgDefInputsOutputs</CollectUpToDateCheckInputDesignTimeDependsOn>
+    <CollectUpToDateCheckOutputDesignTimeDependsOn>$(CollectUpToDateCheckOutputDesignTimeDependsOn);_SetGeneratePkgDefInputsOutputs</CollectUpToDateCheckOutputDesignTimeDependsOn>
+  </PropertyGroup>
 
   <!--
     Initializes metadata of PkgDefBrokeredService items.
@@ -293,12 +302,10 @@
     <Error Text="GeneratePkgDefFile is true but the project did not produce any entries (PkgDef* items) to be written to pkgdef file"
            Condition="'@(_PkgDefLines)' == ''"/>
 
-    <!-- Write final pkgdef content. If the CTO file was changed, touch the pkgdef file to cause a re-merge (see VSSDK targets). -->
     <WriteLinesToFile File="$(_GeneratePkgDefOutputFile)"
                       Lines="@(_PkgDefLines)"
                       Overwrite="true"
-                      Encoding="UTF-8"
-                      WriteOnlyWhenDifferent="!$([MSBuild]::ValueOrDefault('$(CTOFileHasChanged)', 'false'))" />
+                      Encoding="UTF-8" />
     <ItemGroup>
       <FileWrites Include="$(_GeneratePkgDefOutputFile)" />
     </ItemGroup>

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -142,7 +142,7 @@
            Condition="$([MSBuild]::ValueOrDefault('$(ExtensionsPath)', '').Contains('16.0'))"/>
   </Target>
 
-  <Import Project="GeneratePkgDef.targets" Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(GeneratePkgDefFile)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'" />
+  <Import Project="GeneratePkgDef.targets" Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(GeneratePkgDefFile)' == 'true' and '$(BuildingForLiveUnitTesting)' != 'true'" />
 
   <!-- Import workarounds for the fast up to date check, but only if VsSdkTargetsImported is set which is set in the VS SDK targets themselves;
        if we don't have that condition, we might try to include it when we don't have some targets we depend on, and things will break -->


### PR DESCRIPTION
Our custom logic for generating pkgdef files allows other files to be included in the output; those weren't being fed to the fast-up-to- date check so changes to the files wouldn't apply without a rebuild.