### PR TITLE
Fix sign type parameter in official build

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -290,13 +290,13 @@ extends:
 
         - task: MicroBuildSigningPlugin@4
           inputs:
-            signType: $(SignType)
+            signType: ${{ parameters.SignType }}
             zipSources: false
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
             # Set ConnectedPMEServiceName if the build is a CI build, otherwise it is not needed
             ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
               ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
-          condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
+          condition: and(succeeded(), in('${{ parameters.SignType }}', 'test', 'real'))
 
         - download: profilingInputs
           artifact: merged mibc
@@ -324,7 +324,7 @@ extends:
                        /p:RepositoryName=$(Build.Repository.Name)
                        /p:VisualStudioDropName=$(VisualStudio.DropName)
                        /p:VSCodeOptimizationDataRoot="$(VSCodeOptimizationDataRoot)"
-                       /p:DotNetSignType=$(SignType)
+                       /p:DotNetSignType=${{ parameters.SignType }}
                        /p:DotnetPublishUsingPipelines=true
                        /p:IgnoreIbcMergeErrors=true
                        /p:GenerateSbom=true


### PR DESCRIPTION
signtype pipeline parameter didn't work because it was being referenced as a variable

val build where changing the value works - https://dev.azure.com/dnceng/internal/_build/results?buildId=2795744&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=20fcf628-b65c-5865-625a-1cef81cda63b