### PR TITLE
Update Fix-all for "var or explicit-type" to only fix the subset of matches that violated the same rule as the original.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
 
 internal static class CSharpTypeStyleUtilities
 {
+    public const string EquivalenceyKey = nameof(EquivalenceyKey);
+
     public const string BuiltInType = nameof(BuiltInType);
     public const string TypeIsApparent = nameof(TypeIsApparent);
     public const string Elsewhere = nameof(Elsewhere);
@@ -28,9 +30,9 @@ internal abstract partial class CSharpTypeStyleDiagnosticAnalyzerBase(
         [CSharpCodeStyleOptions.VarForBuiltInTypes, CSharpCodeStyleOptions.VarWhenTypeIsApparent, CSharpCodeStyleOptions.VarElsewhere],
         title, message)
 {
-    private static readonly ImmutableDictionary<string, string?> BuiltInTypeProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.BuiltInType, "");
-    private static readonly ImmutableDictionary<string, string?> TypeIsApparentProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.TypeIsApparent, "");
-    private static readonly ImmutableDictionary<string, string?> ElsewhereProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.Elsewhere, "");
+    private static readonly ImmutableDictionary<string, string?> BuiltInTypeProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.EquivalenceyKey, CSharpTypeStyleUtilities.BuiltInType);
+    private static readonly ImmutableDictionary<string, string?> TypeIsApparentProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.EquivalenceyKey, CSharpTypeStyleUtilities.TypeIsApparent);
+    private static readonly ImmutableDictionary<string, string?> ElsewhereProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.EquivalenceyKey, CSharpTypeStyleUtilities.Elsewhere);
 
     protected abstract CSharpTypeStyleHelper Helper { get; }
 

--- a/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -2,14 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
+
+internal static class CSharpTypeStyleUtilities
+{
+    public const string BuiltInType = nameof(BuiltInType);
+    public const string TypeIsApparent = nameof(TypeIsApparent);
+    public const string Elsewhere = nameof(Elsewhere);
+}
 
 internal abstract partial class CSharpTypeStyleDiagnosticAnalyzerBase(
     string diagnosticId,
@@ -21,6 +28,10 @@ internal abstract partial class CSharpTypeStyleDiagnosticAnalyzerBase(
         [CSharpCodeStyleOptions.VarForBuiltInTypes, CSharpCodeStyleOptions.VarWhenTypeIsApparent, CSharpCodeStyleOptions.VarElsewhere],
         title, message)
 {
+    private static readonly ImmutableDictionary<string, string?> BuiltInTypeProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.BuiltInType, "");
+    private static readonly ImmutableDictionary<string, string?> TypeIsApparentProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.TypeIsApparent, "");
+    private static readonly ImmutableDictionary<string, string?> ElsewhereProperties = ImmutableDictionary<string, string?>.Empty.Add(CSharpTypeStyleUtilities.Elsewhere, "");
+
     protected abstract CSharpTypeStyleHelper Helper { get; }
 
     public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
@@ -52,9 +63,18 @@ internal abstract partial class CSharpTypeStyleDiagnosticAnalyzerBase(
 
         // The severity preference is not Hidden, as indicated by IsStylePreferred.
         var descriptor = Descriptor;
-        context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, declaredType.StripRefIfNeeded().Span, typeStyle.Notification, context.Options));
+        context.ReportDiagnostic(DiagnosticHelper.Create(
+            descriptor,
+            declarationStatement.SyntaxTree.GetLocation(declaredType.StripRefIfNeeded().Span),
+            typeStyle.Notification,
+            context.Options,
+            additionalLocations: null,
+            typeStyle.Context switch
+            {
+                CSharpTypeStyleHelper.Context.BuiltInType => BuiltInTypeProperties,
+                CSharpTypeStyleHelper.Context.TypeIsApparent => TypeIsApparentProperties,
+                CSharpTypeStyleHelper.Context.Elsewhere => ElsewhereProperties,
+                _ => throw ExceptionUtilities.UnexpectedValue(typeStyle.Context),
+            }));
     }
-
-    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode declaration, TextSpan diagnosticSpan, NotificationOption2 notificationOption, AnalyzerOptions analyzerOptions)
-        => DiagnosticHelper.Create(descriptor, declaration.SyntaxTree.GetLocation(diagnosticSpan), notificationOption, analyzerOptions, additionalLocations: null, properties: null);
 }

--- a/src/Analyzers/CSharp/CodeFixes/UseImplicitOrExplicitType/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseImplicitOrExplicitType/UseExplicitTypeCodeFixProvider.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -35,9 +36,15 @@ internal sealed class UseExplicitTypeCodeFixProvider() : SyntaxEditorBasedCodeFi
 
     public override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        RegisterCodeFix(context, CSharpAnalyzersResources.Use_explicit_type_instead_of_var, nameof(CSharpAnalyzersResources.Use_explicit_type_instead_of_var));
+        RegisterCodeFix(
+            context,
+            CSharpAnalyzersResources.Use_explicit_type_instead_of_var,
+            context.Diagnostics.First().Properties[CSharpTypeStyleUtilities.EquivalenceyKey]!);
         return Task.CompletedTask;
     }
+
+    protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic, Document document, string? equivalenceKey, CancellationToken cancellationToken)
+        => diagnostic.Properties[CSharpTypeStyleUtilities.EquivalenceyKey] == equivalenceKey;
 
     protected override async Task FixAllAsync(
         Document document, ImmutableArray<Diagnostic> diagnostics,

--- a/src/Analyzers/CSharp/CodeFixes/UseImplicitOrExplicitType/UseImplicitTypeCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseImplicitOrExplicitType/UseImplicitTypeCodeFixProvider.cs
@@ -5,9 +5,11 @@
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -25,9 +27,15 @@ internal sealed class UseImplicitTypeCodeFixProvider() : SyntaxEditorBasedCodeFi
 
     public override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        RegisterCodeFix(context, CSharpAnalyzersResources.use_var_instead_of_explicit_type, nameof(CSharpAnalyzersResources.use_var_instead_of_explicit_type));
+        RegisterCodeFix(
+            context,
+            CSharpAnalyzersResources.use_var_instead_of_explicit_type,
+            context.Diagnostics.First().Properties[CSharpTypeStyleUtilities.EquivalenceyKey]!);
         return Task.CompletedTask;
     }
+
+    protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic, Document document, string? equivalenceKey, CancellationToken cancellationToken)
+        => diagnostic.Properties[CSharpTypeStyleUtilities.EquivalenceyKey] == equivalenceKey;
 
     protected override Task FixAllAsync(
         Document document, ImmutableArray<Diagnostic> diagnostics,

--- a/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/Analyzers/CSharp/Tests/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.InlineDeclaration;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitType;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitOrExplicitType;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -15,7 +15,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitType;
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitOrExplicitType;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
 public sealed partial class UseExplicitTypeTests(ITestOutputHelper logger)

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitType;
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitOrExplicitType;
 
 public partial class UseExplicitTypeTests
 {

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
@@ -81,8 +81,8 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     int i1 = 0;
-                    Program p = new Program();
-                    Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+                    var p = new Program();
+                    var tuple = Tuple.Create(true, 1);
 
                     return i1;
                 }
@@ -191,8 +191,8 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     int i1 = 0;
-                    Program p = new Program();
-                    Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+                    var p = new Program();
+                    var tuple = Tuple.Create(true, 1);
 
                     return i1;
                 }
@@ -206,8 +206,8 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     int i2 = 0;
-                    Program2 p2 = new Program2();
-                    Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
+                    var p2 = new Program2();
+                    var tuple2 = Tuple.Create(true, 1);
 
                     return i2;
                 }
@@ -301,8 +301,8 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     int i1 = 0;
-                    Program p = new Program();
-                    Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+                    var p = new Program();
+                    var tuple = Tuple.Create(true, 1);
 
                     return i1;
                 }
@@ -316,8 +316,8 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     int i2 = 0;
-                    Program2 p2 = new Program2();
-                    Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
+                    var p2 = new Program2();
+                    var tuple2 = Tuple.Create(true, 1);
 
                     return i2;
                 }
@@ -333,8 +333,8 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     int i3 = 0;
-                    Program2 p3 = new Program2();
-                    Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
+                    var p3 = new Program2();
+                    var tuple3 = Tuple.Create(true, 1);
 
                     return i3;
                 }
@@ -359,6 +359,7 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     {|FixAllInDocument:var|} p = this;
+                    var p2 = this;
                     var i1 = 0;
                     var tuple = Tuple.Create(true, 1);
 
@@ -379,7 +380,8 @@ public partial class UseExplicitTypeTests
                 static int F(int x, int y)
                 {
                     Program p = this;
-                    int i1 = 0;
+                    Program p2 = this;
+                    var i1 = 0;
                     var tuple = Tuple.Create(true, 1);
 
                     return i1;

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -16,7 +16,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitType;
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitOrExplicitType;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
 public sealed partial class UseImplicitTypeTests(ITestOutputHelper? logger = null)

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
@@ -81,8 +81,8 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i1 = 0;
-                    var p = new Program();
-                    var tuple = Tuple.Create(true, 1);
+                    Program p = new Program();
+                    Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
 
                     return i1;
                 }
@@ -191,8 +191,8 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i1 = 0;
-                    var p = new Program();
-                    var tuple = Tuple.Create(true, 1);
+                    Program p = new Program();
+                    Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
 
                     return i1;
                 }
@@ -206,8 +206,8 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i2 = 0;
-                    var p2 = new Program2();
-                    var tuple2 = Tuple.Create(true, 1);
+                    Program p2 = new Program2();
+                    Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
 
                     return i2;
                 }
@@ -301,8 +301,8 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i1 = 0;
-                    var p = new Program();
-                    var tuple = Tuple.Create(true, 1);
+                    Program p = new Program();
+                    Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
 
                     return i1;
                 }
@@ -316,8 +316,8 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i2 = 0;
-                    var p2 = new Program2();
-                    var tuple2 = Tuple.Create(true, 1);
+                    Program p2 = new Program2();
+                    Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
 
                     return i2;
                 }
@@ -333,8 +333,8 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i3 = 0;
-                    var p3 = new Program2();
-                    var tuple3 = Tuple.Create(true, 1);
+                    Program p3 = new Program2();
+                    Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
 
                     return i3;
                 }

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitType;
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitOrExplicitType;
 
 public partial class UseImplicitTypeTests
 {

--- a/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
@@ -206,7 +206,7 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i2 = 0;
-                    Program p2 = new Program2();
+                    Program2 p2 = new Program2();
                     Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
 
                     return i2;
@@ -316,7 +316,7 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i2 = 0;
-                    Program p2 = new Program2();
+                    Program2 p2 = new Program2();
                     Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
 
                     return i2;
@@ -333,7 +333,7 @@ public partial class UseImplicitTypeTests
                 static int F(int x, int y)
                 {
                     var i3 = 0;
-                    Program p3 = new Program2();
+                    Program2 p3 = new Program2();
                     Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
 
                     return i3;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpTypeStyleHelper.State.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpTypeStyleHelper.State.cs
@@ -53,8 +53,7 @@ internal partial class CSharpTypeStyleHelper
             {
                 this.Context = Context.BuiltInType;
             }
-            else if (
-                declaration is VariableDeclarationSyntax varDecl &&
+            else if (declaration is VariableDeclarationSyntax varDecl &&
                 IsTypeApparentInDeclaration(varDecl, semanticModel, TypeStylePreference, cancellationToken))
             {
                 this.Context = Context.TypeIsApparent;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38953
Followup to https://github.com/dotnet/roslyn/pull/80347