### PR TITLE
Only restore based on assets file changes if the actual content changed

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -127,7 +127,6 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
 
         foreach (var diagnostic in diagnostics)
         {
-            // https://github.com/dotnet/roslyn/issues/78688: Surface diagnostics in editor
             _logger.LogError($"{diagnostic.Location.Path}{diagnostic.Location.Span.Start}: {diagnostic.Message}");
         }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -362,7 +362,8 @@ internal abstract class LanguageServerProjectLoader
                 _projectSystemHostInfo);
 
             var loadedProject = new LoadedProject(projectSystemProject, projectFactory, _fileChangeWatcher, _targetFrameworkManager);
-            loadedProject.NeedsReload += (_, _) => _projectsToReload.AddWork(projectToLoad with { ReportTelemetry = false });
+            loadedProject.NeedsReload += (_, _) =>
+                _projectsToReload.AddWork(projectToLoad with { ReportTelemetry = false });
             return (loadedProject, alreadyExists: false);
         }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
@@ -29,6 +30,7 @@ internal sealed class LoadedProject : IDisposable
     private readonly ProjectSystemProjectOptionsProcessor _optionsProcessor;
     private readonly IFileChangeContext _sourceFileChangeContext;
     private readonly IFileChangeContext _projectFileChangeContext;
+    private readonly IFileChangeContext _assetsFileChangeContext;
     private readonly ProjectTargetFrameworkManager _targetFrameworkManager;
 
     /// <summary>
@@ -40,6 +42,7 @@ internal sealed class LoadedProject : IDisposable
     /// </summary>
     private Lazy<ImmutableArray<Matcher>>? _mostRecentFileMatchers;
     private IWatchedFile? _mostRecentProjectAssetsFileWatcher;
+    private ImmutableArray<byte> _mostRecentProjectAssetsFileContentHash;
     private ImmutableArray<CommandLineReference> _mostRecentMetadataReferences = [];
     private ImmutableArray<CommandLineAnalyzerReference> _mostRecentAnalyzerReferences = [];
 
@@ -63,6 +66,9 @@ internal sealed class LoadedProject : IDisposable
         _projectFileChangeContext = fileWatcher.CreateContext([]);
         _projectFileChangeContext.FileChanged += ProjectFileChangeContext_FileChanged;
         _projectFileChangeContext.EnqueueWatchingFile(_projectFilePath);
+
+        _assetsFileChangeContext = fileWatcher.CreateContext([]);
+        _assetsFileChangeContext.FileChanged += AssetsFileChangeContext_FileChanged;
     }
 
     private void SourceFileChangeContext_FileChanged(object? sender, string filePath)
@@ -93,6 +99,22 @@ internal sealed class LoadedProject : IDisposable
     private void ProjectFileChangeContext_FileChanged(object? sender, string filePath)
     {
         NeedsReload?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void AssetsFileChangeContext_FileChanged(object? sender, string filePath)
+    {
+        // We only want to trigger design time build if the assets file content actually changed from the last time this handler was called.
+        // Sometimes we can get a change event where no content changed (e.g. for a failed restore).
+        // In such cases, proceeding with design-time build can put us in a restore loop (since the design-time build notices that assets are missing).
+        using var assetsFileStream = File.OpenRead(filePath);
+        var sourceText = SourceText.From(assetsFileStream);
+        var contentHash = sourceText.GetContentHash();
+        if (_mostRecentProjectAssetsFileContentHash.IsDefault
+            || !_mostRecentProjectAssetsFileContentHash.SequenceEqual(contentHash))
+        {
+            _mostRecentProjectAssetsFileContentHash = contentHash;
+            NeedsReload?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     public event EventHandler? NeedsReload;
@@ -282,8 +304,9 @@ internal sealed class LoadedProject : IDisposable
             // Dispose of the last once since we're changing the file we're watching.
             _mostRecentProjectAssetsFileWatcher?.Dispose();
             _mostRecentProjectAssetsFileWatcher = currentProjectInfo.ProjectAssetsFilePath is { } assetsFilePath
-                    ? _projectFileChangeContext.EnqueueWatchingFile(assetsFilePath)
+                    ? _assetsFileChangeContext.EnqueueWatchingFile(assetsFilePath)
                     : null;
+            _mostRecentProjectAssetsFileContentHash = default;
         }
     }
 


### PR DESCRIPTION
Closes #80242 

What was happening was, a restore would modify the assets file and cause our watcher to get notified, even though the actual content didn't change. The design time build would notice that assets were still missing and kick off another restore, which would fail again, but generate the file watcher event, in a cycle.

The change is to hash the assets file content when we get a change notification for it, and compare it with the hash from the previous notification, to make sure a meaningful content change has occurred, before kicking off a design time build based on it.

With this change we no longer get a restore loop for a package directive like `#:package Newtonsoft.Json:13.0.4`.
