### PR TITLE
Simplify parser diagnostic location calculation

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -699,7 +699,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                     if (!isGlobal || seen > NamespaceParts.GlobalAttributes)
                                     {
                                         RoslynDebug.Assert(attribute.Target != null, "Must have a target as IsPossibleGlobalAttributeDeclaration checks for that");
-                                        attribute = this.AddError(attribute, attribute.Target.Identifier, ErrorCode.ERR_GlobalAttributesNotFirst);
+
+                                        attribute = attribute.Update(
+                                            attribute.OpenBracketToken,
+                                            attribute.Target.Update(
+                                                this.AddError(attribute.Target.Identifier, ErrorCode.ERR_GlobalAttributesNotFirst),
+                                                attribute.Target.ColonToken),
+                                            attribute.Attributes,
+                                            attribute.CloseBracketToken);
+
                                         this.AddSkippedNamespaceText(ref openBraceOrSemicolon, ref body, ref initialBadNodes, attribute);
                                     }
                                     else

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -5119,6 +5119,19 @@ class Test
             ParseAndValidate(test, Diagnostic(ErrorCode.ERR_GlobalAttributesNotFirst, "assembly"));
         }
 
+        [Fact, WorkItem(863438, "DevDiv/Personal")]
+        public void CS1730ERR_GlobalAttributesNotFirst2()
+        {
+            var test = """
+                class Test
+                {
+                }
+                [  assembly  :System.Attribute]
+                """;
+
+            ParseAndValidate(test, Diagnostic(ErrorCode.ERR_GlobalAttributesNotFirst, "assembly"));
+        }
+
         [Fact(), WorkItem(527039, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527039")]
         public void CS1732ERR_ParameterExpected()
         {


### PR DESCRIPTION
As part of trying to fix https://github.com/dotnet/roslyn/issues/79935 i'm looking to see if we can greatly simplify how offsets are used to place diagnostics in syntax diagnostics.

That has involved auditing all usages of offsets.  This let me to this function, which is quite complex and used in only location.  That location is trivial to update to a much simpler form that avoids the need for complex computation.