### PR TITLE
Temporarily re-add ITypeSymbol extension APIs

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
@@ -156,6 +156,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool ITypeSymbol.IsNativeIntegerType => UnderlyingTypeSymbol.IsNativeIntegerType;
 
+#nullable enable
+        bool ITypeSymbol.IsExtension => UnderlyingTypeSymbol.IsExtension;
+
+        IParameterSymbol? ITypeSymbol.ExtensionParameter => UnderlyingTypeSymbol.ExtensionParameter?.GetPublicSymbol();
+#nullable disable
+
         string ITypeSymbol.ToDisplayString(CodeAnalysis.NullableFlowState topLevelNullability, SymbolDisplayFormat format)
         {
             return SymbolDisplay.ToDisplayString(this, topLevelNullability, format);

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -24,7 +24,9 @@ Microsoft.CodeAnalysis.IEventSymbol.PartialImplementationPart.get -> Microsoft.C
 Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext.AddEmbeddedAttributeDefinition() -> void
 Microsoft.CodeAnalysis.RuntimeCapability.RuntimeAsyncMethods = 9 -> Microsoft.CodeAnalysis.RuntimeCapability
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.ToString() -> string!
+Microsoft.CodeAnalysis.ITypeSymbol.IsExtension.get -> bool
 Microsoft.CodeAnalysis.TypeKind.Extension = 14 -> Microsoft.CodeAnalysis.TypeKind
+Microsoft.CodeAnalysis.ITypeSymbol.ExtensionParameter.get -> Microsoft.CodeAnalysis.IParameterSymbol?
 const Microsoft.CodeAnalysis.WellKnownMemberNames.AdditionAssignmentOperatorName = "op_AdditionAssignment" -> string!
 const Microsoft.CodeAnalysis.WellKnownMemberNames.BitwiseAndAssignmentOperatorName = "op_BitwiseAndAssignment" -> string!
 const Microsoft.CodeAnalysis.WellKnownMemberNames.BitwiseOrAssignmentOperatorName = "op_BitwiseOrAssignment" -> string!

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -200,12 +200,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Is this a symbol for an extension declaration.
         /// </summary>
-        bool IsExtension { get; }
+        new bool IsExtension { get; }
 
         /// <summary>
         /// The extension parameter if this is an extension declaration (<see cref="IsExtension"/> is true).
         /// Note: this may be null even if <see cref="IsExtension"/> is true, in error cases.
         /// </summary>
-        IParameterSymbol? ExtensionParameter { get; }
+        new IParameterSymbol? ExtensionParameter { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -81,6 +81,12 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         bool IsNativeIntegerType { get; }
 
+        [Obsolete($"This API will be removed in the future. Use {nameof(INamedTypeSymbol)}.{nameof(INamedTypeSymbol.IsExtension)} instead.")]
+        bool IsExtension { get; }
+
+        [Obsolete($"This API will be removed in the future. Use {nameof(INamedTypeSymbol)}.{nameof(INamedTypeSymbol.ExtensionParameter)} instead.")]
+        IParameterSymbol? ExtensionParameter { get; }
+
         /// <summary>
         /// The original definition of this symbol. If this symbol is constructed from another
         /// symbol by type substitution then <see cref="OriginalDefinition"/> gets the original symbol as it was defined in

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -782,5 +782,19 @@ Done:
         Private Function ITypeSymbolInternal_GetITypeSymbol() As ITypeSymbol Implements ITypeSymbolInternal.GetITypeSymbol
             Return Me
         End Function
+
+        <Obsolete>
+        Private ReadOnly Property ITypeSymbol_IsExtension As Boolean Implements ITypeSymbol.IsExtension
+            Get
+                Return False
+            End Get
+        End Property
+
+        <Obsolete>
+        Private ReadOnly Property ITypeSymbol_ExtensionParameter As IParameterSymbol Implements ITypeSymbol.ExtensionParameter
+            Get
+                Return Nothing
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
@@ -1476,8 +1476,10 @@ Microsoft.CodeAnalysis.ITypeSymbol.ToMinimalDisplayString(Microsoft.CodeAnalysis
 Microsoft.CodeAnalysis.ITypeSymbol.WithNullableAnnotation(Microsoft.CodeAnalysis.NullableAnnotation)
 Microsoft.CodeAnalysis.ITypeSymbol.get_AllInterfaces
 Microsoft.CodeAnalysis.ITypeSymbol.get_BaseType
+Microsoft.CodeAnalysis.ITypeSymbol.get_ExtensionParameter
 Microsoft.CodeAnalysis.ITypeSymbol.get_Interfaces
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsAnonymousType
+Microsoft.CodeAnalysis.ITypeSymbol.get_IsExtension
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsNativeIntegerType
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsReadOnly
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsRecord

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -42,6 +42,12 @@ internal abstract class CodeGenerationTypeSymbol(
 
     public bool IsNativeIntegerType => false;
 
+#if !ROSLYN_4_12_OR_LOWER
+    bool ITypeSymbol.IsExtension => false;
+
+    IParameterSymbol ITypeSymbol.ExtensionParameter => null;
+#endif
+
     public static ImmutableArray<ITypeSymbol> TupleElementTypes => default;
 
     public static ImmutableArray<string> TupleElementNames => default;


### PR DESCRIPTION
Source build is currently blocked (see https://github.com/dotnet/dotnet/pull/2276#issuecomment-3289369908) because ILLink analyzer which lives in runtime is compiled against rc1 roslyn (which has the extension APIs on ITypeSymbol). Then winforms repo is compiled in source build, using the just-built ILLink analyzer but against the latest roslyn, hence failing with MissingMethodException (because the API on ITypeSymbol doesn't exist).

Temporarily re-adding the APIs is the simplest solution to unblock the flow I think.