### PR TITLE
Properly populate ExportedType metadata table for forwarded extension blocks.

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -613,25 +614,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             if (haveExtensions)
             {
-                var seenGroupingTypes = PooledHashSet<PENamedTypeSymbol>.GetInstance();
                 var groupingTypes = ArrayBuilder<PENamedTypeSymbol>.GetInstance();
-
-                foreach (var type in symbol.GetTypeMembers(""))
-                {
-                    if (!type.IsExtension)
-                    {
-                        continue;
-                    }
-
-                    var groupingType = ((PENamedTypeSymbol)type).ExtensionGroupingType;
-                    if (seenGroupingTypes.Add(groupingType))
-                    {
-                        groupingTypes.Add(groupingType);
-                    }
-                }
-
-                seenGroupingTypes.Free();
-                groupingTypes.Sort((x, y) => x.MetadataToken.CompareTo(y.MetadataToken));
+                GetNestedExtensionGroupingTypes((PENamedTypeSymbol)symbol, groupingTypes);
                 Debug.Assert(!groupingTypes.IsEmpty);
 
                 foreach (var groupingType in groupingTypes)
@@ -643,17 +627,40 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
         }
 
-        public sealed override ImmutableArray<Cci.ExportedType> GetExportedTypes(DiagnosticBag diagnostics)
+        private static ArrayBuilder<PENamedTypeSymbol> GetNestedExtensionGroupingTypes(PENamedTypeSymbol symbol, ArrayBuilder<PENamedTypeSymbol> groupingTypes)
+        {
+            var seenGroupingTypes = PooledHashSet<PENamedTypeSymbol>.GetInstance();
+
+            foreach (var type in symbol.GetTypeMembers(""))
+            {
+                if (!type.IsExtension)
+                {
+                    continue;
+                }
+
+                var groupingType = ((PENamedTypeSymbol)type).ExtensionGroupingType;
+                if (seenGroupingTypes.Add(groupingType))
+                {
+                    groupingTypes.Add(groupingType);
+                }
+            }
+
+            seenGroupingTypes.Free();
+            groupingTypes.Sort((x, y) => x.MetadataToken.CompareTo(y.MetadataToken));
+            return groupingTypes;
+        }
+
+        public sealed override ImmutableArray<Cci.ExportedType> GetExportedTypes(EmitContext context)
         {
             Debug.Assert(HaveDeterminedTopLevelTypes);
 
             if (_lazyExportedTypes.IsDefault)
             {
-                var initialized = ImmutableInterlocked.InterlockedInitialize(ref _lazyExportedTypes, CalculateExportedTypes());
+                var initialized = ImmutableInterlocked.InterlockedInitialize(ref _lazyExportedTypes, CalculateExportedTypes(context));
 
                 if (initialized && _lazyExportedTypes.Length > 0)
                 {
-                    ReportExportedTypeNameCollisions(_lazyExportedTypes, diagnostics);
+                    ReportExportedTypeNameCollisions(_lazyExportedTypes, context.Diagnostics);
                 }
             }
 
@@ -664,7 +671,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         /// Builds an array of public type symbols defined in netmodules included in the compilation
         /// and type forwarders defined in this compilation or any included netmodule (in this order).
         /// </summary>
-        private ImmutableArray<Cci.ExportedType> CalculateExportedTypes()
+        private ImmutableArray<Cci.ExportedType> CalculateExportedTypes(EmitContext context)
         {
             SourceAssemblySymbol sourceAssembly = SourceModule.ContainingSourceAssembly;
             var builder = ArrayBuilder<Cci.ExportedType>.GetInstance();
@@ -679,7 +686,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
 
             Debug.Assert(OutputKind.IsNetModule() == sourceAssembly.DeclaringCompilation.Options.OutputKind.IsNetModule());
-            GetForwardedTypes(sourceAssembly, builder);
+            GetForwardedTypes(sourceAssembly, builder, context);
 
             return builder.ToImmutableAndFree();
         }
@@ -688,14 +695,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         /// <summary>
         /// Returns a set of top-level forwarded types
         /// </summary>
-        internal static HashSet<NamedTypeSymbol> GetForwardedTypes(SourceAssemblySymbol sourceAssembly, ArrayBuilder<Cci.ExportedType>? builder)
+        internal static HashSet<NamedTypeSymbol> GetForwardedTypes(SourceAssemblySymbol sourceAssembly, ArrayBuilder<Cci.ExportedType>? builder, EmitContext? context)
         {
             var seenTopLevelForwardedTypes = new HashSet<NamedTypeSymbol>();
-            GetForwardedTypes(seenTopLevelForwardedTypes, sourceAssembly.GetSourceDecodedWellKnownAttributeData(), builder);
+            GetForwardedTypes(seenTopLevelForwardedTypes, sourceAssembly.GetSourceDecodedWellKnownAttributeData(), builder, context);
 
             if (!sourceAssembly.DeclaringCompilation.Options.OutputKind.IsNetModule())
             {
-                GetForwardedTypes(seenTopLevelForwardedTypes, sourceAssembly.GetNetModuleDecodedWellKnownAttributeData(), builder);
+                GetForwardedTypes(seenTopLevelForwardedTypes, sourceAssembly.GetNetModuleDecodedWellKnownAttributeData(), builder, context);
             }
 
             return seenTopLevelForwardedTypes;
@@ -709,14 +716,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             foreach (var exportedType in exportedTypes)
             {
-                var type = (NamedTypeSymbol)exportedType.Type.GetInternalSymbol();
+                Debug.Assert(exportedType.Type.AsGenericTypeInstanceReference is null);
+                Debug.Assert(exportedType.Type.AsSpecializedNestedTypeReference is null);
 
-                Debug.Assert(type.IsDefinition);
-
-                if (!type.IsTopLevelType())
+                if (exportedType.Type.AsNestedTypeReference is not null)
                 {
                     continue;
                 }
+
+                // Other types are expected to be top-level types backed by regular C# type symbols.
+                var type = (NamedTypeSymbol)exportedType.Type.GetInternalSymbol();
+
+                Debug.Assert(type.IsDefinition);
+                Debug.Assert(type.IsTopLevelType());
 
                 // exported types are not emitted in EnC deltas (hence generation 0):
                 string fullEmittedName = MetadataHelpers.BuildQualifiedName(
@@ -772,8 +784,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private static void GetForwardedTypes(
             HashSet<NamedTypeSymbol> seenTopLevelTypes,
             CommonAssemblyWellKnownAttributeData<NamedTypeSymbol> wellKnownAttributeData,
-            ArrayBuilder<Cci.ExportedType>? builder)
+            ArrayBuilder<Cci.ExportedType>? builder,
+            EmitContext? contextOpt)
         {
+            Debug.Assert(builder is null || contextOpt is not null);
+
             if (wellKnownAttributeData?.ForwardedTypes?.Count > 0)
             {
                 // (type, index of the parent exported type in builder, or -1 if the type is a top-level type)
@@ -798,6 +813,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                     if (builder is object)
                     {
+                        Debug.Assert(contextOpt is not null);
+                        var context = contextOpt.GetValueOrDefault();
+
                         // Return all nested types.
                         // Note the order: depth first, children in reverse order (to match dev10, not a requirement).
                         Debug.Assert(stack.Count == 0);
@@ -805,38 +823,126 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                         while (stack.Count > 0)
                         {
-                            var (type, parentIndex) = stack.Pop();
-
-                            // In general, we don't want private types to appear in the ExportedTypes table.
-                            // BREAK: dev11 emits these types.  The problem was discovered in dev10, but failed
-                            // to meet the bar Bug: Dev10/258038 and was left as-is.
-                            if (type.DeclaredAccessibility == Accessibility.Private)
-                            {
-                                // NOTE: this will also exclude nested types of type
-                                continue;
-                            }
-
-                            // NOTE: not bothering to put nested types in seenTypes - the top-level type is adequate protection.
-
-                            int index = builder.Count;
-                            builder.Add(new Cci.ExportedType(type.GetCciAdapter(), parentIndex, isForwarder: true));
-
-                            // Iterate backwards so they get popped in forward order.
-                            ImmutableArray<NamedTypeSymbol> nested = type.GetTypeMembers(); // Ordered.
-                            for (int i = nested.Length - 1; i >= 0; i--)
-                            {
-                                if (nested[i].IsExtension)
-                                {
-                                    continue; // https://github.com/dotnet/roslyn/issues/78963 - This is a temporary handling, we should get grouping and marker types processed instead.
-                                }
-
-                                stack.Push((nested[i], index));
-                            }
+                            processTopItemFromStack(stack, context, builder);
                         }
                     }
                 }
 
                 stack.Free();
+            }
+
+            static void processTopItemFromStack(ArrayBuilder<(NamedTypeSymbol type, int parentIndex)> stack, EmitContext context, ArrayBuilder<Cci.ExportedType> builder)
+            {
+                var (type, parentIndex) = stack.Pop();
+
+                Debug.Assert(type is { ContainingModule: SourceModuleSymbol } or PENamedTypeSymbol or RetargetingNamedTypeSymbol);
+
+                // In general, we don't want private types to appear in the ExportedTypes table.
+                // BREAK: dev11 emits these types.  The problem was discovered in dev10, but failed
+                // to meet the bar Bug: Dev10/258038 and was left as-is.
+                if (type.DeclaredAccessibility == Accessibility.Private)
+                {
+                    // NOTE: this will also exclude nested types of type
+                    return;
+                }
+
+                // NOTE: not bothering to put nested types in seenTypes - the top-level type is adequate protection.
+
+                int index = builder.Count;
+                builder.Add(new Cci.ExportedType(type.GetCciAdapter(), parentIndex, isForwarder: true));
+
+                ImmutableArray<NamedTypeSymbol> nested = type.GetTypeMembers(); // Ordered.
+
+                if (nested.Any(n => n.IsExtension))
+                {
+                    switch (type)
+                    {
+                        case PENamedTypeSymbol peType:
+                            {
+                                var groupingTypes = ArrayBuilder<PENamedTypeSymbol>.GetInstance();
+                                GetNestedExtensionGroupingTypes(peType, groupingTypes);
+                                Debug.Assert(!groupingTypes.IsEmpty);
+
+                                // Iterate backwards so they get popped in forward order.
+                                for (int i = groupingTypes.Count - 1; i >= 0; i--)
+                                {
+                                    stack.Push((groupingTypes[i], index));
+                                }
+
+                                groupingTypes.Free();
+
+                                pushNestedTypes(stack, index, nested);
+                            }
+                            break;
+
+                        case SourceMemberContainerTypeSymbol sourceType:
+                            {
+                                pushAndProcessNestedTypes(stack, context, index, nested, builder);
+
+                                foreach (var groupingType in sourceType.GetExtensionGroupingInfo().GetGroupingTypes())
+                                {
+                                    int groupingIndex = builder.Count;
+                                    builder.Add(new Cci.ExportedType(groupingType, index, isForwarder: true));
+
+                                    foreach (var markerType in groupingType.GetNestedTypes(context))
+                                    {
+                                        builder.Add(new Cci.ExportedType(markerType, groupingIndex, isForwarder: true));
+                                    }
+                                }
+                            }
+                            break;
+
+                        case RetargetingNamedTypeSymbol retargetingType:
+                            {
+                                pushAndProcessNestedTypes(stack, context, index, nested, builder);
+
+                                foreach ((Cci.INestedTypeReference GroupingType, ImmutableArray<Cci.INestedTypeReference> MarkerTypes) item in retargetingType.GetExtensionGroupingAndMarkerTypesForTypeForwarding(context))
+                                {
+                                    int groupingIndex = builder.Count;
+                                    builder.Add(new Cci.ExportedType(item.GroupingType, index, isForwarder: true));
+
+                                    foreach (var markerType in item.MarkerTypes)
+                                    {
+                                        builder.Add(new Cci.ExportedType(markerType, groupingIndex, isForwarder: true));
+                                    }
+                                }
+                            }
+                            break;
+
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(type);
+                    }
+                }
+                else
+                {
+                    pushNestedTypes(stack, index, nested);
+                }
+            }
+
+            static void pushNestedTypes(ArrayBuilder<(NamedTypeSymbol type, int parentIndex)> stack, int index, ImmutableArray<NamedTypeSymbol> nested)
+            {
+                // Iterate backwards so they get popped in forward order.
+                for (int i = nested.Length - 1; i >= 0; i--)
+                {
+                    if (nested[i].IsExtension)
+                    {
+                        continue; // Extension blocks are handled separately
+                    }
+
+                    stack.Push((nested[i], index));
+                }
+            }
+
+            static void pushAndProcessNestedTypes(ArrayBuilder<(NamedTypeSymbol type, int parentIndex)> stack, EmitContext context, int index, ImmutableArray<NamedTypeSymbol> nested, ArrayBuilder<Cci.ExportedType> builder)
+            {
+                int currentStackSize = stack.Count;
+
+                pushNestedTypes(stack, index, nested);
+
+                while (stack.Count > currentStackSize)
+                {
+                    processTopItemFromStack(stack, context, builder);
+                }
             }
         }
 #nullable disable

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -8,9 +8,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.Cci;
 using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
@@ -40,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         private CachedUseSiteInfo<AssemblySymbol> _lazyCachedUseSiteInfo = CachedUseSiteInfo<AssemblySymbol>.Uninitialized;
 
         private StrongBox<ParameterSymbol> _lazyExtensionParameter;
+        private ImmutableArray<(Cci.INestedTypeReference GroupingType, ImmutableArray<Cci.INestedTypeReference> MarkerTypes)> _lazyExtensionGroupingAndMarkerTypesForTypeForwarding;
 
         public RetargetingNamedTypeSymbol(RetargetingModuleSymbol retargetingModule, NamedTypeSymbol underlyingType, TupleExtraData tupleData = null)
             : base(underlyingType, tupleData)
@@ -477,5 +483,106 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
         internal override string? ExtensionMarkerName
             => _underlyingType.ExtensionMarkerName;
+
+#nullable enable
+
+        internal ImmutableArray<(Cci.INestedTypeReference GroupingType, ImmutableArray<Cci.INestedTypeReference> MarkerTypes)> GetExtensionGroupingAndMarkerTypesForTypeForwarding(EmitContext context)
+        {
+            if (_lazyExtensionGroupingAndMarkerTypesForTypeForwarding.IsDefault)
+            {
+                var builder = ArrayBuilder<(Cci.INestedTypeReference GroupingType, ImmutableArray<Cci.INestedTypeReference> MarkerTypes)>.GetInstance();
+                var markerTypes = ArrayBuilder<Cci.INestedTypeReference>.GetInstance();
+
+                ImmutableArray<INestedTypeDefinition> groupingTypes = ((SourceMemberContainerTypeSymbol)_underlyingType).GetExtensionGroupingInfo().GetGroupingTypes();
+
+                foreach (var groupingType in groupingTypes)
+                {
+                    var retargetedGroupingType = new ForwardedExtensionGroupingOrMarkerType(this.GetCciAdapter(), groupingType);
+                    markerTypes.Clear();
+
+                    foreach (var markerType in groupingType.GetNestedTypes(context))
+                    {
+                        markerTypes.Add(new ForwardedExtensionGroupingOrMarkerType(retargetedGroupingType, markerType));
+                    }
+
+                    builder.Add((retargetedGroupingType, markerTypes.ToImmutable()));
+                }
+
+                markerTypes.Free();
+
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyExtensionGroupingAndMarkerTypesForTypeForwarding, builder.ToImmutableAndFree());
+            }
+
+            return _lazyExtensionGroupingAndMarkerTypesForTypeForwarding;
+        }
+
+        /// <summary>
+        /// Used only to point to forwarded types and implements only API surface required to emit information about them.
+        /// </summary>
+        private sealed class ForwardedExtensionGroupingOrMarkerType : Cci.INestedTypeReference
+        {
+            private readonly Cci.ITypeReference _containingType;
+            private readonly Cci.INestedTypeReference _underlying;
+
+            public ForwardedExtensionGroupingOrMarkerType(Cci.ITypeReference containingType, Cci.INestedTypeReference underlying)
+            {
+                _containingType = containingType;
+                _underlying = underlying;
+            }
+
+            bool INestedTypeReference.InheritsEnclosingTypeTypeParameters => throw ExceptionUtilities.Unreachable();
+
+            ushort INamedTypeReference.GenericParameterCount => _underlying.GenericParameterCount;
+
+            bool INamedTypeReference.MangleName => _underlying.MangleName;
+
+            string? INamedTypeReference.AssociatedFileIdentifier => _underlying.AssociatedFileIdentifier;
+
+            bool ITypeReference.IsEnum => throw ExceptionUtilities.Unreachable();
+
+            bool ITypeReference.IsValueType => throw ExceptionUtilities.Unreachable();
+
+            Cci.PrimitiveTypeCode ITypeReference.TypeCode => throw ExceptionUtilities.Unreachable();
+
+            TypeDefinitionHandle ITypeReference.TypeDef => throw ExceptionUtilities.Unreachable();
+
+            IGenericMethodParameterReference? ITypeReference.AsGenericMethodParameterReference => null;
+
+            IGenericTypeInstanceReference? ITypeReference.AsGenericTypeInstanceReference => null;
+
+            IGenericTypeParameterReference? ITypeReference.AsGenericTypeParameterReference => null;
+
+            INamespaceTypeReference? ITypeReference.AsNamespaceTypeReference => null;
+
+            INestedTypeReference? ITypeReference.AsNestedTypeReference => this;
+
+            ISpecializedNestedTypeReference? ITypeReference.AsSpecializedNestedTypeReference => null;
+
+            string? INamedEntity.Name => _underlying.Name;
+
+            IDefinition? IReference.AsDefinition(EmitContext context) => null;
+
+            INamespaceTypeDefinition? ITypeReference.AsNamespaceTypeDefinition(EmitContext context) => null;
+
+            INestedTypeDefinition? ITypeReference.AsNestedTypeDefinition(EmitContext context) => null;
+
+            ITypeDefinition? ITypeReference.AsTypeDefinition(EmitContext context) => null;
+
+            void IReference.Dispatch(MetadataVisitor visitor)
+            {
+                throw ExceptionUtilities.Unreachable();
+            }
+
+            IEnumerable<ICustomAttribute> IReference.GetAttributes(EmitContext context)
+            {
+                throw ExceptionUtilities.Unreachable();
+            }
+
+            ITypeReference ITypeMemberReference.GetContainingType(EmitContext context) => _containingType;
+
+            ISymbolInternal? IReference.GetInternalSymbol() => null;
+
+            ITypeDefinition? ITypeReference.GetResolvedType(EmitContext context) => null;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2937,7 +2937,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override IEnumerable<NamedTypeSymbol> GetAllTopLevelForwardedTypes()
         {
-            return PEModuleBuilder.GetForwardedTypes(this, builder: null);
+            return PEModuleBuilder.GetForwardedTypes(this, builder: null, context: null);
         }
 
         public override AssemblyMetadata GetMetadata() => null;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -29160,7 +29160,7 @@ public static class C1
                 ".<G>$34505F560D9EACF86A87F3ED1F85E448 0x27000001 (ExportedType) 0x0002",
                 ".<M>$69A44968D4F2B90D6BA4472A51F540A4 0x27000007 (ExportedType) 0x0002",
             ], actual);
-        });
+        }).VerifyDiagnostics();
     }
 
     [Fact]
@@ -29200,7 +29200,7 @@ public static class C1
                 ".<G>$BA41CFE2B5EDAEB8C1B9062F59ED4D69 0x27000001 (ExportedType) 0x0002",
                 ".<M>$F4B4FFE41AB49E80A4ECF390CF6EB372 0x27000004 (ExportedType) 0x0002",
             ], actual);
-        });
+        }).VerifyDiagnostics();
     }
 
     [Fact]
@@ -29324,6 +29324,567 @@ internal static class C1
             // error CS0101: The namespace '<global namespace>' already contains a definition for 'C1'
             Diagnostic(ErrorCode.ERR_DuplicateNameInNS).WithArguments("C1", "<global namespace>").WithLocation(1, 1)
             );
+    }
+
+    [Fact]
+    public void ExportedTypes_06()
+    {
+        string source = @"
+public static class C1
+{
+    extension<T>(int i)
+    {
+    }
+}
+";
+        var moduleComp = CreateCompilation(source, options: TestOptions.ReleaseModule);
+        var moduleRef = moduleComp.EmitToImageReference();
+
+        CompileAndVerify("", references: [moduleRef], assemblyValidator: (assembly) =>
+        {
+            var reader = assembly.GetMetadataReader();
+
+            var actual = from h in reader.ExportedTypes
+                         let et = reader.GetExportedType(h)
+                         select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+            AssertEx.Equal(
+            [
+                ".C1 0x26000001 (AssemblyFile) 0x0001",
+                ".<G>$B8D310208B4544F25EEBACB9990FC73B`1 0x27000001 (ExportedType) 0x0002",
+                ".<M>$B39C5C386A2E3E9242B293D9323EC48A 0x27000002 (ExportedType) 0x0002",
+            ], actual);
+        }).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ForwardedTypes_01()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+
+    extension(string s)
+    {
+    }
+
+    extension(ref int i)
+    {
+    }
+
+    public class C2
+    {
+        public class C3;
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll);
+
+        var source2 = "[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(C1))]";
+
+        CompileAndVerify(source2, references: [comp1.EmitToImageReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        CompileAndVerify(source2, references: [comp1.ToMetadataReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        CompileAndVerify(source2, references: [comp1.ToMetadataReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        static void validateAssembly(PEAssembly assembly)
+        {
+            var reader = assembly.GetMetadataReader();
+
+            var actual = from h in reader.ExportedTypes
+                         let et = reader.GetExportedType(h)
+                         select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+            AssertEx.Equal(
+            [
+                ".C1 0x23000002 (AssemblyReference) 0x200000",
+                ".C2 0x27000001 (ExportedType) 0x0000",
+                ".C3 0x27000002 (ExportedType) 0x0000",
+                ".<G>$BA41CFE2B5EDAEB8C1B9062F59ED4D69 0x27000001 (ExportedType) 0x0000",
+                ".<M>$F4B4FFE41AB49E80A4ECF390CF6EB372 0x27000004 (ExportedType) 0x0000",
+                ".<M>$56B5C634B2E52051C75D91F71BA8833A 0x27000004 (ExportedType) 0x0000",
+                ".<G>$34505F560D9EACF86A87F3ED1F85E448 0x27000001 (ExportedType) 0x0000",
+                ".<M>$69A44968D4F2B90D6BA4472A51F540A4 0x27000007 (ExportedType) 0x0000",
+            ], actual);
+        }
+    }
+
+    [Fact]
+    public void ForwardedTypes_02()
+    {
+        string source1 = @"
+namespace NS1.NS2;
+
+public static class C1
+{
+    extension(int i)
+    {
+    }
+
+    extension(string s)
+    {
+    }
+
+    extension(ref int i)
+    {
+    }
+
+    public class C2
+    {
+        public class C3;
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll);
+
+        var source2 = "[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(NS1.NS2.C1))]";
+
+        CompileAndVerify(source2, references: [comp1.EmitToImageReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        CompileAndVerify(source2, references: [comp1.ToMetadataReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        CompileAndVerify(source2, references: [comp1.ToMetadataReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        static void validateAssembly(PEAssembly assembly)
+        {
+            var reader = assembly.GetMetadataReader();
+
+            var actual = from h in reader.ExportedTypes
+                         let et = reader.GetExportedType(h)
+                         select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+            AssertEx.Equal(
+            [
+                "NS1.NS2.C1 0x23000002 (AssemblyReference) 0x200000",
+                ".C2 0x27000001 (ExportedType) 0x0000",
+                ".C3 0x27000002 (ExportedType) 0x0000",
+                ".<G>$BA41CFE2B5EDAEB8C1B9062F59ED4D69 0x27000001 (ExportedType) 0x0000",
+                ".<M>$F4B4FFE41AB49E80A4ECF390CF6EB372 0x27000004 (ExportedType) 0x0000",
+                ".<M>$56B5C634B2E52051C75D91F71BA8833A 0x27000004 (ExportedType) 0x0000",
+                ".<G>$34505F560D9EACF86A87F3ED1F85E448 0x27000001 (ExportedType) 0x0000",
+                ".<M>$69A44968D4F2B90D6BA4472A51F540A4 0x27000007 (ExportedType) 0x0000",
+            ], actual);
+        }
+    }
+
+    [Fact]
+    public void ForwardedTypes_03()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension<T>(int i)
+    {
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll);
+
+        var source2 = "[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(C1))]";
+
+        CompileAndVerify(source2, references: [comp1.EmitToImageReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        CompileAndVerify(source2, references: [comp1.ToMetadataReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        CompileAndVerify(source2, references: [comp1.ToMetadataReference()], assemblyValidator: validateAssembly).VerifyDiagnostics();
+
+        static void validateAssembly(PEAssembly assembly)
+        {
+            var reader = assembly.GetMetadataReader();
+
+            var actual = from h in reader.ExportedTypes
+                         let et = reader.GetExportedType(h)
+                         select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+            AssertEx.Equal(
+            [
+                ".C1 0x23000002 (AssemblyReference) 0x200000",
+                ".<G>$B8D310208B4544F25EEBACB9990FC73B`1 0x27000001 (ExportedType) 0x0000",
+                ".<M>$B39C5C386A2E3E9242B293D9323EC48A 0x27000002 (ExportedType) 0x0000",
+            ], actual);
+        }
+    }
+
+    [Fact]
+    public void ForwardedTypes_04()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll);
+
+        var source2 = @"
+extern alias A;
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(A::C1))]
+
+static class C1
+{
+    extension(int i)
+    {
+    }
+}
+";
+
+        var comp = CreateCompilation(source2, references: [comp1.EmitToImageReference().WithAliases(["A"])]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8006: Forwarded type 'C1' conflicts with type declared in primary module of this assembly.
+            Diagnostic(ErrorCode.ERR_ForwardedTypeConflictsWithDeclaration).WithArguments("C1").WithLocation(1, 1)
+            );
+
+        comp = CreateCompilation(source2, references: [comp1.ToMetadataReference().WithAliases(["A"])]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8006: Forwarded type 'C1' conflicts with type declared in primary module of this assembly.
+            Diagnostic(ErrorCode.ERR_ForwardedTypeConflictsWithDeclaration).WithArguments("C1").WithLocation(1, 1)
+            );
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        comp = CreateCompilation(source2, references: [comp1.ToMetadataReference().WithAliases(["A"])]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8006: Forwarded type 'C1' conflicts with type declared in primary module of this assembly.
+            Diagnostic(ErrorCode.ERR_ForwardedTypeConflictsWithDeclaration).WithArguments("C1").WithLocation(1, 1)
+            );
+    }
+
+    [Fact]
+    public void ForwardedTypes_05()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+
+    extension(string s)
+    {
+    }
+
+    extension(ref int i)
+    {
+    }
+
+    public class C2
+    {
+        public class C3;
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll);
+        var comp1ImageRef = comp1.EmitToImageReference();
+
+        var source2 = "[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(C1))]";
+
+        var comp2 = CreateCompilation(source2, options: TestOptions.DebugModule, references: [comp1ImageRef]);
+        var comp2ImageRef = comp2.EmitToImageReference();
+
+        CompileAndVerify("", references: [comp1ImageRef, comp2ImageRef], assemblyValidator: validateAssembly, verify: Verification.Skipped).VerifyDiagnostics();
+
+        CompileAndVerify("", references: [comp1.ToMetadataReference(), comp2ImageRef], assemblyValidator: validateAssembly, verify: Verification.Skipped).VerifyDiagnostics();
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        CompileAndVerify("", references: [comp1.ToMetadataReference(), comp2ImageRef], assemblyValidator: validateAssembly, verify: Verification.Skipped).VerifyDiagnostics();
+
+        static void validateAssembly(PEAssembly assembly)
+        {
+            var reader = assembly.GetMetadataReader();
+
+            var actual = from h in reader.ExportedTypes
+                         let et = reader.GetExportedType(h)
+                         select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+            AssertEx.Equal(
+            [
+                ".C1 0x23000002 (AssemblyReference) 0x200000",
+                ".C2 0x27000001 (ExportedType) 0x0000",
+                ".C3 0x27000002 (ExportedType) 0x0000",
+                ".<G>$BA41CFE2B5EDAEB8C1B9062F59ED4D69 0x27000001 (ExportedType) 0x0000",
+                ".<M>$F4B4FFE41AB49E80A4ECF390CF6EB372 0x27000004 (ExportedType) 0x0000",
+                ".<M>$56B5C634B2E52051C75D91F71BA8833A 0x27000004 (ExportedType) 0x0000",
+                ".<G>$34505F560D9EACF86A87F3ED1F85E448 0x27000001 (ExportedType) 0x0000",
+                ".<M>$69A44968D4F2B90D6BA4472A51F540A4 0x27000007 (ExportedType) 0x0000",
+            ], actual);
+        }
+    }
+
+    [Fact]
+    public void ForwardedTypes_06()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+
+    extension(string s)
+    {
+    }
+
+    extension(ref int i)
+    {
+    }
+
+    public class C2
+    {
+        public class C3;
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll, assemblyName: "Extensions");
+        var comp1ImageRef = comp1.EmitToImageReference();
+
+        var source2 = "[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(C1))]";
+
+        var comp2 = CreateCompilation(source2, options: TestOptions.DebugModule, references: [comp1ImageRef]);
+        var comp2ImageRef = comp2.EmitToImageReference();
+
+        CreateCompilation("", references: [comp2ImageRef]).VerifyEmitDiagnostics(
+            // error CS0012: The type 'C1' is defined in an assembly that is not referenced. You must add a reference to assembly 'Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("C1", "Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+            );
+
+        string source3 = @"
+public static class C1
+{
+}
+";
+        comp1 = CreateCompilation(source3, options: TestOptions.ReleaseDll, assemblyName: "Extensions");
+
+        CompileAndVerify("", references: [comp1.ToMetadataReference(), comp2ImageRef], assemblyValidator: validateAssembly, verify: Verification.Skipped).VerifyDiagnostics();
+
+        static void validateAssembly(PEAssembly assembly)
+        {
+            var reader = assembly.GetMetadataReader();
+
+            var actual = from h in reader.ExportedTypes
+                         let et = reader.GetExportedType(h)
+                         select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+            AssertEx.Equal(
+            [
+                ".C1 0x23000002 (AssemblyReference) 0x200000",
+            ], actual);
+        }
+    }
+
+    [Fact]
+    public void ForwardedTypes_07()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll, assemblyName: "Extensions");
+
+        var module = CreateCompilation(source1, options: TestOptions.ReleaseModule, assemblyName: "Module");
+        var moduleRef = module.EmitToImageReference();
+
+        var source2 = @"
+extern alias A;
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(A::C1))]
+";
+
+        var comp = CreateCompilation(source2, references: [comp1.EmitToImageReference().WithAliases(["A"]), moduleRef]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8008: Type 'C1' forwarded to assembly 'Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' exported from module 'Module.netmodule'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypeConflictsWithExportedType).WithArguments("C1", "Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Module.netmodule").WithLocation(1, 1)
+            );
+
+        comp = CreateCompilation(source2, references: [comp1.ToMetadataReference().WithAliases(["A"]), moduleRef]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8008: Type 'C1' forwarded to assembly 'Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' exported from module 'Module.netmodule'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypeConflictsWithExportedType).WithArguments("C1", "Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Module.netmodule").WithLocation(1, 1)
+            );
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        comp = CreateCompilation(source2, references: [comp1.ToMetadataReference().WithAliases(["A"]), moduleRef]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8008: Type 'C1' forwarded to assembly 'Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' exported from module 'Module.netmodule'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypeConflictsWithExportedType).WithArguments("C1", "Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Module.netmodule").WithLocation(1, 1)
+            );
+    }
+
+    [Fact]
+    public void ForwardedTypes_08()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll, assemblyName: "Extensions1");
+        var comp2 = CreateCompilation(source1, options: TestOptions.ReleaseDll, assemblyName: "Extensions2");
+
+        var source2 = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(C1))]
+";
+
+        var module1 = CreateCompilation(source2, references: [comp1.ToMetadataReference()], options: TestOptions.ReleaseModule, assemblyName: "Module1");
+        var module1Ref = module1.EmitToImageReference();
+
+        var module2 = CreateCompilation(source2, references: [comp2.ToMetadataReference()], options: TestOptions.ReleaseModule, assemblyName: "Module2");
+        var module2Ref = module2.EmitToImageReference();
+
+        var comp = CreateCompilation("", references: [comp1.EmitToImageReference(), comp2.EmitToImageReference(), module1Ref, module2Ref]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8007: Type 'C1' forwarded to assembly 'Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' forwarded to assembly 'Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypesConflict).WithArguments("C1", "Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+            );
+
+        comp = CreateCompilation("", references: [comp1.ToMetadataReference(), comp2.ToMetadataReference(), module1Ref, module2Ref]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8007: Type 'C1' forwarded to assembly 'Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' forwarded to assembly 'Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypesConflict).WithArguments("C1", "Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+            );
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        comp2 = comp2.AddReferences(comp3Ref);
+
+        comp = CreateCompilation("", references: [comp1.ToMetadataReference(), comp2.ToMetadataReference(), module1Ref, module2Ref]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8007: Type 'C1' forwarded to assembly 'Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' forwarded to assembly 'Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypesConflict).WithArguments("C1", "Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+            );
+    }
+
+    [Fact]
+    public void ForwardedTypes_09()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll, assemblyName: "Extensions1");
+        var comp2 = CreateCompilation(source1, options: TestOptions.ReleaseDll, assemblyName: "Extensions2");
+
+        var source2 = @"
+extern alias A;
+extern alias B;
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(A::C1))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(B::C1))]
+";
+
+        var comp = CreateCompilation(source2, references: [comp1.EmitToImageReference().WithAliases(["A"]), comp2.EmitToImageReference().WithAliases(["B"])]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8007: Type 'C1' forwarded to assembly 'Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' forwarded to assembly 'Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypesConflict).WithArguments("C1", "Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+            );
+
+        comp = CreateCompilation(source2, references: [comp1.ToMetadataReference().WithAliases(["A"]), comp2.ToMetadataReference().WithAliases(["B"])]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8007: Type 'C1' forwarded to assembly 'Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' forwarded to assembly 'Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypesConflict).WithArguments("C1", "Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+            );
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+        comp2 = comp2.AddReferences(comp3Ref);
+
+        comp = CreateCompilation(source2, references: [comp1.ToMetadataReference().WithAliases(["A"]), comp2.ToMetadataReference().WithAliases(["B"])]);
+        comp.VerifyEmitDiagnostics(
+            // error CS8007: Type 'C1' forwarded to assembly 'Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' conflicts with type 'C1' forwarded to assembly 'Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            Diagnostic(ErrorCode.ERR_ForwardedTypesConflict).WithArguments("C1", "Extensions2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C1", "Extensions1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+            );
+    }
+
+    [Fact]
+    public void ForwardedTypes_10()
+    {
+        string source1 = @"
+public static class C1
+{
+    extension(int i)
+    {
+    }
+}
+";
+        var comp1 = CreateCompilation(source1, options: TestOptions.ReleaseDll, assemblyName: "Extensions1");
+
+        var source2 = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(C1))]
+";
+
+        var module1 = CreateCompilation(source2, references: [comp1.ToMetadataReference()], options: TestOptions.ReleaseModule, assemblyName: "Module1");
+        var module1Ref = module1.EmitToImageReference();
+
+        var module2 = CreateCompilation(source2, references: [comp1.ToMetadataReference()], options: TestOptions.ReleaseModule, assemblyName: "Module2");
+        var module2Ref = module2.EmitToImageReference();
+
+        var comp = CreateCompilation("", references: [comp1.EmitToImageReference(), module1Ref, module2Ref]);
+        CompileAndVerify(comp, validator: validateAssembly, verify: Verification.Skipped).VerifyDiagnostics();
+
+        comp = CreateCompilation("", references: [comp1.ToMetadataReference(), module1Ref, module2Ref]);
+        CompileAndVerify(comp, validator: validateAssembly, verify: Verification.Skipped).VerifyDiagnostics();
+
+        var comp3 = CreateCompilation("public class ForceRetargeting;", options: TestOptions.ReleaseDll);
+        var comp3Ref = comp3.EmitToImageReference();
+
+        comp1 = comp1.AddReferences(comp3Ref);
+
+        comp = CreateCompilation("", references: [comp1.ToMetadataReference(), module1Ref, module2Ref]);
+        CompileAndVerify(comp, validator: validateAssembly, verify: Verification.Skipped).VerifyDiagnostics();
+
+        static void validateAssembly(PEAssembly assembly)
+        {
+            var reader = assembly.GetMetadataReader();
+
+            var actual = from h in reader.ExportedTypes
+                         let et = reader.GetExportedType(h)
+                         select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+            AssertEx.Equal(
+            [
+                ".C1 0x23000002 (AssemblyReference) 0x200000",
+                ".<G>$BA41CFE2B5EDAEB8C1B9062F59ED4D69 0x27000001 (ExportedType) 0x0000",
+                ".<M>$F4B4FFE41AB49E80A4ECF390CF6EB372 0x27000002 (ExportedType) 0x0000",
+            ], actual);
+        }
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/79193")]

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// Public types defined in other modules making up this assembly and to which other assemblies may refer to via this assembly
         /// followed by types forwarded to another assembly.
         /// </summary>
-        public abstract ImmutableArray<Cci.ExportedType> GetExportedTypes(DiagnosticBag diagnostics);
+        public abstract ImmutableArray<Cci.ExportedType> GetExportedTypes(EmitContext context);
 
         /// <summary>
         /// Used to distinguish which style to pick while writing native PDB information.

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2221,7 +2221,7 @@ namespace Microsoft.Cci
                 return;
             }
 
-            var exportedTypes = module.GetExportedTypes(Context.Diagnostics);
+            var exportedTypes = module.GetExportedTypes(Context);
             if (exportedTypes.Length == 0)
             {
                 return;

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Cci
             Visit(module.GetSourceModuleAttributes());
             Visit(module.GetTopLevelTypeDefinitions(Context));
 
-            foreach (var exportedType in module.GetExportedTypes(Context.Diagnostics))
+            foreach (var exportedType in module.GetExportedTypes(Context))
             {
                 VisitExportedType(exportedType.Type);
             }

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -378,14 +378,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Loop While stack.Count > 0
         End Function
 
-        Public NotOverridable Overrides Function GetExportedTypes(diagnostics As DiagnosticBag) As ImmutableArray(Of Cci.ExportedType)
+        Public NotOverridable Overrides Function GetExportedTypes(context As EmitContext) As ImmutableArray(Of Cci.ExportedType)
             Debug.Assert(HaveDeterminedTopLevelTypes)
 
             If _lazyExportedTypes.IsDefault Then
                 Dim initialized = ImmutableInterlocked.InterlockedInitialize(_lazyExportedTypes, CalculateExportedTypes())
 
                 If initialized AndAlso _lazyExportedTypes.Length > 0 Then
-                    ReportExportedTypeNameCollisions(_lazyExportedTypes, diagnostics)
+                    ReportExportedTypeNameCollisions(_lazyExportedTypes, context.Diagnostics)
                 End If
             End If
 


### PR DESCRIPTION
Closes #79894.