### PR TITLE
Fix a replay bug

### DIFF
--- a/src/Tools/Replay/Replay.cs
+++ b/src/Tools/Replay/Replay.cs
@@ -186,6 +186,7 @@ static async IAsyncEnumerable<BuildData> BuildAllAsync(
     var maxParallel = options.MaxParallel;
     var tasks = new List<Task<BuildData>>(capacity: maxParallel);
     var outputSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    var completed = 0;
 
     do
     {
@@ -204,7 +205,8 @@ static async IAsyncEnumerable<BuildData> BuildAllAsync(
 
         var buildData = await completedTask.ConfigureAwait(false);
         yield return buildData;
-    } while (index < compilerCalls.Count);
+        completed++;
+    } while (completed < compilerCalls.Count);
 
     string GetOutputName(CompilerCall compilerCall)
     {


### PR DESCRIPTION
There is a bug in the loop condition where it wouldn't wait for every compilation to be completed before exiting. This is likely why on some runs we observed that shutdown was taking a long time to complete; it was waiting for these compilations to finish.