### PR TITLE
Reduce allocations in XmlDocumentationProvider.GetDocumentationForSymbol

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -11,7 +11,6 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Xml;
-using System.Xml.Linq;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
@@ -55,13 +54,6 @@ public abstract class XmlDocumentationProvider : DocumentationProvider
         return new FileBasedXmlDocumentationProvider(xmlDocCommentFilePath);
     }
 
-    private XDocument GetXDocument(CancellationToken cancellationToken)
-    {
-        using var stream = GetSourceStream(cancellationToken);
-        using var xmlReader = XmlReader.Create(stream, s_xmlSettings);
-        return XDocument.Load(xmlReader);
-    }
-
     protected override string GetDocumentationForSymbol(string documentationMemberID, CultureInfo preferredCulture, CancellationToken cancellationToken = default)
     {
         if (_docComments == null)
@@ -70,16 +62,26 @@ public abstract class XmlDocumentationProvider : DocumentationProvider
             {
                 try
                 {
-                    var comments = new Dictionary<string, string>();
-
-                    var doc = GetXDocument(cancellationToken);
-                    foreach (var e in doc.Descendants("member"))
+                    using (var stream = GetSourceStream(cancellationToken))
+                    using (var xmlReader = XmlReader.Create(stream, s_xmlSettings))
                     {
-                        if (e.Attribute("name") != null)
-                            comments[e.Attribute("name").Value] = e.ToString();
+                        var comments = new Dictionary<string, string>();
+                        while (xmlReader.Read())
+                        {
+                            if (xmlReader.NodeType == XmlNodeType.Element && xmlReader.Name == "member")
+                            {
+                                var name = xmlReader.GetAttribute("name");
+                                if (name != null)
+                                {
+                                    // Read the entire <member> element as a string
+                                    var memberXml = xmlReader.ReadOuterXml();
+                                    comments[name] = memberXml;
+                                }
+                            }
+                        }
+ 
+                        _docComments = comments;
                     }
-
-                    _docComments = comments;
                 }
                 catch (Exception)
                 {

--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -79,7 +79,7 @@ public abstract class XmlDocumentationProvider : DocumentationProvider
                                 }
                             }
                         }
- 
+
                         _docComments = comments;
                     }
                 }


### PR DESCRIPTION
Switches the method from XDocument usage to just using the XmlReader directly. 

I do notice one *slight* difference between the two, the old way ends up converting "\n" in the document to "\r\n" whereas the new way doesn't do that conversion. I don't *think* that should have an effect on rendering, but I thought I should mention it.

XmlDocumentationProvider.GetDocumentationForSymbol accounts for 1.4% of total allocations in the ServiceHub process in the razor cohosting speedometer test. I haven't run an insertion against this, but I'm confident that this new way will reduce this number.

<img width="1306" height="273" alt="image" src="https://github.com/user-attachments/assets/3d0f585f-eea1-411d-af46-6091baa03dd0" />