### PR TITLE
Reduce allocations in SourceGeneratedDocumentIdentity.Generate

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -44,6 +44,9 @@ internal readonly partial record struct Checksum
     }
 
     public static Checksum Create(ImmutableArray<string> values)
+        => Create(ImmutableCollectionsMarshal.AsArray(values).AsSpan());
+
+    public static Checksum Create(ReadOnlySpan<string> values)
     {
         using var pooledHash = s_incrementalHashPool.GetPooledObject();
 
@@ -159,11 +162,12 @@ internal readonly partial record struct Checksum
     }
 
     public static Checksum Create(ImmutableArray<byte> bytes)
-    {
-        var source = ImmutableCollectionsMarshal.AsArray(bytes).AsSpan();
+        => Create(ImmutableCollectionsMarshal.AsArray(bytes).AsSpan());
 
+    public static Checksum Create(ReadOnlySpan<byte> bytes)
+    {
         Span<byte> destination = stackalloc byte[XXHash128SizeBytes];
-        XxHash128.Hash(source, destination);
+        XxHash128.Hash(bytes, destination);
         return From(destination);
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -42,47 +42,29 @@ internal readonly record struct SourceGeneratedDocumentIdentity : IEquatable<Sou
         // ensure we don't have collisions.
         var generatorIdentity = SourceGeneratorIdentity.Create(generator, analyzerReference);
 
-        // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
-        // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
-        var projectIdBytes = projectId.Id.ToByteArray();
-
         // The assembly path should exist in any normal scenario; the hashing of the name only would apply if the user loaded a
         // dynamic assembly they produced at runtime and passed us that via a custom AnalyzerReference.
         var assemblyNameToHash = generatorIdentity.AssemblyPath ?? generatorIdentity.AssemblyName;
 
-        var hashInputLength = projectIdBytes.Length
-            + Encoding.Unicode.GetByteCount(assemblyNameToHash)
-            + 2
-            + Encoding.Unicode.GetByteCount(generatorIdentity.TypeName)
-            + 2
-            + Encoding.Unicode.GetByteCount(hintName);
-
-        var hashInput = new byte[hashInputLength];
-
-        Array.Copy(projectIdBytes, 0, hashInput, 0, projectIdBytes.Length);
-        var byteIndex = projectIdBytes.Length;
-
-        // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
-        // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
-        byteIndex += Encoding.Unicode.GetBytes(assemblyNameToHash, 0, assemblyNameToHash.Length, hashInput, byteIndex);
-        byteIndex += 2;
-        byteIndex += Encoding.Unicode.GetBytes(generatorIdentity.TypeName, 0, generatorIdentity.TypeName.Length, hashInput, byteIndex);
-        byteIndex += 2;
-        byteIndex += Encoding.Unicode.GetBytes(hintName, 0, hintName.Length, hashInput, byteIndex);
-
-        // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary. The only requirement
-        // is it must be collision resistant, and provide enough bits to fill a GUID.
 #if NET
-        Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
-        SHA256.HashData(hashInput, hash);
-
-        var guid = new Guid(hash[..16]);
+        Span<byte> bytesToChecksum = stackalloc byte[16];
+        projectId.Id.TryWriteBytes(bytesToChecksum);
 #else
-        using var crytpoAlgorithm = SHA256.Create();
-        var hash = crytpoAlgorithm.ComputeHash(hashInput);
+        var bytesToChecksum = projectId.Id.ToByteArray().AsSpan();
+#endif
 
-        Array.Resize(ref hash, 16);
-        var guid = new Guid(hash);
+        ReadOnlySpan<string> stringsToChecksum = [assemblyNameToHash, generatorIdentity.TypeName, hintName];
+        var stringChecksum = Checksum.Create(stringsToChecksum);
+        var byteChecksum = Checksum.Create(bytesToChecksum);
+        var compositeChecksum = Checksum.Create(stringChecksum, byteChecksum);
+
+        Span<byte> checksumAsBytes = stackalloc byte[16];
+        compositeChecksum.WriteTo(checksumAsBytes);
+
+#if NET
+        var guid = new Guid(checksumAsBytes);
+#else
+        var guid = new Guid(checksumAsBytes.ToArray());
 #endif
 
         var documentId = DocumentId.CreateFromSerialized(projectId, guid, isSourceGenerated: true, hintName);

--- a/src/Workspaces/CoreTest/ChecksumTests.cs
+++ b/src/Workspaces/CoreTest/ChecksumTests.cs
@@ -154,8 +154,8 @@ public sealed class ChecksumTests
     [Fact]
     public void StringArraysProduceDifferentResultsThanConcatenation()
     {
-        var checksum1 = Checksum.Create(["goo", "bar"]);
-        var checksum2 = Checksum.Create(["go", "obar"]);
+        var checksum1 = Checksum.Create(ImmutableArray.Create("goo", "bar"));
+        var checksum2 = Checksum.Create(ImmutableArray.Create("go", "obar"));
         var checksum3 = Checksum.Create("goobar");
         Assert.NotEqual(checksum1, checksum2);
         Assert.NotEqual(checksum2, checksum3);
@@ -175,9 +175,9 @@ public sealed class ChecksumTests
         Assert.NotEqual(Checksum.Null, Checksum.Create(ImmutableArray<Checksum>.Empty));
         Assert.NotEqual(Checksum.Null, Checksum.Create(ImmutableArray<byte>.Empty));
 
-        Assert.NotEqual(Checksum.Null, Checksum.Create([""]));
-        Assert.NotEqual(Checksum.Null, Checksum.Create(["\0"]));
-        Assert.NotEqual(Checksum.Null, Checksum.Create(new string?[] { null }));
+        Assert.NotEqual(Checksum.Null, Checksum.Create(ImmutableArray.Create("")));
+        Assert.NotEqual(Checksum.Null, Checksum.Create(ImmutableArray.Create("\0")));
+        Assert.NotEqual(Checksum.Null, Checksum.Create(new string?[] { null }.AsEnumerable()));
         Assert.NotEqual(Checksum.Null, Checksum.Create(new MemoryStream()));
         Assert.NotEqual(Checksum.Null, Checksum.Create(stackalloc Checksum[] { Checksum.Null }));
         Assert.NotEqual(Checksum.Null, Checksum.Create(ImmutableArray.Create(Checksum.Null)));


### PR DESCRIPTION
1) The ArrayBuilder that was being used commonly ends up exceeding the re-use size threshold, thus negating it's pooling benefit 
2) The ArrayBuilder.ToArray call can be replaced by an upfront array allocation as the size of the array is easy to determine 
3) The Encoding.GetBytes calls can be changed to a non-allocating version 
4) In NET, can avoid creating the SHA256 object
5) In NET, can use the HashData call to avoid allocating a return array 
6) In NET, can create a guid without needing to create a new array

Found this while looking at a profile for the razor speedometer test. This isn't a huge allocator, but it's a couple MB of allocations that should be mostly removed.