### PR TITLE
Rename unified settings from "textEditor" to "language"

### DIFF
--- a/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
@@ -200,4 +200,4 @@
 [$RootKey$\SettingsManifests\{13c3bbb4-f18f-4111-9f54-a0fb010d9194}]
 @="Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\csharpSettings.registration.json"
-"CacheTag"=qword:18C11F0A543B8AD0
+"CacheTag"=qword:8AD12F34C038CB4D

--- a/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
+++ b/src/VisualStudio/CSharp/Impl/UnifiedSettings/csharpSettings.registration.json
@@ -5,7 +5,7 @@
 {
   "properties": {
     // CompletionOptionsStorage.TriggerOnTypingLetters
-    "textEditor.csharp.intellisense.triggerCompletionOnTypingLetters": {
+    "languages.csharp.intellisense.triggerCompletionOnTypingLetters": {
       "title": "@Show_completion_list_after_a_character_is_typed;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -20,12 +20,12 @@
       }
     },
     // CompletionOptionsStorage.TriggerOnDeletion
-    "textEditor.csharp.intellisense.triggerCompletionOnDeletion": {
+    "languages.csharp.intellisense.triggerCompletionOnDeletion": {
       "title": "@Show_completion_list_after_a_character_is_deleted;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": false,
       "order": 1,
-      "enableWhen": "${config:textEditor.csharp.intellisense.triggerCompletionOnTypingLetters}=='true'",
+      "enableWhen": "${config:languages.csharp.intellisense.triggerCompletionOnTypingLetters}=='true'",
       "migration": {
         "pass": {
           "input": {
@@ -36,7 +36,7 @@
       }
     },
     // CompletionOptionsStorage.TriggerInArgumentLists
-    "textEditor.csharp.intellisense.triggerCompletionInArgumentLists": {
+    "languages.csharp.intellisense.triggerCompletionInArgumentLists": {
       "title": "@Automatically_show_completion_list_in_argument_lists;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
       "type": "boolean",
       "default": true,
@@ -51,7 +51,7 @@
       }
     },
     // CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems
-    "textEditor.csharp.intellisense.highlightMatchingPortionsOfCompletionListItems": {
+    "languages.csharp.intellisense.highlightMatchingPortionsOfCompletionListItems": {
       "title": "@Highlight_matching_portions_of_completion_list_items;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -66,7 +66,7 @@
       }
     },
     // CompletionViewOptionsStorage.ShowCompletionItemFilters
-    "textEditor.csharp.intellisense.showCompletionItemFilters": {
+    "languages.csharp.intellisense.showCompletionItemFilters": {
       "title": "@Show_completion_item_filters;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -81,7 +81,7 @@
       }
     },
     // CompleteStatementOptionsStorage.AutomaticallyCompleteStatementOnSemicolon
-    "textEditor.csharp.intellisense.completeStatementOnSemicolon": {
+    "languages.csharp.intellisense.completeStatementOnSemicolon": {
       "title": "@Automatically_complete_statement_on_semicolon;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
       "type": "boolean",
       "default": true,
@@ -96,7 +96,7 @@
       }
     },
     // CompletionOptionsStorage.SnippetsBehavior
-    "textEditor.csharp.intellisense.snippetsBehavior": {
+    "languages.csharp.intellisense.snippetsBehavior": {
       "title": "@Snippets_behavior;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "neverInclude", "alwaysInclude", "includeAfterTypingIdentifierQuestionTab" ],
@@ -135,7 +135,7 @@
       }
     },
     // CompletionOptionsStorage.EnterKeyBehavior
-    "textEditor.csharp.intellisense.returnKeyCompletionBehavior": {
+    "languages.csharp.intellisense.returnKeyCompletionBehavior": {
       "title": "@Enter_key_behavior;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "never", "afterFullyTypedWord", "always" ],
@@ -174,7 +174,7 @@
       }
     },
     // CompletionOptionsStorage.ShowNameSuggestions
-    "textEditor.csharp.intellisense.showNameCompletionSuggestions": {
+    "languages.csharp.intellisense.showNameCompletionSuggestions": {
       "title": "@Show_name_suggestions;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
       "type": "boolean",
       "default": true,
@@ -189,7 +189,7 @@
       }
     },
     // CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces
-    "textEditor.csharp.intellisense.showCompletionItemsFromUnimportedNamespaces": {
+    "languages.csharp.intellisense.showCompletionItemsFromUnimportedNamespaces": {
       "title": "@Show_items_from_unimported_namespaces;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -204,7 +204,7 @@
       }
     },
     // CompletionViewOptionsStorage.EnableArgumentCompletionSnippets
-    "textEditor.csharp.intellisense.enableArgumentCompletionSnippets": {
+    "languages.csharp.intellisense.enableArgumentCompletionSnippets": {
       "title": "@Tab_twice_to_insert_arguments;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": false,
@@ -224,7 +224,7 @@
       }
     },
     // CompletionOptionsStorage.ShowNewSnippetExperienceUserOption
-    "textEditor.csharp.intellisense.showNewSnippetExperience": {
+    "languages.csharp.intellisense.showNewSnippetExperience": {
       "title": "@Show_new_snippet_experience;..\\Microsoft.VisualStudio.LanguageServices.CSharp.dll",
       "type": "boolean",
       "default": false,
@@ -250,10 +250,10 @@
     }
   },
   "categories": {
-    "textEditor.csharp":{
+    "languages.csharp":{
       "title": "@101;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}"
     },
-    "textEditor.csharp.intellisense": {
+    "languages.csharp.intellisense": {
       "title": "@103;{13c3bbb4-f18f-4111-9f54-a0fb010d9194}",
       "legacyOptionPageId": "EDE66829-7A36-4c5d-8E20-9290195DCF80"
     }

--- a/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
@@ -31,18 +31,18 @@ public sealed class UnifiedSettingsTests
     /// Dictionary containing the option to unified setting path for C#.
     /// </summary>
     private static readonly ImmutableDictionary<IOption2, string> s_csharpUnifiedSettingsStorage = ImmutableDictionary<IOption2, string>.Empty.
-        Add(CompletionOptionsStorage.TriggerOnTypingLetters, "textEditor.csharp.intellisense.triggerCompletionOnTypingLetters").
-        Add(CompletionOptionsStorage.TriggerOnDeletion, "textEditor.csharp.intellisense.triggerCompletionOnDeletion").
-        Add(CompletionOptionsStorage.TriggerInArgumentLists, "textEditor.csharp.intellisense.triggerCompletionInArgumentLists").
-        Add(CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, "textEditor.csharp.intellisense.highlightMatchingPortionsOfCompletionListItems").
-        Add(CompletionViewOptionsStorage.ShowCompletionItemFilters, "textEditor.csharp.intellisense.showCompletionItemFilters").
-        Add(CompleteStatementOptionsStorage.AutomaticallyCompleteStatementOnSemicolon, "textEditor.csharp.intellisense.completeStatementOnSemicolon").
-        Add(CompletionOptionsStorage.SnippetsBehavior, "textEditor.csharp.intellisense.snippetsBehavior").
-        Add(CompletionOptionsStorage.EnterKeyBehavior, "textEditor.csharp.intellisense.returnKeyCompletionBehavior").
-        Add(CompletionOptionsStorage.ShowNameSuggestions, "textEditor.csharp.intellisense.showNameCompletionSuggestions").
-        Add(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, "textEditor.csharp.intellisense.showCompletionItemsFromUnimportedNamespaces").
-        Add(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, "textEditor.csharp.intellisense.enableArgumentCompletionSnippets").
-        Add(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, "textEditor.csharp.intellisense.showNewSnippetExperience");
+        Add(CompletionOptionsStorage.TriggerOnTypingLetters, "languages.csharp.intellisense.triggerCompletionOnTypingLetters").
+        Add(CompletionOptionsStorage.TriggerOnDeletion, "languages.csharp.intellisense.triggerCompletionOnDeletion").
+        Add(CompletionOptionsStorage.TriggerInArgumentLists, "languages.csharp.intellisense.triggerCompletionInArgumentLists").
+        Add(CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, "languages.csharp.intellisense.highlightMatchingPortionsOfCompletionListItems").
+        Add(CompletionViewOptionsStorage.ShowCompletionItemFilters, "languages.csharp.intellisense.showCompletionItemFilters").
+        Add(CompleteStatementOptionsStorage.AutomaticallyCompleteStatementOnSemicolon, "languages.csharp.intellisense.completeStatementOnSemicolon").
+        Add(CompletionOptionsStorage.SnippetsBehavior, "languages.csharp.intellisense.snippetsBehavior").
+        Add(CompletionOptionsStorage.EnterKeyBehavior, "languages.csharp.intellisense.returnKeyCompletionBehavior").
+        Add(CompletionOptionsStorage.ShowNameSuggestions, "languages.csharp.intellisense.showNameCompletionSuggestions").
+        Add(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, "languages.csharp.intellisense.showCompletionItemsFromUnimportedNamespaces").
+        Add(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, "languages.csharp.intellisense.enableArgumentCompletionSnippets").
+        Add(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, "languages.csharp.intellisense.showNewSnippetExperience");
 
     /// <summary>
     /// Array containing the option to expected unified settings for C# intellisense page.
@@ -132,9 +132,9 @@ public sealed class UnifiedSettingsTests
         var categories = jsonDocument!.Root["categories"]!.AsObject();
         var propertyToCategory = categories.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Deserialize<Category>());
         Assert.Equal(2, propertyToCategory.Count);
-        Assert.Equal("C#", propertyToCategory["textEditor.csharp"]!.Title);
-        Assert.Equal("IntelliSense", propertyToCategory["textEditor.csharp.intellisense"]!.Title);
-        Assert.Equal(Guids.CSharpOptionPageIntelliSenseIdString, propertyToCategory["textEditor.csharp.intellisense"]!.LegacyOptionPageId);
+        Assert.Equal("C#", propertyToCategory["languages.csharp"]!.Title);
+        Assert.Equal("IntelliSense", propertyToCategory["languages.csharp.intellisense"]!.Title);
+        Assert.Equal(Guids.CSharpOptionPageIntelliSenseIdString, propertyToCategory["languages.csharp.intellisense"]!.LegacyOptionPageId);
         await VerifyTagAsync(jsonDocument.ToString(), "Roslyn.VisualStudio.Next.UnitTests.csharpPackageRegistration.pkgdef");
     }
 
@@ -148,7 +148,7 @@ public sealed class UnifiedSettingsTests
             Assert.True(s_csharpUnifiedSettingsStorage.ContainsKey(option));
         }
 
-        VerifyProperties(jsonDocument!, "textEditor.csharp.intellisense", s_csharpIntellisenseExpectedSettings);
+        VerifyProperties(jsonDocument!, "languages.csharp.intellisense", s_csharpIntellisenseExpectedSettings);
         await VerifyTagAsync(jsonDocument!.ToString(), "Roslyn.VisualStudio.Next.UnitTests.csharpPackageRegistration.pkgdef");
     }
 
@@ -159,14 +159,14 @@ public sealed class UnifiedSettingsTests
     /// Dictionary containing the option to unified setting path for VB.
     /// </summary>
     private static readonly ImmutableDictionary<IOption2, string> s_visualBasicUnifiedSettingsStorage = ImmutableDictionary<IOption2, string>.Empty.
-        Add(CompletionOptionsStorage.TriggerOnTypingLetters, "textEditor.basic.intellisense.triggerCompletionOnTypingLetters").
-        Add(CompletionOptionsStorage.TriggerOnDeletion, "textEditor.basic.intellisense.triggerCompletionOnDeletion").
-        Add(CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, "textEditor.basic.intellisense.highlightMatchingPortionsOfCompletionListItems").
-        Add(CompletionViewOptionsStorage.ShowCompletionItemFilters, "textEditor.basic.intellisense.showCompletionItemFilters").
-        Add(CompletionOptionsStorage.SnippetsBehavior, "textEditor.basic.intellisense.snippetsBehavior").
-        Add(CompletionOptionsStorage.EnterKeyBehavior, "textEditor.basic.intellisense.returnKeyCompletionBehavior").
-        Add(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, "textEditor.basic.intellisense.showCompletionItemsFromUnimportedNamespaces").
-        Add(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, "textEditor.basic.intellisense.enableArgumentCompletionSnippets");
+        Add(CompletionOptionsStorage.TriggerOnTypingLetters, "languages.basic.intellisense.triggerCompletionOnTypingLetters").
+        Add(CompletionOptionsStorage.TriggerOnDeletion, "languages.basic.intellisense.triggerCompletionOnDeletion").
+        Add(CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, "languages.basic.intellisense.highlightMatchingPortionsOfCompletionListItems").
+        Add(CompletionViewOptionsStorage.ShowCompletionItemFilters, "languages.basic.intellisense.showCompletionItemFilters").
+        Add(CompletionOptionsStorage.SnippetsBehavior, "languages.basic.intellisense.snippetsBehavior").
+        Add(CompletionOptionsStorage.EnterKeyBehavior, "languages.basic.intellisense.returnKeyCompletionBehavior").
+        Add(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, "languages.basic.intellisense.showCompletionItemsFromUnimportedNamespaces").
+        Add(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, "languages.basic.intellisense.enableArgumentCompletionSnippets");
 
     /// <summary>
     /// Array containing the option to expected unified settings for VB intellisense page.
@@ -233,9 +233,9 @@ public sealed class UnifiedSettingsTests
         var categories = jsonDocument!.Root["categories"]!.AsObject();
         var propertyToCategory = categories.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Deserialize<Category>());
         Assert.Equal(2, propertyToCategory.Count);
-        Assert.Equal("Visual Basic", propertyToCategory["textEditor.basic"]!.Title);
-        Assert.Equal("IntelliSense", propertyToCategory["textEditor.basic.intellisense"]!.Title);
-        Assert.Equal(Guids.VisualBasicOptionPageIntelliSenseIdString, propertyToCategory["textEditor.basic.intellisense"]!.LegacyOptionPageId);
+        Assert.Equal("Visual Basic", propertyToCategory["languages.basic"]!.Title);
+        Assert.Equal("IntelliSense", propertyToCategory["languages.basic.intellisense"]!.Title);
+        Assert.Equal(Guids.VisualBasicOptionPageIntelliSenseIdString, propertyToCategory["languages.basic.intellisense"]!.LegacyOptionPageId);
         await VerifyTagAsync(jsonDocument.ToString(), "Roslyn.VisualStudio.Next.UnitTests.visualBasicPackageRegistration.pkgdef");
     }
 
@@ -249,7 +249,7 @@ public sealed class UnifiedSettingsTests
             Assert.True(s_visualBasicUnifiedSettingsStorage.ContainsKey(option));
         }
 
-        VerifyProperties(jsonDocument!, "textEditor.basic.intellisense", s_visualBasicIntellisenseExpectedSettings);
+        VerifyProperties(jsonDocument!, "languages.basic.intellisense", s_visualBasicIntellisenseExpectedSettings);
         await VerifyTagAsync(jsonDocument!.ToString(), "Roslyn.VisualStudio.Next.UnitTests.visualBasicPackageRegistration.pkgdef");
     }
 
@@ -318,7 +318,7 @@ public sealed class UnifiedSettingsTests
         // If the option default value is null, it means the option is in experiment mode and is hidden by a feature flag.
         // In Unified Settings it is not allowed and should be replaced by using the alternative default.
         // Like:
-        //     "textEditor.csharp.intellisense.showNewSnippetExperience": {
+        //     "languages.csharp.intellisense.showNewSnippetExperience": {
         //         "type": "boolean",
         //         "default": false,
         //         "alternateDefault": {

--- a/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
@@ -197,4 +197,4 @@
 [$RootKey$\SettingsManifests\{574fc912-f74f-4b4e-92c3-f695c208a2bb}]
 @="Microsoft.VisualStudio.LanguageServices.VisualBasic.VisualBasicPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\visualBasicSettings.registration.json"
-"CacheTag"=qword:A051BA2C3046E62E
+"CacheTag"=qword:BB2A8024FA5C18D6

--- a/src/VisualStudio/VisualBasic/Impl/UnifiedSettings/visualBasicSettings.registration.json
+++ b/src/VisualStudio/VisualBasic/Impl/UnifiedSettings/visualBasicSettings.registration.json
@@ -5,7 +5,7 @@
 {
   "properties": {
     // CompletionOptionsStorage.TriggerOnTypingLetters
-    "textEditor.basic.intellisense.triggerCompletionOnTypingLetters": {
+    "languages.basic.intellisense.triggerCompletionOnTypingLetters": {
       "title": "@Show_completion_list_after_a_character_is_typed;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -20,7 +20,7 @@
       }
     },
     // CompletionOptionsStorage.TriggerOnDeletion
-    "textEditor.basic.intellisense.triggerCompletionOnDeletion": {
+    "languages.basic.intellisense.triggerCompletionOnDeletion": {
       "title": "@Show_completion_list_after_a_character_is_deleted;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -35,7 +35,7 @@
       }
     },
     // CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems
-    "textEditor.basic.intellisense.highlightMatchingPortionsOfCompletionListItems": {
+    "languages.basic.intellisense.highlightMatchingPortionsOfCompletionListItems": {
       "title": "@Highlight_matching_portions_of_completion_list_items;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -50,7 +50,7 @@
       }
     },
     // CompletionViewOptionsStorage.ShowCompletionItemFilters
-    "textEditor.basic.intellisense.showCompletionItemFilters": {
+    "languages.basic.intellisense.showCompletionItemFilters": {
       "title": "@Show_completion_item_filters;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -65,7 +65,7 @@
       }
     },
     // CompletionOptionsStorage.SnippetsBehavior
-    "textEditor.basic.intellisense.snippetsBehavior": {
+    "languages.basic.intellisense.snippetsBehavior": {
       "title": "@Snippets_behavior;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "neverInclude", "alwaysInclude", "includeAfterTypingIdentifierQuestionTab" ],
@@ -104,7 +104,7 @@
       }
     },
     // CompletionOptionsStorage.EnterKeyBehavior
-    "textEditor.basic.intellisense.returnKeyCompletionBehavior": {
+    "languages.basic.intellisense.returnKeyCompletionBehavior": {
       "title": "@Enter_key_behavior;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "string",
       "enum": [ "never", "afterFullyTypedWord", "always" ],
@@ -143,7 +143,7 @@
       }
     },
     // CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces
-    "textEditor.basic.intellisense.showCompletionItemsFromUnimportedNamespaces": {
+    "languages.basic.intellisense.showCompletionItemsFromUnimportedNamespaces": {
       "title": "@Show_items_from_unimported_namespaces;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": true,
@@ -158,7 +158,7 @@
       }
     },
     // CompletionViewOptionsStorage.EnableArgumentCompletionSnippets
-    "textEditor.basic.intellisense.enableArgumentCompletionSnippets": {
+    "languages.basic.intellisense.enableArgumentCompletionSnippets": {
       "title": "@Tab_twice_to_insert_arguments;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
       "default": false,
@@ -179,10 +179,10 @@
     }
   },
   "categories": {
-    "textEditor.basic":{
+    "languages.basic":{
       "title": "@101;{574fc912-f74f-4b4e-92c3-f695c208a2bb}"
     },
-    "textEditor.basic.intellisense": {
+    "languages.basic.intellisense": {
       "title": "@112;{574fc912-f74f-4b4e-92c3-f695c208a2bb}",
       "legacyOptionPageId": "04460A3B-1B5F-4402-BC6D-89A4F6F0A8D7"
     }


### PR DESCRIPTION
This rename was applied to all the common settings (tab/spaces, etc) and is expected of us as well.