### PR TITLE
Switch ExpressionBodyDiagnosticAnalyzer to use SemanticSpanAnalysis

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
@@ -40,7 +40,7 @@ internal sealed class UseExpressionBodyDiagnosticAnalyzer : AbstractBuiltInCodeS
     }
 
     public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
-        => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
+        => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
     protected override void InitializeWorker(AnalysisContext context)
         => context.RegisterSyntaxNodeAction(AnalyzeSyntax, _syntaxKinds);


### PR DESCRIPTION
The switch to SyntaxTreeWithoutSemanticsAnalysis caused some integration test failures https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12363288&view=ms.vss-test-web.build-test-results-tab&runId=140232751&resultId=100654&paneView=debug

Seems like editorconfig settings aren't being properly resolved with the switch.