### PR TITLE
Reduce allocations in SourceTextStream ctor

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextStreamTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextStreamTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
         [Fact]
         public void Issue1197()
         {
-            var baseText = "food time";
+            var baseText = new string('a', SourceTextStream.BufferSize - 1);
             var text = string.Format("{0}{1}", baseText, '\u2019');
             var encoding = s_utf8NoBom;
             var sourceText = SourceText.From(text, encoding);

--- a/src/Compilers/Core/Portable/Text/SourceTextStream.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextStream.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Text
         private readonly Encoding _encoding;
         private readonly Encoder _encoder;
 
-        private const int BufferSize = 2048;
+        internal const int BufferSize = 2048;
         private static readonly ObjectPool<char[]> s_charArrayPool = new ObjectPool<char[]>(() => new char[BufferSize], size: 8);
 
         private readonly int _minimumTargetBufferCount;
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Text
 
         protected override void Dispose(bool disposing)
         {
-            if (_charBuffer != null)
+            if (disposing && _charBuffer != null)
             {
                 s_charArrayPool.Free(_charBuffer);
                 _charBuffer = null!;


### PR DESCRIPTION
Simple switch to use a pooled char[] as the class already has a lifetime mechanism we can hook into.

Not a huge win, but it's 0.1% (2.3 MB) of all allocations in the RoslynCodeAnalysisService process in the razor speedometer test,.

<img width="1311" height="467" alt="image" src="https://github.com/user-attachments/assets/2b4a5191-f630-47ff-8b46-7a930a5b7e70" />