### PR TITLE
Reduce allocations in AnalyzerConfig.UnescapeSectionName

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -123,7 +123,8 @@ namespace Microsoft.CodeAnalysis
 
         internal static string UnescapeSectionName(string sectionName)
         {
-            var sb = PooledStringBuilder.GetInstance();
+            var pooledStrbuilder = PooledStringBuilder.GetInstance();
+            StringBuilder sb = pooledStrbuilder.Builder;
             SectionNameLexer lexer = new SectionNameLexer(sectionName);
             while (!lexer.IsDone)
             {
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis
                     throw ExceptionUtilities.UnexpectedValue(tokenKind);
                 }
             }
-            return sb.ToStringAndFree();
+            return pooledStrbuilder.ToStringAndFree();
         }
 
         /// <summary>


### PR DESCRIPTION
Just a simple switch to using a pooled StringBuilder. Not a huge allocator, but easy enough to switch.

<img width="1308" height="501" alt="image" src="https://github.com/user-attachments/assets/a231b989-6165-4868-ae59-3ce94a1a59b2" />