### PR TITLE
Avoid implicit null checks while narrowing type for `or` patterns

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_ListPatterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_ListPatterns.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var syntax = list.Syntax;
             var subpatterns = list.Subpatterns;
             var tests = ArrayBuilder<Tests>.GetInstance(4 + subpatterns.Length * 2);
-            output = input = MakeConvertToType(input, list.Syntax, list.NarrowedType, isExplicitTest: false, tests, checkNotNull: true);
+            output = input = MakeConvertToType(input, list.Syntax, list.NarrowedType, isExplicitTest: false, tests);
 
             if (list.HasErrors)
             {


### PR DESCRIPTION
For example, consider `interface I; class A : I;` and `bool M1(A? a) => a is I or null;`. The pattern has type `A` on the input but narrows it to `I` (so if you then added `and var x` for example, the type of `var x` would be `I`). This type narrowing is implemented via a null check and a cast. But that's wrong when one of the nested patterns is `null` as in the example.

In the example, the DAG before this PR was:

```
State 0
    1. [I or null] AND(OR(?DagNonNullTest(t0), ?DagExplicitNullTest(t0)), ?DagNonNullTest(t0))
    Test: ?DagNonNullTest(t0)
    TrueBranch: 2
    FalseBranch: 1
*State 1 FAIL
*State 2
    1. [I or null] MATCH
```

The `AND(., ?DagNonNullTest(t0))` part is the "type narrowing".

Whereas it should be (and after this PR it is):

```
State 0
    1. [I or null] OR(?DagNonNullTest(t0), ?DagExplicitNullTest(t0))
    Test: ?DagNonNullTest(t0)
    TrueBranch: 1
    FalseBranch: 1
*State 1
    1. [I or null] MATCH
```

Fixes https://github.com/dotnet/roslyn/issues/80326.