### PR TITLE
Fix CSharpReplIdeFeatures failing integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
@@ -85,7 +85,7 @@ public class CSharpReplIdeFeatures : AbstractInteractiveWindowTest
     }
 
     [IdeFact]
-    public async Task HighlightRefsMultipleSubmisionsVerifyRenameTagsShowUpWhenInvokedOnSubmittedText()
+    public async Task HighlightRefsMultipleSubmissionsVerifyRenameTagsShowUpWhenInvokedOnSubmittedText()
     {
         await TestServices.InteractiveWindow.SubmitTextAsync("class Goo { }", HangMitigatingCancellationToken);
         await TestServices.InteractiveWindow.SubmitTextAsync("Goo something = new Goo();", HangMitigatingCancellationToken);
@@ -97,7 +97,7 @@ public class CSharpReplIdeFeatures : AbstractInteractiveWindowTest
     }
 
     [IdeFact]
-    public async Task HighlightRefsMultipleSubmisionsVerifyRenameTagsShowUpOnUnsubmittedText()
+    public async Task HighlightRefsMultipleSubmissionsVerifyRenameTagsShowUpOnUnsubmittedText()
     {
         await TestServices.InteractiveWindow.SubmitTextAsync("class Goo { }", HangMitigatingCancellationToken);
         await TestServices.InteractiveWindow.SubmitTextAsync("Goo something = new Goo();", HangMitigatingCancellationToken);
@@ -109,7 +109,7 @@ public class CSharpReplIdeFeatures : AbstractInteractiveWindowTest
     }
 
     [IdeFact]
-    public async Task HighlightRefsMultipleSubmisionsVerifyRenameTagsShowUpOnTypesWhenInvokedOnSubmittedText()
+    public async Task HighlightRefsMultipleSubmissionsVerifyRenameTagsShowUpOnTypesWhenInvokedOnSubmittedText()
     {
         await TestServices.InteractiveWindow.SubmitTextAsync("class Goo { }", HangMitigatingCancellationToken);
         await TestServices.InteractiveWindow.SubmitTextAsync("Goo a;", HangMitigatingCancellationToken);
@@ -121,7 +121,7 @@ public class CSharpReplIdeFeatures : AbstractInteractiveWindowTest
     }
 
     [IdeFact]
-    public async Task HighlightRefsMultipleSubmisionsVerifyRenameTagsShowUpOnTypesWhenInvokedOnUnsubmittedText()
+    public async Task HighlightRefsMultipleSubmissionsVerifyRenameTagsShowUpOnTypesWhenInvokedOnUnsubmittedText()
     {
         await TestServices.InteractiveWindow.SubmitTextAsync("class Goo { }", HangMitigatingCancellationToken);
         await TestServices.InteractiveWindow.SubmitTextAsync("Goo a;", HangMitigatingCancellationToken);
@@ -133,7 +133,7 @@ public class CSharpReplIdeFeatures : AbstractInteractiveWindowTest
     }
 
     [IdeFact]
-    public async Task HighlightRefsMultipleSubmisionsVerifyRenameTagsGoAwayWhenInvokedOnUnsubmittedText()
+    public async Task HighlightRefsMultipleSubmissionsVerifyRenameTagsGoAwayWhenInvokedOnUnsubmittedText()
     {
         await TestServices.InteractiveWindow.SubmitTextAsync("class Goo { }", HangMitigatingCancellationToken);
         await TestServices.InteractiveWindow.SubmitTextAsync("Goo a;", HangMitigatingCancellationToken);
@@ -145,7 +145,7 @@ public class CSharpReplIdeFeatures : AbstractInteractiveWindowTest
     }
 
     [IdeFact]
-    public async Task HighlightRefsMultipleSubmisionsVerifyRenameTagsOnRedefinedVariable()
+    public async Task HighlightRefsMultipleSubmissionsVerifyRenameTagsOnRedefinedVariable()
     {
         await TestServices.InteractiveWindow.SubmitTextAsync("string abc = null;", HangMitigatingCancellationToken);
         await TestServices.InteractiveWindow.SubmitTextAsync("abc = string.Empty;", HangMitigatingCancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
@@ -101,7 +101,7 @@ internal sealed partial class ShellInProcess
         ErrorHandler.ThrowOnFailure(commandService.GetControlDataSourceAsync(
             (uint)__VSCOMMANDTYPES.cCommandTypeButton,
             commandName,
-            timeout: TestHelpers.HangMitigatingTimeout.Milliseconds,
+            timeout: ((int)TestHelpers.HangMitigatingTimeout.TotalMilliseconds),
             out var dataSourceTask));
 
         Assumes.NotNull(dataSourceTask);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
+using Roslyn.Test.Utilities;
 using Xunit;
 using IAsyncDisposable = System.IAsyncDisposable;
 
@@ -100,7 +101,7 @@ internal sealed partial class ShellInProcess
         ErrorHandler.ThrowOnFailure(commandService.GetControlDataSourceAsync(
             (uint)__VSCOMMANDTYPES.cCommandTypeButton,
             commandName,
-            timeout: 0,
+            timeout: TestHelpers.HangMitigatingTimeout.Milliseconds,
             out var dataSourceTask));
 
         Assumes.NotNull(dataSourceTask);


### PR DESCRIPTION
Integration tests were failing here: https://github.com/dotnet/roslyn/blob/main/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpReplIdeFeatures.cs

Specifically the dataSourceTask.GetResult() was throwing an OperationCanceledException:
https://github.com/dotnet/roslyn/blob/main/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs#L107

Seems like the timeout being 0 was immediately canceling the token inappropriately.