### PR TITLE
Switch diagnostic computation into a normal yield-based enumerator

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -791,20 +792,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (greenNode.ContainsDiagnostics)
             {
-                return EnumerateDiagnostics(greenNode, position);
+                return SyntaxTreeDiagnosticEnumerator.EnumerateDiagnostics(this, greenNode, position);
             }
 
             return SpecializedCollections.EmptyEnumerable<Diagnostic>();
         }
 
-        private IEnumerable<Diagnostic> EnumerateDiagnostics(GreenNode node, int position)
-        {
-            var enumerator = new SyntaxTreeDiagnosticEnumerator(this, node, position);
-            while (enumerator.MoveNext())
-            {
-                yield return enumerator.Current;
-            }
-        }
 
         /// <summary>
         /// Gets a list of all the diagnostics associated with the token and any related trivia.

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxTreeDiagnosticEnumerator.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
@@ -11,136 +13,121 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// <summary>
     /// An enumerator for diagnostic lists.
     /// </summary>
-    internal struct SyntaxTreeDiagnosticEnumerator
+    internal static class SyntaxTreeDiagnosticEnumerator
     {
-        private readonly SyntaxTree? _syntaxTree;
-        private NodeIterationStack _stack;
-        private Diagnostic? _current;
-        private int _position;
         private const int DefaultStackCapacity = 8;
 
-        internal SyntaxTreeDiagnosticEnumerator(SyntaxTree syntaxTree, GreenNode? node, int position)
+        public static IEnumerable<Diagnostic> EnumerateDiagnostics(SyntaxTree syntaxTree, GreenNode root, int position)
         {
-            _syntaxTree = null;
-            _current = null;
-            _position = position;
-            if (node != null && node.ContainsDiagnostics)
-            {
-                _syntaxTree = syntaxTree;
-                _stack = new NodeIterationStack(DefaultStackCapacity);
-                _stack.PushNodeOrToken(node);
-            }
-            else
-            {
-                _stack = new NodeIterationStack();
-            }
-        }
+            if (!root.ContainsDiagnostics)
+                yield break;
 
-        /// <summary>
-        /// Moves the enumerator to the next diagnostic instance in the diagnostic list.
-        /// </summary>
-        /// <returns>Returns true if enumerator moved to the next diagnostic, false if the
-        /// enumerator was at the end of the diagnostic list.</returns>
-        public bool MoveNext()
-        {
-            while (_stack.Any())
+            using var stack = new NodeIterationStack(DefaultStackCapacity);
+            stack.PushNodeOrToken(root);
+
+            while (stack.Any())
             {
-                var diagIndex = _stack.Top.DiagnosticIndex;
-                var node = _stack.Top.Node;
-                var diags = node.GetDiagnostics();
-                if (diagIndex < diags.Length - 1)
+                var node = stack.Top.Node;
+
+                if (!stack.Top.ProcessedDiagnostics)
                 {
-                    diagIndex++;
-                    var sdi = (SyntaxDiagnosticInfo)diags[diagIndex];
+                    foreach (SyntaxDiagnosticInfo sdi in node.GetDiagnostics())
+                    {
+                        // For tokens, we've already seen leading trivia (as we push leading/trailing trivia explicit as
+                        // green nodes to process on the stack), so we have to roll back.  For nodes, we have yet to see the
+                        // leading trivia, so those don't need an adjustment.
+                        int leadingWidthAlreadyCounted = node.IsToken ? node.GetLeadingTriviaWidth() : 0;
 
-                    //for tokens, we've already seen leading trivia on the stack, so we have to roll back
-                    //for nodes, we have yet to see the leading trivia
-                    int leadingWidthAlreadyCounted = node.IsToken ? node.GetLeadingTriviaWidth() : 0;
+                        // don't produce locations outside of tree span
+                        var length = syntaxTree.GetRoot().FullSpan.Length;
+                        var spanStart = Math.Min(position - leadingWidthAlreadyCounted + sdi.Offset, length);
+                        var spanWidth = Math.Min(spanStart + sdi.Width, length) - spanStart;
 
-                    // don't produce locations outside of tree span
-                    Debug.Assert(_syntaxTree is object);
-                    var length = _syntaxTree.GetRoot().FullSpan.Length;
-                    var spanStart = Math.Min(_position - leadingWidthAlreadyCounted + sdi.Offset, length);
-                    var spanWidth = Math.Min(spanStart + sdi.Width, length) - spanStart;
+                        yield return new CSDiagnostic(sdi, new SourceLocation(syntaxTree, new TextSpan(spanStart, spanWidth)));
+                    }
 
-                    _current = new CSDiagnostic(sdi, new SourceLocation(_syntaxTree, new TextSpan(spanStart, spanWidth)));
-
-                    _stack.UpdateDiagnosticIndexForStackTop(diagIndex);
-                    return true;
+                    stack.MarkProcessedDiagnosticsForStackTop();
                 }
 
-                var slotIndex = _stack.Top.SlotIndex;
-tryAgain:
-                if (slotIndex < node.SlotCount - 1)
+                if (tryContinueWithThisNode(node))
+                    continue;
+
+                // Weren't able to continue with this node. Pop it so we continue processing its parent.
+                stack.Pop();
+            }
+
+            yield break;
+
+            bool tryContinueWithThisNode(GreenNode node)
+            {
+                // SlotCount is 0 when we hit tokens or normal trivia. In this case, we just want to move past the
+                // normal width of the item.  Importantly, in the case of tokens, we don't want to move the
+                // full-width.  That would make us double-count the widths of the leading/trailing trivia which
+                // we're walking into as normal green nodes.
+                if (node.SlotCount == 0)
                 {
-                    slotIndex++;
-                    var child = node.GetSlot(slotIndex);
-                    if (child == null)
-                    {
-                        goto tryAgain;
-                    }
-
-                    if (!child.ContainsDiagnostics)
-                    {
-                        _position += child.FullWidth;
-                        goto tryAgain;
-                    }
-
-                    _stack.UpdateSlotIndexForStackTop(slotIndex);
-                    _stack.PushNodeOrToken(child);
+                    position += node.Width;
                 }
                 else
                 {
-                    if (node.SlotCount == 0)
+                    var nextSlotIndex = stack.Top.SlotIndex;
+                    while (++nextSlotIndex < node.SlotCount)
                     {
-                        _position += node.Width;
+                        var child = node.GetSlot(nextSlotIndex);
+                        if (child == null)
+                            continue;
+
+                        // If the child doesn't have diagnostics anywhere in it, we can skip it entirely.
+                        if (!child.ContainsDiagnostics)
+                        {
+                            position += child.FullWidth;
+                            continue;
+                        }
+
+                        stack.UpdateSlotIndexForStackTop(nextSlotIndex);
+                        stack.PushNodeOrToken(child);
+
+                        return true;
                     }
-
-                    _stack.Pop();
                 }
-            }
 
-            return false;
-        }
-
-        /// <summary>
-        /// The current diagnostic that the enumerator is pointing at.
-        /// </summary>
-        public Diagnostic Current
-        {
-            get { Debug.Assert(_current is object); return _current; }
-        }
-
-        private struct NodeIteration
-        {
-            internal readonly GreenNode Node;
-            internal int DiagnosticIndex;
-            internal int SlotIndex;
-
-            internal NodeIteration(GreenNode node)
-            {
-                this.Node = node;
-                this.SlotIndex = -1;
-                this.DiagnosticIndex = -1;
+                // Weren't able to continue with this node. Pop it so we continue processing its parent.
+                return false;
             }
         }
 
-        private struct NodeIterationStack
+        private struct NodeIteration(GreenNode node)
         {
-            private NodeIteration[] _stack;
+            /// <summary>
+            /// The node we're on.
+            /// </summary>
+            public readonly GreenNode Node = node;
+
+            /// <summary>
+            /// The index of the child of <see cref="Node"/> that we're on. Initially at -1 as we're pointing at the
+            /// node itself, not any children.
+            /// </summary>
+            public int SlotIndex = -1;
+
+            /// <summary>
+            /// We'll hit nodes multiple times.  First, when we run into them, and next, when we've processed all their
+            /// children and are on the way back up.  This tracks whether we've processed the diagnostics already so we
+            /// don't do it twice.
+            /// </summary>
+            public bool ProcessedDiagnostics;
+        }
+
+        private struct NodeIterationStack(int capacity) : IDisposable
+        {
+            private NodeIteration[] _stack = ArrayPool<NodeIteration>.Shared.Rent(capacity);
             private int _count;
 
-            internal NodeIterationStack(int capacity)
-            {
-                Debug.Assert(capacity > 0);
-                _stack = new NodeIteration[capacity];
-                _count = 0;
-            }
+            public readonly void Dispose()
+                => ArrayPool<NodeIteration>.Shared.Return(_stack, clearArray: true);
 
-            internal void PushNodeOrToken(GreenNode node)
+            public void PushNodeOrToken(GreenNode node)
             {
-                var token = node as Syntax.InternalSyntax.SyntaxToken;
-                if (token != null)
+                if (node is Syntax.InternalSyntax.SyntaxToken token)
                 {
                     PushToken(token);
                 }
@@ -152,26 +139,22 @@ tryAgain:
 
             private void PushToken(Syntax.InternalSyntax.SyntaxToken token)
             {
-                var trailing = token.GetTrailingTrivia();
-                if (trailing != null)
-                {
-                    this.Push(trailing);
-                }
-
+                // Push in reverse order of processing.
+                this.Push(token.GetTrailingTrivia());
                 this.Push(token);
-                var leading = token.GetLeadingTrivia();
-                if (leading != null)
-                {
-                    this.Push(leading);
-                }
+                this.Push(token.GetLeadingTrivia());
             }
 
-            private void Push(GreenNode node)
+            private void Push(GreenNode? node)
             {
+                if (node is null)
+                    return;
+
                 if (_count >= _stack.Length)
                 {
-                    var tmp = new NodeIteration[_stack.Length * 2];
+                    var tmp = ArrayPool<NodeIteration>.Shared.Rent(_stack.Length * 2);
                     Array.Copy(_stack, tmp, _stack.Length);
+                    ArrayPool<NodeIteration>.Shared.Return(_stack, clearArray: true);
                     _stack = tmp;
                 }
 
@@ -179,25 +162,16 @@ tryAgain:
                 _count++;
             }
 
-            internal void Pop()
-            {
-                _count--;
-            }
+            public void Pop()
+                => _count--;
 
-            internal bool Any()
-            {
-                return _count > 0;
-            }
+            public readonly bool Any()
+                => _count > 0;
 
-            internal NodeIteration Top
-            {
-                get
-                {
-                    return this[_count - 1];
-                }
-            }
+            public readonly NodeIteration Top
+                => this[_count - 1];
 
-            internal NodeIteration this[int index]
+            public readonly NodeIteration this[int index]
             {
                 get
                 {
@@ -207,19 +181,11 @@ tryAgain:
                 }
             }
 
-            internal void UpdateSlotIndexForStackTop(int slotIndex)
-            {
-                Debug.Assert(_stack != null);
-                Debug.Assert(_count > 0);
-                _stack[_count - 1].SlotIndex = slotIndex;
-            }
+            public readonly void UpdateSlotIndexForStackTop(int slotIndex)
+                => _stack[_count - 1].SlotIndex = slotIndex;
 
-            internal void UpdateDiagnosticIndexForStackTop(int diagnosticIndex)
-            {
-                Debug.Assert(_stack != null);
-                Debug.Assert(_count > 0);
-                _stack[_count - 1].DiagnosticIndex = diagnosticIndex;
-            }
+            public readonly void MarkProcessedDiagnosticsForStackTop()
+                => _stack[_count - 1].ProcessedDiagnostics = true;
         }
     }
 }


### PR DESCRIPTION
Simplifies the logic a bunch here as we can just store normal data on the real stack, instead of having to simulate it with an explicit capture.