### PR TITLE
Delete old workaround that's now obsolete

### DIFF
--- a/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
+++ b/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
+  <!-- Add a workaround for https://github.com/dotnet/project-system/issues/9651 until we decide what we want to do there long term. -->
   <PropertyGroup>
     <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);RemoveBuildOutputSourceItems</CollectUpToDateCheckInputDesignTimeDependsOn>
   </PropertyGroup>
 
-  <!-- Add a workaround for https://github.com/dotnet/project-system/issues/9651 until we decide what we want to do there long term. -->
   <Target Name="RemoveBuildOutputSourceItems" DependsOnTargets="AddUpToDateCheckVSIXSourceItems" Condition="'$(CreateVsixContainer)' == 'true'">
     <ItemGroup>
       <_ItemsInObjDirectory Include="$(IntermediateOutputPath)\**\*" Set="VsixItems" />

--- a/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
+++ b/eng/targets/VisualStudio.FastUpToDateCheckWorkarounds.targets
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
-
-  <!-- The 9.0 Arcade targets we are consuming don't have Sets specified for the items, and don't include all items correctly. This overrides
-       those targets so they don't interfere. These two empty targets can be deleted when we've removed the support from Arcade in favor of
-       built-in support in the VS SDK, and we are consuming that support in this repo. -->
-
-  <Target Name="CollectVsixUpToDateCheckInput">
-  </Target>
-
-  <Target Name="CollectVsixUpToDateCheckBuilt">
-  </Target>
-
   <PropertyGroup>
     <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);RemoveBuildOutputSourceItems</CollectUpToDateCheckInputDesignTimeDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
We've been on 10.0 arcade targets for awhile now.